### PR TITLE
feat(OnDeviceTraining): change float to SymInt32 conversion

### DIFF
--- a/src/arithmetic/MinMax.c
+++ b/src/arithmetic/MinMax.c
@@ -1,6 +1,19 @@
 #include "MinMax.h"
 #include "DTypes.h"
 
+#include <math.h>
+
+float findAbsMaxFloat(uint8_t *bytes, size_t numberOfElements) {
+    float *values = (float *) bytes;
+    float max = fabsf(values[0]);
+
+    for (size_t i = 1; i < numberOfElements; i++) {
+        if (fabsf(values[i]) > max) {
+            max = fabsf(values[i]);
+        }
+    }
+    return max;
+}
 
 float findMaxFloat(uint8_t *bytes, size_t numberOfElements) {
     size_t bytesPerElement = sizeof(float);

--- a/src/arithmetic/Rounding.c
+++ b/src/arithmetic/Rounding.c
@@ -6,7 +6,7 @@
 
 // round to even, when fractional is EXACTLY 0.5
 int32_t roundHTE(float input) {
-    return round(input); //round(input);
+    return round(input);
 }
 
 float randfloat() {

--- a/src/arithmetic/include/MinMax.h
+++ b/src/arithmetic/include/MinMax.h
@@ -4,6 +4,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
+float findAbsMaxFloat(uint8_t *bytes, size_t numberOfElements);
 float findMaxFloat(uint8_t *bytes, size_t numberOfElements);
 float findMinFloat(uint8_t *bytes, size_t numberOfElements);
 

--- a/src/layer/Linear.c
+++ b/src/layer/Linear.c
@@ -65,6 +65,7 @@ void linearCalcWeightGradsFloat32(tensor_t *forwardInput, tensor_t *loss, tensor
 
     matmulFloat32Tensors(loss, forwardInput, &intermediateWGrad);
     addFloat32TensorsInplace(weightGrads, &intermediateWGrad);
+
 }
 
 void linearCalcWeightGradsFloatWithConversion(linearConfig_t *linearConfig, tensor_t *forwardInput,
@@ -223,7 +224,22 @@ void backwardFloat(linearConfig_t *linearConfig, tensor_t *forwardInput, tensor_
 
 
 void linearCalcWeightGradsSymInt32(tensor_t *loss, tensor_t *forwardInput, tensor_t *weightGrads) {
-    matmulSymInt32Tensors(loss, forwardInput, weightGrads);
+    size_t numberOfWeights = calcNumberOfElementsByTensor(weightGrads);
+
+    symInt32QConfig_t *wgQC = weightGrads->quantization->qConfig;
+
+    tensor_t intermediateWGrad;
+    int32_t intermediateWGradData[numberOfWeights];
+    symInt32QConfig_t intermediateWGradQC;
+    initSymInt32QConfig(wgQC->roundingMode, &intermediateWGradQC);
+    quantization_t intermediateWGradQ;
+    initSymInt32Quantization(&intermediateWGradQC, &intermediateWGradQ);
+    setTensorValues(&intermediateWGrad, (uint8_t *)intermediateWGradData, weightGrads->shape,
+                    &intermediateWGradQ, weightGrads->sparsity);
+
+    matmulSymInt32Tensors(loss, forwardInput, &intermediateWGrad);
+
+    addSymInt32TensorsInplace(weightGrads, &intermediateWGrad);
 }
 
 void linearCalcWeightGradsSymInt32WithConversion(linearConfig_t *linearConfig, tensor_t *loss,
@@ -253,7 +269,7 @@ void linearCalcWeightGradsSymInt32WithConversion(linearConfig_t *linearConfig, t
 
     tensor_t lossSymInt32;
     size_t sizeLoss = calcNumberOfElementsByTensor(loss);
-    uint32_t lossSymInt32Data[sizeLoss];
+    int32_t lossSymInt32Data[sizeLoss];
     quantization_t lossSymInt32Q;
     symInt32QConfig_t lossSymInt32QC;
     initSymInt32QConfig(roundingMode, &lossSymInt32QC);
@@ -280,16 +296,7 @@ void linearCalcWeightGradsSymInt32WithConversion(linearConfig_t *linearConfig, t
         wG = &wGSymInt32;
     }
 
-    tensor_t intermediateWG;
-    int32_t intermediateWGData[sizeWeightGrads];
-    quantization_t intermediateWGQ;
-    symInt32QConfig_t intermediateWGQC;
-    initSymInt32QConfig(roundingMode, &intermediateWGQC);
-    initSymInt32Quantization(&intermediateWGQC, &intermediateWGQ);
-    setTensorValues(&intermediateWG, (uint8_t *)intermediateWGData, wG->shape, &intermediateWGQ, wG->sparsity);
-
-    linearCalcWeightGradsSymInt32(l, fwdIn, &intermediateWG);
-    addSymInt32TensorsInplace(wG, &intermediateWG);
+    linearCalcWeightGradsSymInt32(l, fwdIn, wG);
     convertTensor(wG, paramWG);
 }
 
@@ -308,7 +315,7 @@ void linearCalcBiasGradsSymInt32WithConversion(linearConfig_t *linearConfig, ten
 
     tensor_t lossSymInt32;
     size_t sizeLoss = calcNumberOfElementsByTensor(l);
-    uint32_t lossSymInt32Data[sizeLoss];
+    int32_t lossSymInt32Data[sizeLoss];
     quantization_t lossSymInt32Q;
     symInt32QConfig_t lossSymInt32QC;
     initSymInt32QConfig(roundingMode, &lossSymInt32QC);
@@ -322,7 +329,7 @@ void linearCalcBiasGradsSymInt32WithConversion(linearConfig_t *linearConfig, ten
 
     tensor_t bGSymInt32;
     size_t sizeBias = calcNumberOfElementsByTensor(bG);
-    uint32_t bGSymInt32Data[sizeBias];
+    int32_t bGSymInt32Data[sizeBias];
     quantization_t bGSymInt32Q;
     symInt32QConfig_t bGSymInt32QC;
     initSymInt32QConfig(roundingMode, &bGSymInt32QC);
@@ -355,7 +362,7 @@ void linearCalcPropLossSymInt32WithConversion(linearConfig_t *linearConfig, tens
 
     tensor_t wSymInt32;
     size_t sizeWeights = calcNumberOfElementsByTensor(w);
-    uint32_t wSymInt32Data[sizeWeights];
+    int32_t wSymInt32Data[sizeWeights];
     quantization_t wSymInt32Q;
     symInt32QConfig_t wSymInt32QC;
     initSymInt32QConfig(roundingMode, &wSymInt32QC);
@@ -369,7 +376,7 @@ void linearCalcPropLossSymInt32WithConversion(linearConfig_t *linearConfig, tens
 
     tensor_t lSymInt32;
     size_t sizeL = calcNumberOfElementsByTensor(l);
-    uint32_t lSymInt32Data[sizeL];
+    int32_t lSymInt32Data[sizeL];
     quantization_t lSymInt32Q;
     symInt32QConfig_t lSymInt32QC;
     initSymInt32QConfig(roundingMode, &lSymInt32QC);
@@ -401,7 +408,7 @@ void backwardSymInt32(linearConfig_t *linearConfig, tensor_t *forwardInput, tens
     initSymInt32QConfig(weightGradsSymInt32QC->roundingMode, &intermediateWeightGradsQC);
     quantization_t intermediateWeightGradsQ;
     initSymInt32Quantization(&intermediateWeightGradsQC, &intermediateWeightGradsQ);
-    uint32_t intermediateWeightGradsData[numberOfWeights];
+    int32_t intermediateWeightGradsData[numberOfWeights];
     setTensorValues(&intermediateWeightGradsSymInt32, (uint8_t *)intermediateWeightGradsData,
                     weightGrads->shape, &intermediateWeightGradsQ, NULL);
 

--- a/src/loss_functions/MSE.c
+++ b/src/loss_functions/MSE.c
@@ -39,8 +39,6 @@ float mseLossForwardSymInt32(tensor_t *output, tensor_t *label) {
     setTensorValuesForConversion((uint8_t *)labelFloatData, &labelFloatQ, label, &labelFloat);
     convertTensor(label, &labelFloat);
 
-
-
     float *outputFloatArr = (float *)outputFloat.data;
     float *labelFloatArr = (float *)labelFloat.data;
 

--- a/src/optimizer/Sgd.c
+++ b/src/optimizer/Sgd.c
@@ -87,7 +87,7 @@ static void sgdStepMFloat(optimizer_t *optim) {
         parameter_t *param = optim->parameter[i];
         size_t numberOfValues = calcNumberOfElementsByParameter(param);
         float *gradArr = (float *)param->grad->data;
-        float *dataArr = (float *)param->param->data;
+        float *paramArr = (float *)param->param->data;
 
         states_t *states = optim->states[i];
         tensor_t *state = states->stateBuffers[0];
@@ -95,9 +95,9 @@ static void sgdStepMFloat(optimizer_t *optim) {
         float *stateArr = (float *)state->data;
 
         for (size_t elementIndex = 0; elementIndex < numberOfValues; ++elementIndex) {
-            float grad = gradArr[elementIndex] + sgd->weightDecay * dataArr[elementIndex];
+            float grad = gradArr[elementIndex] + sgd->weightDecay * paramArr[elementIndex];
             stateArr[elementIndex] = sgd->momentumFactor * stateArr[elementIndex] + grad;
-            dataArr[elementIndex] -= sgd->learningRate * stateArr[elementIndex];
+            paramArr[elementIndex] -= sgd->learningRate * stateArr[elementIndex];
         }
     }
 }
@@ -115,7 +115,6 @@ static void sgdStepMSymInt32(optimizer_t *optim) {
         uint8_t paramFloatData[numberOfValues * sizeof(float)];
         setTensorValuesForConversion(paramFloatData, &paramFloatQ, param->param, &paramFloat);
         convertTensor(param->param, &paramFloat);
-
         float *paramFloatArr = (float *)paramFloat.data;
 
         tensor_t gradFloat;
@@ -125,7 +124,6 @@ static void sgdStepMSymInt32(optimizer_t *optim) {
         uint8_t *gradFloatDataBytes = (uint8_t *)gradFloatData;
         setTensorValuesForConversion(gradFloatDataBytes, &gradFloatQ, param->grad, &gradFloat);
         convertTensor(param->grad, &gradFloat);
-
         float *gradFloatArr = (float *)gradFloat.data;
 
         states_t *states = optim->states[i];
@@ -139,8 +137,6 @@ static void sgdStepMSymInt32(optimizer_t *optim) {
         setTensorValuesForConversion(stateFloatData, &stateFloatQ, state,
                                      &stateFloat);
         convertTensor(state, &stateFloat);
-
-
         float *stateFloatArr = (float *)stateFloat.data;
 
         for (size_t j = 0; j < numberOfValues; ++j) {
@@ -178,7 +174,7 @@ void sgdZeroGrad(optimizer_t *optimizer) {
 
         if(param->grad->quantization->type == SYM_INT32) {
             symInt32QConfig_t *symIntQ = param->grad->quantization->qConfig;
-            symIntQ->scale = 0.f;
+            symIntQ->scale = 1.f;
         }
     }
 }

--- a/src/tensor/Quantization.c
+++ b/src/tensor/Quantization.c
@@ -7,6 +7,13 @@
 void initSymInt32QConfig(roundingMode_t roundingMode, symInt32QConfig_t *symInt32QConfig) {
     symInt32QConfig->roundingMode = roundingMode;
     symInt32QConfig->scale = 1.f;
+    symInt32QConfig->qMaxBits = 16;
+}
+
+void initSymInt32QConfigWithQMaxBits(roundingMode_t roundingMode, symInt32QConfig_t *symInt32QConfig, uint8_t qMaxBits) {
+    symInt32QConfig->roundingMode = roundingMode;
+    symInt32QConfig->scale = 1.f;
+    symInt32QConfig->qMaxBits = qMaxBits;
 }
 
 void initSymQConfig(uint8_t qBits, roundingMode_t roundingMode, symQConfig_t *symQConfig) {

--- a/src/tensor/Tensor.c
+++ b/src/tensor/Tensor.c
@@ -32,12 +32,12 @@ size_t calcBytesPerElement(quantization_t *quantization) {
         return sizeof(int32_t);
     case FLOAT32:
         return sizeof(float);
+    case SYM_INT32:
+        return sizeof(int32_t);
     case ASYM:
         asymQConfig_t *asymQConfig = quantization->qConfig;
         uint32_t qBits = asymQConfig->qBits;
         return ceil((float)qBits / (float)8);
-    default:
-        return 0;
     }
 }
 
@@ -47,6 +47,8 @@ size_t calcBitsPerElement(quantization_t *quantization) {
         return sizeof(int32_t) * 8;
     case FLOAT32:
         return sizeof(float) * 8;
+    case SYM_INT32:
+        return sizeof(int32_t) * 8;
     case ASYM:
         asymQConfig_t *asymQConfig = quantization->qConfig;
         return asymQConfig->qBits;
@@ -284,7 +286,7 @@ void printTensor(tensor_t *t) {
     case SYM_INT32:
         symInt32QConfig_t *symQC = q->qConfig;
         printf("SYM_INT32 \n");
-        printf("scale=%f\n", symQC->scale);
+        printf("scale=%e\n", symQC->scale);
         printf("Data \n");
         for (size_t i = 0; i < numValues; i++) {
             size_t byteIndex = i * sizeof(int32_t);
@@ -295,7 +297,7 @@ void printTensor(tensor_t *t) {
     case ASYM:
         asymQConfig_t *lq = q->qConfig;
         printf("ASYM\n");
-        printf("scale=%f\n", lq->scale);
+        printf("scale=%e\n", lq->scale);
         printf("offset=%i\n", lq->zeroPoint);
         printf("Data \n");
         for (size_t i = 0; i < numValues; i++) {

--- a/src/tensor/TensorConversion.c
+++ b/src/tensor/TensorConversion.c
@@ -7,6 +7,8 @@
 #include "math.h"
 #include "MinMax.h"
 
+#include <stdlib.h>
+
 void zeroTensorData(tensor_t *tensor) {
     size_t numberOfElements = calcNumberOfElementsByTensor(tensor);
     size_t bytesPerElement = calcBytesPerElement(tensor->quantization);
@@ -83,20 +85,36 @@ void convertFloatTensorToInt32Tensor(tensor_t *inputTensor, tensor_t *outputTens
     copyDimsAndSparsityToTensor(inputTensor, outputTensor);
 }
 
+
 void convertFloatTensorToSymInt32Tensor(tensor_t *inputTensor, tensor_t *outputTensor) {
     size_t numberOfElements = calcNumberOfElementsByTensor(inputTensor);
 
-    float *input = (float *)inputTensor->data;
-    int32_t inputAsInt32[numberOfElements];
+    float absMax = findAbsMaxFloat(inputTensor->data, numberOfElements);
 
-    for (size_t i = 0; i < numberOfElements; i++) {
-        inputAsInt32[i] = (int32_t)roundf(input[i]);
+    symInt32QConfig_t *symInt32QC = outputTensor->quantization->qConfig;
+    uint8_t qMaxBits = symInt32QC->qMaxBits;
+
+    const float qMax = powf(2, (float)qMaxBits - 1) - 1;
+    const float qMin = -powf(2, (float)qMaxBits - 1);
+
+    float scale;
+    if (absMax == 0.f) {
+        scale = 1.f;
+    } else {
+        scale = absMax / qMax;
     }
 
-    symInt32QConfig_t *outputSymInt32QConfig = outputTensor->quantization->qConfig;
-    outputSymInt32QConfig->scale = 1;
+    symInt32QConfig_t *outputSymInt32QC = outputTensor->quantization->qConfig;
+    outputSymInt32QC->scale = scale;
 
-    memcpy(outputTensor->data, inputAsInt32, numberOfElements * sizeof(int32_t));
+    int32_t *outputInt32 = (int32_t *)outputTensor->data;
+    float *inputFloat = (float *)inputTensor->data;
+
+    for (size_t i = 0; i < numberOfElements; i++) {
+        outputInt32[i] = roundByMode(
+            clamp(inputFloat[i] / scale, qMin, qMax),
+            outputSymInt32QC->roundingMode);
+    }
 }
 
 // I DON'T HAVE TO IMPLEMENT SYM CONVERSIONS!
@@ -107,7 +125,7 @@ void convertFloatTensorToSymTensor(tensor_t *inputTensor, tensor_t *outputTensor
     float max = findMaxFloat(inputTensor->data, numberOfElements);
 
     symQConfig_t *outputSymQConfig = outputTensor->quantization->qConfig;
-    float qMax = pow(2, outputSymQConfig->qBits);
+    float qMax = powf(2, outputSymQConfig->qBits);
 
     float scale = (min - max) / qMax;
     outputSymQConfig->scale = scale;
@@ -162,7 +180,6 @@ void convertFloatTensorToAsymTensor(tensor_t *inputTensor, tensor_t *outputTenso
     byteConversion(outputElement, 32, outputTensor->data, asymQConfig->qBits, numberOfElements);
 
     copyDimsAndSparsityToTensor(inputTensor, outputTensor);
-
 }
 
 // Important: Scale is ignored!
@@ -353,15 +370,37 @@ conversionFunction_t conversionMatrix[5][5] = {
     }
 };
 
+static void convertTensorsWithSameType(tensor_t *inputTensor, tensor_t *outputTensor,
+                                       qtype_t qType) {
+    size_t numberOfElements = calcNumberOfElementsByTensor(inputTensor);
+    size_t bytesPerElement = calcBytesPerElement(inputTensor->quantization);
+
+    memcpy(outputTensor->data, inputTensor->data, numberOfElements * bytesPerElement);
+
+    switch (qType) {
+    case SYM_INT32:
+        symInt32QConfig_t *inputSymIntQC = inputTensor->quantization->qConfig;
+        symInt32QConfig_t *outputSymIntQC = outputTensor->quantization->qConfig;
+        outputSymIntQC->scale = inputSymIntQC->scale;
+        break;
+    case ASYM:
+        asymQConfig_t *inputAsymQC = inputTensor->quantization->qConfig;
+        asymQConfig_t *outputAsymQC = outputTensor->quantization->qConfig;
+        outputAsymQC->scale = inputAsymQC->scale;
+        outputAsymQC->zeroPoint = inputAsymQC->zeroPoint;
+        break;
+    default:
+        break;
+    }
+}
+
 
 void convertTensor(tensor_t *inputTensor, tensor_t *outputTensor) {
     qtype_t inputDType = inputTensor->quantization->type;
     qtype_t outputDType = outputTensor->quantization->type;
-    size_t numberOfElements = calcNumberOfElementsByTensor(inputTensor);
-    size_t bytesPerElement = calcBytesPerElement(inputTensor->quantization);
 
     if (inputDType == outputDType) {
-        memcpy(outputTensor->data, inputTensor->data, numberOfElements * bytesPerElement);
+        convertTensorsWithSameType(inputTensor, outputTensor, inputDType);
     } else {
         conversionFunction_t conversionFn = conversionMatrix[inputDType][outputDType];
         conversionFn(inputTensor, outputTensor);

--- a/src/tensor/include/Quantization.h
+++ b/src/tensor/include/Quantization.h
@@ -17,6 +17,7 @@ typedef struct symInt32QConfig
 {
     float scale;
     roundingMode_t roundingMode;
+    uint8_t qMaxBits;
 } symInt32QConfig_t;
 
 typedef struct symQConfig
@@ -41,8 +42,9 @@ typedef struct quantization
     void* qConfig;
 } quantization_t;
 
-
+// Important: This sets qMaxBits to 16
 void initSymInt32QConfig(roundingMode_t roundingMode, symInt32QConfig_t* symInt32QConfig);
+void initSymInt32QConfigWithQMaxBits(roundingMode_t roundingMode, symInt32QConfig_t *symInt32QConfig, uint8_t qMaxBits);
 void initSymQConfig(uint8_t qBits, roundingMode_t roundingMode, symQConfig_t* symQConfig);
 void initAsymQConfig(uint8_t qBits, roundingMode_t roundingMode, asymQConfig_t* asymQConfig);
 

--- a/src/userAPI/InferenceAPI.c
+++ b/src/userAPI/InferenceAPI.c
@@ -50,15 +50,14 @@ static void initPingPongBufferOutput(tensor_t *buffer, layer_t *currentLayer, sh
     quantization_t *q = *reserveMemory(sizeof(quantization_t));
     switch (currentQ->type) {
     case FLOAT32:
-        q->type = FLOAT32;
-        q->qConfig = NULL;
+        initFloat32Quantization(q);
         break;
     case SYM_INT32:
-        q->type = SYM_INT32;
         symInt32QConfig_t *currentQC = currentQ->qConfig;
         symInt32QConfig_t *symInt32QC = *reserveMemory(sizeof(symInt32QConfig_t));
-        symInt32QC->roundingMode = currentQC->roundingMode;
-        q->qConfig = symInt32QC;
+
+        initSymInt32QConfig(currentQC->roundingMode, symInt32QC);
+        initSymInt32Quantization(symInt32QC, q);
         break;
     default:
         break;
@@ -92,6 +91,7 @@ static void initPingPongBufferInput(tensor_t *input, tensor_t *buffer) {
         q->qConfig = NULL;
         break;
     case SYM_INT32:
+
         q->type = SYM_INT32;
         symInt32QConfig_t *currentQC = currentQ->qConfig;
         symInt32QConfig_t *symInt32QC = *reserveMemory(sizeof(symInt32QConfig_t));
@@ -126,12 +126,12 @@ tensor_t *inference(layer_t **model, size_t numberOfLayers, tensor_t *input) {
         forwardFn_t forward = layerFunctions[currentLayerType].forward;
 
         if (!toggle) {
-            initPingPongBufferOutput(&pong, currentLayer, input->shape, input->sparsity);
+            initPingPongBufferOutput(&pong, currentLayer, ping.shape, ping.sparsity);
             forward(currentLayer, &ping, &pong);
             deInitPingPongBuffer(&ping);
             toggle = true;
         } else {
-            initPingPongBufferOutput(&ping, currentLayer, input->shape, input->sparsity);
+            initPingPongBufferOutput(&ping, currentLayer, pong.shape, pong.sparsity);
             forward(currentLayer, &pong, &ping);
             deInitPingPongBuffer(&pong);
             toggle = false;

--- a/src/userAPI/QuantizationAPI.c
+++ b/src/userAPI/QuantizationAPI.c
@@ -28,8 +28,3 @@ quantization_t *quantizationInitAsym(uint8_t qBits, roundingMode_t roundingMode)
     initAsymQuantization(qC, q);
     return q;
 }
-
-void freeQuantization(quantization_t *quantization) {
-    freeReservedMemory(quantization->qConfig);
-    freeReservedMemory(quantization);
-}

--- a/src/userAPI/TensorAPI.c
+++ b/src/userAPI/TensorAPI.c
@@ -285,15 +285,16 @@ quantization_t *getQLike(quantization_t *quantization) {
     case SYM_INT32:
         symInt32QConfig_t *likeSymInt32QC = *reserveMemory(sizeof(symInt32QConfig_t));
         symInt32QConfig_t *symInt32QC = quantization->qConfig;
-        likeSymInt32QC->roundingMode = symInt32QC->roundingMode;
-        likeQ->qConfig = likeSymInt32QC;
+
+        initSymInt32QConfig(symInt32QC->roundingMode, likeSymInt32QC);
+        initSymInt32Quantization(likeSymInt32QC, likeQ);
         break;
     case ASYM:
         asymQConfig_t *likeAsymQC = *reserveMemory(sizeof(asymQConfig_t));
         asymQConfig_t *asymQC = quantization->qConfig;
-        likeAsymQC->qBits = asymQC->qBits;
-        likeAsymQC->roundingMode = asymQC->roundingMode;
-        likeQ->qConfig = likeAsymQC;
+
+        initAsymQConfig(asymQC->qBits, asymQC->roundingMode, likeAsymQC);
+        initAsymQuantization(likeAsymQC, likeQ);
         break;
     default:
         return NULL;

--- a/src/userAPI/TrainingAPI.c
+++ b/src/userAPI/TrainingAPI.c
@@ -62,16 +62,14 @@ static void initLayerOutputs(tensor_t **layerOutputs, layer_t **model, size_t si
         quantization_t *q = *reserveMemory(sizeof(quantization_t));
         switch (currentQ->type) {
         case FLOAT32:
-            q->type = FLOAT32;
-            q->qConfig = NULL;
+            initFloat32Quantization(q);
             break;
         case SYM_INT32:
             q->type = SYM_INT32;
             symInt32QConfig_t *currentQC = currentQ->qConfig;
             symInt32QConfig_t *qC = *reserveMemory(sizeof(symInt32QConfig_t));
-            qC->scale = currentQC->scale;
-            qC->roundingMode = currentQC->roundingMode;
-            q->qConfig = qC;
+            initSymInt32QConfig(currentQC->roundingMode, qC);
+            initSymInt32Quantization(qC, q);
             break;
         default:
             break;
@@ -118,16 +116,13 @@ static void initGradTensor(tensor_t *grad, tensor_t *layerOutput, layer_t *layer
     quantization_t *q = *reserveMemory(sizeof(quantization_t));
     switch (currentQ->type) {
     case FLOAT32:
-        q->type = FLOAT32;
-        q->qConfig = NULL;
+        initFloat32Quantization(q);
         break;
     case SYM_INT32:
-        q->type = SYM_INT32;
         symInt32QConfig_t *currentQC = currentQ->qConfig;
         symInt32QConfig_t *qC = *reserveMemory(sizeof(symInt32QConfig_t));
-        qC->scale = currentQC->scale;
-        qC->roundingMode = currentQC->roundingMode;
-        q->qConfig = qC;
+        initSymInt32QConfig(currentQC->roundingMode, qC);
+        initSymInt32Quantization(qC, q);
         break;
     default:
         break;
@@ -191,6 +186,8 @@ trainingStats_t *calculateGrads(layer_t **model, size_t sizeNetwork,
     copyTensor(trainingStats->output, layerOutputs[sizeNetwork]);
 
     // LOSS
+
+    // TODO this is hardcoded and needs to be changed!!!
     lossFunctions_t mseFns = lossFunctions[MSE];
 
     float loss = mseFns.forward(layerOutputs[sizeNetwork], label);

--- a/src/userAPI/include/QuantizationAPI.h
+++ b/src/userAPI/include/QuantizationAPI.h
@@ -12,6 +12,4 @@ quantization_t* quantizationInitSymInt32(roundingMode_t roundingMode);
 
 quantization_t* quantizationInitAsym(uint8_t qBits, roundingMode_t roundingMode);
 
-void freeQuantization(quantization_t* quantization);
-
 #endif //QUANTIZATIONAPI_H

--- a/src/userAPI/include/TrainingAPI.h
+++ b/src/userAPI/include/TrainingAPI.h
@@ -19,4 +19,6 @@ trainingStats_t *trainingEpoch(layer_t **model, size_t sizeNetwork,
 
 void freeTrainingStats(trainingStats_t *trainingStats);
 
+void scaleGradients(layer_t **model, size_t modelSize, float scale);
+
 #endif //TRAINING_H

--- a/test/unit/arithmetic/CMakeLists.txt
+++ b/test/unit/arithmetic/CMakeLists.txt
@@ -3,6 +3,8 @@ add_elastic_ai_unit_test(
         Add
         MORE_LIBS
         Tensor
+        TensorAPI
+        QuantizationAPI
         Arithmetic
 )
 

--- a/test/unit/arithmetic/UnitTestAdd.c
+++ b/test/unit/arithmetic/UnitTestAdd.c
@@ -1,8 +1,11 @@
 #include "Add.h"
 #include "Tensor.h"
 #include "unity.h"
+#include "TensorAPI.h"
 
 #include <DTypes.h>
+#include <QuantizationAPI.h>
+#include <TensorConversion.h>
 #include <string.h>
 
 void setUp() {}
@@ -154,40 +157,7 @@ void testAddFloat32TensorsInplace() {
     TEST_ASSERT_EQUAL_FLOAT_ARRAY(expected, aTensor.data, numberOfElements);
 }
 
-void testAddSymInt32TensorsInplaceWithSameScale() {
-    size_t numberOfValues = 6;
-
-    symInt32QConfig_t aQC;
-    initSymInt32QConfig(HTE, &aQC);
-    quantization_t aQ;
-    initSymInt32Quantization(&aQC, &aQ);
-
-    int32_t aData[] = {1, 2, 3, 4, 5, 6};
-    uint8_t *aDataBytes = (uint8_t *)aData;
-    tensor_t aTensor;
-
-    size_t dims[] = {numberOfValues};
-    size_t numberOfDims = 1;
-    size_t orderOfDims[] = {0};
-    shape_t shape = {
-        .dimensions = dims,
-        .numberOfDimensions = numberOfDims,
-        .orderOfDimensions = orderOfDims
-    };
-
-    setTensorValues(&aTensor, aDataBytes, &shape, &aQ, NULL);
-
-    addSymInt32TensorsInplace(&aTensor, &aTensor);
-
-    int32_t actual[numberOfValues];
-    readBytesAsInt32Array(numberOfValues, aTensor.data, actual);
-
-    int32_t expected[] = {2, 4, 6, 8, 10, 12};
-
-    TEST_ASSERT_EQUAL_INT32_ARRAY(expected, actual, numberOfValues);
-}
-
-void testAddSymInt32TensorsInplaceWithDifferentScale() {
+void testAddSymInt32TensorsInplace() {
     size_t numberOfValues = 6;
 
     symInt32QConfig_t aQC;
@@ -225,12 +195,20 @@ void testAddSymInt32TensorsInplaceWithDifferentScale() {
 
     addSymInt32TensorsInplace(&aTensor, &bTensor);
 
-    int32_t actual[numberOfValues];
-    readBytesAsInt32Array(numberOfValues, aTensor.data, actual);
+    symInt32QConfig_t *symInt32QC = aTensor.quantization->qConfig;
+    printf("scale: %e\n", symInt32QC->scale);
+    printTensor(&aTensor);
 
-    int32_t expected[] = {3, 6, 9, 12, 15, 18};
+    float actual[numberOfValues];
+    quantization_t *floatQ = quantizationInitFloat();
+    tensor_t *floatTensor = tensorInit(actual, dims, numberOfDims, floatQ, NULL);
+    convertTensor(&aTensor, floatTensor);
 
-    TEST_ASSERT_EQUAL_INT32_ARRAY(expected, actual, numberOfValues);
+    float_t expected[] = {3, 6, 9, 12, 15, 18};
+
+    for(size_t i = 0; i < numberOfValues; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(0.1f, expected[i], actual[i]);
+    }
 }
 
 void testAddInt32TensorWithSymInt32TensorInplace() {
@@ -312,8 +290,7 @@ int main(void) {
 
     RUN_TEST(testAddFloat32TensorsInplace);
 
-    RUN_TEST(testAddSymInt32TensorsInplaceWithSameScale);
-    RUN_TEST(testAddSymInt32TensorsInplaceWithDifferentScale);
+    RUN_TEST(testAddSymInt32TensorsInplace);
     RUN_TEST(testAddInt32TensorWithSymInt32TensorInplace);
     RUN_TEST(testAddFloat32TensorToSymInt32TensorInplace);
 

--- a/test/unit/layer/UnitTestLinear.c
+++ b/test/unit/layer/UnitTestLinear.c
@@ -117,14 +117,9 @@ void testLinearForwardSymInt32() {
     linearForward(linearLayer, input, output);
 
     float outputFloatData[numberOfOutputs];
-    quantization_t outputFloatQ;
-    initFloat32Quantization(&outputFloatQ);
-    tensor_t outputFloat;
-    setTensorValuesForConversion((uint8_t *)outputFloatData, &outputFloatQ, output, &outputFloat);
-    convertTensor(output, &outputFloat);
-
-    float *actual = (float *)outputFloat.data;
-
+    tensor_t *outputFloat = tensorInitFloat(outputFloatData, outputDims, outputNumberOfDims, NULL);
+    convertTensor(output, outputFloat);
+    float *actual = (float *)outputFloat->data;
     float expected[] = {-5, -4};
 
     for (size_t i = 0; i < numberOfOutputs; i++) {
@@ -372,11 +367,11 @@ void testLinearBackwardSymInt32() {
     parameter_t *weights = parameterInit(weightsParam, weightsGrad);
 
 
-    int32_t biasData[] = {-1, 3};
+    float biasData[] = {-1, 3};
     size_t biasDims[] = {2, 1};
     size_t biasNumberOfDims = 2;
-    tensor_t *biasParam = tensorInitInt32(biasData, biasDims, biasNumberOfDims, NULL);
-    tensor_t *biasGrad = gradInitInt32(biasParam, NULL);
+    tensor_t *biasParam = tensorInitSymInt32(biasData, biasDims, biasNumberOfDims, HTE, NULL);
+    tensor_t *biasGrad = gradInitSymInt32(biasParam, HTE, NULL);
     parameter_t *bias = parameterInit(biasParam, biasGrad);
 
     float forwardInputData[] = {0.f, 1.f, 2.f};

--- a/test/unit/layer/UnitTestRelu.c
+++ b/test/unit/layer/UnitTestRelu.c
@@ -55,25 +55,31 @@ void testReluForwardFloat() {
 }
 
 void testReluForwardSymInt32() {
+    size_t numberOfValues = 6;
+    size_t dims[] = {2, 3};
+    size_t numberOfDims = 2;
+
     float inputData[] = {-1.f, 0.f, 1.f, 2.f, 5.f, -6.f};
-    size_t inputDims[] = {2, 3};
-    size_t inputNumberOfDims = 2;
-    tensor_t *input = tensorInitSymInt32(inputData, inputDims, inputNumberOfDims, HTE, NULL);
+    tensor_t *input = tensorInitSymInt32(inputData, dims, numberOfDims, HTE, NULL);
 
     float outputData[6];
-    size_t outputDims[] = {2, 3};
-    size_t outputNumberOfDims = 2;
-    tensor_t *output = tensorInitSymInt32(outputData, outputDims, outputNumberOfDims, HTE, NULL);
+    tensor_t *output = tensorInitSymInt32(outputData, dims, numberOfDims, HTE, NULL);
 
     quantization_t *symIntQ = quantizationInitSymInt32(HTE);
     layer_t *reluLayer = reluLayerInit(symIntQ, symIntQ);
     layerFunctions_t reluFns = layerFunctions[RELU];
     reluFns.forward(reluLayer, input, output);
 
-    int32_t expected[] = {0, 0, 1, 2, 5, 0};
-    int32_t *actual = (int32_t *)output->data;
+    float outputFloatData[6];
+    tensor_t *outputFloat = tensorInitFloat(outputFloatData, dims, numberOfDims, NULL);
+    convertTensor(output, outputFloat);
 
-    TEST_ASSERT_EQUAL_INT32_ARRAY(expected, actual, 6);
+    float expected[] = {0, 0, 1, 2, 5, 0};
+    float *actual = (float *)outputFloat->data;
+
+    for(size_t i = 0; i < numberOfValues; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(0.1f, expected[i], actual[i]);
+    }
 }
 
 void testReluBackwardFloat() {
@@ -104,7 +110,7 @@ void testReluBackwardFloat() {
 }
 
 void testReluBackwardSymInt32() {
-    size_t numberOfElements = 6;
+    size_t numberOfValues = 6;
 
     size_t dims[] = {6};
     size_t numberOfDims = 1;
@@ -115,7 +121,7 @@ void testReluBackwardSymInt32() {
     float lossData[] = {0.f, 2.f, -4.f, 6.f, 3.f, 2.f};
     tensor_t *loss = tensorInitSymInt32(lossData, dims, numberOfDims, HTE, NULL);
 
-    float propLossData[numberOfElements];
+    float propLossData[numberOfValues];
     tensor_t *propLoss = tensorInitSymInt32(propLossData, dims, numberOfDims, HTE, NULL);
 
     quantization_t *symIntQ = quantizationInitSymInt32(HTE);
@@ -123,10 +129,16 @@ void testReluBackwardSymInt32() {
     layerFunctions_t reluFns = layerFunctions[RELU];
     reluFns.backward(reluLayer, forwardInput, loss, propLoss);
 
-    int32_t expected[] = {0, 0, -4, 6, 3, 0};
-    int32_t *actual = (int32_t *)propLoss->data;
+    float expected[] = {0, 0, -4, 6, 3, 0};
 
-    TEST_ASSERT_EQUAL_INT32_ARRAY(expected, actual, numberOfElements);
+    float propLossFloatData[6];
+    tensor_t *propLossFloat = tensorInitFloat(propLossFloatData, dims, numberOfDims, NULL);
+    convertTensor(propLoss, propLossFloat);
+    float *actual = (float *)propLossFloat->data;
+
+    for(size_t i = 0; i < numberOfValues; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(0.1f, expected[i], actual[i]);
+    }
 }
 
 

--- a/test/unit/layer/UnitTestSoftmax.c
+++ b/test/unit/layer/UnitTestSoftmax.c
@@ -25,7 +25,7 @@ void unitTestSoftmaxForwardFloat() {
     layerFunctions_t softmaxFns = layerFunctions[SOFTMAX];
     softmaxFns.forward(softmaxLayer, input, output);
 
-    float expected[] = {2.3008e-03, 6.2543e-03, 1.7001e-02, 4.6213e-02, 9.2822e-01, 1.5503e-05};
+    float expected[] = {2.3008e-03f, 6.2543e-03f, 1.7001e-02f, 4.6213e-02f, 9.2822e-01f, 1.5503e-05f};
 
     float *actual = (float *)output->data;
 
@@ -37,28 +37,31 @@ void unitTestSoftmaxForwardFloat() {
 void unitTestSoftmaxForwardSymInt32() {
     size_t inputSize = 6;
 
+    size_t dims[] = {2, 3};
+    size_t numberOfDims = 2;
+
     float inputData[] = {-1.f, 0.f, 1.f, 2.f, 5.f, -6.f};
-    size_t inputDims[] = {2, 3};
-    size_t inputNumberOfDims = 2;
-    tensor_t *input = tensorInitSymInt32(inputData, inputDims, inputNumberOfDims, HTE, NULL);
+
+    tensor_t *input = tensorInitSymInt32(inputData, dims, numberOfDims, HTE, NULL);
 
     float outputData[inputSize];
-    size_t outputDims[] = {2, 3};
-    size_t outputNumberOfDims = 2;
-    tensor_t *output = tensorInitSymInt32(outputData, outputDims, outputNumberOfDims, HTE, NULL);
+    tensor_t *output = tensorInitSymInt32(outputData, dims, numberOfDims, HTE, NULL);
 
     quantization_t *symIntQ = quantizationInitSymInt32(HTE);
     layer_t *softmaxLayer = softmaxLayerInit(symIntQ, symIntQ);
     layerFunctions_t softmaxFns = layerFunctions[SOFTMAX];
     softmaxFns.forward(softmaxLayer, input, output);
 
+    float outputFloatData[inputSize];
+    tensor_t *outputFloat = tensorInitFloat(outputFloatData, dims, numberOfDims, NULL);
+    convertTensor(output, outputFloat);
 
-    int32_t expected[] = {0, 0, 0, 0, 1, 0};
+    float expected[] = {2.3008e-03f, 6.2543e-03f, 1.7001e-02f, 4.6213e-02f, 9.2822e-01f, 1.5503e-05f};
+    float *actual = (float *)outputFloat->data;
 
-    // TODO check behaviour
-    // does it even make sense to do softmax in int32??
-
-    TEST_ASSERT_EQUAL_INT32_ARRAY(expected, output->data, 6);
+    for(size_t i = 0; i < inputSize; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(0.1f, expected[i], actual[i]);
+    }
 }
 
 void unitTestSoftmaxBackwardFloat() {
@@ -85,8 +88,8 @@ void unitTestSoftmaxBackwardFloat() {
     layerFunctions_t softmaxFns = layerFunctions[SOFTMAX];
     softmaxFns.backward(softmaxLayer, input, loss, propLoss);
 
-    float expected[] = {-6.9173e-03, -6.2947e-03, -1.1912e-01, 1.3834e-01, -5.9973e-03,
-                        -1.5603e-05};
+    float expected[] = {-6.9173e-03f, -6.2947e-03f, -1.1912e-01f, 1.3834e-01f, -5.9973e-03f,
+                        -1.5603e-05f};
 
     float *actual = (float *)propLoss->data;
 
@@ -98,7 +101,7 @@ void unitTestSoftmaxBackwardFloat() {
 void unitTestSoftmaxBackwardSymInt32() {
     size_t inputSize = 6;
 
-    float inputData[] = {2.3008e-03, 6.2543e-03, 1.7001e-02, 4.6213e-02, 9.2822e-01, 1.5503e-05};
+    float inputData[] = {2.3008e-03f, 6.2543e-03f, 1.7001e-02f, 4.6213e-02f, 9.2822e-01f, 1.5503e-05f};
     size_t inputDims[] = {2, 3};
     size_t inputNumberOfDims = 2;
     tensor_t *input = tensorInitSymInt32(inputData, inputDims, inputNumberOfDims, HTE, NULL);
@@ -118,16 +121,13 @@ void unitTestSoftmaxBackwardSymInt32() {
     layerFunctions_t softmaxFns = layerFunctions[SOFTMAX];
     softmaxFns.backward(softmaxLayer, input, loss, propLoss);
 
-    float expected[] = {-6.9173e-03, -6.2947e-03, -1.1912e-01, 1.3834e-01, -5.9973e-03,
-                        -1.5603e-05};
+    float expected[] = {-6.9173e-03f, -6.2947e-03f, -1.1912e-01f, 1.3834e-01f, -5.9973e-03f,
+                        -1.5603e-05f};
 
     float propLossDataFloat[inputSize];
     tensor_t *propLossFloat = tensorInitFloat(propLossDataFloat, propLossDims, propLossNumberOfDims, NULL);
-
-
     convertTensor(propLoss, propLossFloat);
-
-    float *actual = (float *)propLoss->data;
+    float *actual = (float *)propLossFloat->data;
 
     for (size_t i = 0; i < inputSize; i++) {
         TEST_ASSERT_FLOAT_WITHIN(0.01f, expected[i], actual[i]);

--- a/test/unit/loss_functions/UnitTestMSE.c
+++ b/test/unit/loss_functions/UnitTestMSE.c
@@ -132,7 +132,7 @@ void testMSELossBackwardSymInt32() {
     float *actual = (float *)result.data;
 
     for(size_t i = 0; i < numberOfElements; i++) {
-        TEST_ASSERT_FLOAT_WITHIN(0.1f, expected[i], actual[i]);
+        TEST_ASSERT_FLOAT_WITHIN(0.5f, expected[i], actual[i]);
     }
 }
 

--- a/test/unit/tensor/UnitTestTensorConversion.c
+++ b/test/unit/tensor/UnitTestTensorConversion.c
@@ -159,7 +159,7 @@ void testConversionFloatInt() {
 void testConversionFloatSymInt32() {
     uint8_t numValues = 6;
 
-    float floatData[] = {1.1f, 2.1f, 3.1f, 4.1f, -1.1f, -2.1f};
+    float floatData[] = {1.5f, 2.9f, 3.2f, 4.5f, -1.2f, -6.7f};
     size_t dims[] = {numValues};
     size_t numberOfDims = 1;
     size_t orderOfDims[] = {0};
@@ -185,9 +185,19 @@ void testConversionFloatSymInt32() {
     setTensorValues(&symInt32Tensor, (uint8_t *)symInt32Data, &shape, &symInt32Q, NULL);
     convertTensor(&floatTensor, &symInt32Tensor);
 
-    int32_t expected[] = {1, 2, 3, 4, -1, -2};
+    float expectedScale = 0.000204474f;
+    int32_t expectedData[] = {7336, 14183, 15650, 22008, -5869, -32767};
 
-    TEST_ASSERT_EQUAL_INT32_ARRAY(expected, symInt32Tensor.data, numValues);
+    symInt32QConfig_t *outputSymInt32QC = symInt32Tensor.quantization->qConfig;
+    TEST_ASSERT_FLOAT_WITHIN(0.000001f, expectedScale, outputSymInt32QC->scale);
+    TEST_ASSERT_EQUAL_INT32_ARRAY(expectedData, symInt32Tensor.data, numValues);
+
+    convertTensor(&symInt32Tensor, &floatTensor);
+    float expectedFloat[] = {1.5f, 2.9f, 3.2f, 4.5f, -1.2f, -6.7f};
+    float *actualFloat = (float *)floatTensor.data;
+    for (size_t i = 0; i < 6; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(0.0001f, expectedFloat[i], actualFloat[i]);
+    }
 }
 
 void testConversionFloatAsym() {

--- a/test/unit/userAPI/UnitTestTrainingAPI.c
+++ b/test/unit/userAPI/UnitTestTrainingAPI.c
@@ -11,6 +11,7 @@
 #include "Linear.h"
 
 void testCalcGradsLinearFloat_WeightsMatchPyTorch() {
+    size_t numberOfWeights = 6;
     float weightData[] = {1.f, 1.f, 1.f, 1.f, 1.f, 1.f};
     size_t weightDims[] = {2, 3};
     size_t weightNumberOfDims = 2;


### PR DESCRIPTION
## Problem
- currently we convert from float to SymInt32 by just rounding and casting to int32
- this leads to undesired behaviour, as SymInt32 is now the only other possible quantization for layer functions

## Solution 
- implement actual conversions with calculation of scale



# How do we choose qMax?

- if we just use INT32_MAX (2³¹-1), i observe multiple issues:
	1. INT32_MAX cannot be represented by floats (2³¹-1 --> 2³¹)
	2. scales are very small (e-10)
	3. matmul results in the combined scale being even smaller that cannot be represented by float
	4. matmul of values equal to qMax will result in overflow

## Experiments
- find soft lower constraint (we can always use up less memory)
- find hard upper constraint ( we can't keep using more memory)

## Results
- hard upper constraint:
	- worst case --> all values are == qMax
	  - this is actually realistic, as max of values is mapped to qMax with our symmetric quantization
	- for int32 (N = 
$$N \cdot qMax² \lt 2^{31} \Rightarrow qMax \lt \sqrt{ \frac{2^{31}-1} {N} }$$
- FAN_IN = Number of products in one accumulation
	- linear layer = in_features
	- convolution = channel * kernel_height * kernel_width

- for MNIST we get good precision from qMax >= 8 bit
- from 16 bit onward, we get deminishing returns

- so for int32, the only viable options are 8 and 16 bit qMax
	- the choice depends on the fan_in factor
	- low fan_in --> 16 bit will have higher precision
	- high fan_in --> 8 bit will prevent overflow


## How large must fan_in be for overflow with 16 bit?
$$qMax_{16} = 2^{15}-1 = 32767 $$$$ 32767² \cdot fan\_in  \le 2^{31}-1$$
$$fan\_in \le \frac {2^{31} -1} {32767²} = \frac {2147483647} {1073676290} \approx 2$$

## How large must fan_ in be for overflow with 8 bit?
$$ qMax_{8} = 2^{7}-1 = 127 $$$$ 127² \cdot fan_in  \le 2^{31}-1$$$$ fan\_in \le \frac {2^{31} -1} {127²} = \frac {2147483647} {16129} \approx 133.000$$

