### PR TITLE
fix(#67): fix memory leaks and wrong sizeof

### DIFF
--- a/experiments/MnistExperiment.c
+++ b/experiments/MnistExperiment.c
@@ -296,6 +296,8 @@ int main(void) {
             inferenceStats_t *validationResult = inferenceWithLoss(
                 model, sizeModel, batch->samples[0]->item, batch->samples[0]->label, CROSS_ENTROPY);
             validationLoss += validationResult->loss;
+            freeInferenceStats(validationResult);
+            freeBatch(batch);
         }
 
         validationLoss /= (float)testDatasetSize;

--- a/src/userApi/data_loader/DataLoaderApi.c
+++ b/src/userApi/data_loader/DataLoaderApi.c
@@ -61,7 +61,7 @@ static batch_t *getBatch(dataLoader_t *dataLoader, size_t index) {
 
     size_t batchSize = dataLoader->batchSize;
     batch->size = batchSize;
-    batch->samples = *reserveMemory(batchSize * sizeof(sample_t));
+    batch->samples = *reserveMemory(batchSize * sizeof(sample_t *));
 
     size_t sampleIndex = index * batchSize;
 


### PR DESCRIPTION
## Summary

Fixes #67 — three pre-existing bugs found during #66 review:

- **Validation loop memory leak (inferenceStats):** `inferenceWithLoss()` called 10K×/epoch with return value never freed → added `freeInferenceStats(validationResult)`
- **Validation loop memory leak (batch):** `getBatch()` allocations never freed in the same loop → added `freeBatch(batch)`
- **Wrong sizeof in batch allocation:** `sizeof(sample_t)` instead of `sizeof(sample_t *)` for a `sample_t **` array → over-allocates 2× on 64-bit

## Test plan

- [x] `cmake --build --preset unit_test_debug` compiles cleanly
- [x] `ctest --preset unit_test_debug` — all 26 tests pass
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>