### PR TITLE
fix: scope clang-format rules to all C-family files, not just C++

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -3,8 +3,6 @@ BasedOnStyle: llvm
 ColumnLimit: 100
 IncludeBlocks: Preserve
 SortIncludes: CaseSensitive
----
-Language: Cpp
 IndentWidth: 4
 AllowShortBlocksOnASingleLine: Empty
 AllowShortFunctionsOnASingleLine: Empty

--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,4 @@ data/
 ### Claude
 CLAUDE.md
 claude*
+docs/superpowers/


### PR DESCRIPTION
## Context

Re-open of #79. #79 was merged into the Stage-1 feature branch (`76-flatten-layer-stage1`) instead of `main` because that was its base at the time. Stage 1 was subsequently rebased to drop the config commit, so it now lives here as its own PR targeting `main` — the originally intended order.

## Summary

The `.clang-format` config had its `IndentWidth: 4`, `InsertBraces: true`, and similar rules gated behind a `Language: Cpp` second YAML document. Because `Language: Cpp` matches only `.cpp`/`.hh` (not `.c`), `.c` files silently fell back to the LLVM default 2-space indent — producing an unintended split between C and C++ formatting.

This PR collapses the two YAML documents into one, so the rules apply uniformly to every C-family source file.

## Why now

Prerequisite for #78 (uniform formatting + CI format-check). Running `clang-format -i` across the tree with the current config would leave `.c` files at 2-space and `.cpp`/`.h` at 4-space — not what we want.

## Scope

- `.clang-format`: remove the `---` separator and `Language: Cpp` line; everything else unchanged.
- No source files touched — the codebase-wide reformat is the next step and gets its own PR (#78, Step 1).

## Test plan
- [x] Config still valid YAML (clang-format does not error on load)
- [x] Existing CI (`c-build-and-test`, `python-test`) passes on this PR

Part of #78