### PR TITLE
Introduce layer type quantization

### DIFF
--- a/src/arithmetic/Matmul.c
+++ b/src/arithmetic/Matmul.c
@@ -98,7 +98,8 @@ void matmulIntTensors(tensor_t *aTensor, tensor_t *bTensor, tensor_t *outputTens
     }
 }
 
-void matmulIntTensorsWithInstructionCounter(tensor_t *aTensor, tensor_t *bTensor, tensor_t *outputTensor) {
+void matmulIntTensorsWithInstructionCounter(tensor_t *aTensor, tensor_t *bTensor,
+                                            tensor_t *outputTensor) {
     if (aTensor->shape->numberOfDimensions > 2 || bTensor->shape->numberOfDimensions > 2) {
         printf("Error: Matmul only supports up to 2D Tensors\n");
         return;
@@ -264,7 +265,8 @@ void matmulFloatTensors(tensor_t *aTensor, tensor_t *bTensor, tensor_t *outputTe
     }
 }
 
-void matmulFloatTensorsWithInstructionCounter(tensor_t *aTensor, tensor_t *bTensor, tensor_t *outputTensor) {
+void matmulFloatTensorsWithInstructionCounter(tensor_t *aTensor, tensor_t *bTensor,
+                                              tensor_t *outputTensor) {
     if (aTensor->shape->numberOfDimensions > 2 || bTensor->shape->numberOfDimensions > 2) {
         printf("Error: Matmul only supports up to 2D Tensors\n");
         return;
@@ -351,7 +353,7 @@ void matmulFloat32Tensors(tensor_t *aTensor, tensor_t *bTensor, tensor_t *output
     MATMUL_FUNC_FLOAT(aTensor, bTensor, outputTensor);
 }
 
-void matmulSymIntTensors(tensor_t* aTensor, tensor_t* bTensor, tensor_t* outputTensor) {
+void matmulSymIntTensors(tensor_t *aTensor, tensor_t *bTensor, tensor_t *outputTensor) {
     matmulInt32Tensors(aTensor, bTensor, outputTensor);
 
     symInt32QConfig_t *aSymInt32QC = aTensor->quantization->qConfig;
@@ -360,7 +362,8 @@ void matmulSymIntTensors(tensor_t* aTensor, tensor_t* bTensor, tensor_t* outputT
     outputSymInt32QC->scale = aSymInt32QC->scale * bSymInt32QC->scale;
 }
 
-void matmulSymIntTensorsWithInstructionCounter(tensor_t* aTensor, tensor_t* bTensor, tensor_t* outputTensor) {
+void matmulSymIntTensorsWithInstructionCounter(tensor_t *aTensor, tensor_t *bTensor,
+                                               tensor_t *outputTensor) {
     matmulInt32Tensors(aTensor, bTensor, outputTensor);
 
     symInt32QConfig_t *aSymInt32QC = aTensor->quantization->qConfig;
@@ -371,7 +374,7 @@ void matmulSymIntTensorsWithInstructionCounter(tensor_t* aTensor, tensor_t* bTen
     ++matmulInstructionCounter;
 }
 
-void matmulSymInt32Tensors(tensor_t* aTensor, tensor_t* bTensor, tensor_t* outputTensor) {
+void matmulSymInt32Tensors(tensor_t *aTensor, tensor_t *bTensor, tensor_t *outputTensor) {
     MATMUL_FUNC_SYM_INT32(aTensor, bTensor, outputTensor);
 }
 

--- a/src/layer/CMakeLists.txt
+++ b/src/layer/CMakeLists.txt
@@ -1,6 +1,4 @@
-add_library(Conv1d
-        Conv1d.c
-)
+add_library(Conv1d Conv1d.c)
 target_include_directories(Conv1d PUBLIC include)
 target_link_libraries(Conv1d PRIVATE
         DTypes
@@ -8,9 +6,7 @@ target_link_libraries(Conv1d PRIVATE
         Arithmetic
 )
 
-add_library(Conv1dTransposed
-        Conv1dTransposed.c
-)
+add_library(Conv1dTransposed Conv1dTransposed.c)
 target_include_directories(Conv1dTransposed PUBLIC include)
 target_link_libraries(Conv1dTransposed PRIVATE
         DTypes
@@ -18,9 +14,7 @@ target_link_libraries(Conv1dTransposed PRIVATE
         Arithmetic
 )
 
-add_library(Layer
-        Layer.c
-)
+add_library(Layer Layer.c)
 target_include_directories(Layer PUBLIC include)
 target_link_libraries(Layer PRIVATE
         DTypes
@@ -28,11 +22,10 @@ target_link_libraries(Layer PRIVATE
         Arithmetic
         Linear
         Relu
+        Softmax
 )
 
-add_library(Linear
-        Linear.c
-)
+add_library(Linear Linear.c)
 target_include_directories(Linear PUBLIC include)
 target_link_libraries(Linear PRIVATE
         DTypes
@@ -43,9 +36,15 @@ target_link_libraries(Linear PRIVATE
         Layer
 )
 
-add_library(Relu
-        Relu.c
+add_library(QuantizationLayer QuantizationLayer.c)
+target_include_directories(QuantizationLayer PUBLIC include)
+target_link_libraries(QuantizationLayer PRIVATE
+        TensorConversion
+        Tensor
+        Rounding
 )
+
+add_library(Relu Relu.c)
 target_include_directories(Relu PUBLIC include)
 target_link_libraries(Relu PRIVATE
         DTypes
@@ -55,14 +54,13 @@ target_link_libraries(Relu PRIVATE
         Layer
 )
 
-add_library(Softmax
-        Softmax.c
-)
+add_library(Softmax Softmax.c)
 target_include_directories(Softmax PUBLIC include)
 target_link_libraries(Softmax PRIVATE
         DTypes
         Tensor
         Arithmetic
+        Layer
 )
 
 add_library(CommonLayerLibs INTERFACE)

--- a/src/layer/Layer.c
+++ b/src/layer/Layer.c
@@ -1,32 +1,16 @@
-#include <math.h>
-
 #include "Layer.h"
 #include "Linear.h"
 #include "Relu.h"
+#include "Softmax.h"
 
 layerFunctions_t layerFunctions[] = {
     [LINEAR] = {linearForward, linearBackward, linearCalcOutputShape},
     [RELU] = {reluForward, reluBackward, reluCalcOutputShape},
     [CONV1D] = {NULL, NULL, NULL},
-    [SOFTMAX] = {NULL, NULL, NULL}
+    [SOFTMAX] = {softmaxForward, softmaxBackward, softmaxCalcOutputShape}
 };
 
-void initLayer(layer_t *layer, layerType_t type, layerConfig_t* config, layerQType_t qType, qtype_t inputQType, quantization_t* outputQ) {
+void initLayer(layer_t *layer, layerType_t type, layerConfig_t* config) {
     layer->type = type;
     layer->config = config;
-    layer->qType = qType;
-    layer->inputQType = inputQType;
-    layer->outputQ = outputQ;
-}
-
-size_t calcBytesOutputData(quantization_t *outputQ, size_t numberOfOutputs) {
-    switch (outputQ->type) {
-    case FLOAT32:
-        return numberOfOutputs * sizeof(float);
-    case ASYM:
-        size_t bitsPerElement = calcBitsPerElement(outputQ);
-        return ceilf((float)(bitsPerElement * numberOfOutputs / 8));
-    default:
-        return 0;
-    }
 }

--- a/src/layer/QuantizationLayer.c
+++ b/src/layer/QuantizationLayer.c
@@ -1,0 +1,9 @@
+#include "TensorConversion.h"
+#include "QuantizationLayer.h"
+
+void quantization(tensor_t *input, tensor_t *output) {
+    qtype_t inputQType = input->quantization->type;
+    qtype_t outputQType = output->quantization->type;
+    conversionFunction_t conversion = conversionMatrix[inputQType][outputQType];
+    conversion(input, output);
+}

--- a/src/layer/include/Layer.h
+++ b/src/layer/include/Layer.h
@@ -2,9 +2,10 @@
 #define ODT_LAYER_H
 
 #include "Tensor.h"
-#include "Linear.h"
 
 typedef struct linearConfig linearConfig_t;
+typedef struct reluConfig reluConfig_t;
+typedef struct softmaxConfig softmaxConfig_t;
 
 typedef enum layerType
 {
@@ -12,7 +13,8 @@ typedef enum layerType
     RELU,
     CONV1D,
     SOFTMAX,
-    SEQUENTIAL
+    SEQUENTIAL,
+    QUANTIZATION
 } layerType_t;
 
 typedef enum layerQType
@@ -24,15 +26,14 @@ typedef enum layerQType
 typedef union layerConfig
 {
     linearConfig_t* linear;
+    reluConfig_t* relu;
+    softmaxConfig_t* softmax;
 } layerConfig_t;
 
 typedef struct layer
 {
     layerType_t type;
     layerConfig_t* config;
-    layerQType_t qType;
-    qtype_t inputQType;
-    quantization_t* outputQ;
 } layer_t;
 
 typedef void (*forwardFn_t)(layer_t* layer, tensor_t* inputTensor, tensor_t* outputTensor);
@@ -49,10 +50,6 @@ typedef struct layerFunctions
 
 extern layerFunctions_t layerFunctions[];
 
-void initLayer(layer_t* layer, layerType_t layerType, layerConfig_t* config, layerQType_t qType, qtype_t inputQType,
-               quantization_t* outputQ);
-
-
-size_t calcBytesOutputData(quantization_t* outputQ, size_t numberOfOutputs);
+void initLayer(layer_t* layer, layerType_t layerType, layerConfig_t* config);
 
 #endif

--- a/src/layer/include/Linear.h
+++ b/src/layer/include/Linear.h
@@ -8,22 +8,42 @@ typedef struct linearConfig
 {
     parameter_t* weights;
     parameter_t* bias;
+
+    quantization_t* forwardQ;
+    quantization_t* weightGradQ;
+    quantization_t* biasGradQ;
+    quantization_t* propLossQ;
 } linearConfig_t;
 
-void linearInitConfig(linearConfig_t* linearConfig, parameter_t* weights, parameter_t* bias);
+void linearInitConfig(linearConfig_t *linearConfig, parameter_t *weights, parameter_t *bias,
+                      quantization_t *forwardQ, quantization_t *weightGradQ,
+                      quantization_t *biasGradQ, quantization_t *propLossQ);
 
-void linearForward(layer_t *linearLayer, tensor_t* input, tensor_t* output);
+// IMPORTANT: Assumes all tensors have FLOAT32 quantization
+void linearForwardFloat(tensor_t* w, tensor_t* b, tensor_t* input, tensor_t* output);
+// IMPORTANT: Assumes all tensors have SYM_INT32 quantization
+void linearForwardSymInt32(tensor_t* w, tensor_t* b, tensor_t* input, tensor_t* output);
+// IMPORTANT: Used for mismatched quantizations
+void linearForward(layer_t* linearLayer, tensor_t* input, tensor_t* output);
 
-void linearBackward(layer_t *linearLayer, tensor_t* forwardInput, tensor_t* loss, tensor_t* propLossTensor);
+// IMPORTANT: Assumes all tensors have FLOAT32 quantization
+void backwardFloat(linearConfig_t* linearConfig, tensor_t* forwardInput, tensor_t* loss,
+                   tensor_t* propLossTensor);
+// IMPORTANT: Assumes all tensors have SYM_INT32 quantization
+void backwardSymInt32(linearConfig_t *linearConfig, tensor_t *forwardInput, tensor_t *loss,
+                         tensor_t *propLossTensor);
+// IMPORTANT: Used for mismatched quantizations
+void linearBackward(layer_t* linearLayer, tensor_t* forwardInput, tensor_t* loss, tensor_t* propLossTensor);
+
 
 void linearCalcWeightGradsFloat32(tensor_t* loss, tensor_t* forwardInput, tensor_t* weightGrads);
 void linearCalcBiasGradsFloat32(tensor_t* biasGrads, tensor_t* loss);
 void linearCalcPropLossFloat32(tensor_t* weights, tensor_t* loss, tensor_t* propLoss);
 
-void linearCalcWeightGradsAsym(tensor_t* loss, tensor_t* forwardInput, tensor_t* weightGrads);
-void linearCalcBiasGradsAsym(tensor_t* biasGrads, tensor_t* loss);
-void linearCalcPropLossAsym(tensor_t* weights, tensor_t* loss, tensor_t* propLoss);
+void linearCalcWeightGradsSymInt32(tensor_t* loss, tensor_t* forwardInput, tensor_t* weightGrads);
+void linearCalcBiasGradsSymInt32(tensor_t* biasGrads, tensor_t* loss);
+void linearCalcPropLossSymInt32(tensor_t* weights, tensor_t* loss, tensor_t* propLoss);
 
-void linearCalcOutputShape(layer_t *linearLayer, shape_t *inputShape, shape_t *outputShape);
+void linearCalcOutputShape(layer_t* linearLayer, shape_t* inputShape, shape_t* outputShape);
 
 #endif // ENV5_RUNTIME_LINEAR_H

--- a/src/layer/include/QuantizationLayer.h
+++ b/src/layer/include/QuantizationLayer.h
@@ -1,0 +1,10 @@
+#ifndef QUANTIZATIONLAYER_H
+#define QUANTIZATIONLAYER_H
+
+#include "Tensor.h"
+
+void quantizationForward(tensor_t *input, tensor_t *output);
+
+void quantizationBackward(tensor_t *input, tensor_t *output);
+
+#endif //QUANTIZATIONLAYER_H

--- a/src/layer/include/Relu.h
+++ b/src/layer/include/Relu.h
@@ -2,11 +2,25 @@
 #define ENV5_RUNTIME_RELU_H
 
 #include "Tensor.h"
-#include "Layer.h"
 
-void reluForward(layer_t *reluLayer, tensor_t* input, tensor_t* output);
-void reluBackward(layer_t *reluLayer, tensor_t* forwardInput, tensor_t* loss, tensor_t* propLoss);
+typedef struct layer layer_t;
 
-void reluCalcOutputShape(layer_t *reluLayer, shape_t *inputShape, shape_t *outputShape);
+typedef struct reluConfig
+{
+    quantization_t* forwardQ;
+    quantization_t* backwardQ;
+} reluConfig_t;
+
+void reluInit(reluConfig_t* reluConfig, quantization_t* forwardQ, quantization_t* backwardQ);
+
+void reluForwardFloat(tensor_t *input, tensor_t *output);
+void reluForwardAsym(tensor_t *input, tensor_t *output);
+void reluForward(layer_t* reluLayer, tensor_t* input, tensor_t* output);
+
+void reluBackwardFloat(tensor_t *forwardInput, tensor_t *loss, tensor_t *propLoss);
+void reluBackwardAsym(tensor_t *forwardInput, tensor_t *loss, tensor_t *propLoss);
+void reluBackward(layer_t* reluLayer, tensor_t* forwardInput, tensor_t* loss, tensor_t* propLoss);
+
+void reluCalcOutputShape(layer_t* reluLayer, shape_t* inputShape, shape_t* outputShape);
 
 #endif // ENV5_RUNTIME_RELU_H

--- a/src/layer/include/Softmax.h
+++ b/src/layer/include/Softmax.h
@@ -1,19 +1,22 @@
 #ifndef ENV5_RUNTIME_SOFTMAX_H
 #define ENV5_RUNTIME_SOFTMAX_H
 
-#include <stddef.h>
-
 #include "Layer.h"
 
 typedef struct softmaxConfig
 {
-    size_t size;
+    quantization_t* forwardQ;
+    quantization_t* backwardQ;
 } softmaxConfig_t;
 
-void initSoftmaxLayer(layer_t* softmaxLayer);
+void softmaxInitConfig(softmaxConfig_t* softmaxConfig, quantization_t* forwardQ, quantization_t* backwardQ);
+
+void softmaxInitLayer(layerConfig_t* softmaxConfig, layer_t* softmaxLayer);
 
 void softmaxForward(layer_t* softmaxLayer, tensor_t* input, tensor_t* output);
 
 void softmaxBackward(layer_t* softmaxLayer, tensor_t* input, tensor_t* loss, tensor_t* propLoss);
+
+void softmaxCalcOutputShape(layer_t *softmaxLayer, shape_t *inputShape, shape_t *outputShape);
 
 #endif // ENV5_RUNTIME_SOFTMAX_H

--- a/src/loss_functions/MSE.c
+++ b/src/loss_functions/MSE.c
@@ -22,7 +22,7 @@ float mseLossForwardFloat(tensor_t *output, tensor_t *label) {
     return sum / (float)size;
 }
 
-float mseLossForwardAsym(tensor_t *output, tensor_t *label) {
+float mseLossForwardSymInt32(tensor_t *output, tensor_t *label) {
     size_t size = calcNumberOfElementsByTensor(output);
 
     tensor_t outputFloat;
@@ -58,11 +58,8 @@ float mseLossForward(tensor_t *output, tensor_t *label) {
     switch (output->quantization->type) {
     case FLOAT32:
         return mseLossForwardFloat(output, label);
-    case ASYM:
-        return mseLossForwardAsym(output, label);
-    default:
-        // TODO this is shit
-        return 0.f;
+    case SYM_INT32:
+        return mseLossForwardSymInt32(output, label);
     }
 }
 
@@ -80,7 +77,7 @@ void mseLossBackwardFloat(tensor_t *modelOutput, tensor_t *label, tensor_t *resu
     }
 }
 
-void mseLossBackwardAsym(tensor_t *modelOutput, tensor_t *label, tensor_t *result) {
+void mseLossBackwardSymInt32(tensor_t *modelOutput, tensor_t *label, tensor_t *result) {
     size_t numberOfElements = calcNumberOfElementsByTensor(modelOutput);
 
     tensor_t modelOutputFloat;
@@ -125,8 +122,8 @@ void mseLossBackward(tensor_t *modelOutput, tensor_t *label, tensor_t *result) {
     case FLOAT32:
         mseLossBackwardFloat(modelOutput, label, result);
         break;
-    case ASYM:
-        mseLossBackwardAsym(modelOutput, label, result);
+    case SYM_INT32:
+        mseLossBackwardSymInt32(modelOutput, label, result);
         break;
     default:
         printf("Error in MSE Backward: qtype not supported\n");

--- a/src/optimizer/CMakeLists.txt
+++ b/src/optimizer/CMakeLists.txt
@@ -4,6 +4,7 @@ target_link_libraries(Optimizer PRIVATE
         Quantization
         Rounding
         Layer
+        Tensor
 )
 
 add_library(Sgd Sgd.c)

--- a/src/optimizer/Sgd.c
+++ b/src/optimizer/Sgd.c
@@ -32,7 +32,7 @@ static void sgdStepFloat(optimizer_t *optim) {
     }
 }
 
-static void sgdStepAsym(optimizer_t *optim) {
+static void sgdStepSymInt32(optimizer_t *optim) {
     sgd_t *sgd = (sgd_t *)optim->impl;
 
     for (size_t stateIndex = 0; stateIndex < optim->sizeStates; stateIndex++) {
@@ -73,8 +73,8 @@ void sgdStep(optimizer_t *optimizer) {
     case FLOAT32:
         sgdStepFloat(optimizer);
         break;
-    case ASYM:
-        sgdStepAsym(optimizer);
+    case SYM_INT32:
+        sgdStepSymInt32(optimizer);
         break;
     default:
         break;
@@ -102,7 +102,7 @@ static void sgdStepMFloat(optimizer_t *optim) {
     }
 }
 
-static void sgdStepMAsym(optimizer_t *optim) {
+static void sgdStepMSymInt32(optimizer_t *optim) {
     sgd_t *sgd = optim->impl->sgd;
 
     for (size_t i = 0; i < optim->sizeStates; i++) {
@@ -151,7 +151,6 @@ static void sgdStepMAsym(optimizer_t *optim) {
 
         convertTensor(&stateFloat, state);
         convertTensor(&paramFloat, param->param);
-        convertTensor(&gradFloat, param->grad);
     }
 }
 
@@ -160,8 +159,8 @@ void sgdStepM(optimizer_t *optimizer) {
     case FLOAT32:
         sgdStepMFloat(optimizer);
         break;
-    case ASYM:
-        sgdStepMAsym(optimizer);
+    case SYM_INT32:
+        sgdStepMSymInt32(optimizer);
         break;
     default:
         break;
@@ -176,10 +175,10 @@ void sgdZeroGrad(optimizer_t *optimizer) {
         size_t totalNumberOfBytes = ceil(paramSize * bitsPerElement / 8);
 
         memset(param->grad->data, 0, totalNumberOfBytes);
-        qtype_t currentQType = param->grad->quantization->type;
-        if (currentQType == ASYM) {
-            asymQConfig_t *currentAsymQC = param->grad->quantization->qConfig;
-            currentAsymQC->zeroPoint = 0;
+
+        if(param->grad->quantization->type == SYM_INT32) {
+            symInt32QConfig_t *symIntQ = param->grad->quantization->qConfig;
+            symIntQ->scale = 0.f;
         }
     }
 }

--- a/src/optimizer/include/Sgd.h
+++ b/src/optimizer/include/Sgd.h
@@ -11,7 +11,6 @@ typedef struct sgd {
 
 void sgdInit(sgd_t *sgd, float learningRate, float momentumFactor, float weightDecay);
 
-// TODO
 void sgdStep(optimizer_t *optimizer);
 
 void sgdStepM(optimizer_t *optimizer);

--- a/src/tensor/include/Tensor.h
+++ b/src/tensor/include/Tensor.h
@@ -59,6 +59,7 @@ tensor_t* getGradTensorFromParameter(parameter_t* parameter);
 size_t calcBytesPerElement(quantization_t* quantization);
 size_t calcBitsPerElement(quantization_t* quantization);
 size_t calcBytesPerTensor(tensor_t* tensor);
+size_t calcNumberOfBytesForData(quantization_t *q, size_t numberOfElements);
 
 size_t calcNumberOfElementsByShape(shape_t* shape);
 size_t calcNumberOfElementsByTensor(tensor_t* tensor);

--- a/src/tensor/include/TensorConversion.h
+++ b/src/tensor/include/TensorConversion.h
@@ -1,5 +1,5 @@
-#ifndef ENV5_RUNTIME_TENSORCONVERSION_H
-#define ENV5_RUNTIME_TENSORCONVERSION_H
+#ifndef TENSOR_CONVERSION_H
+#define TENSOR_CONVERSION_H
 
 #include "Tensor.h"
 
@@ -7,4 +7,6 @@ typedef void (*conversionFunction_t)(tensor_t* inputTensor, tensor_t* outputTens
 
 void convertTensor(tensor_t* inputTensor, tensor_t* outputTensor);
 
-#endif // ENV5_RUNTIME_TENSORCONVERSION_H
+extern conversionFunction_t conversionMatrix[5][5];
+
+#endif // TENSOR_CONVERSION_H

--- a/src/userAPI/CMakeLists.txt
+++ b/src/userAPI/CMakeLists.txt
@@ -52,6 +52,15 @@ target_link_libraries(SgdAPI PRIVATE
         Optimizer
 )
 
+add_library(SoftmaxAPI SoftmaxAPI.c)
+target_include_directories(SoftmaxAPI PUBLIC include)
+target_link_libraries(SoftmaxAPI PRIVATE
+        Layer
+        Tensor
+        Rounding
+        StorageAPI
+)
+
 add_library(StorageAPI StorageAPI.c)
 target_include_directories(StorageAPI PUBLIC include)
 target_link_libraries(StorageAPI PRIVATE

--- a/src/userAPI/InferenceAPI.c
+++ b/src/userAPI/InferenceAPI.c
@@ -1,69 +1,152 @@
 #include <stdio.h>
+#include <stdbool.h>
 
 #include "Tensor.h"
 #include "Layer.h"
 #include "InferenceAPI.h"
 #include "TensorAPI.h"
+
 #include "StorageAPI.h"
+#include "Linear.h"
+#include "Relu.h"
+#include "TensorConversion.h"
+
+// Initializes ping pong buffer to match output
+static void initPingPongBufferOutput(tensor_t *buffer, layer_t *currentLayer, shape_t *inputShape,
+                                     sparsity_t *inputSparsity) {
+    layerType_t currentLayerType = currentLayer->type;
+    quantization_t *currentQ = NULL;
+
+    switch (currentLayerType) {
+    case LINEAR:
+        currentQ = currentLayer->config->linear->forwardQ;
+        break;
+    case RELU:
+        currentQ = currentLayer->config->relu->forwardQ;
+        break;
+    default:
+        break;
+    }
+
+    size_t outputNumberOfDims = inputShape->numberOfDimensions;
+    size_t sizeDims = outputNumberOfDims;
+
+    shape_t *outShape = *reserveMemory(sizeof(shape_t));
+    size_t *outDims = *reserveMemory(sizeDims * sizeof(size_t));
+    size_t *outOrder = *reserveMemory(sizeDims * sizeof(size_t));
+
+    outShape->dimensions = outDims;
+    outShape->numberOfDimensions = outputNumberOfDims;
+    outShape->orderOfDimensions = outOrder;
+
+    calcOutputShapeFn_t calcOutputShape = layerFunctions[currentLayerType].calcOutputShape;
+    calcOutputShape(currentLayer, inputShape, outShape);
+
+    size_t numValues =
+        calcNumberOfElementsByShape(outShape);
+    size_t sizeData = calcNumberOfBytesForData(currentQ, numValues);
+    uint8_t *data = *reserveMemory(sizeData);
+
+    quantization_t *q = *reserveMemory(sizeof(quantization_t));
+    switch (currentQ->type) {
+    case FLOAT32:
+        q->type = FLOAT32;
+        q->qConfig = NULL;
+        break;
+    case SYM_INT32:
+        q->type = SYM_INT32;
+        symInt32QConfig_t *currentQC = currentQ->qConfig;
+        symInt32QConfig_t *symInt32QC = *reserveMemory(sizeof(symInt32QConfig_t));
+        symInt32QC->roundingMode = currentQC->roundingMode;
+        q->qConfig = symInt32QC;
+        break;
+    default:
+        break;
+    }
+
+    setTensorValues(buffer, data, outShape, q, inputSparsity);
+}
+
+// Initializes ping pong buffer to match given input
+static void initPingPongBufferInput(tensor_t *input, tensor_t *buffer) {
+    quantization_t *currentQ = input->quantization;
+
+    size_t sizeDims = input->shape->numberOfDimensions;
+
+    shape_t *outShape = *reserveMemory(sizeof(shape_t));
+    size_t *outDims = *reserveMemory(sizeDims * sizeof(size_t));
+    size_t *outOrder = *reserveMemory(sizeDims * sizeof(size_t));
+
+    outShape->dimensions = outDims;
+    outShape->numberOfDimensions = sizeDims;
+    outShape->orderOfDimensions = outOrder;
+
+    size_t numValues = calcNumberOfElementsByTensor(input);
+    size_t sizeData = calcNumberOfBytesForData(currentQ, numValues);
+    uint8_t *data = *reserveMemory(sizeData);
+
+    quantization_t *q = *reserveMemory(sizeof(quantization_t));
+    switch (currentQ->type) {
+    case FLOAT32:
+        q->type = FLOAT32;
+        q->qConfig = NULL;
+        break;
+    case SYM_INT32:
+        q->type = SYM_INT32;
+        symInt32QConfig_t *currentQC = currentQ->qConfig;
+        symInt32QConfig_t *symInt32QC = *reserveMemory(sizeof(symInt32QConfig_t));
+        symInt32QC->roundingMode = currentQC->roundingMode;
+        q->qConfig = symInt32QC;
+        break;
+    default:
+        break;
+    }
+
+    setTensorValues(buffer, data, outShape, q, input->sparsity);
+
+    copyTensor(buffer, input);
+}
+
+static void deInitPingPongBuffer(tensor_t *buffer) {
+    freeData(buffer);
+    freeShape(buffer->shape);
+    freeQuantization(buffer->quantization);
+}
 
 tensor_t *inference(layer_t **model, size_t numberOfLayers, tensor_t *input) {
+    tensor_t ping;
+    tensor_t pong;
+    bool toggle = false;
+
+    initPingPongBufferInput(input, &ping);
+
     for (size_t i = 0; i < numberOfLayers; i++) {
         layer_t *currentLayer = model[i];
         layerType_t currentLayerType = currentLayer->type;
-        quantization_t *currentQ = currentLayer->outputQ;
-
-        size_t outputNumberOfDims = input->shape->numberOfDimensions;
-        size_t sizeDims = outputNumberOfDims;
-        size_t outDims[sizeDims];
-        size_t outOrder[sizeDims];
-
-        shape_t outShape;
-        outShape.dimensions = outDims;
-        outShape.numberOfDimensions = outputNumberOfDims;
-        outShape.orderOfDimensions = outOrder;
-
-        calcOutputShapeFn_t calcOutputShape = layerFunctions[currentLayerType].calcOutputShape;
-        calcOutputShape(currentLayer, input->shape, &outShape);
-
-        size_t numValues =
-            calcNumberOfElementsByShape(&outShape);
-
-        size_t sizeData = calcBytesOutputData(currentLayer->outputQ, numValues);
-        uint8_t data[sizeData];
-
-        quantization_t q;
-        asymQConfig_t asymQConfig;
-        switch (currentQ->type) {
-        case FLOAT32:
-            q.type = FLOAT32;
-            q.qConfig = NULL;
-            break;
-        case ASYM:
-            q.type = ASYM;
-            asymQConfig_t *currentQC = currentQ->qConfig;
-            asymQConfig.qBits = currentQC->qBits;
-            asymQConfig.roundingMode = currentQC->roundingMode;
-            q.qConfig = &asymQConfig;
-            break;
-        default:
-            break;
-        }
-
-        tensor_t intermediateOutput;
-        setTensorValues(&intermediateOutput, data, &outShape, &q, input->sparsity);
-
         forwardFn_t forward = layerFunctions[currentLayerType].forward;
-        forward(currentLayer, input, &intermediateOutput);
 
-        if (i == numberOfLayers - 1) {
-            tensor_t *output = getTensorLike(&intermediateOutput);
-            copyTensor(output, &intermediateOutput);
-            return output;
+        if (!toggle) {
+            initPingPongBufferOutput(&pong, currentLayer, input->shape, input->sparsity);
+            forward(currentLayer, &ping, &pong);
+            deInitPingPongBuffer(&ping);
+            toggle = true;
+        } else {
+            initPingPongBufferOutput(&ping, currentLayer, input->shape, input->sparsity);
+            forward(currentLayer, &pong, &ping);
+            deInitPingPongBuffer(&pong);
+            toggle = false;
         }
-
-        copyTensor(input, &intermediateOutput);
     }
-    return NULL;
+
+    if (!toggle) {
+        tensor_t *output = getTensorLike(&ping);
+        convertTensor(&ping, output);
+        return output;
+    }
+
+    tensor_t *output = getTensorLike(&pong);
+    convertTensor(&pong, output);
+    return output;
 }
 
 inferenceStats_t *reserveInferenceStats(tensor_t *label) {
@@ -92,7 +175,18 @@ inferenceStats_t *inferenceWithLoss(layer_t **model, size_t numberOfLayers, tens
     for (size_t i = 0; i < numberOfLayers; i++) {
         layer_t *currentLayer = model[i];
         layerType_t currentLayerType = currentLayer->type;
-        quantization_t *currentQ = currentLayer->outputQ;
+        quantization_t *currentQ = NULL;
+
+        switch (currentLayerType) {
+        case LINEAR:
+            currentQ = currentLayer->config->linear->forwardQ;
+            break;
+        case RELU:
+            currentQ = currentLayer->config->relu->forwardQ;
+            break;
+        default:
+            break;
+        }
 
         size_t outputNumberOfDims = input->shape->numberOfDimensions;
         size_t sizeDims = outputNumberOfDims;
@@ -110,22 +204,21 @@ inferenceStats_t *inferenceWithLoss(layer_t **model, size_t numberOfLayers, tens
         size_t numValues =
             calcNumberOfElementsByShape(&outShape);
 
-        size_t sizeData = calcBytesOutputData(currentLayer->outputQ, numValues);
+        size_t sizeData = calcNumberOfBytesForData(currentQ, numValues);
         uint8_t data[sizeData];
 
         quantization_t q;
-        asymQConfig_t asymQConfig;
+        symInt32QConfig_t symInt32QConfig;
         switch (currentQ->type) {
         case FLOAT32:
             q.type = FLOAT32;
             q.qConfig = NULL;
             break;
         case ASYM:
-            q.type = ASYM;
-            asymQConfig_t *currentQC = currentQ->qConfig;
-            asymQConfig.qBits = currentQC->qBits;
-            asymQConfig.roundingMode = currentQC->roundingMode;
-            q.qConfig = &asymQConfig;
+            q.type = SYM_INT32;
+            symInt32QConfig_t *currentQC = currentQ->qConfig;
+            symInt32QConfig.roundingMode = currentQC->roundingMode;
+            q.qConfig = &symInt32QConfig;
             break;
         default:
             break;

--- a/src/userAPI/LinearAPI.c
+++ b/src/userAPI/LinearAPI.c
@@ -1,26 +1,16 @@
 #include <stdlib.h>
+#include <stdio.h>
 
 #include "Layer.h"
 #include "Tensor.h"
 #include "StorageAPI.h"
 #include "LinearAPI.h"
+#include "Linear.h"
 
-#include <stdio.h>
-
-void freeLinearLayer(layer_t *linearLayer) {
-    linearConfig_t *linearConfig = linearLayer->config->linear;
-    freeReservedMemory(linearConfig);
-    freeReservedMemory(linearLayer);
-}
-
-layer_t *linearLayerInit(parameter_t *weights, parameter_t *bias, layerQType_t layerQType,
-                         qtype_t inputQType, quantization_t *outputQ) {
+layer_t *linearLayerInit(parameter_t *weights, parameter_t *bias, quantization_t *forwardQ, quantization_t *weightGradsQ, quantization_t *biasGradsQ, quantization_t *propLossQ) {
     layer_t *linearLayer = *reserveMemory(sizeof(layer_t));
 
     linearLayer->type = LINEAR;
-    linearLayer->qType = layerQType;
-    linearLayer->outputQ = outputQ;
-    linearLayer->inputQType = inputQType;
 
     layerConfig_t *layerConfig = *reserveMemory(sizeof(layerConfig_t));
     linearConfig_t *linearConfig = *reserveMemory(sizeof(linearConfig_t));
@@ -28,20 +18,20 @@ layer_t *linearLayerInit(parameter_t *weights, parameter_t *bias, layerQType_t l
 
     linearConfig->weights = weights;
     linearConfig->bias = bias;
+    linearConfig->forwardQ = forwardQ;
+    linearConfig->weightGradQ = weightGradsQ;
+    linearConfig->biasGradQ = biasGradsQ;
+    linearConfig->propLossQ = propLossQ;
 
     linearLayer->config = layerConfig;
 
     return linearLayer;
 }
 
-layer_t *linearLayerInitNonTrainable(tensor_t *weights, tensor_t *bias, layerQType_t layerQType,
-                                     qtype_t inputQType, quantization_t *outputQ) {
+layer_t *linearLayerInitNonTrainable(tensor_t *weights, tensor_t *bias, quantization_t *forwardQ) {
     layer_t *linearLayer = *reserveMemory(sizeof(layer_t));
 
     linearLayer->type = LINEAR;
-    linearLayer->qType = layerQType;
-    linearLayer->outputQ = outputQ;
-    linearLayer->inputQType = inputQType;
 
     layerConfig_t *layerConfig = *reserveMemory(sizeof(layerConfig_t));
     linearConfig_t *linearConfig = *reserveMemory(sizeof(linearConfig_t));
@@ -51,8 +41,15 @@ layer_t *linearLayerInitNonTrainable(tensor_t *weights, tensor_t *bias, layerQTy
     linearConfig->weights->grad = NULL;
     linearConfig->bias->param = bias;
     linearConfig->bias->grad = NULL;
+    linearConfig->forwardQ = forwardQ;
 
     linearLayer->config = layerConfig;
 
     return linearLayer;
+}
+
+void freeLinearLayer(layer_t *linearLayer) {
+    linearConfig_t *linearConfig = linearLayer->config->linear;
+    freeReservedMemory(linearConfig);
+    freeReservedMemory(linearLayer);
 }

--- a/src/userAPI/ReluAPI.c
+++ b/src/userAPI/ReluAPI.c
@@ -1,14 +1,20 @@
 #include "StorageAPI.h"
 #include "ReluAPI.h"
+#include "Relu.h"
 
-layer_t *reluLayerInit(layerQType_t layerQType, qtype_t inputQType, quantization_t *outputQ) {
+layer_t *reluLayerInit(quantization_t *forwardQ, quantization_t *backwardQ) {
     layer_t *reluLayer = *reserveMemory(sizeof(layer_t));
 
     reluLayer->type = RELU;
-    reluLayer->qType = layerQType;
-    reluLayer->config = NULL;
-    reluLayer->inputQType = inputQType;
-    reluLayer->outputQ = outputQ;
+
+    layerConfig_t *reluConfig = *reserveMemory(sizeof(layerConfig_t));
+
+    reluConfig_t *reluCfg = *reserveMemory(sizeof(reluConfig_t));
+    reluConfig->relu = reluCfg;
+    reluCfg->forwardQ = forwardQ;
+    reluCfg->backwardQ = backwardQ;
+
+    reluLayer->config = reluConfig;
 
     return reluLayer;
 }

--- a/src/userAPI/SgdAPI.c
+++ b/src/userAPI/SgdAPI.c
@@ -3,6 +3,7 @@
 #include "StorageAPI.h"
 #include "SgdAPI.h"
 #include "TensorAPI.h"
+#include "Linear.h"
 
 #include <stdio.h>
 

--- a/src/userAPI/SoftmaxAPI.c
+++ b/src/userAPI/SoftmaxAPI.c
@@ -1,0 +1,19 @@
+#include "StorageAPI.h"
+#include "Softmax.h"
+#include "SoftmaxAPI.h"
+
+layer_t *softmaxLayerInit(quantization_t *forwardQ, quantization_t *backwardQ) {
+    layer_t *softmaxLayer = *reserveMemory(sizeof(layer_t));
+
+    softmaxLayer->type = SOFTMAX;
+
+    layerConfig_t *layerConfig = *reserveMemory(sizeof(layerConfig_t));
+    softmaxConfig_t *softmaxConfig = *reserveMemory(sizeof(softmaxConfig_t));
+    layerConfig->softmax = softmaxConfig;
+
+    softmaxConfig->forwardQ = forwardQ;
+    softmaxConfig->backwardQ = backwardQ;
+    softmaxLayer->config = layerConfig;
+
+    return  softmaxLayer;
+}

--- a/src/userAPI/include/LinearAPI.h
+++ b/src/userAPI/include/LinearAPI.h
@@ -3,8 +3,10 @@
 
 #include "Layer.h"
 
-layer_t* linearLayerInit(parameter_t* weights, parameter_t* bias, layerQType_t layerQType, qtype_t inputQType,
-                         quantization_t* outputQ);
+layer_t* linearLayerInit(parameter_t* weights, parameter_t* bias, quantization_t* forwardQ,
+                         quantization_t* weightGradsQ, quantization_t* biasGradsQ, quantization_t* propLossQ);
+
+layer_t* linearLayerInitNonTrainable(tensor_t* weights, tensor_t* bias, quantization_t* forwardQ);
 
 void freeLinearLayer(layer_t* linearLayer);
 

--- a/src/userAPI/include/ReluAPI.h
+++ b/src/userAPI/include/ReluAPI.h
@@ -3,7 +3,7 @@
 
 #include "Layer.h"
 
-layer_t* reluLayerInit(layerQType_t layerQType, qtype_t inputQType, quantization_t* outputQ);
+layer_t *reluLayerInit(quantization_t *forwardQ, quantization_t *backwardQ);
 
 void freeReluLayer(layer_t* reluLayer);
 

--- a/src/userAPI/include/SoftmaxAPI.h
+++ b/src/userAPI/include/SoftmaxAPI.h
@@ -1,0 +1,9 @@
+#ifndef SOFTMAXAPI_H
+#define SOFTMAXAPI_H
+
+#include "Tensor.h"
+#include "Layer.h"
+
+layer_t *softmaxLayerInit(quantization_t *forwardQ, quantization_t *backwardQ);
+
+#endif //SOFTMAXAPI_H

--- a/src/userAPI/include/TensorAPI.h
+++ b/src/userAPI/include/TensorAPI.h
@@ -4,20 +4,17 @@
 #include "Tensor.h"
 
 tensor_t* tensorInitInt32(int32_t* data, size_t* dims, size_t numberOfDims, sparsity_t* sparsity);
-
 tensor_t* tensorInitFloat(float* data, size_t* dims, size_t numberOfDims, sparsity_t* sparsity);
-
 tensor_t* tensorInitSymInt32(float* data, size_t* dims, size_t numberOfDims,
                              roundingMode_t roundingMode, sparsity_t* sparsity);
-
 tensor_t* tensorInitAsym(float* data, size_t* dims, size_t numberOfDims, uint8_t qBits,
                          roundingMode_t roundingMode, sparsity_t* sparsity);
-
 tensor_t* tensorInit(float* data, size_t* dims, size_t numberOfDims, quantization_t* quantization,
                      sparsity_t* sparsity);
 
+tensor_t* gradInitInt32(tensor_t* param, sparsity_t* sparsity);
 tensor_t* gradInitFloat(tensor_t* param, sparsity_t* sparsity);
-
+tensor_t* gradInitSymInt32(tensor_t* param, roundingMode_t roundingMode, sparsity_t* sparsity);
 tensor_t* gradInitAsym(tensor_t* param, uint8_t qBits, roundingMode_t roundingMode, sparsity_t* sparsity);
 
 parameter_t* parameterInit(tensor_t* param, tensor_t* grad);

--- a/test/unit/arithmetic/UnitTestAdd.c
+++ b/test/unit/arithmetic/UnitTestAdd.c
@@ -317,5 +317,5 @@ int main(void) {
     RUN_TEST(testAddInt32TensorWithSymInt32TensorInplace);
     RUN_TEST(testAddFloat32TensorToSymInt32TensorInplace);
 
-    UNITY_END();
+    return UNITY_END();
 }

--- a/test/unit/arithmetic/UnitTestArithmetic.c
+++ b/test/unit/arithmetic/UnitTestArithmetic.c
@@ -178,5 +178,6 @@ int main(void) {
     RUN_TEST(testCalcIndexByRawIndex);
     RUN_TEST(testInt32PointWiseArithmetic);
     RUN_TEST(testFloat32ElementWithTensorArithmetic);
-    UNITY_END();
+
+    return UNITY_END();
 }

--- a/test/unit/arithmetic/UnitTestComparison.c
+++ b/test/unit/arithmetic/UnitTestComparison.c
@@ -104,5 +104,5 @@ int main(void) {
     RUN_TEST(testGteInt32Value);
     RUN_TEST(testGteFloatTensors);
 
-    UNITY_END();
+    return UNITY_END();
 }

--- a/test/unit/arithmetic/UnitTestDiv.c
+++ b/test/unit/arithmetic/UnitTestDiv.c
@@ -105,5 +105,6 @@ int main(void) {
     UNITY_BEGIN();
     RUN_TEST(testDivFloatTensors);
     RUN_TEST(testDivSymInt32TensorsInplace);
-    UNITY_END();
+
+    return UNITY_END();
 }

--- a/test/unit/arithmetic/UnitTestLog.c
+++ b/test/unit/arithmetic/UnitTestLog.c
@@ -15,5 +15,6 @@ void tearDown(){}
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(testLogFloat);
-    UNITY_END();
+
+    return UNITY_END();
 }

--- a/test/unit/arithmetic/UnitTestMatmul.c
+++ b/test/unit/arithmetic/UnitTestMatmul.c
@@ -316,5 +316,6 @@ int main(void) {
     RUN_TEST(testMatmulInt32WithVector);
     RUN_TEST(testMatmulFloatVectors);
     RUN_TEST(testMatmulSymInt32Tensors);
-    UNITY_END();
+
+    return UNITY_END();
 }

--- a/test/unit/arithmetic/UnitTestMul.c
+++ b/test/unit/arithmetic/UnitTestMul.c
@@ -97,5 +97,6 @@ int main(void) {
     UNITY_BEGIN();
     RUN_TEST(testMulFloatTensors);
     RUN_TEST(testMulFloatElementWithTensor);
-    UNITY_END();
+
+    return UNITY_END();
 }

--- a/test/unit/arithmetic/UnitTestRounding.c
+++ b/test/unit/arithmetic/UnitTestRounding.c
@@ -39,5 +39,6 @@ void tearDown(){}
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(testRoundHTE);
-    UNITY_END();
+
+    return UNITY_END();
 }

--- a/test/unit/arithmetic/UnitTestSquare.c
+++ b/test/unit/arithmetic/UnitTestSquare.c
@@ -24,5 +24,6 @@ int main(void) {
     UNITY_BEGIN();
     RUN_TEST(testSquareInt32);
     RUN_TEST(testLogFloat);
-    UNITY_END();
+
+    return UNITY_END();
 }

--- a/test/unit/arithmetic/UnitTestSub.c
+++ b/test/unit/arithmetic/UnitTestSub.c
@@ -135,5 +135,6 @@ int main(void) {
     RUN_TEST(testSubInt32Tensors);
     RUN_TEST(testSubInt32ElementWithTensor);
     RUN_TEST(testSubSymInt32Tensors);
-    UNITY_END();
+
+    return UNITY_END();
 }

--- a/test/unit/layer/CMakeLists.txt
+++ b/test/unit/layer/CMakeLists.txt
@@ -3,6 +3,9 @@ add_elastic_ai_unit_test(
         Linear
         MORE_LIBS
         CommonLayerLibs
+        TensorAPI
+        QuantizationAPI
+        LinearAPI
 )
 
 
@@ -11,6 +14,9 @@ add_elastic_ai_unit_test(
         Relu
         MORE_LIBS
         CommonLayerLibs
+        ReluAPI
+        TensorAPI
+        QuantizationAPI
 )
 
 add_elastic_ai_unit_test(
@@ -18,4 +24,7 @@ add_elastic_ai_unit_test(
         Softmax
         MORE_LIBS
         CommonLayerLibs
+        TensorAPI
+        SoftmaxAPI
+        QuantizationAPI
 )

--- a/test/unit/layer/UnitTestSoftmax.c
+++ b/test/unit/layer/UnitTestSoftmax.c
@@ -1,235 +1,133 @@
+#include <stdlib.h>
+
 #include "Softmax.h"
 #include "unity.h"
 #include "TensorConversion.h"
-#include <stdlib.h>
+#include "SoftmaxAPI.h"
+#include "TensorAPI.h"
+#include "QuantizationAPI.h"
 
 void unitTestSoftmaxForwardFloat() {
     size_t inputSize = 6;
 
-    tensor_t input;
     float inputData[] = {-1.f, 0.f, 1.f, 2.f, 5.f, -6.f};
     size_t inputDims[] = {2, 3};
     size_t inputNumberOfDims = 2;
-    size_t inputOrderOfDims[] = {0, 1};
-    shape_t inputShape;
-    setShape(&inputShape, inputDims, inputNumberOfDims, inputOrderOfDims);
-    quantization_t inputQ;
-    initFloat32Quantization(&inputQ);
-    setTensorValues(&input, (uint8_t *)inputData, &inputShape, &inputQ, NULL);
+    tensor_t *input = tensorInitFloat(inputData, inputDims, inputNumberOfDims, NULL);
 
-    tensor_t output;
     float outputData[inputSize];
     size_t outputDims[] = {2, 3};
     size_t outputNumberOfDims = 2;
-    size_t outputOrderOfDims[] = {0, 1};
-    shape_t outputShape;
-    setShape(&outputShape, outputDims, outputNumberOfDims, outputOrderOfDims);
-    quantization_t outputQ;
-    initFloat32Quantization(&outputQ);
-    setTensorValues(&output, (uint8_t *)outputData, &outputShape, &outputQ, NULL);
+    tensor_t *output = tensorInitFloat(outputData, outputDims, outputNumberOfDims, NULL);
 
-    layer_t softmaxLayer;
-    initSoftmaxLayer(&softmaxLayer);
-    softmaxLayer.inputQType = inputQ.type;
-
-    softmaxForward(&softmaxLayer, &input, &output);
+    quantization_t *floatQ = quantizationInitFloat();
+    layer_t *softmaxLayer = softmaxLayerInit(floatQ, floatQ);
+    layerFunctions_t softmaxFns = layerFunctions[SOFTMAX];
+    softmaxFns.forward(softmaxLayer, input, output);
 
     float expected[] = {2.3008e-03, 6.2543e-03, 1.7001e-02, 4.6213e-02, 9.2822e-01, 1.5503e-05};
 
-    float *actual = (float *)output.data;
+    float *actual = (float *)output->data;
 
     for (size_t i = 0; i < inputSize; i++) {
         TEST_ASSERT_FLOAT_WITHIN(0.0001f, expected[i], actual[i]);
     }
 }
 
-void unitTestSoftmaxForwardAsym() {
+void unitTestSoftmaxForwardSymInt32() {
     size_t inputSize = 6;
 
-    tensor_t input;
     float inputData[] = {-1.f, 0.f, 1.f, 2.f, 5.f, -6.f};
     size_t inputDims[] = {2, 3};
     size_t inputNumberOfDims = 2;
-    size_t inputOrderOfDims[] = {0, 1};
-    shape_t inputShape;
-    setShape(&inputShape, inputDims, inputNumberOfDims, inputOrderOfDims);
-    quantization_t inputQ;
-    initFloat32Quantization(&inputQ);
-    setTensorValues(&input, (uint8_t *)inputData, &inputShape, &inputQ, NULL);
+    tensor_t *input = tensorInitSymInt32(inputData, inputDims, inputNumberOfDims, HTE, NULL);
 
-    tensor_t inputAsym;
-    asymQConfig_t inputAsymQC;
-    initAsymQConfig(8, HTE, &inputAsymQC);
-    quantization_t inputAsymQ;
-    initAsymQuantization(&inputAsymQC, &inputAsymQ);
-    uint8_t inputAsymData[inputSize];
-    setTensorValuesForConversion(inputAsymData, &inputAsymQ, &input, &inputAsym);
-    convertTensor(&input, &inputAsym);
-
-    tensor_t output;
     float outputData[inputSize];
     size_t outputDims[] = {2, 3};
     size_t outputNumberOfDims = 2;
-    size_t outputOrderOfDims[] = {0, 1};
-    shape_t outputShape;
-    setShape(&outputShape, outputDims, outputNumberOfDims, outputOrderOfDims);
-    quantization_t outputQ;
-    initFloat32Quantization(&outputQ);
-    setTensorValues(&output, (uint8_t *)outputData, &outputShape, &outputQ, NULL);
+    tensor_t *output = tensorInitSymInt32(outputData, outputDims, outputNumberOfDims, HTE, NULL);
 
-    tensor_t outputAsym;
-    asymQConfig_t outputAsymQC;
-    initAsymQConfig(8, HTE, &outputAsymQC);
-    quantization_t outputAsymQ;
-    initAsymQuantization(&outputAsymQC, &outputAsymQ);
-    uint8_t outputAsymData[inputSize];
-    setTensorValuesForConversion(outputAsymData, &outputAsymQ, &output, &outputAsym);
-    convertTensor(&output, &outputAsym);
+    quantization_t *symIntQ = quantizationInitSymInt32(HTE);
+    layer_t *softmaxLayer = softmaxLayerInit(symIntQ, symIntQ);
+    layerFunctions_t softmaxFns = layerFunctions[SOFTMAX];
+    softmaxFns.forward(softmaxLayer, input, output);
 
-    layer_t softmaxLayer;
-    initSoftmaxLayer(&softmaxLayer);
-    softmaxLayer.inputQType = inputAsymQ.type;
 
-    softmaxForward(&softmaxLayer, &inputAsym, &outputAsym);
+    int32_t expected[] = {0, 0, 0, 0, 1, 0};
 
-    float expected[] = {2.3008e-03, 6.2543e-03, 1.7001e-02, 4.6213e-02, 9.2822e-01, 1.5503e-05};
+    // TODO check behaviour
+    // does it even make sense to do softmax in int32??
 
-    convertTensor(&outputAsym, &output);
-
-    float *actual = (float *)output.data;
-
-    for (size_t i = 0; i < inputSize; i++) {
-        TEST_ASSERT_FLOAT_WITHIN(0.01f, expected[i], actual[i]);
-    }
+    TEST_ASSERT_EQUAL_INT32_ARRAY(expected, output->data, 6);
 }
 
 void unitTestSoftmaxBackwardFloat() {
     size_t inputSize = 6;
 
-    tensor_t input;
     float inputData[] = {2.3008e-03, 6.2543e-03, 1.7001e-02, 4.6213e-02, 9.2822e-01, 1.5503e-05};
     size_t inputDims[] = {2, 3};
     size_t inputNumberOfDims = 2;
-    size_t inputOrderOfDims[] = {0, 1};
-    shape_t inputShape;
-    setShape(&inputShape, inputDims, inputNumberOfDims, inputOrderOfDims);
-    quantization_t inputQ;
-    initFloat32Quantization(&inputQ);
-    setTensorValues(&input, (uint8_t *)inputData, &inputShape, &inputQ, NULL);
+    tensor_t *input = tensorInitFloat(inputData, inputDims, inputNumberOfDims, NULL);
 
-    tensor_t loss;
+
     float lossData[] = {0.f, 2.f, -4.f, 6.f, 3.f, 2.f};
     size_t lossDims[] = {2, 3};
     size_t lossNumberOfDims = 2;
-    size_t lossOrderOfDims[] = {0, 1};
-    shape_t lossShape;
-    setShape(&lossShape, lossDims, lossNumberOfDims, lossOrderOfDims);
-    quantization_t lossQ;
-    initFloat32Quantization(&lossQ);
-    setTensorValues(&loss, (uint8_t *)lossData, &lossShape, &lossQ, NULL);
+    tensor_t *loss = tensorInitFloat(lossData, lossDims, lossNumberOfDims, NULL);
 
-    tensor_t propLoss;
     float propLossData[inputSize];
     size_t propLossDims[] = {2, 3};
     size_t propLossNumberOfDims = 2;
-    size_t propLossOrderOfDims[] = {0, 1};
-    shape_t propLossShape;
-    setShape(&propLossShape, propLossDims, propLossNumberOfDims, propLossOrderOfDims);
-    quantization_t propLossQ;
-    initFloat32Quantization(&propLossQ);
-    setTensorValues(&propLoss, (uint8_t *)propLossData, &propLossShape, &propLossQ, NULL);
+    tensor_t *propLoss = tensorInitFloat(propLossData, propLossDims, propLossNumberOfDims, NULL);
 
-    layer_t softmaxLayer;
-    initSoftmaxLayer(&softmaxLayer);
-    softmaxLayer.inputQType = inputQ.type;
-
-    softmaxBackward(&softmaxLayer, &input, &loss, &propLoss);
+    quantization_t *floatQ = quantizationInitFloat();
+    layer_t *softmaxLayer = softmaxLayerInit(floatQ, floatQ);
+    layerFunctions_t softmaxFns = layerFunctions[SOFTMAX];
+    softmaxFns.backward(softmaxLayer, input, loss, propLoss);
 
     float expected[] = {-6.9173e-03, -6.2947e-03, -1.1912e-01, 1.3834e-01, -5.9973e-03,
                         -1.5603e-05};
 
-    float *actual = (float *)propLoss.data;
+    float *actual = (float *)propLoss->data;
 
     for (size_t i = 0; i < inputSize; i++) {
         TEST_ASSERT_FLOAT_WITHIN(0.0001f, expected[i], actual[i]);
     }
 }
 
-void unitTestSoftmaxBackwardAsym() {
+void unitTestSoftmaxBackwardSymInt32() {
     size_t inputSize = 6;
 
-    tensor_t input;
     float inputData[] = {2.3008e-03, 6.2543e-03, 1.7001e-02, 4.6213e-02, 9.2822e-01, 1.5503e-05};
     size_t inputDims[] = {2, 3};
     size_t inputNumberOfDims = 2;
-    size_t inputOrderOfDims[] = {0, 1};
-    shape_t inputShape;
-    setShape(&inputShape, inputDims, inputNumberOfDims, inputOrderOfDims);
-    quantization_t inputQ;
-    initFloat32Quantization(&inputQ);
-    setTensorValues(&input, (uint8_t *)inputData, &inputShape, &inputQ, NULL);
+    tensor_t *input = tensorInitSymInt32(inputData, inputDims, inputNumberOfDims, HTE, NULL);
 
-    tensor_t inputAsym;
-    asymQConfig_t inputAsymQC;
-    initAsymQConfig(8, HTE, &inputAsymQC);
-    quantization_t inputAsymQ;
-    initAsymQuantization(&inputAsymQC, &inputAsymQ);
-    uint8_t inputAsymData[inputSize];
-    setTensorValuesForConversion(inputAsymData, &inputAsymQ, &input, &inputAsym);
-    convertTensor(&input, &inputAsym);
-
-    tensor_t loss;
     float lossData[] = {0.f, 2.f, -4.f, 6.f, 3.f, 2.f};
     size_t lossDims[] = {2, 3};
     size_t lossNumberOfDims = 2;
-    size_t lossOrderOfDims[] = {0, 1};
-    shape_t lossShape;
-    setShape(&lossShape, lossDims, lossNumberOfDims, lossOrderOfDims);
-    quantization_t lossQ;
-    initFloat32Quantization(&lossQ);
-    setTensorValues(&loss, (uint8_t *)lossData, &lossShape, &lossQ, NULL);
+    tensor_t *loss = tensorInitSymInt32(lossData, lossDims, lossNumberOfDims,HTE, NULL);
 
-    tensor_t lossAsym;
-    asymQConfig_t lossAsymQC;
-    initAsymQConfig(8, HTE, &lossAsymQC);
-    quantization_t lossAsymQ;
-    initAsymQuantization(&lossAsymQC, &lossAsymQ);
-    uint8_t lossAsymData[inputSize];
-    setTensorValuesForConversion(lossAsymData, &lossAsymQ, &loss, &lossAsym);
-    convertTensor(&loss, &lossAsym);
-
-    tensor_t propLoss;
     float propLossData[inputSize];
     size_t propLossDims[] = {2, 3};
     size_t propLossNumberOfDims = 2;
-    size_t propLossOrderOfDims[] = {0, 1};
-    shape_t propLossShape;
-    setShape(&propLossShape, propLossDims, propLossNumberOfDims, propLossOrderOfDims);
-    quantization_t propLossQ;
-    initFloat32Quantization(&propLossQ);
-    setTensorValues(&propLoss, (uint8_t *)propLossData, &propLossShape, &propLossQ, NULL);
+    tensor_t *propLoss = tensorInitSymInt32(propLossData, propLossDims, propLossNumberOfDims, HTE, NULL);
 
-    tensor_t propLossAsym;
-    asymQConfig_t propLossAsymQC;
-    initAsymQConfig(8, HTE, &propLossAsymQC);
-    quantization_t propLossAsymQ;
-    initAsymQuantization(&propLossAsymQC, &propLossAsymQ);
-    uint8_t propLossAsymData[inputSize];
-    setTensorValuesForConversion(propLossAsymData, &propLossAsymQ, &propLoss, &propLossAsym);
-    convertTensor(&propLoss, &propLossAsym);
-
-    layer_t softmaxLayer;
-    initSoftmaxLayer(&softmaxLayer);
-    softmaxLayer.inputQType = inputAsymQ.type;
-
-    softmaxBackward(&softmaxLayer, &inputAsym, &lossAsym, &propLossAsym);
+    quantization_t *symIntQ = quantizationInitSymInt32(HTE);
+    layer_t *softmaxLayer = softmaxLayerInit(symIntQ, symIntQ);
+    layerFunctions_t softmaxFns = layerFunctions[SOFTMAX];
+    softmaxFns.backward(softmaxLayer, input, loss, propLoss);
 
     float expected[] = {-6.9173e-03, -6.2947e-03, -1.1912e-01, 1.3834e-01, -5.9973e-03,
                         -1.5603e-05};
 
-    convertTensor(&propLossAsym, &propLoss);
+    float propLossDataFloat[inputSize];
+    tensor_t *propLossFloat = tensorInitFloat(propLossDataFloat, propLossDims, propLossNumberOfDims, NULL);
 
-    float *actual = (float *)propLoss.data;
+
+    convertTensor(propLoss, propLossFloat);
+
+    float *actual = (float *)propLoss->data;
 
     for (size_t i = 0; i < inputSize; i++) {
         TEST_ASSERT_FLOAT_WITHIN(0.01f, expected[i], actual[i]);
@@ -242,9 +140,9 @@ void tearDown() {}
 int main() {
     UNITY_BEGIN();
     RUN_TEST(unitTestSoftmaxForwardFloat);
-    RUN_TEST(unitTestSoftmaxForwardAsym);
+    RUN_TEST(unitTestSoftmaxForwardSymInt32);
 
     RUN_TEST(unitTestSoftmaxBackwardFloat);
-    RUN_TEST(unitTestSoftmaxBackwardAsym);
-    UNITY_END();
+    RUN_TEST(unitTestSoftmaxBackwardSymInt32);
+    return UNITY_END();
 }

--- a/test/unit/loss_functions/CMakeLists.txt
+++ b/test/unit/loss_functions/CMakeLists.txt
@@ -4,6 +4,8 @@ add_elastic_ai_unit_test(
         MORE_LIBS
         CommonLayerLibs
         Log
+        SoftmaxAPI
+        QuantizationAPI
 )
 
 add_elastic_ai_unit_test(

--- a/test/unit/loss_functions/UnitTestMSE.c
+++ b/test/unit/loss_functions/UnitTestMSE.c
@@ -64,7 +64,7 @@ void testMSELossBackwardFloat() {
     }
 }
 
-void testMSELossBackwardAsym() {
+void testMSELossBackwardSymInt32() {
     size_t numberOfElements = 3;
 
     size_t dims[] = {numberOfElements};
@@ -82,14 +82,14 @@ void testMSELossBackwardAsym() {
     float modelOutputData[] = {1.f, 2.f, -3.f};
     setTensorValues(&modelOutput, (uint8_t *)modelOutputData, &shape, &modelOutputQ, NULL);
 
-    tensor_t modelOutputAsym;
-    asymQConfig_t modelOutputAsymQC;
-    initAsymQConfig(8, HTE, &modelOutputAsymQC);
-    quantization_t modelOutputAsymQ;
-    initAsymQuantization(&modelOutputAsymQC, &modelOutputAsymQ);
-    uint8_t modelOutputAsymData[numberOfElements];
-    setTensorValuesForConversion(modelOutputAsymData, &modelOutputAsymQ, &modelOutput, &modelOutputAsym);
-    convertTensor(&modelOutput, &modelOutputAsym);
+    tensor_t modelOutputSymInt32;
+    symInt32QConfig_t modelOutputSymInt32QC;
+    initSymInt32QConfig(HTE, &modelOutputSymInt32QC);
+    quantization_t modelOutputSymInt32Q;
+    initSymInt32Quantization(&modelOutputSymInt32QC, &modelOutputSymInt32Q);
+    uint8_t modelOutputSymInt32Data[numberOfElements];
+    setTensorValuesForConversion(modelOutputSymInt32Data, &modelOutputSymInt32Q, &modelOutput, &modelOutputSymInt32);
+    convertTensor(&modelOutput, &modelOutputSymInt32);
 
     tensor_t label;
     quantization_t labelQ;
@@ -97,14 +97,14 @@ void testMSELossBackwardAsym() {
     float labelData[] = {-5.f, -4.f, 2.f};
     setTensorValues(&label, (uint8_t *)labelData, &shape, &labelQ, NULL);
 
-    tensor_t labelAsym;
-    asymQConfig_t labelAsymQC;
-    initAsymQConfig(8, HTE, &labelAsymQC);
-    quantization_t labelAsymQ;
-    initAsymQuantization(&labelAsymQC, &labelAsymQ);
-    uint8_t labelAsymData[numberOfElements];
-    setTensorValuesForConversion(labelAsymData, &labelAsymQ, &label, &labelAsym);
-    convertTensor(&label, &labelAsym);
+    tensor_t labelSymInt32;
+    symInt32QConfig_t labelSymInt32QC;
+    initSymInt32QConfig(HTE, &labelSymInt32QC);
+    quantization_t labelSymInt32Q;
+    initSymInt32Quantization(&labelSymInt32QC, &labelSymInt32Q);
+    uint8_t labelSymInt32Data[numberOfElements];
+    setTensorValuesForConversion(labelSymInt32Data, &labelSymInt32Q, &label, &labelSymInt32);
+    convertTensor(&label, &labelSymInt32);
 
 
     tensor_t result;
@@ -113,26 +113,26 @@ void testMSELossBackwardAsym() {
     float resultData[numberOfElements];
     setTensorValues(&result, (uint8_t *)resultData, &shape, &resultQ, NULL);
 
-    tensor_t resultAsym;
-    asymQConfig_t resultAsymQC;
-    initAsymQConfig(8, HTE, &resultAsymQC);
-    quantization_t resultAsymQ;
-    initAsymQuantization(&resultAsymQC, &resultAsymQ);
-    uint8_t resultAsymData[numberOfElements];
-    setTensorValuesForConversion(resultAsymData, &resultAsymQ, &result, &resultAsym);
-    convertTensor(&result, &resultAsym);
+    tensor_t resultSymInt32;
+    symInt32QConfig_t resultSymInt32QC;
+    initSymInt32QConfig(HTE, &resultSymInt32QC);
+    quantization_t resultSymInt32Q;
+    initSymInt32Quantization(&resultSymInt32QC, &resultSymInt32Q);
+    uint8_t resultSymInt32Data[numberOfElements];
+    setTensorValuesForConversion(resultSymInt32Data, &resultSymInt32Q, &result, &resultSymInt32);
+    convertTensor(&result, &resultSymInt32);
 
 
-    mseLossBackward(&modelOutputAsym, &labelAsym, &resultAsym);
+    mseLossBackward(&modelOutputSymInt32, &labelSymInt32, &resultSymInt32);
 
-    convertTensor(&resultAsym, &result);
+    convertTensor(&resultSymInt32, &result);
 
-    float expected[] = {4.f, 4.f, -4.f};
+    float expected[] = {4.f, 4.f, -3.f};
 
     float *actual = (float *)result.data;
 
     for(size_t i = 0; i < numberOfElements; i++) {
-        TEST_ASSERT_FLOAT_WITHIN(1.f, expected[i], actual[i]);
+        TEST_ASSERT_FLOAT_WITHIN(0.1f, expected[i], actual[i]);
     }
 }
 
@@ -145,7 +145,7 @@ int main(void) {
     RUN_TEST(testMSEForward);
 
     RUN_TEST(testMSELossBackwardFloat);
-    RUN_TEST(testMSELossBackwardAsym);
+    RUN_TEST(testMSELossBackwardSymInt32);
 
-    UNITY_END();
+    return UNITY_END();
 }

--- a/test/unit/optimizer/CMakeLists.txt
+++ b/test/unit/optimizer/CMakeLists.txt
@@ -6,4 +6,5 @@ add_elastic_ai_unit_test(
         SgdAPI
         TensorAPI
         LinearAPI
+        ReluAPI
 )

--- a/test/unit/optimizer/UnitTestSgd.c
+++ b/test/unit/optimizer/UnitTestSgd.c
@@ -11,6 +11,8 @@
 #include "TensorAPI.h"
 #include "OptimizerAPI.h"
 
+#include <ReluAPI.h>
+
 void setUp() {}
 void tearDown() {}
 
@@ -32,16 +34,15 @@ void testSgdMCreateOptim() {
     tensor_t *biasGrad = tensorInitFloat(biasGradData, biasDims, biasNumberOfDims, NULL);
     parameter_t *bias = parameterInit(biasParam, biasGrad);
 
-    quantization_t outputQ;
-    initFloat32Quantization(&outputQ);
-    layer_t *linear0 = linearLayerInit(weights, bias, FLOAT32, FLOAT32, &outputQ);
+    quantization_t testQ;
+    initFloat32Quantization(&testQ);
+    layer_t *linear0 = linearLayerInit(weights, bias, &testQ, &testQ, &testQ, &testQ);
 
-    layer_t relu0;
-    initLayer(&relu0, RELU, NULL, FLOAT_LAYER, FLOAT32, NULL);
+    layer_t *relu0 = reluLayerInit(&testQ, &testQ);
 
-    layer_t *linear1 = linearLayerInit(weights, bias, FLOAT32, FLOAT32, &outputQ);
+    layer_t *linear1 = linearLayerInit(weights, bias, &testQ, &testQ, &testQ, &testQ);
 
-    layer_t *model[] = {linear0, &relu0, linear1};
+    layer_t *model[] = {linear0, relu0, linear1};
     size_t sizeModel = sizeof(model) / sizeof(model[0]);
     float lr = 0.1f;
     float momentumFactor = 0.9f;
@@ -98,9 +99,9 @@ void testSGDStep() {
     biasGrad->data = (uint8_t *) biasGradData;
     parameter_t *bias = parameterInit(biasParam, biasGrad);
 
-    quantization_t outputQ;
-    initFloat32Quantization(&outputQ);
-    layer_t *linear = linearLayerInit(weights, bias, FLOAT_LAYER, FLOAT32, &outputQ);
+    quantization_t testQ;
+    initFloat32Quantization(&testQ);
+    layer_t *linear = linearLayerInit(weights, bias, &testQ, &testQ, &testQ, &testQ);
 
     layer_t *model[] = {linear};
     size_t modelSize = 1;
@@ -152,9 +153,9 @@ void testSGDZeroGrad() {
     biasGrad->data = (uint8_t *)biasGradData;
     parameter_t *bias = parameterInit(biasParam, biasGrad);
 
-    quantization_t outputQ;
-    initFloat32Quantization(&outputQ);
-    layer_t *linear = linearLayerInit(weights, bias, FLOAT_LAYER, FLOAT32, &outputQ);
+    quantization_t testQ;
+    initFloat32Quantization(&testQ);
+    layer_t *linear = linearLayerInit(weights, bias, &testQ, &testQ, &testQ, &testQ);
 
     layer_t *model[] = {linear};
     size_t modelSize = 1;
@@ -180,5 +181,5 @@ int main() {
     RUN_TEST(testSgdMCreateOptim);
     RUN_TEST(testSGDStep);
     RUN_TEST(testSGDZeroGrad);
-    UNITY_END();
+    return UNITY_END();
 }

--- a/test/unit/tensor/UnitTestTensor.c
+++ b/test/unit/tensor/UnitTestTensor.c
@@ -182,5 +182,5 @@ int main(void) {
     RUN_TEST(testReadByte);
 
     RUN_TEST(testCopyTensor);
-    UNITY_END();
+    return UNITY_END();
 }

--- a/test/unit/tensor/UnitTestTensorConversion.c
+++ b/test/unit/tensor/UnitTestTensorConversion.c
@@ -7,55 +7,6 @@
 #include <stddef.h>
 #include <stdlib.h>
 
-/*void testConversionFloatInt32() {
-    float expected[] = {1, 2, 3};
-
-    size_t num_values = 3;
-    float floatData[] = {1.f, 2.f, 3.f};
-    size_t floatDims[] = {3};
-    size_t floatOrders[] = {0};
-    uint8_t floatSparsityBitmask[] = {0x03};
-    quantization_t floatQ = {
-        .type = FLOAT32,
-        .qConfig = NULL
-    };
-    size_t FloatNumBytes = calcBitsPerElement(&floatQ) * num_values;
-    uint8_t floatUInt8Data[FloatNumBytes];
-    writeFloatArrayToByteArray(num_values, floatData, floatUInt8Data);
-    tensor_t floatTensor = {
-        .data = floatUInt8Data,
-        .quantization = &floatQ,
-        .sparsityBitmask = floatSparsityBitmask,
-        .numberOfDimensions = 1,
-        .dimensions = floatDims,
-        .orderOfDimensions = floatOrders
-    };
-
-    int32_t intData[3];
-    size_t intDims[1];
-    size_t intOrders[1];
-    uint8_t IntSparsityBitmask[num_values / 8 + 1];
-    quantization_t intQ = {
-        .type = INT32,
-        .qConfig = NULL
-    };
-    size_t IntNumBytes = calcBitsPerElement(&intQ) * num_values;
-    uint8_t uint8Data[IntNumBytes];
-    tensor_t intTensor = {
-        .data = uint8Data,
-        .quantization = &intQ,
-        .sparsityBitmask = IntSparsityBitmask,
-        .numberOfDimensions = 1,
-        .dimensions = intDims,
-        .orderOfDimensions = intOrders
-    };
-
-    convertTensor(&floatTensor, &intTensor);
-    readBytesAsInt32Array(num_values, uint8Data, intData);
-    TEST_ASSERT_EQUAL_INT_ARRAY(expected, intData, num_values);
-}*/
-
-
 void testConversionIntFloat() {
     uint8_t numValues = 6;
 
@@ -90,6 +41,7 @@ void testConversionIntFloat() {
     TEST_ASSERT_EQUAL_FLOAT_ARRAY(expected, actual, numValues);
 
 }
+
 void testConversionIntSymInt32() {
     uint8_t numValues = 6;
 
@@ -124,6 +76,7 @@ void testConversionIntSymInt32() {
     TEST_ASSERT_EQUAL_INT32_ARRAY(intTensor.data, symInt32Tensor.data, numValues);
 
 }
+
 void testConversionIntAsym() {
     size_t numValues = 6;
     size_t dims[] = {numValues};
@@ -202,6 +155,7 @@ void testConversionFloatInt() {
 
     TEST_ASSERT_EQUAL_INT32_ARRAY(expected, actual, numValues);
 }
+
 void testConversionFloatSymInt32() {
     uint8_t numValues = 6;
 
@@ -235,6 +189,7 @@ void testConversionFloatSymInt32() {
 
     TEST_ASSERT_EQUAL_INT32_ARRAY(expected, symInt32Tensor.data, numValues);
 }
+
 void testConversionFloatAsym() {
     size_t numValues = 6;
     size_t dims[] = {numValues};
@@ -298,7 +253,6 @@ void testConversionSymInt32Int() {
     tensor_t symInt32Tensor;
     setTensorValues(&symInt32Tensor, (uint8_t *)symInt32Data, &shape, &symInt32Q, NULL);
 
-
     int32_t intData[numValues];
     quantization_t intQ;
     initInt32Quantization(&intQ);
@@ -311,6 +265,7 @@ void testConversionSymInt32Int() {
 
     TEST_ASSERT_EQUAL_INT32_ARRAY(expected, intTensor.data, numValues);
 }
+
 void testConversionSymInt32Float() {
     uint8_t numValues = 6;
 
@@ -353,6 +308,7 @@ void testConversionSymInt32Float() {
 
     TEST_ASSERT_EQUAL_FLOAT_ARRAY(expected, floatTensor.data, numValues);
 }
+
 void testConversionSymInt32Asym() {
     uint8_t numValues = 6;
 
@@ -439,6 +395,7 @@ void testConversionAsymInt() {
     int32_t expectedData[] = {5, 11, 16, 20, -5, -11};
     TEST_ASSERT_EQUAL_INT32_ARRAY(expectedData, actual, numValues);
 }
+
 void testConversionAsymFloat() {
     size_t numValues = 6;
     size_t dims[] = {numValues};
@@ -476,6 +433,7 @@ void testConversionAsymFloat() {
     float expectedData[] = {0.9375f, 2.0625f, 3.f, 3.75f, -0.9375f, -2.0625f};
     TEST_ASSERT_EQUAL_FLOAT_ARRAY(expectedData, actual, numValues);
 }
+
 void testConversionAsymSymInt32() {
     size_t numValues = 6;
     size_t dims[] = {numValues};
@@ -525,25 +483,21 @@ void tearDown() {}
 int main(void) {
     UNITY_BEGIN();
 
-
     RUN_TEST(testConversionIntFloat);
     RUN_TEST(testConversionIntSymInt32);
     RUN_TEST(testConversionIntAsym);
-
 
     RUN_TEST(testConversionFloatInt);
     RUN_TEST(testConversionFloatSymInt32);
     RUN_TEST(testConversionFloatAsym);
 
-
     RUN_TEST(testConversionSymInt32Int);
     RUN_TEST(testConversionSymInt32Float);
     RUN_TEST(testConversionSymInt32Asym);
-
 
     RUN_TEST(testConversionAsymInt);
     RUN_TEST(testConversionAsymFloat);
     RUN_TEST(testConversionAsymSymInt32);
 
-    UNITY_END();
+    return UNITY_END();
 }

--- a/test/unit/userAPI/UnitTestTrainingAPI.c
+++ b/test/unit/userAPI/UnitTestTrainingAPI.c
@@ -6,9 +6,9 @@
 #include "SgdAPI.h"
 #include "unity.h"
 #include "TrainingAPI.h"
-#include "StorageAPI.h"
 #include "TensorConversion.h"
 #include "QuantizationAPI.h"
+#include "Linear.h"
 
 void testCalcGradsLinearFloat_WeightsMatchPyTorch() {
     float weightData[] = {1.f, 1.f, 1.f, 1.f, 1.f, 1.f};
@@ -46,10 +46,9 @@ void testCalcGradsLinearFloat_WeightsMatchPyTorch() {
     size_t input2NumberOfDims = 2;
     tensor_t *input2 = tensorInitFloat(input2Data, input2Dims, input2NumberOfDims, NULL);
 
-    quantization_t outputQ;
-    initFloat32Quantization(&outputQ);
-    layer_t *linear = linearLayerInit(weights, bias, FLOAT_LAYER, input0->quantization->type,
-                                      &outputQ);
+    quantization_t testQ;
+    initFloat32Quantization(&testQ);
+    layer_t *linear = linearLayerInit(weights, bias, &testQ, &testQ, &testQ, &testQ);
 
     layer_t *model[] = {linear};
     size_t sizeModel = 1;
@@ -101,106 +100,62 @@ void testCalcGradsLinearFloat_WeightsMatchPyTorch() {
 }
 
 
-void testCalcGradsLinearAsym_WeightsMatchPyTorch() {
+void testCalcGradsLinearSymInt32_WeightsMatchPyTorch() {
     size_t numberOfWeights = 6;
     size_t numberOfInputs = 3;
 
-    float weightDataFloat[] = {1.f, 1.f, 1.f, 1.f, 1.f, 1.f};
+    float weightData[] = {1.f, 1.f, 1.f, 1.f, 1.f, 1.f};
     size_t weightDims[] = {2, 3};
     size_t weightNumberOfDims = 2;
-    tensor_t *weightsParamFloat = tensorInitFloat(weightDataFloat, weightDims, weightNumberOfDims,
-                                                  NULL);
+    tensor_t *weightsParam = tensorInitSymInt32(weightData, weightDims, weightNumberOfDims, HTE,
+                                                NULL);
+    tensor_t *weightsGrad = gradInitSymInt32(weightsParam, HTE, NULL);
+    parameter_t *weights = parameterInit(weightsParam, weightsGrad);
 
-    float weightDataAsym[numberOfWeights];
-    tensor_t *weightsParamAsym = tensorInitAsym(weightDataAsym, weightDims, weightNumberOfDims, 8,
-                                                HTE, NULL);
-    convertTensor(weightsParamFloat, weightsParamAsym);
-
-    float weightGradAsymData[] = {0.f, 0.f, 0.f, 0.f, 0.f, 0.f};
-    tensor_t *weightsGradAsym = tensorInitAsym(weightGradAsymData, weightDims, weightNumberOfDims,
-                                               8, HTE, NULL);
-
-    parameter_t *weights = parameterInit(weightsParamAsym, weightsGradAsym);
-
-
-    // IMPORTANT: WHEN ASYM --> BIASQ = INT32
-    int32_t biasData[] = {-1, 3};
+    float biasData[] = {-1.f, 3.f};
     size_t biasDims[] = {2, 1};
     size_t biasNumberOfDims = 2;
-    tensor_t *biasParam = tensorInitInt32(biasData, biasDims, biasNumberOfDims, NULL);
-
-    tensor_t *biasGradAsym = gradInitAsym(biasParam, 8, HTE, NULL);
-
-    parameter_t *bias = parameterInit(biasParam, biasGradAsym);
-
+    tensor_t *biasParam = tensorInitSymInt32(biasData, biasDims, biasNumberOfDims, HTE, NULL);
+    tensor_t *biasGrad = gradInitSymInt32(biasParam, HTE, NULL);
+    parameter_t *bias = parameterInit(biasParam, biasGrad);
 
     float input0Data[] = {-4.f, 1.f, 9.f,};
     size_t input0Dims[] = {1, 3};
     size_t input0NumberOfDims = 2;
-    tensor_t *input0Float = tensorInitFloat(input0Data, input0Dims, input0NumberOfDims, NULL);
-
-    float input0DataAsym[numberOfInputs];
-    tensor_t *input0Asym = tensorInitAsym(input0DataAsym, input0Dims, input0NumberOfDims, 8, HTE,
-                                          NULL);
-    convertTensor(input0Float, input0Asym);
+    tensor_t *input0 = tensorInitSymInt32(input0Data, input0Dims, input0NumberOfDims, HTE, NULL);
 
     float input1Data[] = {5.f, -1.f, 2.f};
     size_t input1Dims[] = {1, 3};
     size_t input1NumberOfDims = 2;
-    tensor_t *input1Float = tensorInitFloat(input1Data, input1Dims, input1NumberOfDims, NULL);
-
-    float input1DataAsym[numberOfInputs];
-    tensor_t *input1Asym = tensorInitAsym(input1DataAsym, input1Dims, input1NumberOfDims, 8, HTE,
-                                          NULL);
-    convertTensor(input1Float, input1Asym);
+    tensor_t *input1 = tensorInitSymInt32(input1Data, input1Dims, input1NumberOfDims, HTE, NULL);
 
     float input2Data[] = {-7.f, -5.f, 6.f};
     size_t input2Dims[] = {1, 3};
     size_t input2NumberOfDims = 2;
-    tensor_t *input2Float = tensorInitFloat(input2Data, input2Dims, input2NumberOfDims, NULL);
+    tensor_t *input2 = tensorInitSymInt32(input2Data, input2Dims, input2NumberOfDims, HTE, NULL);
 
-    float input2DataAsym[numberOfInputs];
-    tensor_t *input2Asym = tensorInitAsym(input2DataAsym, input2Dims, input2NumberOfDims, 8, HTE,
-                                          NULL);
-    convertTensor(input2Float, input2Asym);
-
-    quantization_t *outputQ = quantizationInitAsym(8, HTE);
-    layer_t *linear = linearLayerInit(weights, bias, ASYM_LAYER, ASYM, outputQ);
+    quantization_t *testQ = quantizationInitSymInt32(HTE);
+    layer_t *linear = linearLayerInit(weights, bias, testQ, testQ, testQ, testQ);
 
     layer_t *model[] = {linear};
     size_t modelSize = 1;
 
-
     float label0Data[] = {59.f, -23.f};
     size_t label0Dims[] = {2, 1};
     size_t label0NumberOfDims = 2;
-    tensor_t *label0Float = tensorInitFloat(label0Data, label0Dims, label0NumberOfDims, NULL);
-
-    float label0DataAsym[numberOfInputs];
-    tensor_t *label0Asym = tensorInitAsym(label0DataAsym, label0Dims, label0NumberOfDims, 8, HTE, NULL);
-    convertTensor(label0Float, label0Asym);
-
+    tensor_t *label0 = tensorInitSymInt32(label0Data, label0Dims, label0NumberOfDims, HTE, NULL);
 
     float label1Data[] = {43.f, 249.f};
     size_t label1Dims[] = {2, 1};
     size_t label1NumberOfDims = 2;
-    tensor_t *label1Float = tensorInitFloat(label1Data, label1Dims, label1NumberOfDims, NULL);
-
-    float label1DataAsym[numberOfInputs];
-    tensor_t *label1Asym = tensorInitAsym(label1DataAsym, label1Dims, label1NumberOfDims, 8, HTE, NULL);
-    convertTensor(label1Float, label1Asym);
-
+    tensor_t *label1 = tensorInitSymInt32(label1Data, label1Dims, label1NumberOfDims, HTE, NULL);
 
     float label2Data[] = {23.f, 457.f};
     size_t label2Dims[] = {2, 1};
     size_t label2NumberOfDims = 2;
-    tensor_t *label2Float = tensorInitFloat(label2Data, label2Dims, label2NumberOfDims, NULL);
+    tensor_t *label2 = tensorInitSymInt32(label2Data, label2Dims, label2NumberOfDims, HTE, NULL);
 
-    float label2DataAsym[numberOfInputs];
-    tensor_t *label2Asym = tensorInitAsym(label2DataAsym, label2Dims, label2NumberOfDims, 8, HTE, NULL);
-    convertTensor(label2Float, label2Asym);
-
-    optimizer_t *sgd = sgdMCreateOptim(0.01f, 0.f, 0.f, model, modelSize, ASYM);
+    optimizer_t *sgd = sgdMCreateOptim(0.01f, 0.f, 0.f, model, modelSize, SYM_INT32);
     optimizerFunctions_t sgdFns = optimizerFunctions[SGD_M];
 
     // IMPORTANT: we want only the weights to be trainable, to check against pytorch learned weights!
@@ -208,9 +163,12 @@ void testCalcGradsLinearAsym_WeightsMatchPyTorch() {
     sgd->sizeStates = 1;
 
     for (size_t i = 0; i < 100; i++) {
-        trainingStats_t *trainingStats0 = calculateGrads(model, modelSize, MSE, input0Asym, label0Asym);
-        trainingStats_t *trainingStats1 = calculateGrads(model, modelSize, MSE, input1Asym, label1Asym);
-        trainingStats_t *trainingStats2 = calculateGrads(model, modelSize, MSE, input2Asym, label2Asym);
+        trainingStats_t *trainingStats0 = calculateGrads(model, modelSize, MSE, input0,
+                                                         label0);
+        trainingStats_t *trainingStats1 = calculateGrads(model, modelSize, MSE, input1,
+                                                         label1);
+        trainingStats_t *trainingStats2 = calculateGrads(model, modelSize, MSE, input2,
+                                                         label2);
 
         sgdFns.step(sgd);
         sgdFns.zero(sgd);
@@ -219,7 +177,6 @@ void testCalcGradsLinearAsym_WeightsMatchPyTorch() {
         freeTrainingStats(trainingStats1);
         freeTrainingStats(trainingStats2);
     }
-
 
     float expectedWeights[] = {5.f, -1.f, 9.f, 22.f, -100.f, 18.f};
 
@@ -232,10 +189,8 @@ void testCalcGradsLinearAsym_WeightsMatchPyTorch() {
     convertTensor(linear->config->linear->weights->param, &actualWeights);
 
     float *actualWeightsArr = (float *)actualWeights.data;
-    const float errorPercent = 0.06f;
     for (size_t i = 0; i < 6; i++) {
-        float currentThreshold = actualWeightsArr[i] * errorPercent;
-        TEST_ASSERT_FLOAT_WITHIN(currentThreshold, expectedWeights[i], actualWeightsArr[i]);
+        TEST_ASSERT_FLOAT_WITHIN(1.f, expectedWeights[i], actualWeightsArr[i]);
     }
 }
 
@@ -245,6 +200,6 @@ void tearDown() {}
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(testCalcGradsLinearFloat_WeightsMatchPyTorch);
-    RUN_TEST(testCalcGradsLinearAsym_WeightsMatchPyTorch);
-    UNITY_END();
+    RUN_TEST(testCalcGradsLinearSymInt32_WeightsMatchPyTorch);
+    return UNITY_END();
 }


### PR DESCRIPTION
- introduce quantization layer
- remove input and outputQ
- introduce bias, weights and backprop quantizations (for linear), remove layerQType
     - MOVE FROM LAYER.H TO LINEAR, RELU etc.
 ---
- remove scale equal case in addSymInt32
- change possible layer quantizations from FLOAT/ASYM to FLOAT/SYMINT32
- edit all framework layers to adapt to new layer quantizations