### PR TITLE
feat(OnDeviceTraining): implement symInt forward with float backward

### DIFF
--- a/src/arithmetic/Matmul.c
+++ b/src/arithmetic/Matmul.c
@@ -361,6 +361,7 @@ void matmulSymIntTensors(tensor_t *aTensor, tensor_t *bTensor, tensor_t *outputT
     symInt32QConfig_t *aSymInt32QC = aTensor->quantization->qConfig;
     symInt32QConfig_t *bSymInt32QC = bTensor->quantization->qConfig;
     symInt32QConfig_t *outputSymInt32QC = outputTensor->quantization->qConfig;
+
     outputSymInt32QC->scale = aSymInt32QC->scale * bSymInt32QC->scale;
 }
 

--- a/src/layer/Linear.c
+++ b/src/layer/Linear.c
@@ -41,8 +41,8 @@ void linearForwardSymInt32(tensor_t *w, tensor_t *b, tensor_t *input, tensor_t *
 void linearForward(layer_t *linearLayer, tensor_t *input, tensor_t *output) {
     linearConfig_t *linearConfig = linearLayer->config->linear;
 
-    tensor_t *weights = getTensorFromParameter(linearConfig->weights);
-    tensor_t *bias = getTensorFromParameter(linearConfig->bias);
+    tensor_t *weights = getParamFromParameter(linearConfig->weights);
+    tensor_t *bias = getParamFromParameter(linearConfig->bias);
 
     switch (linearConfig->forwardQ->type) {
     case FLOAT32:
@@ -75,7 +75,7 @@ void linearCalcWeightGradsFloat32(tensor_t *forwardInput, tensor_t *loss, tensor
 
 void linearCalcWeightGradsFloatWithConversion(linearConfig_t *linearConfig, tensor_t *forwardInput,
                                               tensor_t *loss) {
-    tensor_t *paramWG = getGradTensorFromParameter(linearConfig->weights);
+    tensor_t *paramWG = getGradFromParameter(linearConfig->weights);
     tensor_t *wG = paramWG;
     tensor_t *fwdIn = forwardInput;
     tensor_t *l = loss;
@@ -128,7 +128,7 @@ void linearCalcBiasGradsFloat32(tensor_t *loss, tensor_t *biasGrad) {
 }
 
 void linearCalcBiasGradsFloatWithConversion(linearConfig_t *linearConfig, tensor_t *loss) {
-    tensor_t *paramBG = getGradTensorFromParameter(linearConfig->bias);
+    tensor_t *paramBG = getGradFromParameter(linearConfig->bias);
     tensor_t *bG = paramBG;
     tensor_t *l = loss;
 
@@ -170,7 +170,7 @@ void linearCalcPropLossFloat32(tensor_t *loss, tensor_t *weights, tensor_t *prop
 
 void linearCalcPropLossFloatWithConversion(linearConfig_t *linearConfig, tensor_t *loss,
                                            tensor_t *propLoss) {
-    tensor_t *w = getTensorFromParameter(linearConfig->weights);
+    tensor_t *w = getParamFromParameter(linearConfig->weights);
     tensor_t *l = loss;
     tensor_t *pL = propLoss;
 
@@ -208,9 +208,9 @@ void backwardFloat(linearConfig_t *linearConfig, tensor_t *forwardInput, tensor_
     size_t numberOfWeights =
         calcNumberOfElementsByShape(linearConfig->weights->param->shape);
 
-    tensor_t *weightGrad = getGradTensorFromParameter(linearConfig->weights);
+    tensor_t *weightGrad = getGradFromParameter(linearConfig->weights);
 
-    tensor_t *biasGrad = getGradTensorFromParameter(linearConfig->bias);
+    tensor_t *biasGrad = getGradFromParameter(linearConfig->bias);
 
     tensor_t intermediateWGrad;
     uint8_t intermediateWGradData[numberOfWeights * sizeof(float)];
@@ -222,7 +222,7 @@ void backwardFloat(linearConfig_t *linearConfig, tensor_t *forwardInput, tensor_
 
     linearCalcBiasGradsFloat32(loss, biasGrad);
 
-    tensor_t *weightData = getTensorFromParameter(linearConfig->weights);
+    tensor_t *weightData = getParamFromParameter(linearConfig->weights);
 
     linearCalcPropLossFloat32(loss, weightData, propLossTensor);
 }
@@ -252,7 +252,7 @@ void linearCalcWeightGradsSymInt32WithConversion(linearConfig_t *linearConfig, t
     symInt32QConfig_t *symInt32QC = linearConfig->weightGradQ->qConfig;
     roundingMode_t roundingMode = symInt32QC->roundingMode;
 
-    tensor_t *paramWG = getGradTensorFromParameter(linearConfig->weights);
+    tensor_t *paramWG = getGradFromParameter(linearConfig->weights);
     tensor_t *wG = paramWG;
     tensor_t *fwdIn = forwardInput;
     tensor_t *l = loss;
@@ -314,7 +314,7 @@ void linearCalcBiasGradsSymInt32WithConversion(linearConfig_t *linearConfig, ten
     symInt32QConfig_t *symInt32QC = linearConfig->weightGradQ->qConfig;
     roundingMode_t roundingMode = symInt32QC->roundingMode;
 
-    tensor_t *paramBG = getGradTensorFromParameter(linearConfig->bias);
+    tensor_t *paramBG = getGradFromParameter(linearConfig->bias);
     tensor_t *bG = paramBG;
     tensor_t *l = loss;
 
@@ -362,7 +362,7 @@ void linearCalcPropLossSymInt32WithConversion(linearConfig_t *linearConfig, tens
     symInt32QConfig_t *symInt32QC = linearConfig->weightGradQ->qConfig;
     roundingMode_t roundingMode = symInt32QC->roundingMode;
 
-    tensor_t *w = getTensorFromParameter(linearConfig->weights);
+    tensor_t *w = getParamFromParameter(linearConfig->weights);
     tensor_t *l = loss;
 
     tensor_t wSymInt32;
@@ -402,9 +402,9 @@ void backwardSymInt32(linearConfig_t *linearConfig, tensor_t *forwardInput, tens
     size_t numberOfWeights =
         calcNumberOfElementsByShape(linearConfig->weights->param->shape);
 
-    tensor_t *weights = getTensorFromParameter(linearConfig->weights);
-    tensor_t *weightGrads = getGradTensorFromParameter(linearConfig->weights);
-    tensor_t *biasGrads = getGradTensorFromParameter(linearConfig->bias);
+    tensor_t *weights = getParamFromParameter(linearConfig->weights);
+    tensor_t *weightGrads = getGradFromParameter(linearConfig->weights);
+    tensor_t *biasGrads = getGradFromParameter(linearConfig->bias);
 
     symInt32QConfig_t *weightGradsSymInt32QC = weightGrads->quantization->qConfig;
 

--- a/src/tensor/Tensor.c
+++ b/src/tensor/Tensor.c
@@ -225,11 +225,11 @@ void byteConversion(uint8_t *dataIn, size_t dataInBits, uint8_t *dataOut, size_t
 }
 
 
-tensor_t *getTensorFromParameter(parameter_t *parameter) {
+tensor_t *getParamFromParameter(parameter_t *parameter) {
     return parameter->param;
 }
 
-tensor_t *getGradTensorFromParameter(parameter_t *parameter) {
+tensor_t *getGradFromParameter(parameter_t *parameter) {
     return parameter->grad;
 }
 

--- a/src/tensor/include/Tensor.h
+++ b/src/tensor/include/Tensor.h
@@ -53,8 +53,8 @@ uint8_t readByte(uint8_t data, uint8_t startbit, uint8_t endbit);
 
 void byteConversion(uint8_t* dataIn, size_t dataInBits, uint8_t* dataOut, size_t dataOutBits, size_t numValues);
 
-tensor_t* getTensorFromParameter(parameter_t* parameter);
-tensor_t* getGradTensorFromParameter(parameter_t* parameter);
+tensor_t* getParamFromParameter(parameter_t* parameter);
+tensor_t* getGradFromParameter(parameter_t* parameter);
 
 size_t calcBytesPerElement(quantization_t* quantization);
 size_t calcBitsPerElement(quantization_t* quantization);

--- a/test/unit/userAPI/CMakeLists.txt
+++ b/test/unit/userAPI/CMakeLists.txt
@@ -21,4 +21,6 @@ add_elastic_ai_unit_test(
         SgdAPI
         QuantizationAPI
         LossFunction
+        InferenceAPI
+        ReluAPI
 )

--- a/test/unit/userAPI/UnitTestTrainingAPI.c
+++ b/test/unit/userAPI/UnitTestTrainingAPI.c
@@ -9,6 +9,8 @@
 #include "TensorConversion.h"
 #include "QuantizationAPI.h"
 #include "Linear.h"
+#include "ReluAPI.h"
+#include "InferenceAPI.h"
 
 void testCalcGradsLinearFloat_WeightsMatchPyTorch() {
     size_t numberOfWeights = 6;
@@ -76,7 +78,7 @@ void testCalcGradsLinearFloat_WeightsMatchPyTorch() {
     // That's why we set sizeStates to 1 (bias states are ignored).
     sgd->sizeStates = 1;
 
-    for (size_t i = 0; i < 100; i++) {
+    for (size_t i = 0; i < 23; i++) {
         trainingStats_t *trainingStats0 = calculateGrads(model, sizeModel, MSE, input0, label0);
         trainingStats_t *trainingStats1 = calculateGrads(model, sizeModel, MSE, input1, label1);
         trainingStats_t *trainingStats2 = calculateGrads(model, sizeModel, MSE, input2, label2);
@@ -163,7 +165,7 @@ void testCalcGradsLinearSymInt32_WeightsMatchPyTorch() {
     // That's why we set sizeStates to 1 (bias states are ignored).
     sgd->sizeStates = 1;
 
-    for (size_t i = 0; i < 100; i++) {
+    for (size_t i = 0; i < 28; i++) {
         trainingStats_t *trainingStats0 = calculateGrads(model, modelSize, MSE, input0,
                                                          label0);
         trainingStats_t *trainingStats1 = calculateGrads(model, modelSize, MSE, input1,
@@ -195,6 +197,103 @@ void testCalcGradsLinearSymInt32_WeightsMatchPyTorch() {
     }
 }
 
+void testForwardSymInt_BackwardFloat() {
+    size_t numberOfWeights = 6;
+    size_t numberOfInputs = 3;
+
+    float weightData[] = {1.f, 1.f, 1.f, 1.f, 1.f, 1.f};
+    size_t weightDims[] = {2, 3};
+    size_t weightNumberOfDims = 2;
+    tensor_t *weightsParam = tensorInitSymInt32(weightData, weightDims, weightNumberOfDims, HTE,
+                                                NULL);
+    tensor_t *weightsGrad = gradInitSymInt32(weightsParam, HTE, NULL);
+    parameter_t *weights = parameterInit(weightsParam, weightsGrad);
+
+    float biasData[] = {-1.f, 3.f};
+    size_t biasDims[] = {2, 1};
+    size_t biasNumberOfDims = 2;
+    tensor_t *biasParam = tensorInitSymInt32(biasData, biasDims, biasNumberOfDims, HTE, NULL);
+    tensor_t *biasGrad = gradInitSymInt32(biasParam, HTE, NULL);
+    parameter_t *bias = parameterInit(biasParam, biasGrad);
+
+    float input0Data[] = {-4.f, 1.f, 9.f,};
+    size_t input0Dims[] = {1, 3};
+    size_t input0NumberOfDims = 2;
+    tensor_t *input0 = tensorInitSymInt32(input0Data, input0Dims, input0NumberOfDims, HTE, NULL);
+
+    float input1Data[] = {5.f, -1.f, 2.f};
+    size_t input1Dims[] = {1, 3};
+    size_t input1NumberOfDims = 2;
+    tensor_t *input1 = tensorInitSymInt32(input1Data, input1Dims, input1NumberOfDims, HTE, NULL);
+
+    float input2Data[] = {-7.f, -5.f, 6.f};
+    size_t input2Dims[] = {1, 3};
+    size_t input2NumberOfDims = 2;
+    tensor_t *input2 = tensorInitSymInt32(input2Data, input2Dims, input2NumberOfDims, HTE, NULL);
+
+    quantization_t *forwardQ = quantizationInitSymInt32(HTE);
+    quantization_t *backwardQ = quantizationInitFloat();
+    layer_t *linear = linearLayerInit(weights, bias, forwardQ, backwardQ, backwardQ, backwardQ);
+
+    layer_t *model[] = {linear};
+    size_t modelSize = 1;
+
+    float label0Data[] = {59.f, -23.f};
+    size_t label0Dims[] = {2, 1};
+    size_t label0NumberOfDims = 2;
+    tensor_t *label0 = tensorInitSymInt32(label0Data, label0Dims, label0NumberOfDims, HTE, NULL);
+
+    float label1Data[] = {43.f, 249.f};
+    size_t label1Dims[] = {2, 1};
+    size_t label1NumberOfDims = 2;
+    tensor_t *label1 = tensorInitSymInt32(label1Data, label1Dims, label1NumberOfDims, HTE, NULL);
+
+    float label2Data[] = {23.f, 457.f};
+    size_t label2Dims[] = {2, 1};
+    size_t label2NumberOfDims = 2;
+    tensor_t *label2 = tensorInitSymInt32(label2Data, label2Dims, label2NumberOfDims, HTE, NULL);
+
+    optimizer_t *sgd = sgdMCreateOptim(0.01f, 0.f, 0.f, model, modelSize, SYM_INT32);
+    optimizerFunctions_t sgdFns = optimizerFunctions[SGD_M];
+
+    // IMPORTANT: we want only the weights to be trainable, to check against pytorch learned weights!
+    // That's why we set sizeStates to 1 (bias states are ignored).y
+    sgd->sizeStates = 1;
+
+    for (size_t i = 0; i < 32; i++) {
+        trainingStats_t *trainingStats0 = calculateGrads(model, modelSize, MSE, input0,
+                                                         label0);
+        trainingStats_t *trainingStats1 = calculateGrads(model, modelSize, MSE, input1,
+                                                         label1);
+        trainingStats_t *trainingStats2 = calculateGrads(model, modelSize, MSE, input2,
+                                                         label2);
+
+        sgdFns.step(sgd);
+        sgdFns.zero(sgd);
+
+        freeTrainingStats(trainingStats0);
+        freeTrainingStats(trainingStats1);
+        freeTrainingStats(trainingStats2);
+    }
+
+    float expectedWeights[] = {5.f, -1.f, 9.f, 22.f, -100.f, 18.f};
+
+    tensor_t actualWeights;
+    float data[numberOfWeights];
+    quantization_t q;
+    initFloat32Quantization(&q);
+    setTensorValuesForConversion((uint8_t *)data, &q, linear->config->linear->weights->param,
+                                 &actualWeights);
+    convertTensor(linear->config->linear->weights->param, &actualWeights);
+    float *actualWeightsArr = (float *) actualWeights.data;
+
+    const float errorPercent = 0.03f;
+    for (size_t i = 0; i < 6; i++) {
+        float currentThreshold = actualWeightsArr[i] * errorPercent;
+        TEST_ASSERT_FLOAT_WITHIN(currentThreshold, expectedWeights[i], actualWeightsArr[i]);
+    }
+}
+
 void setUp() {}
 void tearDown() {}
 
@@ -202,5 +301,6 @@ int main(void) {
     UNITY_BEGIN();
     RUN_TEST(testCalcGradsLinearFloat_WeightsMatchPyTorch);
     RUN_TEST(testCalcGradsLinearSymInt32_WeightsMatchPyTorch);
+    RUN_TEST(testForwardSymInt_BackwardFloat);
     return UNITY_END();
 }


### PR DESCRIPTION
## Problem
- we want to be able to use different quantizations for forward and backward
    - symInt32 forward -> float backward

## Solution
- since we have made the quantization setup of each layer a lot more customizable, all we need to do is add different quantizations during layer initialization

```c
    quantization_t *forwardQ = quantizationInitSymInt32(HTE);
    quantization_t *backwardQ = quantizationInitFloat();
    layer_t *linear = linearLayerInit(weights, bias, forwardQ, backwardQ, backwardQ, backwardQ);
```