### PR TITLE
Fix build failure due to missing library in TraningAPI

### DIFF
--- a/src/userAPI/CMakeLists.txt
+++ b/src/userAPI/CMakeLists.txt
@@ -94,6 +94,7 @@ target_link_libraries(TrainingAPI PRIVATE
         MSE
         Optimizer
         Common
+        LossFunction
 )
 
 


### PR DESCRIPTION
fix #27 by linking LossFunction library in TrainingAPI