### PR TITLE
fix(#81): initialize SymInt32 output buffers in tests to prevent NaN→int UB

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -45,6 +45,15 @@
       "cacheVariables": {
         "DEBUG_MODE_DEBUG": "ON"
       }
+    },
+    {
+      "name": "unit_test_asan",
+      "displayName": "Unit-Test-ASan",
+      "inherits": "host",
+      "cacheVariables": {
+        "CMAKE_C_FLAGS": "-fsanitize=address,undefined -fno-sanitize=function -fno-omit-frame-pointer -fno-sanitize-recover=all -g -O1",
+        "CMAKE_EXE_LINKER_FLAGS": "-fsanitize=address,undefined"
+      }
     }
   ],
   "buildPresets": [
@@ -76,6 +85,12 @@
       "name": "unit_test_debug",
       "inherits": "host",
       "configurePreset": "unit_test_debug",
+      "targets": "all_unit_tests"
+    },
+    {
+      "name": "unit_test_asan",
+      "inherits": "host",
+      "configurePreset": "unit_test_asan",
       "targets": "all_unit_tests"
     }
   ],
@@ -134,6 +149,24 @@
         "include": {
           "label": "unit"
         }
+      }
+    },
+    {
+      "name": "unit_test_asan",
+      "displayName": "Unit Tests (ASan + UBSan)",
+      "configurePreset": "unit_test_asan",
+      "output": {
+        "outputJUnitFile": "unit-test-asan.junit",
+        "outputOnFailure": true
+      },
+      "filter": {
+        "include": {
+          "label": "unit"
+        }
+      },
+      "environment": {
+        "ASAN_OPTIONS": "detect_leaks=0:abort_on_error=1:halt_on_error=1:strict_string_checks=1:check_initialization_order=1",
+        "UBSAN_OPTIONS": "print_stacktrace=1:halt_on_error=1"
       }
     }
   ]

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -9,7 +9,7 @@ the dataset. This:
 
 - keeps dataset code independent of downstream model topology
 - allows one dataset to feed models with different input ranks
-- matches the PyTorch / Keras / elastic-ai.creator IR convention, so ir2c
-  can compile each shape transform to a corresponding C layer
+- matches the PyTorch / Keras / elastic-ai.creator IR convention, so a future
+  ir2c can compile each shape transform to a corresponding C layer
 
 For flatten-to-2D, use `flattenLayerInit()` from `FlattenApi.h`.

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -1,0 +1,15 @@
+# Project Conventions
+
+## Data Shape Convention
+
+Datasets deliver samples in their natural geometric shape (e.g. `[C, H, W]`
+for images, `[C, L]` for time series). Any `reshape`, `flatten`, or `view`
+operation is the **first layer of the model**, not a preprocessing step in
+the dataset. This:
+
+- keeps dataset code independent of downstream model topology
+- allows one dataset to feed models with different input ranks
+- matches the PyTorch / Keras / elastic-ai.creator IR convention, so ir2c
+  can compile each shape transform to a corresponding C layer
+
+For flatten-to-2D, use `flattenLayerInit()` from `FlattenApi.h`.

--- a/experiments/CMakeLists.txt
+++ b/experiments/CMakeLists.txt
@@ -13,6 +13,9 @@ target_link_libraries(MnistExperiment PRIVATE
         ReluApi
         Relu
 
+        FlattenApi
+        Flatten
+
         QuantizationApi
         Quantization
 

--- a/experiments/MnistExperiment.c
+++ b/experiments/MnistExperiment.c
@@ -25,31 +25,30 @@
 #define LOG "MnistExperimentLog.csv"
 #endif
 
-
-#include <stdlib.h>
-#include <time.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
+#include <time.h>
 
+#include "CSVHelper.h"
+#include "CalculateGradsSequential.h"
+#include "Common.h"
 #include "DataLoader.h"
 #include "DataLoaderApi.h"
-#include "NPYLoaderApi.h"
+#include "FlattenApi.h"
+#include "InferenceApi.h"
 #include "Layer.h"
+#include "LinearApi.h"
+#include "NPYLoaderApi.h"
 #include "Quantization.h"
 #include "QuantizationApi.h"
-#include "LinearApi.h"
 #include "ReluApi.h"
-#include "TensorApi.h"
-#include "Tensor.h"
 #include "SgdApi.h"
-#include "StorageApi.h"
 #include "SoftmaxApi.h"
-#include "InferenceApi.h"
-#include "CSVHelper.h"
-#include "Common.h"
+#include "StorageApi.h"
+#include "Tensor.h"
+#include "TensorApi.h"
 #include "TrainingLoopApi.h"
-#include "CalculateGradsSequential.h"
-
 
 static dataset_t trainDataset;
 static dataset_t testDataset;
@@ -57,195 +56,129 @@ static dataset_t testDataset;
 static size_t batchSize = 32;
 
 static void initDataSets() {
-    tensorArray_t *trainItems = npyLoad(MNIST_TRAIN_X);
-    tensorArray_t *trainLabels = npyLoad(MNIST_TRAIN_Y);
-    trainDataset.items = trainItems;
-    trainDataset.labels = trainLabels;
+  tensorArray_t *trainItems = npyLoad(MNIST_TRAIN_X);
+  tensorArray_t *trainLabels = npyLoad(MNIST_TRAIN_Y);
+  trainDataset.items = trainItems;
+  trainDataset.labels = trainLabels;
 
-    tensorArray_t *testItems = npyLoad(MNIST_TEST_X);
-    tensorArray_t *testLabels = npyLoad(MNIST_TEST_Y);
-    testDataset.items = testItems;
-    testDataset.labels = testLabels;
+  tensorArray_t *testItems = npyLoad(MNIST_TEST_X);
+  tensorArray_t *testLabels = npyLoad(MNIST_TEST_Y);
+  testDataset.items = testItems;
+  testDataset.labels = testLabels;
 }
 
 static sample_t *getTrainSample(size_t id) {
-    sample_t *sample = npyGetSample(&trainDataset, id);
-    return sample;
+  sample_t *sample = npyGetSample(&trainDataset, id);
+  return sample;
 }
 
 static sample_t *getTestSample(size_t id) {
-    sample_t *sample = npyGetSample(&testDataset, id);
-    return sample;
+  sample_t *sample = npyGetSample(&testDataset, id);
+  return sample;
 }
 
-static size_t getTrainDatasetSize() {
-    return trainDataset.items->size;
-}
+static size_t getTrainDatasetSize() { return trainDataset.items->size; }
 
-static size_t getTestDatasetSize() {
-    return testDataset.items->size;
-}
-
-// raw tensor dims look like this: [1, 28, 28]
-// we want dims to look like this: [1, 28*28] (linear layer only accepts 2D tensors)
-static void flattenItemDims() {
-
-    size_t trainNumberOfTensors = getTrainDatasetSize();
-    size_t testNumberOfTensors = getTestDatasetSize();
-
-    size_t numberOfDims = 2;
-
-    shape_t *shape;
-
-    for (size_t i = 0; i < trainNumberOfTensors; i++) {
-        shape = trainDataset.items->array[i]->shape;
-        size_t *newDims = *reserveMemory(numberOfDims * sizeof(size_t));
-        size_t newDimsData[] = {shape->dimensions[0],
-                                shape->dimensions[2] * shape->dimensions[2]};
-        size_t *newOrder = *reserveMemory(numberOfDims * sizeof(size_t));
-
-        for (size_t j = 0; j < numberOfDims; j++) {
-            newDims[j] = newDimsData[j];
-            newOrder[j] = j;
-        }
-
-        freeReservedMemory(shape->dimensions);
-        freeReservedMemory(shape->orderOfDimensions);
-
-        shape->numberOfDimensions = numberOfDims;
-        shape->dimensions = newDims;
-        shape->orderOfDimensions = newOrder;
-    }
-
-    for (size_t i = 0; i < testNumberOfTensors; i++) {
-        shape = testDataset.items->array[i]->shape;
-        size_t *newDims = *reserveMemory(numberOfDims * sizeof(size_t));
-        size_t newDimsData[] = {shape->dimensions[0],
-                                shape->dimensions[2] * shape->dimensions[2]};
-        size_t *newOrder = *reserveMemory(numberOfDims * sizeof(size_t));
-        for (size_t j = 0; j < numberOfDims; j++) {
-            newDims[j] = newDimsData[j];
-            newOrder[j] = j;
-        }
-
-        freeReservedMemory(shape->dimensions);
-        freeReservedMemory(shape->orderOfDimensions);
-
-        shape->numberOfDimensions = numberOfDims;
-        shape->dimensions = newDims;
-        shape->orderOfDimensions = newOrder;
-
-    }
-}
+static size_t getTestDatasetSize() { return testDataset.items->size; }
 
 static void epochCallback(size_t epoch, float trainLoss, epochStats_t evalStats) {
-    char row[256] = {0};
-    sprintf(row, "%lu, %f, %f, %f, %f, %f, %f\n",
-            epoch, trainLoss, evalStats.loss, evalStats.accuracy,
-            evalStats.precision, evalStats.recall, evalStats.f1);
-    PRINT_DEBUG("%s\n", row);
+  char row[256] = {0};
+  sprintf(row, "%lu, %f, %f, %f, %f, %f, %f\n", epoch, trainLoss, evalStats.loss,
+          evalStats.accuracy, evalStats.precision, evalStats.recall, evalStats.f1);
+  PRINT_DEBUG("%s\n", row);
 
-    char *rows[] = {row};
-    size_t entriesInRow[] = {7};
-    csvData_t csvData;
-    setCSVData(&csvData, rows, 1, entriesInRow);
-    csvWriteRowsByBufferSize(LOG, &csvData, "a");
+  char *rows[] = {row};
+  size_t entriesInRow[] = {7};
+  csvData_t csvData;
+  setCSVData(&csvData, rows, 1, entriesInRow);
+  csvWriteRowsByBufferSize(LOG, &csvData, "a");
 }
 
 static void writeCsvHeader(char *filePath) {
-    char *header = "epoch, train_loss, eval_loss, eval_accuracy, eval_precision, eval_recall, eval_f1\n";
-    char *row[] = {header};
-    size_t entriesInRow[] = {7};
-    csvData_t csvData;
-    setCSVData(&csvData, row, 1, entriesInRow);
-    csvWriteRowsByBufferSize(filePath, &csvData, "w");
+  char *header =
+      "epoch, train_loss, eval_loss, eval_accuracy, eval_precision, eval_recall, eval_f1\n";
+  char *row[] = {header};
+  size_t entriesInRow[] = {7};
+  csvData_t csvData;
+  setCSVData(&csvData, row, 1, entriesInRow);
+  csvWriteRowsByBufferSize(filePath, &csvData, "w");
 }
 
-#define MODEL_SIZE 4
+#define MODEL_SIZE 5
 
 static void buildModel(layer_t **model) {
-    quantization_t *q = quantizationInitFloat();
+  quantization_t *q = quantizationInitFloat();
 
-    // Linear 784→20
-    static float weight0Data[20 * 28 * 28] = {0};
-    static size_t weight0Dims[] = {20, 28 * 28};
-    tensor_t *weight0Param = tensorInitWithDistribution(XAVIER_UNIFORM, weight0Data, weight0Dims, 2, q, NULL, 28*28, 20);
-    tensor_t *weight0Grad = gradInitFloat(weight0Param, NULL);
-    parameter_t *weight0 = parameterInit(weight0Param, weight0Grad);
+  // Flatten [1, 28, 28] -> [1, 784]
+  model[0] = flattenLayerInit();
 
-    static float bias0Data[20] = {0};
-    static size_t bias0Dims[] = {1, 20};
-    tensor_t *bias0Param = tensorInitWithDistribution(ZEROS, bias0Data, bias0Dims, 2, q, NULL, 1, 20);
-    tensor_t *bias0Grad = gradInitFloat(bias0Param, NULL);
-    parameter_t *bias0 = parameterInit(bias0Param, bias0Grad);
+  // Linear 784→20
+  static float weight0Data[20 * 28 * 28] = {0};
+  static size_t weight0Dims[] = {20, 28 * 28};
+  tensor_t *weight0Param =
+      tensorInitWithDistribution(XAVIER_UNIFORM, weight0Data, weight0Dims, 2, q, NULL, 28 * 28, 20);
+  tensor_t *weight0Grad = gradInitFloat(weight0Param, NULL);
+  parameter_t *weight0 = parameterInit(weight0Param, weight0Grad);
 
-    model[0] = linearLayerInit(weight0, bias0, q, q, q, q);
+  static float bias0Data[20] = {0};
+  static size_t bias0Dims[] = {1, 20};
+  tensor_t *bias0Param = tensorInitWithDistribution(ZEROS, bias0Data, bias0Dims, 2, q, NULL, 1, 20);
+  tensor_t *bias0Grad = gradInitFloat(bias0Param, NULL);
+  parameter_t *bias0 = parameterInit(bias0Param, bias0Grad);
 
-    // ReLU
-    model[1] = reluLayerInit(q, q);
+  model[1] = linearLayerInit(weight0, bias0, q, q, q, q);
 
-    // Linear 20→10
-    static float weight1Data[10 * 20] = {0};
-    static size_t weight1Dims[] = {10, 20};
-    tensor_t *weight1Param = tensorInitWithDistribution(XAVIER_UNIFORM, weight1Data, weight1Dims, 2, q, NULL, 20, 10);
-    tensor_t *weight1Grad = gradInitFloat(weight1Param, NULL);
-    parameter_t *weight1 = parameterInit(weight1Param, weight1Grad);
+  // ReLU
+  model[2] = reluLayerInit(q, q);
 
-    static float bias1Data[10] = {0};
-    static size_t bias1Dims[] = {1, 10};
-    tensor_t *bias1Param = tensorInitWithDistribution(ZEROS, bias1Data, bias1Dims, 2, q, NULL, 1, 10);
-    tensor_t *bias1Grad = gradInitFloat(bias1Param, NULL);
-    parameter_t *bias1 = parameterInit(bias1Param, bias1Grad);
+  // Linear 20→10
+  static float weight1Data[10 * 20] = {0};
+  static size_t weight1Dims[] = {10, 20};
+  tensor_t *weight1Param =
+      tensorInitWithDistribution(XAVIER_UNIFORM, weight1Data, weight1Dims, 2, q, NULL, 20, 10);
+  tensor_t *weight1Grad = gradInitFloat(weight1Param, NULL);
+  parameter_t *weight1 = parameterInit(weight1Param, weight1Grad);
 
-    model[2] = linearLayerInit(weight1, bias1, q, q, q, q);
+  static float bias1Data[10] = {0};
+  static size_t bias1Dims[] = {1, 10};
+  tensor_t *bias1Param = tensorInitWithDistribution(ZEROS, bias1Data, bias1Dims, 2, q, NULL, 1, 10);
+  tensor_t *bias1Grad = gradInitFloat(bias1Param, NULL);
+  parameter_t *bias1 = parameterInit(bias1Param, bias1Grad);
 
-    // Softmax
-    model[3] = softmaxLayerInit(q, q);
+  model[3] = linearLayerInit(weight1, bias1, q, q, q, q);
+
+  // Softmax
+  model[4] = softmaxLayerInit(q, q);
 }
 
-
 int main(void) {
-    writeCsvHeader(LOG);
+  writeCsvHeader(LOG);
 
-    size_t numberOfEpochs = 10;
-    initDataSets();
-    flattenItemDims();
+  size_t numberOfEpochs = 10;
+  initDataSets();
 
-    dataLoader_t *trainDataloader = dataLoaderInit(getTrainSample,
-                                                   getTrainDatasetSize,
-                                                   batchSize,
-                                                   NULL,
-                                                   NULL,
-                                                   false,
-                                                   0,
-                                                   true);
+  dataLoader_t *trainDataloader =
+      dataLoaderInit(getTrainSample, getTrainDatasetSize, batchSize, NULL, NULL, false, 0, true);
 
-    dataLoader_t *testDataloader = dataLoaderInit(getTestSample,
-                                                  getTestDatasetSize,
-                                                  1,
-                                                  NULL,
-                                                  NULL,
-                                                  false,
-                                                  0,
-                                                  true);
+  dataLoader_t *testDataloader =
+      dataLoaderInit(getTestSample, getTestDatasetSize, 1, NULL, NULL, false, 0, true);
 
-    layer_t *model[MODEL_SIZE];
-    buildModel(model);
+  layer_t *model[MODEL_SIZE];
+  buildModel(model);
 
-    optimizer_t *sgd = sgdMCreateOptim(0.001f, 0.f, 0.f, model, MODEL_SIZE, FLOAT32);
+  optimizer_t *sgd = sgdMCreateOptim(0.001f, 0.f, 0.f, model, MODEL_SIZE, FLOAT32);
 
-    clock_t start = clock();
+  clock_t start = clock();
 
-    trainingRunResult_t result = trainingRun(model, MODEL_SIZE, CROSS_ENTROPY,
-                                             trainDataloader, testDataloader, sgd,
-                                             numberOfEpochs, calculateGradsSequential,
-                                             inferenceWithLoss, epochCallback);
+  trainingRunResult_t result =
+      trainingRun(model, MODEL_SIZE, CROSS_ENTROPY, trainDataloader, testDataloader, sgd,
+                  numberOfEpochs, calculateGradsSequential, inferenceWithLoss, epochCallback);
 
-    clock_t end = clock();
+  clock_t end = clock();
 
-    double duration_sec = (double)(end - start) / CLOCKS_PER_SEC;
-    PRINT_INFO("Training finished in %f seconds\n", duration_sec);
-    PRINT_INFO("Final train loss: %f, eval loss: %f\n", result.finalTrainLoss,
-                result.finalEvalStats.loss);
-    PRINT_INFO("Final accuracy: %.2f%%\n", result.finalEvalStats.accuracy * 100.0f);
+  double duration_sec = (double)(end - start) / CLOCKS_PER_SEC;
+  PRINT_INFO("Training finished in %f seconds\n", duration_sec);
+  PRINT_INFO("Final train loss: %f, eval loss: %f\n", result.finalTrainLoss,
+             result.finalEvalStats.loss);
+  PRINT_INFO("Final accuracy: %.2f%%\n", result.finalEvalStats.accuracy * 100.0f);
 }

--- a/experiments/MnistExperiment.c
+++ b/experiments/MnistExperiment.c
@@ -56,129 +56,135 @@ static dataset_t testDataset;
 static size_t batchSize = 32;
 
 static void initDataSets() {
-  tensorArray_t *trainItems = npyLoad(MNIST_TRAIN_X);
-  tensorArray_t *trainLabels = npyLoad(MNIST_TRAIN_Y);
-  trainDataset.items = trainItems;
-  trainDataset.labels = trainLabels;
+    tensorArray_t *trainItems = npyLoad(MNIST_TRAIN_X);
+    tensorArray_t *trainLabels = npyLoad(MNIST_TRAIN_Y);
+    trainDataset.items = trainItems;
+    trainDataset.labels = trainLabels;
 
-  tensorArray_t *testItems = npyLoad(MNIST_TEST_X);
-  tensorArray_t *testLabels = npyLoad(MNIST_TEST_Y);
-  testDataset.items = testItems;
-  testDataset.labels = testLabels;
+    tensorArray_t *testItems = npyLoad(MNIST_TEST_X);
+    tensorArray_t *testLabels = npyLoad(MNIST_TEST_Y);
+    testDataset.items = testItems;
+    testDataset.labels = testLabels;
 }
 
 static sample_t *getTrainSample(size_t id) {
-  sample_t *sample = npyGetSample(&trainDataset, id);
-  return sample;
+    sample_t *sample = npyGetSample(&trainDataset, id);
+    return sample;
 }
 
 static sample_t *getTestSample(size_t id) {
-  sample_t *sample = npyGetSample(&testDataset, id);
-  return sample;
+    sample_t *sample = npyGetSample(&testDataset, id);
+    return sample;
 }
 
-static size_t getTrainDatasetSize() { return trainDataset.items->size; }
+static size_t getTrainDatasetSize() {
+    return trainDataset.items->size;
+}
 
-static size_t getTestDatasetSize() { return testDataset.items->size; }
+static size_t getTestDatasetSize() {
+    return testDataset.items->size;
+}
 
 static void epochCallback(size_t epoch, float trainLoss, epochStats_t evalStats) {
-  char row[256] = {0};
-  sprintf(row, "%lu, %f, %f, %f, %f, %f, %f\n", epoch, trainLoss, evalStats.loss,
-          evalStats.accuracy, evalStats.precision, evalStats.recall, evalStats.f1);
-  PRINT_DEBUG("%s\n", row);
+    char row[256] = {0};
+    sprintf(row, "%lu, %f, %f, %f, %f, %f, %f\n", epoch, trainLoss, evalStats.loss,
+            evalStats.accuracy, evalStats.precision, evalStats.recall, evalStats.f1);
+    PRINT_DEBUG("%s\n", row);
 
-  char *rows[] = {row};
-  size_t entriesInRow[] = {7};
-  csvData_t csvData;
-  setCSVData(&csvData, rows, 1, entriesInRow);
-  csvWriteRowsByBufferSize(LOG, &csvData, "a");
+    char *rows[] = {row};
+    size_t entriesInRow[] = {7};
+    csvData_t csvData;
+    setCSVData(&csvData, rows, 1, entriesInRow);
+    csvWriteRowsByBufferSize(LOG, &csvData, "a");
 }
 
 static void writeCsvHeader(char *filePath) {
-  char *header =
-      "epoch, train_loss, eval_loss, eval_accuracy, eval_precision, eval_recall, eval_f1\n";
-  char *row[] = {header};
-  size_t entriesInRow[] = {7};
-  csvData_t csvData;
-  setCSVData(&csvData, row, 1, entriesInRow);
-  csvWriteRowsByBufferSize(filePath, &csvData, "w");
+    char *header =
+        "epoch, train_loss, eval_loss, eval_accuracy, eval_precision, eval_recall, eval_f1\n";
+    char *row[] = {header};
+    size_t entriesInRow[] = {7};
+    csvData_t csvData;
+    setCSVData(&csvData, row, 1, entriesInRow);
+    csvWriteRowsByBufferSize(filePath, &csvData, "w");
 }
 
 #define MODEL_SIZE 5
 
 static void buildModel(layer_t **model) {
-  quantization_t *q = quantizationInitFloat();
+    quantization_t *q = quantizationInitFloat();
 
-  // Flatten [1, 28, 28] -> [1, 784]
-  model[0] = flattenLayerInit();
+    // Flatten [1, 28, 28] -> [1, 784]
+    model[0] = flattenLayerInit();
 
-  // Linear 784→20
-  static float weight0Data[20 * 28 * 28] = {0};
-  static size_t weight0Dims[] = {20, 28 * 28};
-  tensor_t *weight0Param =
-      tensorInitWithDistribution(XAVIER_UNIFORM, weight0Data, weight0Dims, 2, q, NULL, 28 * 28, 20);
-  tensor_t *weight0Grad = gradInitFloat(weight0Param, NULL);
-  parameter_t *weight0 = parameterInit(weight0Param, weight0Grad);
+    // Linear 784→20
+    static float weight0Data[20 * 28 * 28] = {0};
+    static size_t weight0Dims[] = {20, 28 * 28};
+    tensor_t *weight0Param = tensorInitWithDistribution(XAVIER_UNIFORM, weight0Data, weight0Dims, 2,
+                                                        q, NULL, 28 * 28, 20);
+    tensor_t *weight0Grad = gradInitFloat(weight0Param, NULL);
+    parameter_t *weight0 = parameterInit(weight0Param, weight0Grad);
 
-  static float bias0Data[20] = {0};
-  static size_t bias0Dims[] = {1, 20};
-  tensor_t *bias0Param = tensorInitWithDistribution(ZEROS, bias0Data, bias0Dims, 2, q, NULL, 1, 20);
-  tensor_t *bias0Grad = gradInitFloat(bias0Param, NULL);
-  parameter_t *bias0 = parameterInit(bias0Param, bias0Grad);
+    static float bias0Data[20] = {0};
+    static size_t bias0Dims[] = {1, 20};
+    tensor_t *bias0Param =
+        tensorInitWithDistribution(ZEROS, bias0Data, bias0Dims, 2, q, NULL, 1, 20);
+    tensor_t *bias0Grad = gradInitFloat(bias0Param, NULL);
+    parameter_t *bias0 = parameterInit(bias0Param, bias0Grad);
 
-  model[1] = linearLayerInit(weight0, bias0, q, q, q, q);
+    model[1] = linearLayerInit(weight0, bias0, q, q, q, q);
 
-  // ReLU
-  model[2] = reluLayerInit(q, q);
+    // ReLU
+    model[2] = reluLayerInit(q, q);
 
-  // Linear 20→10
-  static float weight1Data[10 * 20] = {0};
-  static size_t weight1Dims[] = {10, 20};
-  tensor_t *weight1Param =
-      tensorInitWithDistribution(XAVIER_UNIFORM, weight1Data, weight1Dims, 2, q, NULL, 20, 10);
-  tensor_t *weight1Grad = gradInitFloat(weight1Param, NULL);
-  parameter_t *weight1 = parameterInit(weight1Param, weight1Grad);
+    // Linear 20→10
+    static float weight1Data[10 * 20] = {0};
+    static size_t weight1Dims[] = {10, 20};
+    tensor_t *weight1Param =
+        tensorInitWithDistribution(XAVIER_UNIFORM, weight1Data, weight1Dims, 2, q, NULL, 20, 10);
+    tensor_t *weight1Grad = gradInitFloat(weight1Param, NULL);
+    parameter_t *weight1 = parameterInit(weight1Param, weight1Grad);
 
-  static float bias1Data[10] = {0};
-  static size_t bias1Dims[] = {1, 10};
-  tensor_t *bias1Param = tensorInitWithDistribution(ZEROS, bias1Data, bias1Dims, 2, q, NULL, 1, 10);
-  tensor_t *bias1Grad = gradInitFloat(bias1Param, NULL);
-  parameter_t *bias1 = parameterInit(bias1Param, bias1Grad);
+    static float bias1Data[10] = {0};
+    static size_t bias1Dims[] = {1, 10};
+    tensor_t *bias1Param =
+        tensorInitWithDistribution(ZEROS, bias1Data, bias1Dims, 2, q, NULL, 1, 10);
+    tensor_t *bias1Grad = gradInitFloat(bias1Param, NULL);
+    parameter_t *bias1 = parameterInit(bias1Param, bias1Grad);
 
-  model[3] = linearLayerInit(weight1, bias1, q, q, q, q);
+    model[3] = linearLayerInit(weight1, bias1, q, q, q, q);
 
-  // Softmax
-  model[4] = softmaxLayerInit(q, q);
+    // Softmax
+    model[4] = softmaxLayerInit(q, q);
 }
 
 int main(void) {
-  writeCsvHeader(LOG);
+    writeCsvHeader(LOG);
 
-  size_t numberOfEpochs = 10;
-  initDataSets();
+    size_t numberOfEpochs = 10;
+    initDataSets();
 
-  dataLoader_t *trainDataloader =
-      dataLoaderInit(getTrainSample, getTrainDatasetSize, batchSize, NULL, NULL, false, 0, true);
+    dataLoader_t *trainDataloader =
+        dataLoaderInit(getTrainSample, getTrainDatasetSize, batchSize, NULL, NULL, false, 0, true);
 
-  dataLoader_t *testDataloader =
-      dataLoaderInit(getTestSample, getTestDatasetSize, 1, NULL, NULL, false, 0, true);
+    dataLoader_t *testDataloader =
+        dataLoaderInit(getTestSample, getTestDatasetSize, 1, NULL, NULL, false, 0, true);
 
-  layer_t *model[MODEL_SIZE];
-  buildModel(model);
+    layer_t *model[MODEL_SIZE];
+    buildModel(model);
 
-  optimizer_t *sgd = sgdMCreateOptim(0.001f, 0.f, 0.f, model, MODEL_SIZE, FLOAT32);
+    optimizer_t *sgd = sgdMCreateOptim(0.001f, 0.f, 0.f, model, MODEL_SIZE, FLOAT32);
 
-  clock_t start = clock();
+    clock_t start = clock();
 
-  trainingRunResult_t result =
-      trainingRun(model, MODEL_SIZE, CROSS_ENTROPY, trainDataloader, testDataloader, sgd,
-                  numberOfEpochs, calculateGradsSequential, inferenceWithLoss, epochCallback);
+    trainingRunResult_t result =
+        trainingRun(model, MODEL_SIZE, CROSS_ENTROPY, trainDataloader, testDataloader, sgd,
+                    numberOfEpochs, calculateGradsSequential, inferenceWithLoss, epochCallback);
 
-  clock_t end = clock();
+    clock_t end = clock();
 
-  double duration_sec = (double)(end - start) / CLOCKS_PER_SEC;
-  PRINT_INFO("Training finished in %f seconds\n", duration_sec);
-  PRINT_INFO("Final train loss: %f, eval loss: %f\n", result.finalTrainLoss,
-             result.finalEvalStats.loss);
-  PRINT_INFO("Final accuracy: %.2f%%\n", result.finalEvalStats.accuracy * 100.0f);
+    double duration_sec = (double)(end - start) / CLOCKS_PER_SEC;
+    PRINT_INFO("Training finished in %f seconds\n", duration_sec);
+    PRINT_INFO("Final train loss: %f, eval loss: %f\n", result.finalTrainLoss,
+               result.finalEvalStats.loss);
+    PRINT_INFO("Final accuracy: %.2f%%\n", result.finalEvalStats.accuracy * 100.0f);
 }

--- a/src/layer/CMakeLists.txt
+++ b/src/layer/CMakeLists.txt
@@ -23,6 +23,7 @@ target_link_libraries(Layer PRIVATE
         Linear
         Relu
         Softmax
+        Flatten
 )
 
 add_library(Linear Linear.c)
@@ -66,6 +67,16 @@ target_link_libraries(Softmax PRIVATE
         Common
 )
 
+add_library(Flatten Flatten.c)
+target_include_directories(Flatten PUBLIC include)
+target_link_libraries(Flatten PRIVATE
+        DTypes
+        Tensor
+        Arithmetic
+        Layer
+        Common
+)
+
 add_library(CommonLayerLibs INTERFACE)
 target_link_libraries(CommonLayerLibs INTERFACE
         Layer
@@ -73,6 +84,7 @@ target_link_libraries(CommonLayerLibs INTERFACE
         Relu
         Conv1d
         Softmax
+        Flatten
         Rounding
         Tensor
         Sgd

--- a/src/layer/Flatten.c
+++ b/src/layer/Flatten.c
@@ -28,6 +28,12 @@ void flattenBackward(layer_t *flattenLayer, tensor_t *forwardInput, tensor_t *lo
   size_t numberOfElements = calcNumberOfElementsByTensor(loss);
   size_t numberOfBytes = calcNumberOfBytesForData(loss->quantization, numberOfElements);
   memcpy(propLoss->data, loss->data, numberOfBytes);
+
+  if (loss->quantization->type == SYM_INT32) {
+    symInt32QConfig_t *lossQC = loss->quantization->qConfig;
+    symInt32QConfig_t *propLossQC = propLoss->quantization->qConfig;
+    propLossQC->scale = lossQC->scale;
+  }
 }
 
 void flattenCalcOutputShape(layer_t *flattenLayer, shape_t *inputShape, shape_t *outputShape) {

--- a/src/layer/Flatten.c
+++ b/src/layer/Flatten.c
@@ -1,16 +1,17 @@
 #define SOURCE_FILE "FLATTEN"
 
 #include <stdlib.h>
+#include <string.h>
 
 #include "Common.h"
 #include "Flatten.h"
 
 void flattenForward(layer_t *flattenLayer, tensor_t *input, tensor_t *output) {
   (void)flattenLayer;
-  (void)input;
-  (void)output;
-  PRINT_ERROR("flattenForward not implemented yet");
-  exit(1);
+
+  size_t numberOfElements = calcNumberOfElementsByTensor(input);
+  size_t numberOfBytes = calcNumberOfBytesForData(input->quantization, numberOfElements);
+  memcpy(output->data, input->data, numberOfBytes);
 }
 
 void flattenBackward(layer_t *flattenLayer, tensor_t *forwardInput, tensor_t *loss,

--- a/src/layer/Flatten.c
+++ b/src/layer/Flatten.c
@@ -24,10 +24,10 @@ void flattenBackward(layer_t *flattenLayer, tensor_t *forwardInput, tensor_t *lo
                      tensor_t *propLoss) {
   (void)flattenLayer;
   (void)forwardInput;
-  (void)loss;
-  (void)propLoss;
-  PRINT_ERROR("flattenBackward not implemented yet");
-  exit(1);
+
+  size_t numberOfElements = calcNumberOfElementsByTensor(loss);
+  size_t numberOfBytes = calcNumberOfBytesForData(loss->quantization, numberOfElements);
+  memcpy(propLoss->data, loss->data, numberOfBytes);
 }
 
 void flattenCalcOutputShape(layer_t *flattenLayer, shape_t *inputShape, shape_t *outputShape) {

--- a/src/layer/Flatten.c
+++ b/src/layer/Flatten.c
@@ -25,8 +25,15 @@ void flattenBackward(layer_t *flattenLayer, tensor_t *forwardInput, tensor_t *lo
 
 void flattenCalcOutputShape(layer_t *flattenLayer, shape_t *inputShape, shape_t *outputShape) {
   (void)flattenLayer;
-  (void)inputShape;
-  (void)outputShape;
-  PRINT_ERROR("flattenCalcOutputShape not implemented yet");
-  exit(1);
+
+  size_t batch = inputShape->dimensions[0];
+  size_t features = 1;
+  for (size_t i = 1; i < inputShape->numberOfDimensions; i++) {
+    features *= inputShape->dimensions[i];
+  }
+
+  outputShape->dimensions[0] = batch;
+  outputShape->dimensions[1] = features;
+  outputShape->numberOfDimensions = 2;
+  setOrderOfDimsForNewTensor(outputShape->numberOfDimensions, outputShape->orderOfDimensions);
 }

--- a/src/layer/Flatten.c
+++ b/src/layer/Flatten.c
@@ -45,6 +45,8 @@ void flattenCalcOutputShape(layer_t *flattenLayer, shape_t *inputShape, shape_t 
         features *= inputShape->dimensions[i];
     }
 
+    // Precondition: caller allocates outputShape->dimensions and
+    // ->orderOfDimensions with >= 2 slots, regardless of input rank.
     outputShape->dimensions[0] = batch;
     outputShape->dimensions[1] = features;
     outputShape->numberOfDimensions = 2;

--- a/src/layer/Flatten.c
+++ b/src/layer/Flatten.c
@@ -7,46 +7,46 @@
 #include "Flatten.h"
 
 void flattenForward(layer_t *flattenLayer, tensor_t *input, tensor_t *output) {
-  (void)flattenLayer;
+    (void)flattenLayer;
 
-  size_t numberOfElements = calcNumberOfElementsByTensor(input);
-  size_t numberOfBytes = calcNumberOfBytesForData(input->quantization, numberOfElements);
-  memcpy(output->data, input->data, numberOfBytes);
+    size_t numberOfElements = calcNumberOfElementsByTensor(input);
+    size_t numberOfBytes = calcNumberOfBytesForData(input->quantization, numberOfElements);
+    memcpy(output->data, input->data, numberOfBytes);
 
-  if (input->quantization->type == SYM_INT32) {
-    symInt32QConfig_t *inputQC = input->quantization->qConfig;
-    symInt32QConfig_t *outputQC = output->quantization->qConfig;
-    outputQC->scale = inputQC->scale;
-  }
+    if (input->quantization->type == SYM_INT32) {
+        symInt32QConfig_t *inputQC = input->quantization->qConfig;
+        symInt32QConfig_t *outputQC = output->quantization->qConfig;
+        outputQC->scale = inputQC->scale;
+    }
 }
 
 void flattenBackward(layer_t *flattenLayer, tensor_t *forwardInput, tensor_t *loss,
                      tensor_t *propLoss) {
-  (void)flattenLayer;
-  (void)forwardInput;
+    (void)flattenLayer;
+    (void)forwardInput;
 
-  size_t numberOfElements = calcNumberOfElementsByTensor(loss);
-  size_t numberOfBytes = calcNumberOfBytesForData(loss->quantization, numberOfElements);
-  memcpy(propLoss->data, loss->data, numberOfBytes);
+    size_t numberOfElements = calcNumberOfElementsByTensor(loss);
+    size_t numberOfBytes = calcNumberOfBytesForData(loss->quantization, numberOfElements);
+    memcpy(propLoss->data, loss->data, numberOfBytes);
 
-  if (loss->quantization->type == SYM_INT32) {
-    symInt32QConfig_t *lossQC = loss->quantization->qConfig;
-    symInt32QConfig_t *propLossQC = propLoss->quantization->qConfig;
-    propLossQC->scale = lossQC->scale;
-  }
+    if (loss->quantization->type == SYM_INT32) {
+        symInt32QConfig_t *lossQC = loss->quantization->qConfig;
+        symInt32QConfig_t *propLossQC = propLoss->quantization->qConfig;
+        propLossQC->scale = lossQC->scale;
+    }
 }
 
 void flattenCalcOutputShape(layer_t *flattenLayer, shape_t *inputShape, shape_t *outputShape) {
-  (void)flattenLayer;
+    (void)flattenLayer;
 
-  size_t batch = inputShape->dimensions[0];
-  size_t features = 1;
-  for (size_t i = 1; i < inputShape->numberOfDimensions; i++) {
-    features *= inputShape->dimensions[i];
-  }
+    size_t batch = inputShape->dimensions[0];
+    size_t features = 1;
+    for (size_t i = 1; i < inputShape->numberOfDimensions; i++) {
+        features *= inputShape->dimensions[i];
+    }
 
-  outputShape->dimensions[0] = batch;
-  outputShape->dimensions[1] = features;
-  outputShape->numberOfDimensions = 2;
-  setOrderOfDimsForNewTensor(outputShape->numberOfDimensions, outputShape->orderOfDimensions);
+    outputShape->dimensions[0] = batch;
+    outputShape->dimensions[1] = features;
+    outputShape->numberOfDimensions = 2;
+    setOrderOfDimsForNewTensor(outputShape->numberOfDimensions, outputShape->orderOfDimensions);
 }

--- a/src/layer/Flatten.c
+++ b/src/layer/Flatten.c
@@ -1,0 +1,32 @@
+#define SOURCE_FILE "FLATTEN"
+
+#include <stdlib.h>
+
+#include "Common.h"
+#include "Flatten.h"
+
+void flattenForward(layer_t *flattenLayer, tensor_t *input, tensor_t *output) {
+  (void)flattenLayer;
+  (void)input;
+  (void)output;
+  PRINT_ERROR("flattenForward not implemented yet");
+  exit(1);
+}
+
+void flattenBackward(layer_t *flattenLayer, tensor_t *forwardInput, tensor_t *loss,
+                     tensor_t *propLoss) {
+  (void)flattenLayer;
+  (void)forwardInput;
+  (void)loss;
+  (void)propLoss;
+  PRINT_ERROR("flattenBackward not implemented yet");
+  exit(1);
+}
+
+void flattenCalcOutputShape(layer_t *flattenLayer, shape_t *inputShape, shape_t *outputShape) {
+  (void)flattenLayer;
+  (void)inputShape;
+  (void)outputShape;
+  PRINT_ERROR("flattenCalcOutputShape not implemented yet");
+  exit(1);
+}

--- a/src/layer/Flatten.c
+++ b/src/layer/Flatten.c
@@ -12,6 +12,12 @@ void flattenForward(layer_t *flattenLayer, tensor_t *input, tensor_t *output) {
   size_t numberOfElements = calcNumberOfElementsByTensor(input);
   size_t numberOfBytes = calcNumberOfBytesForData(input->quantization, numberOfElements);
   memcpy(output->data, input->data, numberOfBytes);
+
+  if (input->quantization->type == SYM_INT32) {
+    symInt32QConfig_t *inputQC = input->quantization->qConfig;
+    symInt32QConfig_t *outputQC = output->quantization->qConfig;
+    outputQC->scale = inputQC->scale;
+  }
 }
 
 void flattenBackward(layer_t *flattenLayer, tensor_t *forwardInput, tensor_t *loss,

--- a/src/layer/Layer.c
+++ b/src/layer/Layer.c
@@ -14,6 +14,6 @@ layerFunctions_t layerFunctions[] = {
     [FLATTEN] = {flattenForward, flattenBackward, flattenCalcOutputShape}};
 
 void initLayer(layer_t *layer, layerType_t type, layerConfig_t *config) {
-  layer->type = type;
-  layer->config = config;
+    layer->type = type;
+    layer->config = config;
 }

--- a/src/layer/Layer.c
+++ b/src/layer/Layer.c
@@ -1,19 +1,19 @@
 #define SOURCE_FILE "LAYER"
 
+#include "Layer.h"
+#include "Flatten.h"
 #include "Linear.h"
 #include "Relu.h"
 #include "Softmax.h"
-#include "Layer.h"
-
 
 layerFunctions_t layerFunctions[] = {
     [LINEAR] = {linearForward, linearBackward, linearCalcOutputShape},
     [RELU] = {reluForward, reluBackward, reluCalcOutputShape},
     [CONV1D] = {NULL, NULL, NULL},
-    [SOFTMAX] = {softmaxForward, softmaxBackward, softmaxCalcOutputShape}
-};
+    [SOFTMAX] = {softmaxForward, softmaxBackward, softmaxCalcOutputShape},
+    [FLATTEN] = {flattenForward, flattenBackward, flattenCalcOutputShape}};
 
-void initLayer(layer_t *layer, layerType_t type, layerConfig_t* config) {
-    layer->type = type;
-    layer->config = config;
+void initLayer(layer_t *layer, layerType_t type, layerConfig_t *config) {
+  layer->type = type;
+  layer->config = config;
 }

--- a/src/layer/include/Flatten.h
+++ b/src/layer/include/Flatten.h
@@ -1,0 +1,12 @@
+#ifndef ODT_FLATTEN_H
+#define ODT_FLATTEN_H
+
+#include "Layer.h"
+#include "Tensor.h"
+
+void flattenForward(layer_t *flattenLayer, tensor_t *input, tensor_t *output);
+void flattenBackward(layer_t *flattenLayer, tensor_t *forwardInput, tensor_t *loss,
+                     tensor_t *propLoss);
+void flattenCalcOutputShape(layer_t *flattenLayer, shape_t *inputShape, shape_t *outputShape);
+
+#endif

--- a/src/layer/include/Layer.h
+++ b/src/layer/include/Layer.h
@@ -7,49 +7,42 @@ typedef struct linearConfig linearConfig_t;
 typedef struct reluConfig reluConfig_t;
 typedef struct softmaxConfig softmaxConfig_t;
 
-typedef enum layerType
-{
+typedef enum layerType {
     LINEAR,
     RELU,
     CONV1D,
     SOFTMAX,
+    FLATTEN,
     SEQUENTIAL,
     QUANTIZATION
 } layerType_t;
 
-typedef enum layerQType
-{
-    FLOAT_LAYER,
-    ASYM_LAYER
-} layerQType_t;
+typedef enum layerQType { FLOAT_LAYER, ASYM_LAYER } layerQType_t;
 
-typedef union layerConfig
-{
-    linearConfig_t* linear;
-    reluConfig_t* relu;
-    softmaxConfig_t* softmax;
+typedef union layerConfig {
+    linearConfig_t *linear;
+    reluConfig_t *relu;
+    softmaxConfig_t *softmax;
 } layerConfig_t;
 
-typedef struct layer
-{
+typedef struct layer {
     layerType_t type;
-    layerConfig_t* config;
+    layerConfig_t *config;
 } layer_t;
 
-typedef void (*forwardFn_t)(layer_t* layer, tensor_t* inputTensor, tensor_t* outputTensor);
-typedef void (*backwardFn_t)(layer_t* layer, tensor_t* forwardInput, tensor_t* loss, tensor_t* propLoss);
-typedef void (*calcOutputShapeFn_t)(layer_t* layer, shape_t* inputShape, shape_t* outputShape);
+typedef void (*forwardFn_t)(layer_t *layer, tensor_t *inputTensor, tensor_t *outputTensor);
+typedef void (*backwardFn_t)(layer_t *layer, tensor_t *forwardInput, tensor_t *loss,
+                             tensor_t *propLoss);
+typedef void (*calcOutputShapeFn_t)(layer_t *layer, shape_t *inputShape, shape_t *outputShape);
 
-typedef struct layerFunctions
-{
+typedef struct layerFunctions {
     forwardFn_t forward;
     backwardFn_t backward;
     calcOutputShapeFn_t calcOutputShape;
 } layerFunctions_t;
 
-
 extern layerFunctions_t layerFunctions[];
 
-void initLayer(layer_t* layer, layerType_t layerType, layerConfig_t* config);
+void initLayer(layer_t *layer, layerType_t layerType, layerConfig_t *config);
 
 #endif

--- a/src/serial/Deserialize.c
+++ b/src/serial/Deserialize.c
@@ -12,106 +12,106 @@
 #include "Tensor.h"
 
 void deserializeTensor(tensor_t *tensor, FILE *f) {
-  deserializeShape(tensor->shape, f);
-  deserializeQuantization(tensor->quantization, f);
+    deserializeShape(tensor->shape, f);
+    deserializeQuantization(tensor->quantization, f);
 
-  size_t numberOfValues = calcNumberOfElementsByShape(tensor->shape);
-  size_t bytesPerValue = calcBytesPerElement(tensor->quantization);
+    size_t numberOfValues = calcNumberOfElementsByShape(tensor->shape);
+    size_t bytesPerValue = calcBytesPerElement(tensor->quantization);
 
-  deserializeData(tensor->data, numberOfValues, bytesPerValue, f);
-  deserializeSparsity();
+    deserializeData(tensor->data, numberOfValues, bytesPerValue, f);
+    deserializeSparsity();
 }
 
 void deserializeParameter(parameter_t *parameter, FILE *f) {
-  deserializeTensor(parameter->param, f);
-  deserializeTensor(parameter->grad, f);
+    deserializeTensor(parameter->param, f);
+    deserializeTensor(parameter->grad, f);
 }
 
 void deserializeModel(layer_t **model, size_t sizeModel, FILE *f) {
-  for (size_t i = 0; i < sizeModel; i++) {
-    deserializeLayer(model[i], f);
-  }
+    for (size_t i = 0; i < sizeModel; i++) {
+        deserializeLayer(model[i], f);
+    }
 }
 
 // Helper Functions
 
 static void deserialize(void *values, size_t numberOfElements, size_t sizeOfElement, FILE *f) {
-  fread(values, numberOfElements, sizeOfElement, f);
+    fread(values, numberOfElements, sizeOfElement, f);
 }
 
 static void deserializeShape(shape_t *shape, FILE *f) {
-  deserialize(&shape->numberOfDimensions, 1, sizeof(size_t), f);
-  deserialize(shape->dimensions, shape->numberOfDimensions, sizeof(size_t), f);
-  deserialize(shape->orderOfDimensions, shape->numberOfDimensions, sizeof(size_t), f);
+    deserialize(&shape->numberOfDimensions, 1, sizeof(size_t), f);
+    deserialize(shape->dimensions, shape->numberOfDimensions, sizeof(size_t), f);
+    deserialize(shape->orderOfDimensions, shape->numberOfDimensions, sizeof(size_t), f);
 }
 
 static void deserializeQuantization(quantization_t *q, FILE *f) {
-  deserialize(&q->type, 1, sizeof(qtype_t), f);
-  deserializeQConfig(q, f);
+    deserialize(&q->type, 1, sizeof(qtype_t), f);
+    deserializeQConfig(q, f);
 }
 
 static void deserializeData(uint8_t *data, size_t numberOfValues, size_t bytesPerValue, FILE *f) {
-  deserialize(data, numberOfValues, bytesPerValue, f);
+    deserialize(data, numberOfValues, bytesPerValue, f);
 }
 
 static void deserializeQConfig(quantization_t *q, FILE *f) {
-  switch (q->type) {
-  case INT32:
-  case FLOAT32:
-    break;
-  case SYM_INT32:
-    symInt32QConfig_t *symIntQC = q->qConfig;
-    deserialize(&symIntQC->scale, 1, sizeof(float), f);
-    deserialize(&symIntQC->roundingMode, 1, sizeof(roundingMode_t), f);
-    deserialize(&symIntQC->qMaxBits, 1, sizeof(uint8_t), f);
-    break;
-  case SYM:
-    symQConfig_t *symQC = q->qConfig;
-    deserialize(&symQC->scale, 1, sizeof(float), f);
-    deserialize(&symQC->qBits, 1, sizeof(uint8_t), f);
-    break;
-  case ASYM:
-    asymQConfig_t *asymQC = q->qConfig;
-    deserialize(&asymQC->scale, 1, sizeof(float), f);
-    deserialize(&asymQC->qBits, 1, sizeof(uint8_t), f);
-    deserialize(&asymQC->roundingMode, 1, sizeof(roundingMode_t), f);
-    deserialize(&asymQC->zeroPoint, 1, sizeof(int16_t), f);
-    break;
-  default:
-    PRINT_ERROR("Unknown qType!");
-    exit(1);
-  }
+    switch (q->type) {
+    case INT32:
+    case FLOAT32:
+        break;
+    case SYM_INT32:
+        symInt32QConfig_t *symIntQC = q->qConfig;
+        deserialize(&symIntQC->scale, 1, sizeof(float), f);
+        deserialize(&symIntQC->roundingMode, 1, sizeof(roundingMode_t), f);
+        deserialize(&symIntQC->qMaxBits, 1, sizeof(uint8_t), f);
+        break;
+    case SYM:
+        symQConfig_t *symQC = q->qConfig;
+        deserialize(&symQC->scale, 1, sizeof(float), f);
+        deserialize(&symQC->qBits, 1, sizeof(uint8_t), f);
+        break;
+    case ASYM:
+        asymQConfig_t *asymQC = q->qConfig;
+        deserialize(&asymQC->scale, 1, sizeof(float), f);
+        deserialize(&asymQC->qBits, 1, sizeof(uint8_t), f);
+        deserialize(&asymQC->roundingMode, 1, sizeof(roundingMode_t), f);
+        deserialize(&asymQC->zeroPoint, 1, sizeof(int16_t), f);
+        break;
+    default:
+        PRINT_ERROR("Unknown qType!");
+        exit(1);
+    }
 }
 
 // TODO
 static void deserializeSparsity() {}
 
 static void deserializeLayer(layer_t *layer, FILE *f) {
-  switch (layer->type) {
-  case LINEAR:
-    linearConfig_t *linearConfig = layer->config->linear;
-    deserializeParameter(linearConfig->weights, f);
-    deserializeParameter(linearConfig->bias, f);
-    deserializeQuantization(linearConfig->forwardQ, f);
-    deserializeQuantization(linearConfig->weightGradQ, f);
-    deserializeQuantization(linearConfig->biasGradQ, f);
-    deserializeQuantization(linearConfig->propLossQ, f);
-    break;
-  case RELU:
-    reluConfig_t *reluConfig = layer->config->relu;
-    deserializeQuantization(reluConfig->forwardQ, f);
-    deserializeQuantization(reluConfig->backwardQ, f);
-    break;
-  case SOFTMAX:
-    softmaxConfig_t *softmaxConfig = layer->config->softmax;
-    deserializeQuantization(softmaxConfig->forwardQ, f);
-    deserializeQuantization(softmaxConfig->backwardQ, f);
-    break;
-  case FLATTEN:
-    // Flatten carries no state (no parameters, no quantization).
-    break;
-  default:
-    PRINT_ERROR("Unsupported qtype!\n");
-    exit(1);
-  }
+    switch (layer->type) {
+    case LINEAR:
+        linearConfig_t *linearConfig = layer->config->linear;
+        deserializeParameter(linearConfig->weights, f);
+        deserializeParameter(linearConfig->bias, f);
+        deserializeQuantization(linearConfig->forwardQ, f);
+        deserializeQuantization(linearConfig->weightGradQ, f);
+        deserializeQuantization(linearConfig->biasGradQ, f);
+        deserializeQuantization(linearConfig->propLossQ, f);
+        break;
+    case RELU:
+        reluConfig_t *reluConfig = layer->config->relu;
+        deserializeQuantization(reluConfig->forwardQ, f);
+        deserializeQuantization(reluConfig->backwardQ, f);
+        break;
+    case SOFTMAX:
+        softmaxConfig_t *softmaxConfig = layer->config->softmax;
+        deserializeQuantization(softmaxConfig->forwardQ, f);
+        deserializeQuantization(softmaxConfig->backwardQ, f);
+        break;
+    case FLATTEN:
+        // Flatten carries no state (no parameters, no quantization).
+        break;
+    default:
+        PRINT_ERROR("Unsupported qtype!\n");
+        exit(1);
+    }
 }

--- a/src/serial/Deserialize.c
+++ b/src/serial/Deserialize.c
@@ -2,115 +2,116 @@
 
 #include <stdlib.h>
 
-#include "DeserializeInternal.h"
-#include "Deserialize.h"
 #include "Common.h"
-#include "Tensor.h"
-#include "Rounding.h"
+#include "Deserialize.h"
+#include "DeserializeInternal.h"
 #include "Linear.h"
 #include "Relu.h"
+#include "Rounding.h"
 #include "Softmax.h"
-
+#include "Tensor.h"
 
 void deserializeTensor(tensor_t *tensor, FILE *f) {
-    deserializeShape(tensor->shape, f);
-    deserializeQuantization(tensor->quantization, f);
+  deserializeShape(tensor->shape, f);
+  deserializeQuantization(tensor->quantization, f);
 
-    size_t numberOfValues = calcNumberOfElementsByShape(tensor->shape);
-    size_t bytesPerValue = calcBytesPerElement(tensor->quantization);
+  size_t numberOfValues = calcNumberOfElementsByShape(tensor->shape);
+  size_t bytesPerValue = calcBytesPerElement(tensor->quantization);
 
-    deserializeData(tensor->data, numberOfValues, bytesPerValue, f);
-    deserializeSparsity();
+  deserializeData(tensor->data, numberOfValues, bytesPerValue, f);
+  deserializeSparsity();
 }
 
 void deserializeParameter(parameter_t *parameter, FILE *f) {
-    deserializeTensor(parameter->param, f);
-    deserializeTensor(parameter->grad, f);
+  deserializeTensor(parameter->param, f);
+  deserializeTensor(parameter->grad, f);
 }
 
 void deserializeModel(layer_t **model, size_t sizeModel, FILE *f) {
-    for (size_t i = 0; i < sizeModel; i++) {
-        deserializeLayer(model[i], f);
-    }
+  for (size_t i = 0; i < sizeModel; i++) {
+    deserializeLayer(model[i], f);
+  }
 }
 
 // Helper Functions
 
 static void deserialize(void *values, size_t numberOfElements, size_t sizeOfElement, FILE *f) {
-    fread(values, numberOfElements, sizeOfElement, f);
+  fread(values, numberOfElements, sizeOfElement, f);
 }
 
 static void deserializeShape(shape_t *shape, FILE *f) {
-    deserialize(&shape->numberOfDimensions, 1, sizeof(size_t), f);
-    deserialize(shape->dimensions, shape->numberOfDimensions, sizeof(size_t), f);
-    deserialize(shape->orderOfDimensions, shape->numberOfDimensions, sizeof(size_t), f);
+  deserialize(&shape->numberOfDimensions, 1, sizeof(size_t), f);
+  deserialize(shape->dimensions, shape->numberOfDimensions, sizeof(size_t), f);
+  deserialize(shape->orderOfDimensions, shape->numberOfDimensions, sizeof(size_t), f);
 }
 
 static void deserializeQuantization(quantization_t *q, FILE *f) {
-    deserialize(&q->type, 1, sizeof(qtype_t), f);
-    deserializeQConfig(q, f);
+  deserialize(&q->type, 1, sizeof(qtype_t), f);
+  deserializeQConfig(q, f);
 }
 
 static void deserializeData(uint8_t *data, size_t numberOfValues, size_t bytesPerValue, FILE *f) {
-    deserialize(data, numberOfValues, bytesPerValue, f);
+  deserialize(data, numberOfValues, bytesPerValue, f);
 }
 
 static void deserializeQConfig(quantization_t *q, FILE *f) {
-    switch (q->type) {
-    case INT32:
-    case FLOAT32:
-        break;
-    case SYM_INT32:
-        symInt32QConfig_t *symIntQC = q->qConfig;
-        deserialize(&symIntQC->scale, 1, sizeof(float), f);
-        deserialize(&symIntQC->roundingMode, 1, sizeof(roundingMode_t), f);
-        deserialize(&symIntQC->qMaxBits, 1, sizeof(uint8_t), f);
-        break;
-    case SYM:
-        symQConfig_t *symQC = q->qConfig;
-        deserialize(&symQC->scale, 1, sizeof(float), f);
-        deserialize(&symQC->qBits, 1, sizeof(uint8_t), f);
-        break;
-    case ASYM:
-        asymQConfig_t *asymQC = q->qConfig;
-        deserialize(&asymQC->scale, 1, sizeof(float), f);
-        deserialize(&asymQC->qBits, 1, sizeof(uint8_t), f);
-        deserialize(&asymQC->roundingMode, 1, sizeof(roundingMode_t), f);
-        deserialize(&asymQC->zeroPoint, 1, sizeof(int16_t), f);
-        break;
-    default:
-        PRINT_ERROR("Unknown qType!");
-        exit(1);
-    }
+  switch (q->type) {
+  case INT32:
+  case FLOAT32:
+    break;
+  case SYM_INT32:
+    symInt32QConfig_t *symIntQC = q->qConfig;
+    deserialize(&symIntQC->scale, 1, sizeof(float), f);
+    deserialize(&symIntQC->roundingMode, 1, sizeof(roundingMode_t), f);
+    deserialize(&symIntQC->qMaxBits, 1, sizeof(uint8_t), f);
+    break;
+  case SYM:
+    symQConfig_t *symQC = q->qConfig;
+    deserialize(&symQC->scale, 1, sizeof(float), f);
+    deserialize(&symQC->qBits, 1, sizeof(uint8_t), f);
+    break;
+  case ASYM:
+    asymQConfig_t *asymQC = q->qConfig;
+    deserialize(&asymQC->scale, 1, sizeof(float), f);
+    deserialize(&asymQC->qBits, 1, sizeof(uint8_t), f);
+    deserialize(&asymQC->roundingMode, 1, sizeof(roundingMode_t), f);
+    deserialize(&asymQC->zeroPoint, 1, sizeof(int16_t), f);
+    break;
+  default:
+    PRINT_ERROR("Unknown qType!");
+    exit(1);
+  }
 }
 
 // TODO
 static void deserializeSparsity() {}
 
-
 static void deserializeLayer(layer_t *layer, FILE *f) {
-    switch (layer->type) {
-    case LINEAR:
-        linearConfig_t *linearConfig = layer->config->linear;
-        deserializeParameter(linearConfig->weights, f);
-        deserializeParameter(linearConfig->bias, f);
-        deserializeQuantization(linearConfig->forwardQ, f);
-        deserializeQuantization(linearConfig->weightGradQ, f);
-        deserializeQuantization(linearConfig->biasGradQ, f);
-        deserializeQuantization(linearConfig->propLossQ, f);
-        break;
-    case RELU:
-        reluConfig_t *reluConfig = layer->config->relu;
-        deserializeQuantization(reluConfig->forwardQ, f);
-        deserializeQuantization(reluConfig->backwardQ, f);
-        break;
-    case SOFTMAX:
-        softmaxConfig_t *softmaxConfig = layer->config->softmax;
-        deserializeQuantization(softmaxConfig->forwardQ, f);
-        deserializeQuantization(softmaxConfig->backwardQ, f);
-        break;
-    default:
-        PRINT_ERROR("Unsupported qtype!\n");
-        exit(1);
-    }
+  switch (layer->type) {
+  case LINEAR:
+    linearConfig_t *linearConfig = layer->config->linear;
+    deserializeParameter(linearConfig->weights, f);
+    deserializeParameter(linearConfig->bias, f);
+    deserializeQuantization(linearConfig->forwardQ, f);
+    deserializeQuantization(linearConfig->weightGradQ, f);
+    deserializeQuantization(linearConfig->biasGradQ, f);
+    deserializeQuantization(linearConfig->propLossQ, f);
+    break;
+  case RELU:
+    reluConfig_t *reluConfig = layer->config->relu;
+    deserializeQuantization(reluConfig->forwardQ, f);
+    deserializeQuantization(reluConfig->backwardQ, f);
+    break;
+  case SOFTMAX:
+    softmaxConfig_t *softmaxConfig = layer->config->softmax;
+    deserializeQuantization(softmaxConfig->forwardQ, f);
+    deserializeQuantization(softmaxConfig->backwardQ, f);
+    break;
+  case FLATTEN:
+    // Flatten carries no state (no parameters, no quantization).
+    break;
+  default:
+    PRINT_ERROR("Unsupported qtype!\n");
+    exit(1);
+  }
 }

--- a/src/serial/Serialize.c
+++ b/src/serial/Serialize.c
@@ -2,114 +2,116 @@
 
 #include <stdlib.h>
 
-#include "SerializeInternal.h"
-#include "Serialize.h"
 #include "Common.h"
-#include "Tensor.h"
-#include "Rounding.h"
 #include "Layer.h"
 #include "Linear.h"
 #include "Relu.h"
+#include "Rounding.h"
+#include "Serialize.h"
+#include "SerializeInternal.h"
 #include "Softmax.h"
+#include "Tensor.h"
 
 void serializeTensor(tensor_t *tensor, FILE *f) {
-    size_t numberOfValues = calcNumberOfElementsByTensor(tensor);
-    size_t bytesPerValue = calcBytesPerElement(tensor->quantization);
+  size_t numberOfValues = calcNumberOfElementsByTensor(tensor);
+  size_t bytesPerValue = calcBytesPerElement(tensor->quantization);
 
-    serializeShape(tensor->shape, f);
-    serializeQuantization(tensor->quantization, f);
-    serializeData(tensor->data, numberOfValues, bytesPerValue, f);
-    serializeSparsity();
+  serializeShape(tensor->shape, f);
+  serializeQuantization(tensor->quantization, f);
+  serializeData(tensor->data, numberOfValues, bytesPerValue, f);
+  serializeSparsity();
 }
 
 void serializeParameter(parameter_t *parameter, FILE *f) {
-    serializeTensor(parameter->param, f);
-    serializeTensor(parameter->grad, f);
+  serializeTensor(parameter->param, f);
+  serializeTensor(parameter->grad, f);
 }
 
 void serializeModel(layer_t **model, size_t sizeModel, FILE *f) {
-    for (size_t i = 0; i < sizeModel; i++) {
-        serializeLayer(model[i], f);
-    }
+  for (size_t i = 0; i < sizeModel; i++) {
+    serializeLayer(model[i], f);
+  }
 }
 
 // Helper Functions
 
 static void serialize(void *values, size_t numberOfElements, size_t sizeOfElement, FILE *f) {
-    fwrite(values, numberOfElements, sizeOfElement, f);
+  fwrite(values, numberOfElements, sizeOfElement, f);
 }
 
 static void serializeShape(shape_t *shape, FILE *f) {
-    serialize(&shape->numberOfDimensions, 1, sizeof(size_t), f);
-    serialize(shape->dimensions, shape->numberOfDimensions, sizeof(size_t), f);
-    serialize(shape->orderOfDimensions, shape->numberOfDimensions, sizeof(size_t), f);
+  serialize(&shape->numberOfDimensions, 1, sizeof(size_t), f);
+  serialize(shape->dimensions, shape->numberOfDimensions, sizeof(size_t), f);
+  serialize(shape->orderOfDimensions, shape->numberOfDimensions, sizeof(size_t), f);
 }
 
 static void serializeQuantization(quantization_t *q, FILE *f) {
-    serialize(&q->type, 1, sizeof(qtype_t), f);
-    serializeQConfig(q, f);
+  serialize(&q->type, 1, sizeof(qtype_t), f);
+  serializeQConfig(q, f);
 }
 
 static void serializeData(uint8_t *data, size_t numberOfValues, size_t bytesPerValue, FILE *f) {
-    serialize(data, numberOfValues, bytesPerValue, f);
+  serialize(data, numberOfValues, bytesPerValue, f);
 }
 
 static void serializeQConfig(quantization_t *q, FILE *f) {
-    switch (q->type) {
-    case INT32:
-    case FLOAT32:
-        break;
-    case SYM_INT32:
-        symInt32QConfig_t *symIntQC = q->qConfig;
-        serialize(&symIntQC->scale, 1, sizeof(float), f);
-        serialize(&symIntQC->roundingMode, 1, sizeof(roundingMode_t), f);
-        serialize(&symIntQC->qMaxBits, 1, sizeof(uint8_t), f);
-        break;
-    case SYM:
-        symQConfig_t *symQC = q->qConfig;
-        serialize(&symQC->scale, 1, sizeof(float), f);
-        serialize(&symQC->qBits, 1, sizeof(uint8_t), f);
-        break;
-    case ASYM:
-        asymQConfig_t *asymQC = q->qConfig;
-        serialize(&asymQC->scale, 1, sizeof(float), f);
-        serialize(&asymQC->qBits, 1, sizeof(uint8_t), f);
-        serialize(&asymQC->roundingMode, 1, sizeof(roundingMode_t), f);
-        serialize(&asymQC->zeroPoint, 1, sizeof(int16_t), f);
-        break;
-    default:
-        PRINT_ERROR("Unknown qType!");
-        exit(1);
-    }
+  switch (q->type) {
+  case INT32:
+  case FLOAT32:
+    break;
+  case SYM_INT32:
+    symInt32QConfig_t *symIntQC = q->qConfig;
+    serialize(&symIntQC->scale, 1, sizeof(float), f);
+    serialize(&symIntQC->roundingMode, 1, sizeof(roundingMode_t), f);
+    serialize(&symIntQC->qMaxBits, 1, sizeof(uint8_t), f);
+    break;
+  case SYM:
+    symQConfig_t *symQC = q->qConfig;
+    serialize(&symQC->scale, 1, sizeof(float), f);
+    serialize(&symQC->qBits, 1, sizeof(uint8_t), f);
+    break;
+  case ASYM:
+    asymQConfig_t *asymQC = q->qConfig;
+    serialize(&asymQC->scale, 1, sizeof(float), f);
+    serialize(&asymQC->qBits, 1, sizeof(uint8_t), f);
+    serialize(&asymQC->roundingMode, 1, sizeof(roundingMode_t), f);
+    serialize(&asymQC->zeroPoint, 1, sizeof(int16_t), f);
+    break;
+  default:
+    PRINT_ERROR("Unknown qType!");
+    exit(1);
+  }
 }
 
 // TODO
 static void serializeSparsity() {}
 
-
 static void serializeLayer(layer_t *layer, FILE *f) {
-    switch (layer->type) {
-    case LINEAR:
-        linearConfig_t *linearConfig = layer->config->linear;
-        serializeParameter(linearConfig->weights, f);
-        serializeParameter(linearConfig->bias, f);
-        serializeQuantization(linearConfig->forwardQ, f);
-        serializeQuantization(linearConfig->weightGradQ, f);
-        serializeQuantization(linearConfig->biasGradQ, f);
-        serializeQuantization(linearConfig->propLossQ, f);
-        break;
-    case RELU:
-        reluConfig_t *reluConfig = layer->config->relu;
-        serializeQuantization(reluConfig->forwardQ, f);
-        serializeQuantization(reluConfig->backwardQ, f);
-        break;
-    case SOFTMAX:
-        softmaxConfig_t *softmaxConfig = layer->config->softmax;
-        serializeQuantization(softmaxConfig->forwardQ, f);
-        serializeQuantization(softmaxConfig->backwardQ, f);
-        break;
-    default:
-        PRINT_ERROR("Unsupported qtype!\n");
-        exit(1);
-    }
+  switch (layer->type) {
+  case LINEAR:
+    linearConfig_t *linearConfig = layer->config->linear;
+    serializeParameter(linearConfig->weights, f);
+    serializeParameter(linearConfig->bias, f);
+    serializeQuantization(linearConfig->forwardQ, f);
+    serializeQuantization(linearConfig->weightGradQ, f);
+    serializeQuantization(linearConfig->biasGradQ, f);
+    serializeQuantization(linearConfig->propLossQ, f);
+    break;
+  case RELU:
+    reluConfig_t *reluConfig = layer->config->relu;
+    serializeQuantization(reluConfig->forwardQ, f);
+    serializeQuantization(reluConfig->backwardQ, f);
+    break;
+  case SOFTMAX:
+    softmaxConfig_t *softmaxConfig = layer->config->softmax;
+    serializeQuantization(softmaxConfig->forwardQ, f);
+    serializeQuantization(softmaxConfig->backwardQ, f);
+    break;
+  case FLATTEN:
+    // Flatten carries no state (no parameters, no quantization).
+    break;
+  default:
+    PRINT_ERROR("Unsupported qtype!\n");
+    exit(1);
+  }
 }

--- a/src/serial/Serialize.c
+++ b/src/serial/Serialize.c
@@ -13,105 +13,105 @@
 #include "Tensor.h"
 
 void serializeTensor(tensor_t *tensor, FILE *f) {
-  size_t numberOfValues = calcNumberOfElementsByTensor(tensor);
-  size_t bytesPerValue = calcBytesPerElement(tensor->quantization);
+    size_t numberOfValues = calcNumberOfElementsByTensor(tensor);
+    size_t bytesPerValue = calcBytesPerElement(tensor->quantization);
 
-  serializeShape(tensor->shape, f);
-  serializeQuantization(tensor->quantization, f);
-  serializeData(tensor->data, numberOfValues, bytesPerValue, f);
-  serializeSparsity();
+    serializeShape(tensor->shape, f);
+    serializeQuantization(tensor->quantization, f);
+    serializeData(tensor->data, numberOfValues, bytesPerValue, f);
+    serializeSparsity();
 }
 
 void serializeParameter(parameter_t *parameter, FILE *f) {
-  serializeTensor(parameter->param, f);
-  serializeTensor(parameter->grad, f);
+    serializeTensor(parameter->param, f);
+    serializeTensor(parameter->grad, f);
 }
 
 void serializeModel(layer_t **model, size_t sizeModel, FILE *f) {
-  for (size_t i = 0; i < sizeModel; i++) {
-    serializeLayer(model[i], f);
-  }
+    for (size_t i = 0; i < sizeModel; i++) {
+        serializeLayer(model[i], f);
+    }
 }
 
 // Helper Functions
 
 static void serialize(void *values, size_t numberOfElements, size_t sizeOfElement, FILE *f) {
-  fwrite(values, numberOfElements, sizeOfElement, f);
+    fwrite(values, numberOfElements, sizeOfElement, f);
 }
 
 static void serializeShape(shape_t *shape, FILE *f) {
-  serialize(&shape->numberOfDimensions, 1, sizeof(size_t), f);
-  serialize(shape->dimensions, shape->numberOfDimensions, sizeof(size_t), f);
-  serialize(shape->orderOfDimensions, shape->numberOfDimensions, sizeof(size_t), f);
+    serialize(&shape->numberOfDimensions, 1, sizeof(size_t), f);
+    serialize(shape->dimensions, shape->numberOfDimensions, sizeof(size_t), f);
+    serialize(shape->orderOfDimensions, shape->numberOfDimensions, sizeof(size_t), f);
 }
 
 static void serializeQuantization(quantization_t *q, FILE *f) {
-  serialize(&q->type, 1, sizeof(qtype_t), f);
-  serializeQConfig(q, f);
+    serialize(&q->type, 1, sizeof(qtype_t), f);
+    serializeQConfig(q, f);
 }
 
 static void serializeData(uint8_t *data, size_t numberOfValues, size_t bytesPerValue, FILE *f) {
-  serialize(data, numberOfValues, bytesPerValue, f);
+    serialize(data, numberOfValues, bytesPerValue, f);
 }
 
 static void serializeQConfig(quantization_t *q, FILE *f) {
-  switch (q->type) {
-  case INT32:
-  case FLOAT32:
-    break;
-  case SYM_INT32:
-    symInt32QConfig_t *symIntQC = q->qConfig;
-    serialize(&symIntQC->scale, 1, sizeof(float), f);
-    serialize(&symIntQC->roundingMode, 1, sizeof(roundingMode_t), f);
-    serialize(&symIntQC->qMaxBits, 1, sizeof(uint8_t), f);
-    break;
-  case SYM:
-    symQConfig_t *symQC = q->qConfig;
-    serialize(&symQC->scale, 1, sizeof(float), f);
-    serialize(&symQC->qBits, 1, sizeof(uint8_t), f);
-    break;
-  case ASYM:
-    asymQConfig_t *asymQC = q->qConfig;
-    serialize(&asymQC->scale, 1, sizeof(float), f);
-    serialize(&asymQC->qBits, 1, sizeof(uint8_t), f);
-    serialize(&asymQC->roundingMode, 1, sizeof(roundingMode_t), f);
-    serialize(&asymQC->zeroPoint, 1, sizeof(int16_t), f);
-    break;
-  default:
-    PRINT_ERROR("Unknown qType!");
-    exit(1);
-  }
+    switch (q->type) {
+    case INT32:
+    case FLOAT32:
+        break;
+    case SYM_INT32:
+        symInt32QConfig_t *symIntQC = q->qConfig;
+        serialize(&symIntQC->scale, 1, sizeof(float), f);
+        serialize(&symIntQC->roundingMode, 1, sizeof(roundingMode_t), f);
+        serialize(&symIntQC->qMaxBits, 1, sizeof(uint8_t), f);
+        break;
+    case SYM:
+        symQConfig_t *symQC = q->qConfig;
+        serialize(&symQC->scale, 1, sizeof(float), f);
+        serialize(&symQC->qBits, 1, sizeof(uint8_t), f);
+        break;
+    case ASYM:
+        asymQConfig_t *asymQC = q->qConfig;
+        serialize(&asymQC->scale, 1, sizeof(float), f);
+        serialize(&asymQC->qBits, 1, sizeof(uint8_t), f);
+        serialize(&asymQC->roundingMode, 1, sizeof(roundingMode_t), f);
+        serialize(&asymQC->zeroPoint, 1, sizeof(int16_t), f);
+        break;
+    default:
+        PRINT_ERROR("Unknown qType!");
+        exit(1);
+    }
 }
 
 // TODO
 static void serializeSparsity() {}
 
 static void serializeLayer(layer_t *layer, FILE *f) {
-  switch (layer->type) {
-  case LINEAR:
-    linearConfig_t *linearConfig = layer->config->linear;
-    serializeParameter(linearConfig->weights, f);
-    serializeParameter(linearConfig->bias, f);
-    serializeQuantization(linearConfig->forwardQ, f);
-    serializeQuantization(linearConfig->weightGradQ, f);
-    serializeQuantization(linearConfig->biasGradQ, f);
-    serializeQuantization(linearConfig->propLossQ, f);
-    break;
-  case RELU:
-    reluConfig_t *reluConfig = layer->config->relu;
-    serializeQuantization(reluConfig->forwardQ, f);
-    serializeQuantization(reluConfig->backwardQ, f);
-    break;
-  case SOFTMAX:
-    softmaxConfig_t *softmaxConfig = layer->config->softmax;
-    serializeQuantization(softmaxConfig->forwardQ, f);
-    serializeQuantization(softmaxConfig->backwardQ, f);
-    break;
-  case FLATTEN:
-    // Flatten carries no state (no parameters, no quantization).
-    break;
-  default:
-    PRINT_ERROR("Unsupported qtype!\n");
-    exit(1);
-  }
+    switch (layer->type) {
+    case LINEAR:
+        linearConfig_t *linearConfig = layer->config->linear;
+        serializeParameter(linearConfig->weights, f);
+        serializeParameter(linearConfig->bias, f);
+        serializeQuantization(linearConfig->forwardQ, f);
+        serializeQuantization(linearConfig->weightGradQ, f);
+        serializeQuantization(linearConfig->biasGradQ, f);
+        serializeQuantization(linearConfig->propLossQ, f);
+        break;
+    case RELU:
+        reluConfig_t *reluConfig = layer->config->relu;
+        serializeQuantization(reluConfig->forwardQ, f);
+        serializeQuantization(reluConfig->backwardQ, f);
+        break;
+    case SOFTMAX:
+        softmaxConfig_t *softmaxConfig = layer->config->softmax;
+        serializeQuantization(softmaxConfig->forwardQ, f);
+        serializeQuantization(softmaxConfig->backwardQ, f);
+        break;
+    case FLATTEN:
+        // Flatten carries no state (no parameters, no quantization).
+        break;
+    default:
+        PRINT_ERROR("Unsupported qtype!\n");
+        exit(1);
+    }
 }

--- a/src/userApi/layer/CMakeLists.txt
+++ b/src/userApi/layer/CMakeLists.txt
@@ -30,3 +30,13 @@ target_link_libraries(SoftmaxApi PRIVATE
         Common
         StorageApi
 )
+
+add_library(FlattenApi FlattenApi.c)
+target_include_directories(FlattenApi PUBLIC include)
+target_link_libraries(FlattenApi PRIVATE
+        Tensor
+        Rounding
+        Layer
+        Common
+        StorageApi
+)

--- a/src/userApi/layer/FlattenApi.c
+++ b/src/userApi/layer/FlattenApi.c
@@ -6,6 +6,7 @@
 layer_t *flattenLayerInit(void) {
     layer_t *flattenLayer = *reserveMemory(sizeof(layer_t));
     flattenLayer->type = FLATTEN;
+    // Load-bearing: initLayerOutputs' FLATTEN case never reads config.
     flattenLayer->config = NULL;
     return flattenLayer;
 }

--- a/src/userApi/layer/FlattenApi.c
+++ b/src/userApi/layer/FlattenApi.c
@@ -1,0 +1,13 @@
+#define SOURCE_FILE "FLATTEN_API"
+
+#include "FlattenApi.h"
+#include "StorageApi.h"
+
+layer_t *flattenLayerInit(void) {
+  layer_t *flattenLayer = *reserveMemory(sizeof(layer_t));
+  flattenLayer->type = FLATTEN;
+  flattenLayer->config = NULL;
+  return flattenLayer;
+}
+
+void freeFlattenLayer(layer_t *flattenLayer) { freeReservedMemory(flattenLayer); }

--- a/src/userApi/layer/FlattenApi.c
+++ b/src/userApi/layer/FlattenApi.c
@@ -4,10 +4,12 @@
 #include "StorageApi.h"
 
 layer_t *flattenLayerInit(void) {
-  layer_t *flattenLayer = *reserveMemory(sizeof(layer_t));
-  flattenLayer->type = FLATTEN;
-  flattenLayer->config = NULL;
-  return flattenLayer;
+    layer_t *flattenLayer = *reserveMemory(sizeof(layer_t));
+    flattenLayer->type = FLATTEN;
+    flattenLayer->config = NULL;
+    return flattenLayer;
 }
 
-void freeFlattenLayer(layer_t *flattenLayer) { freeReservedMemory(flattenLayer); }
+void freeFlattenLayer(layer_t *flattenLayer) {
+    freeReservedMemory(flattenLayer);
+}

--- a/src/userApi/layer/include/FlattenApi.h
+++ b/src/userApi/layer/include/FlattenApi.h
@@ -1,0 +1,9 @@
+#ifndef ODT_FLATTEN_API_H
+#define ODT_FLATTEN_API_H
+
+#include "Layer.h"
+
+layer_t *flattenLayerInit(void);
+void freeFlattenLayer(layer_t *flattenLayer);
+
+#endif

--- a/src/userApi/training_loop/calculate_grads/CalculateGradsSequential.c
+++ b/src/userApi/training_loop/calculate_grads/CalculateGradsSequential.c
@@ -2,215 +2,216 @@
 
 #include <stdbool.h>
 #include <stdio.h>
-#include <string.h>
 #include <stdlib.h>
+#include <string.h>
 
-#include "LossFunction.h"
-#include "Layer.h"
-#include "TensorApi.h"
-#include "StorageApi.h"
 #include "CalculateGradsSequential.h"
-#include "TrainingLoopApiInternal.h"
-#include "Linear.h"
-#include "Relu.h"
 #include "Common.h"
+#include "Layer.h"
+#include "Linear.h"
+#include "LossFunction.h"
+#include "Relu.h"
 #include "Softmax.h"
+#include "StorageApi.h"
+#include "TensorApi.h"
+#include "TrainingLoopApiInternal.h"
 
+trainingStats_t *calculateGradsSequential(layer_t **model, size_t modelSize, lossType_t lossType,
+                                          tensor_t *input, tensor_t *label) {
 
-trainingStats_t *calculateGradsSequential(layer_t **model, size_t modelSize,
-                                          lossType_t lossType, tensor_t *input,
-                                          tensor_t *label) {
+  tensor_t *layerOutputs[modelSize + 1];
+  layerOutputs[0] = input;
+  initLayerOutputs(layerOutputs, model, modelSize);
 
-    tensor_t *layerOutputs[modelSize + 1];
-    layerOutputs[0] = input;
-    initLayerOutputs(layerOutputs, model, modelSize);
+  // Forward pass
+  for (size_t i = 0; i < modelSize; i++) {
+    layer_t *currentLayer = model[i];
+    layerType_t currentLayerType = currentLayer->type;
+    forwardFn_t forward = layerFunctions[currentLayerType].forward;
+    forward(currentLayer, layerOutputs[i], layerOutputs[i + 1]);
+  }
 
-    // Forward pass
-    for (size_t i = 0; i < modelSize; i++) {
-        layer_t *currentLayer = model[i];
-        layerType_t currentLayerType = currentLayer->type;
-        forwardFn_t forward = layerFunctions[currentLayerType].forward;
-        forward(currentLayer, layerOutputs[i], layerOutputs[i + 1]);
-    }
+  trainingStats_t *trainingStats = initTrainingStats(layerOutputs[modelSize]);
+  copyTensor(trainingStats->output, layerOutputs[modelSize]);
 
-    trainingStats_t *trainingStats = initTrainingStats(layerOutputs[modelSize]);
-    copyTensor(trainingStats->output, layerOutputs[modelSize]);
+  // LOSS
 
-    // LOSS
+  lossFunctions_t lossFns = lossFunctions[lossType];
+  float loss = lossFns.forward(layerOutputs[modelSize], label);
+  trainingStats->loss = loss;
 
-    lossFunctions_t lossFns = lossFunctions[lossType];
-    float loss = lossFns.forward(layerOutputs[modelSize], label);
-    trainingStats->loss = loss;
+  // Backward pass
+  size_t backwardIndex = modelSize - 1;
+  if (lossType == CROSS_ENTROPY) {
+    backwardIndex -= 1;
+  }
 
-    // Backward pass
-    size_t backwardIndex = modelSize - 1;
-    if (lossType == CROSS_ENTROPY) {
-        backwardIndex -= 1;
-    }
+  tensor_t gradNext;
+  initGradTensor(&gradNext, layerOutputs[modelSize]);
+  lossFns.backward(layerOutputs[modelSize], label, &gradNext);
 
-    tensor_t gradNext;
-    initGradTensor(&gradNext, layerOutputs[modelSize]);
-    lossFns.backward(layerOutputs[modelSize], label, &gradNext);
+  for (int i = (int)backwardIndex; i >= 0; i--) {
+    tensor_t gradCurr;
+    initGradTensor(&gradCurr, layerOutputs[i]);
 
-    for (int i = (int)backwardIndex; i >= 0; i--) {
-        tensor_t gradCurr;
-        initGradTensor(&gradCurr, layerOutputs[i]);
+    layerType_t layerType = model[i]->type;
+    backwardFn_t backward = layerFunctions[layerType].backward;
 
-        layerType_t layerType = model[i]->type;
-        backwardFn_t backward = layerFunctions[layerType].backward;
-
-        backward(model[i], layerOutputs[i], &gradNext, &gradCurr);
-
-        deInitGradTensor(&gradNext);
-        gradNext = gradCurr;
-    }
+    backward(model[i], layerOutputs[i], &gradNext, &gradCurr);
 
     deInitGradTensor(&gradNext);
-    deInitLayerOutputs(layerOutputs, modelSize);
+    gradNext = gradCurr;
+  }
 
-    return trainingStats;
+  deInitGradTensor(&gradNext);
+  deInitLayerOutputs(layerOutputs, modelSize);
+
+  return trainingStats;
 }
-
 
 static void initLayerOutputs(tensor_t **layerOutputs, layer_t **model, size_t sizeNetwork) {
-    for (size_t i = 0; i < sizeNetwork; i++) {
-        layer_t *currentLayer = model[i];
-        quantization_t *currentQ = NULL;
+  for (size_t i = 0; i < sizeNetwork; i++) {
+    layer_t *currentLayer = model[i];
+    quantization_t *currentQ = NULL;
 
-        switch (currentLayer->type) {
-        case LINEAR:
-            linearConfig_t *linearConfig = currentLayer->config->linear;
-            currentQ = linearConfig->forwardQ;
-            break;
-        case RELU:
-            reluConfig_t *reluConfig = currentLayer->config->relu;
-            currentQ = reluConfig->forwardQ;
-            break;
-        case SOFTMAX:
-            softmaxConfig_t *softmaxConfig = currentLayer->config->softmax;
-            currentQ = softmaxConfig->forwardQ;
-            break;
-        default:
-            PRINT_ERROR("Unknown Layer Type!");
-            exit(1);
-        }
-
-        calcOutputShapeFn_t calcOutputShape = layerFunctions[currentLayer->type].calcOutputShape;
-        size_t numberOfDims = layerOutputs[i]->shape->numberOfDimensions;
-
-        size_t *dims = *reserveMemory(numberOfDims * sizeof(size_t));
-        size_t *order = *reserveMemory(numberOfDims * sizeof(size_t));
-        shape_t *outShape = *reserveMemory(sizeof(shape_t));
-
-        outShape->dimensions = dims;
-        outShape->numberOfDimensions = numberOfDims;
-        outShape->orderOfDimensions = order;
-
-        calcOutputShape(currentLayer, layerOutputs[i]->shape, outShape);
-
-        size_t numberOfValues = calcNumberOfElementsByShape(outShape);
-        size_t sizeData = calcNumberOfBytesForData(currentQ, numberOfValues);
-        uint8_t *data = *reserveMemory(sizeData);
-
-        quantization_t *q = *reserveMemory(sizeof(quantization_t));
-        switch (currentQ->type) {
-        case FLOAT32:
-            initFloat32Quantization(q);
-            break;
-        case SYM_INT32:
-            q->type = SYM_INT32;
-            symInt32QConfig_t *currentQC = currentQ->qConfig;
-            symInt32QConfig_t *qC = *reserveMemory(sizeof(symInt32QConfig_t));
-            initSymInt32QConfig(currentQC->roundingMode, qC);
-            initSymInt32Quantization(qC, q);
-            break;
-        default:
-            PRINT_ERROR("Unknown QType!");
-            exit(1);
-        }
-
-        tensor_t *tensor = *reserveMemory(sizeof(tensor_t));
-        tensor->data = data;
-        tensor->quantization = q;
-        tensor->shape = outShape;
-
-        tensor->sparsity = NULL;
-        if (layerOutputs[i]->sparsity != NULL) {
-            sparsity_t *sparsity = *reserveMemory(sizeof(sparsity_t));
-            tensor->sparsity = sparsity;
-        }
-
-        layerOutputs[i + 1] = tensor;
+    switch (currentLayer->type) {
+    case LINEAR:
+      linearConfig_t *linearConfig = currentLayer->config->linear;
+      currentQ = linearConfig->forwardQ;
+      break;
+    case RELU:
+      reluConfig_t *reluConfig = currentLayer->config->relu;
+      currentQ = reluConfig->forwardQ;
+      break;
+    case SOFTMAX:
+      softmaxConfig_t *softmaxConfig = currentLayer->config->softmax;
+      currentQ = softmaxConfig->forwardQ;
+      break;
+    case FLATTEN:
+      // Flatten has no per-layer quantization; output dtype equals input dtype.
+      currentQ = layerOutputs[i]->quantization;
+      break;
+    default:
+      PRINT_ERROR("Unknown Layer Type!");
+      exit(1);
     }
-}
 
-static void deInitLayerOutputs(tensor_t **layerOutputs, size_t modelSize) {
-    for (size_t i = 1; i <= modelSize; i++) {
-        freeTensor(layerOutputs[i]);
-    }
-}
+    calcOutputShapeFn_t calcOutputShape = layerFunctions[currentLayer->type].calcOutputShape;
+    size_t numberOfDims = layerOutputs[i]->shape->numberOfDimensions;
 
-static void initGradTensor(tensor_t *grad, tensor_t *layerOutput) {
-    shape_t *currentShape = layerOutput->shape;
-    quantization_t *currentQ = layerOutput->quantization;
+    size_t *dims = *reserveMemory(numberOfDims * sizeof(size_t));
+    size_t *order = *reserveMemory(numberOfDims * sizeof(size_t));
+    shape_t *outShape = *reserveMemory(sizeof(shape_t));
 
-    size_t *dims = *reserveMemory(currentShape->numberOfDimensions * sizeof(size_t));
-    size_t *order = *reserveMemory(currentShape->numberOfDimensions * sizeof(size_t));
-    shape_t *inShape = *reserveMemory(sizeof(shape_t));
+    outShape->dimensions = dims;
+    outShape->numberOfDimensions = numberOfDims;
+    outShape->orderOfDimensions = order;
 
-    inShape->dimensions = dims;
-    inShape->numberOfDimensions = currentShape->numberOfDimensions;
-    inShape->orderOfDimensions = order;
+    calcOutputShape(currentLayer, layerOutputs[i]->shape, outShape);
 
-    memcpy(inShape->dimensions, currentShape->dimensions,
-           currentShape->numberOfDimensions * sizeof(size_t));
-    memcpy(inShape->orderOfDimensions, currentShape->orderOfDimensions,
-           currentShape->numberOfDimensions * sizeof(size_t));
-
-    setOrderOfDimsForNewTensor(inShape->numberOfDimensions, inShape->orderOfDimensions);
-
-    size_t numberOfValues = calcNumberOfElementsByShape(currentShape);
+    size_t numberOfValues = calcNumberOfElementsByShape(outShape);
     size_t sizeData = calcNumberOfBytesForData(currentQ, numberOfValues);
     uint8_t *data = *reserveMemory(sizeData);
 
     quantization_t *q = *reserveMemory(sizeof(quantization_t));
     switch (currentQ->type) {
     case FLOAT32:
-        initFloat32Quantization(q);
-        break;
+      initFloat32Quantization(q);
+      break;
     case SYM_INT32:
-        symInt32QConfig_t *currentQC = currentQ->qConfig;
-        symInt32QConfig_t *qC = *reserveMemory(sizeof(symInt32QConfig_t));
-        initSymInt32QConfig(currentQC->roundingMode, qC);
-        initSymInt32Quantization(qC, q);
-        break;
+      q->type = SYM_INT32;
+      symInt32QConfig_t *currentQC = currentQ->qConfig;
+      symInt32QConfig_t *qC = *reserveMemory(sizeof(symInt32QConfig_t));
+      initSymInt32QConfig(currentQC->roundingMode, qC);
+      initSymInt32Quantization(qC, q);
+      break;
     default:
-        PRINT_ERROR("Unknown QType!");
-        exit(1);
+      PRINT_ERROR("Unknown QType!");
+      exit(1);
     }
 
-    grad->data = data;
-    grad->quantization = q;
-    grad->shape = inShape;
+    tensor_t *tensor = *reserveMemory(sizeof(tensor_t));
+    tensor->data = data;
+    tensor->quantization = q;
+    tensor->shape = outShape;
 
-    grad->sparsity = NULL;
-    if (layerOutput->sparsity != NULL) {
-        sparsity_t *sparsity = *reserveMemory(sizeof(sparsity_t));
-        grad->sparsity = sparsity;
+    tensor->sparsity = NULL;
+    if (layerOutputs[i]->sparsity != NULL) {
+      sparsity_t *sparsity = *reserveMemory(sizeof(sparsity_t));
+      tensor->sparsity = sparsity;
     }
+
+    layerOutputs[i + 1] = tensor;
+  }
+}
+
+static void deInitLayerOutputs(tensor_t **layerOutputs, size_t modelSize) {
+  for (size_t i = 1; i <= modelSize; i++) {
+    freeTensor(layerOutputs[i]);
+  }
+}
+
+static void initGradTensor(tensor_t *grad, tensor_t *layerOutput) {
+  shape_t *currentShape = layerOutput->shape;
+  quantization_t *currentQ = layerOutput->quantization;
+
+  size_t *dims = *reserveMemory(currentShape->numberOfDimensions * sizeof(size_t));
+  size_t *order = *reserveMemory(currentShape->numberOfDimensions * sizeof(size_t));
+  shape_t *inShape = *reserveMemory(sizeof(shape_t));
+
+  inShape->dimensions = dims;
+  inShape->numberOfDimensions = currentShape->numberOfDimensions;
+  inShape->orderOfDimensions = order;
+
+  memcpy(inShape->dimensions, currentShape->dimensions,
+         currentShape->numberOfDimensions * sizeof(size_t));
+  memcpy(inShape->orderOfDimensions, currentShape->orderOfDimensions,
+         currentShape->numberOfDimensions * sizeof(size_t));
+
+  setOrderOfDimsForNewTensor(inShape->numberOfDimensions, inShape->orderOfDimensions);
+
+  size_t numberOfValues = calcNumberOfElementsByShape(currentShape);
+  size_t sizeData = calcNumberOfBytesForData(currentQ, numberOfValues);
+  uint8_t *data = *reserveMemory(sizeData);
+
+  quantization_t *q = *reserveMemory(sizeof(quantization_t));
+  switch (currentQ->type) {
+  case FLOAT32:
+    initFloat32Quantization(q);
+    break;
+  case SYM_INT32:
+    symInt32QConfig_t *currentQC = currentQ->qConfig;
+    symInt32QConfig_t *qC = *reserveMemory(sizeof(symInt32QConfig_t));
+    initSymInt32QConfig(currentQC->roundingMode, qC);
+    initSymInt32Quantization(qC, q);
+    break;
+  default:
+    PRINT_ERROR("Unknown QType!");
+    exit(1);
+  }
+
+  grad->data = data;
+  grad->quantization = q;
+  grad->shape = inShape;
+
+  grad->sparsity = NULL;
+  if (layerOutput->sparsity != NULL) {
+    sparsity_t *sparsity = *reserveMemory(sizeof(sparsity_t));
+    grad->sparsity = sparsity;
+  }
 }
 
 static void deInitGradTensor(tensor_t *tensor) {
-    freeData(tensor);
-    freeShape(tensor->shape);
-    freeQuantization(tensor->quantization);
+  freeData(tensor);
+  freeShape(tensor->shape);
+  freeQuantization(tensor->quantization);
 }
 
 static trainingStats_t *initTrainingStats(tensor_t *output) {
-    trainingStats_t *trainingStats = *reserveMemory(sizeof(trainingStats_t));
+  trainingStats_t *trainingStats = *reserveMemory(sizeof(trainingStats_t));
 
-    tensor_t *o = getTensorLike(output);
-    trainingStats->output = o;
+  tensor_t *o = getTensorLike(output);
+  trainingStats->output = o;
 
-    return trainingStats;
+  return trainingStats;
 }

--- a/src/userApi/training_loop/calculate_grads/CalculateGradsSequential.c
+++ b/src/userApi/training_loop/calculate_grads/CalculateGradsSequential.c
@@ -19,199 +19,199 @@
 trainingStats_t *calculateGradsSequential(layer_t **model, size_t modelSize, lossType_t lossType,
                                           tensor_t *input, tensor_t *label) {
 
-  tensor_t *layerOutputs[modelSize + 1];
-  layerOutputs[0] = input;
-  initLayerOutputs(layerOutputs, model, modelSize);
+    tensor_t *layerOutputs[modelSize + 1];
+    layerOutputs[0] = input;
+    initLayerOutputs(layerOutputs, model, modelSize);
 
-  // Forward pass
-  for (size_t i = 0; i < modelSize; i++) {
-    layer_t *currentLayer = model[i];
-    layerType_t currentLayerType = currentLayer->type;
-    forwardFn_t forward = layerFunctions[currentLayerType].forward;
-    forward(currentLayer, layerOutputs[i], layerOutputs[i + 1]);
-  }
+    // Forward pass
+    for (size_t i = 0; i < modelSize; i++) {
+        layer_t *currentLayer = model[i];
+        layerType_t currentLayerType = currentLayer->type;
+        forwardFn_t forward = layerFunctions[currentLayerType].forward;
+        forward(currentLayer, layerOutputs[i], layerOutputs[i + 1]);
+    }
 
-  trainingStats_t *trainingStats = initTrainingStats(layerOutputs[modelSize]);
-  copyTensor(trainingStats->output, layerOutputs[modelSize]);
+    trainingStats_t *trainingStats = initTrainingStats(layerOutputs[modelSize]);
+    copyTensor(trainingStats->output, layerOutputs[modelSize]);
 
-  // LOSS
+    // LOSS
 
-  lossFunctions_t lossFns = lossFunctions[lossType];
-  float loss = lossFns.forward(layerOutputs[modelSize], label);
-  trainingStats->loss = loss;
+    lossFunctions_t lossFns = lossFunctions[lossType];
+    float loss = lossFns.forward(layerOutputs[modelSize], label);
+    trainingStats->loss = loss;
 
-  // Backward pass
-  size_t backwardIndex = modelSize - 1;
-  if (lossType == CROSS_ENTROPY) {
-    backwardIndex -= 1;
-  }
+    // Backward pass
+    size_t backwardIndex = modelSize - 1;
+    if (lossType == CROSS_ENTROPY) {
+        backwardIndex -= 1;
+    }
 
-  tensor_t gradNext;
-  initGradTensor(&gradNext, layerOutputs[modelSize]);
-  lossFns.backward(layerOutputs[modelSize], label, &gradNext);
+    tensor_t gradNext;
+    initGradTensor(&gradNext, layerOutputs[modelSize]);
+    lossFns.backward(layerOutputs[modelSize], label, &gradNext);
 
-  for (int i = (int)backwardIndex; i >= 0; i--) {
-    tensor_t gradCurr;
-    initGradTensor(&gradCurr, layerOutputs[i]);
+    for (int i = (int)backwardIndex; i >= 0; i--) {
+        tensor_t gradCurr;
+        initGradTensor(&gradCurr, layerOutputs[i]);
 
-    layerType_t layerType = model[i]->type;
-    backwardFn_t backward = layerFunctions[layerType].backward;
+        layerType_t layerType = model[i]->type;
+        backwardFn_t backward = layerFunctions[layerType].backward;
 
-    backward(model[i], layerOutputs[i], &gradNext, &gradCurr);
+        backward(model[i], layerOutputs[i], &gradNext, &gradCurr);
+
+        deInitGradTensor(&gradNext);
+        gradNext = gradCurr;
+    }
 
     deInitGradTensor(&gradNext);
-    gradNext = gradCurr;
-  }
+    deInitLayerOutputs(layerOutputs, modelSize);
 
-  deInitGradTensor(&gradNext);
-  deInitLayerOutputs(layerOutputs, modelSize);
-
-  return trainingStats;
+    return trainingStats;
 }
 
 static void initLayerOutputs(tensor_t **layerOutputs, layer_t **model, size_t sizeNetwork) {
-  for (size_t i = 0; i < sizeNetwork; i++) {
-    layer_t *currentLayer = model[i];
-    quantization_t *currentQ = NULL;
+    for (size_t i = 0; i < sizeNetwork; i++) {
+        layer_t *currentLayer = model[i];
+        quantization_t *currentQ = NULL;
 
-    switch (currentLayer->type) {
-    case LINEAR:
-      linearConfig_t *linearConfig = currentLayer->config->linear;
-      currentQ = linearConfig->forwardQ;
-      break;
-    case RELU:
-      reluConfig_t *reluConfig = currentLayer->config->relu;
-      currentQ = reluConfig->forwardQ;
-      break;
-    case SOFTMAX:
-      softmaxConfig_t *softmaxConfig = currentLayer->config->softmax;
-      currentQ = softmaxConfig->forwardQ;
-      break;
-    case FLATTEN:
-      // Flatten has no per-layer quantization; output dtype equals input dtype.
-      currentQ = layerOutputs[i]->quantization;
-      break;
-    default:
-      PRINT_ERROR("Unknown Layer Type!");
-      exit(1);
+        switch (currentLayer->type) {
+        case LINEAR:
+            linearConfig_t *linearConfig = currentLayer->config->linear;
+            currentQ = linearConfig->forwardQ;
+            break;
+        case RELU:
+            reluConfig_t *reluConfig = currentLayer->config->relu;
+            currentQ = reluConfig->forwardQ;
+            break;
+        case SOFTMAX:
+            softmaxConfig_t *softmaxConfig = currentLayer->config->softmax;
+            currentQ = softmaxConfig->forwardQ;
+            break;
+        case FLATTEN:
+            // Flatten has no per-layer quantization; output dtype equals input dtype.
+            currentQ = layerOutputs[i]->quantization;
+            break;
+        default:
+            PRINT_ERROR("Unknown Layer Type!");
+            exit(1);
+        }
+
+        calcOutputShapeFn_t calcOutputShape = layerFunctions[currentLayer->type].calcOutputShape;
+        size_t numberOfDims = layerOutputs[i]->shape->numberOfDimensions;
+
+        size_t *dims = *reserveMemory(numberOfDims * sizeof(size_t));
+        size_t *order = *reserveMemory(numberOfDims * sizeof(size_t));
+        shape_t *outShape = *reserveMemory(sizeof(shape_t));
+
+        outShape->dimensions = dims;
+        outShape->numberOfDimensions = numberOfDims;
+        outShape->orderOfDimensions = order;
+
+        calcOutputShape(currentLayer, layerOutputs[i]->shape, outShape);
+
+        size_t numberOfValues = calcNumberOfElementsByShape(outShape);
+        size_t sizeData = calcNumberOfBytesForData(currentQ, numberOfValues);
+        uint8_t *data = *reserveMemory(sizeData);
+
+        quantization_t *q = *reserveMemory(sizeof(quantization_t));
+        switch (currentQ->type) {
+        case FLOAT32:
+            initFloat32Quantization(q);
+            break;
+        case SYM_INT32:
+            q->type = SYM_INT32;
+            symInt32QConfig_t *currentQC = currentQ->qConfig;
+            symInt32QConfig_t *qC = *reserveMemory(sizeof(symInt32QConfig_t));
+            initSymInt32QConfig(currentQC->roundingMode, qC);
+            initSymInt32Quantization(qC, q);
+            break;
+        default:
+            PRINT_ERROR("Unknown QType!");
+            exit(1);
+        }
+
+        tensor_t *tensor = *reserveMemory(sizeof(tensor_t));
+        tensor->data = data;
+        tensor->quantization = q;
+        tensor->shape = outShape;
+
+        tensor->sparsity = NULL;
+        if (layerOutputs[i]->sparsity != NULL) {
+            sparsity_t *sparsity = *reserveMemory(sizeof(sparsity_t));
+            tensor->sparsity = sparsity;
+        }
+
+        layerOutputs[i + 1] = tensor;
     }
+}
 
-    calcOutputShapeFn_t calcOutputShape = layerFunctions[currentLayer->type].calcOutputShape;
-    size_t numberOfDims = layerOutputs[i]->shape->numberOfDimensions;
+static void deInitLayerOutputs(tensor_t **layerOutputs, size_t modelSize) {
+    for (size_t i = 1; i <= modelSize; i++) {
+        freeTensor(layerOutputs[i]);
+    }
+}
 
-    size_t *dims = *reserveMemory(numberOfDims * sizeof(size_t));
-    size_t *order = *reserveMemory(numberOfDims * sizeof(size_t));
-    shape_t *outShape = *reserveMemory(sizeof(shape_t));
+static void initGradTensor(tensor_t *grad, tensor_t *layerOutput) {
+    shape_t *currentShape = layerOutput->shape;
+    quantization_t *currentQ = layerOutput->quantization;
 
-    outShape->dimensions = dims;
-    outShape->numberOfDimensions = numberOfDims;
-    outShape->orderOfDimensions = order;
+    size_t *dims = *reserveMemory(currentShape->numberOfDimensions * sizeof(size_t));
+    size_t *order = *reserveMemory(currentShape->numberOfDimensions * sizeof(size_t));
+    shape_t *inShape = *reserveMemory(sizeof(shape_t));
 
-    calcOutputShape(currentLayer, layerOutputs[i]->shape, outShape);
+    inShape->dimensions = dims;
+    inShape->numberOfDimensions = currentShape->numberOfDimensions;
+    inShape->orderOfDimensions = order;
 
-    size_t numberOfValues = calcNumberOfElementsByShape(outShape);
+    memcpy(inShape->dimensions, currentShape->dimensions,
+           currentShape->numberOfDimensions * sizeof(size_t));
+    memcpy(inShape->orderOfDimensions, currentShape->orderOfDimensions,
+           currentShape->numberOfDimensions * sizeof(size_t));
+
+    setOrderOfDimsForNewTensor(inShape->numberOfDimensions, inShape->orderOfDimensions);
+
+    size_t numberOfValues = calcNumberOfElementsByShape(currentShape);
     size_t sizeData = calcNumberOfBytesForData(currentQ, numberOfValues);
     uint8_t *data = *reserveMemory(sizeData);
 
     quantization_t *q = *reserveMemory(sizeof(quantization_t));
     switch (currentQ->type) {
     case FLOAT32:
-      initFloat32Quantization(q);
-      break;
+        initFloat32Quantization(q);
+        break;
     case SYM_INT32:
-      q->type = SYM_INT32;
-      symInt32QConfig_t *currentQC = currentQ->qConfig;
-      symInt32QConfig_t *qC = *reserveMemory(sizeof(symInt32QConfig_t));
-      initSymInt32QConfig(currentQC->roundingMode, qC);
-      initSymInt32Quantization(qC, q);
-      break;
+        symInt32QConfig_t *currentQC = currentQ->qConfig;
+        symInt32QConfig_t *qC = *reserveMemory(sizeof(symInt32QConfig_t));
+        initSymInt32QConfig(currentQC->roundingMode, qC);
+        initSymInt32Quantization(qC, q);
+        break;
     default:
-      PRINT_ERROR("Unknown QType!");
-      exit(1);
+        PRINT_ERROR("Unknown QType!");
+        exit(1);
     }
 
-    tensor_t *tensor = *reserveMemory(sizeof(tensor_t));
-    tensor->data = data;
-    tensor->quantization = q;
-    tensor->shape = outShape;
+    grad->data = data;
+    grad->quantization = q;
+    grad->shape = inShape;
 
-    tensor->sparsity = NULL;
-    if (layerOutputs[i]->sparsity != NULL) {
-      sparsity_t *sparsity = *reserveMemory(sizeof(sparsity_t));
-      tensor->sparsity = sparsity;
+    grad->sparsity = NULL;
+    if (layerOutput->sparsity != NULL) {
+        sparsity_t *sparsity = *reserveMemory(sizeof(sparsity_t));
+        grad->sparsity = sparsity;
     }
-
-    layerOutputs[i + 1] = tensor;
-  }
-}
-
-static void deInitLayerOutputs(tensor_t **layerOutputs, size_t modelSize) {
-  for (size_t i = 1; i <= modelSize; i++) {
-    freeTensor(layerOutputs[i]);
-  }
-}
-
-static void initGradTensor(tensor_t *grad, tensor_t *layerOutput) {
-  shape_t *currentShape = layerOutput->shape;
-  quantization_t *currentQ = layerOutput->quantization;
-
-  size_t *dims = *reserveMemory(currentShape->numberOfDimensions * sizeof(size_t));
-  size_t *order = *reserveMemory(currentShape->numberOfDimensions * sizeof(size_t));
-  shape_t *inShape = *reserveMemory(sizeof(shape_t));
-
-  inShape->dimensions = dims;
-  inShape->numberOfDimensions = currentShape->numberOfDimensions;
-  inShape->orderOfDimensions = order;
-
-  memcpy(inShape->dimensions, currentShape->dimensions,
-         currentShape->numberOfDimensions * sizeof(size_t));
-  memcpy(inShape->orderOfDimensions, currentShape->orderOfDimensions,
-         currentShape->numberOfDimensions * sizeof(size_t));
-
-  setOrderOfDimsForNewTensor(inShape->numberOfDimensions, inShape->orderOfDimensions);
-
-  size_t numberOfValues = calcNumberOfElementsByShape(currentShape);
-  size_t sizeData = calcNumberOfBytesForData(currentQ, numberOfValues);
-  uint8_t *data = *reserveMemory(sizeData);
-
-  quantization_t *q = *reserveMemory(sizeof(quantization_t));
-  switch (currentQ->type) {
-  case FLOAT32:
-    initFloat32Quantization(q);
-    break;
-  case SYM_INT32:
-    symInt32QConfig_t *currentQC = currentQ->qConfig;
-    symInt32QConfig_t *qC = *reserveMemory(sizeof(symInt32QConfig_t));
-    initSymInt32QConfig(currentQC->roundingMode, qC);
-    initSymInt32Quantization(qC, q);
-    break;
-  default:
-    PRINT_ERROR("Unknown QType!");
-    exit(1);
-  }
-
-  grad->data = data;
-  grad->quantization = q;
-  grad->shape = inShape;
-
-  grad->sparsity = NULL;
-  if (layerOutput->sparsity != NULL) {
-    sparsity_t *sparsity = *reserveMemory(sizeof(sparsity_t));
-    grad->sparsity = sparsity;
-  }
 }
 
 static void deInitGradTensor(tensor_t *tensor) {
-  freeData(tensor);
-  freeShape(tensor->shape);
-  freeQuantization(tensor->quantization);
+    freeData(tensor);
+    freeShape(tensor->shape);
+    freeQuantization(tensor->quantization);
 }
 
 static trainingStats_t *initTrainingStats(tensor_t *output) {
-  trainingStats_t *trainingStats = *reserveMemory(sizeof(trainingStats_t));
+    trainingStats_t *trainingStats = *reserveMemory(sizeof(trainingStats_t));
 
-  tensor_t *o = getTensorLike(output);
-  trainingStats->output = o;
+    tensor_t *o = getTensorLike(output);
+    trainingStats->output = o;
 
-  return trainingStats;
+    return trainingStats;
 }

--- a/src/userApi/training_loop/calculate_grads/CalculateGradsSequential.c
+++ b/src/userApi/training_loop/calculate_grads/CalculateGradsSequential.c
@@ -98,6 +98,9 @@ static void initLayerOutputs(tensor_t **layerOutputs, layer_t **model, size_t si
 
         calcOutputShapeFn_t calcOutputShape = layerFunctions[currentLayer->type].calcOutputShape;
         size_t numberOfDims = layerOutputs[i]->shape->numberOfDimensions;
+        if (currentLayer->type == FLATTEN) {
+            numberOfDims = 2;
+        }
 
         size_t *dims = *reserveMemory(numberOfDims * sizeof(size_t));
         size_t *order = *reserveMemory(numberOfDims * sizeof(size_t));

--- a/test/unit/layer/CMakeLists.txt
+++ b/test/unit/layer/CMakeLists.txt
@@ -28,3 +28,13 @@ add_elastic_ai_unit_test(
         SoftmaxApi
         QuantizationApi
 )
+
+add_elastic_ai_unit_test(
+        LIB_UNDER_TEST
+        Flatten
+        MORE_LIBS
+        CommonLayerLibs
+        FlattenApi
+        TensorApi
+        QuantizationApi
+)

--- a/test/unit/layer/UnitTestFlatten.c
+++ b/test/unit/layer/UnitTestFlatten.c
@@ -23,7 +23,7 @@ void testFlattenLayerInit_ReturnsFlattenTypedLayer(void) {
 }
 
 void testFlattenCalcOutputShape_NonSquareInput(void) {
-    // Regression test for the old flattenItemDims bug (dim[2]*dim[2])
+    // Regression: product of all trailing dims, not the squared last dim.
     // Input [1, 3, 4, 5] must flatten to [1, 60], NOT [1, 25] or similar.
     size_t inputDims[] = {1, 3, 4, 5};
     size_t inputOrder[] = {0, 1, 2, 3};

--- a/test/unit/layer/UnitTestFlatten.c
+++ b/test/unit/layer/UnitTestFlatten.c
@@ -22,11 +22,37 @@ void testFlattenLayerInit_ReturnsFlattenTypedLayer(void) {
   freeFlattenLayer(flattenLayer);
 }
 
+void testFlattenCalcOutputShape_NonSquareInput(void) {
+  // Regression test for the old flattenItemDims bug (dim[2]*dim[2])
+  // Input [1, 3, 4, 5] must flatten to [1, 60], NOT [1, 25] or similar.
+  size_t inputDims[] = {1, 3, 4, 5};
+  size_t inputOrder[] = {0, 1, 2, 3};
+  shape_t inputShape = {
+      .dimensions = inputDims, .orderOfDimensions = inputOrder, .numberOfDimensions = 4};
+
+  size_t outputDimsBuf[4] = {0};
+  size_t outputOrderBuf[4] = {0};
+  shape_t outputShape = {
+      .dimensions = outputDimsBuf, .orderOfDimensions = outputOrderBuf, .numberOfDimensions = 0};
+
+  layer_t *flatten = flattenLayerInit();
+  flattenCalcOutputShape(flatten, &inputShape, &outputShape);
+
+  TEST_ASSERT_EQUAL_UINT(2, outputShape.numberOfDimensions);
+  TEST_ASSERT_EQUAL_UINT(1, outputShape.dimensions[0]);
+  TEST_ASSERT_EQUAL_UINT(60, outputShape.dimensions[1]);
+  TEST_ASSERT_EQUAL_UINT(0, outputShape.orderOfDimensions[0]);
+  TEST_ASSERT_EQUAL_UINT(1, outputShape.orderOfDimensions[1]);
+
+  freeFlattenLayer(flatten);
+}
+
 void setUp(void) {}
 void tearDown(void) {}
 
 int main(void) {
   UNITY_BEGIN();
   RUN_TEST(testFlattenLayerInit_ReturnsFlattenTypedLayer);
+  RUN_TEST(testFlattenCalcOutputShape_NonSquareInput);
   return UNITY_END();
 }

--- a/test/unit/layer/UnitTestFlatten.c
+++ b/test/unit/layer/UnitTestFlatten.c
@@ -12,159 +12,159 @@
 #include "unity.h"
 
 void testFlattenLayerInit_ReturnsFlattenTypedLayer(void) {
-  layer_t *flattenLayer = flattenLayerInit();
+    layer_t *flattenLayer = flattenLayerInit();
 
-  TEST_ASSERT_NOT_NULL(flattenLayer);
-  TEST_ASSERT_EQUAL_INT(FLATTEN, flattenLayer->type);
-  TEST_ASSERT_NULL_MESSAGE(flattenLayer->config,
-                           "FLATTEN carries no per-layer config; layer->config must be NULL");
+    TEST_ASSERT_NOT_NULL(flattenLayer);
+    TEST_ASSERT_EQUAL_INT(FLATTEN, flattenLayer->type);
+    TEST_ASSERT_NULL_MESSAGE(flattenLayer->config,
+                             "FLATTEN carries no per-layer config; layer->config must be NULL");
 
-  freeFlattenLayer(flattenLayer);
+    freeFlattenLayer(flattenLayer);
 }
 
 void testFlattenCalcOutputShape_NonSquareInput(void) {
-  // Regression test for the old flattenItemDims bug (dim[2]*dim[2])
-  // Input [1, 3, 4, 5] must flatten to [1, 60], NOT [1, 25] or similar.
-  size_t inputDims[] = {1, 3, 4, 5};
-  size_t inputOrder[] = {0, 1, 2, 3};
-  shape_t inputShape = {
-      .dimensions = inputDims, .orderOfDimensions = inputOrder, .numberOfDimensions = 4};
+    // Regression test for the old flattenItemDims bug (dim[2]*dim[2])
+    // Input [1, 3, 4, 5] must flatten to [1, 60], NOT [1, 25] or similar.
+    size_t inputDims[] = {1, 3, 4, 5};
+    size_t inputOrder[] = {0, 1, 2, 3};
+    shape_t inputShape = {
+        .dimensions = inputDims, .orderOfDimensions = inputOrder, .numberOfDimensions = 4};
 
-  size_t outputDimsBuf[4] = {0};
-  size_t outputOrderBuf[4] = {0};
-  shape_t outputShape = {
-      .dimensions = outputDimsBuf, .orderOfDimensions = outputOrderBuf, .numberOfDimensions = 0};
+    size_t outputDimsBuf[4] = {0};
+    size_t outputOrderBuf[4] = {0};
+    shape_t outputShape = {
+        .dimensions = outputDimsBuf, .orderOfDimensions = outputOrderBuf, .numberOfDimensions = 0};
 
-  layer_t *flatten = flattenLayerInit();
-  flattenCalcOutputShape(flatten, &inputShape, &outputShape);
+    layer_t *flatten = flattenLayerInit();
+    flattenCalcOutputShape(flatten, &inputShape, &outputShape);
 
-  TEST_ASSERT_EQUAL_UINT(2, outputShape.numberOfDimensions);
-  TEST_ASSERT_EQUAL_UINT(1, outputShape.dimensions[0]);
-  TEST_ASSERT_EQUAL_UINT(60, outputShape.dimensions[1]);
-  TEST_ASSERT_EQUAL_UINT(0, outputShape.orderOfDimensions[0]);
-  TEST_ASSERT_EQUAL_UINT(1, outputShape.orderOfDimensions[1]);
+    TEST_ASSERT_EQUAL_UINT(2, outputShape.numberOfDimensions);
+    TEST_ASSERT_EQUAL_UINT(1, outputShape.dimensions[0]);
+    TEST_ASSERT_EQUAL_UINT(60, outputShape.dimensions[1]);
+    TEST_ASSERT_EQUAL_UINT(0, outputShape.orderOfDimensions[0]);
+    TEST_ASSERT_EQUAL_UINT(1, outputShape.orderOfDimensions[1]);
 
-  freeFlattenLayer(flatten);
+    freeFlattenLayer(flatten);
 }
 
 void testFlattenForwardFloat_PreservesBytesAndReshapes(void) {
-  size_t n = 12; // 1 * 2 * 2 * 3
-  float inputData[] = {1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f, 10.f, 11.f, 12.f};
-  size_t inputDims[] = {1, 2, 2, 3};
-  tensor_t *input = tensorInitFloat(inputData, inputDims, 4, NULL);
+    size_t n = 12; // 1 * 2 * 2 * 3
+    float inputData[] = {1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f, 10.f, 11.f, 12.f};
+    size_t inputDims[] = {1, 2, 2, 3};
+    tensor_t *input = tensorInitFloat(inputData, inputDims, 4, NULL);
 
-  float outputData[12] = {0};
-  size_t outputDims[] = {1, 12};
-  tensor_t *output = tensorInitFloat(outputData, outputDims, 2, NULL);
+    float outputData[12] = {0};
+    size_t outputDims[] = {1, 12};
+    tensor_t *output = tensorInitFloat(outputData, outputDims, 2, NULL);
 
-  layer_t *flatten = flattenLayerInit();
-  flattenForward(flatten, input, output);
+    layer_t *flatten = flattenLayerInit();
+    flattenForward(flatten, input, output);
 
-  float *actual = (float *)output->data;
-  TEST_ASSERT_EQUAL_FLOAT_ARRAY(inputData, actual, n);
+    float *actual = (float *)output->data;
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(inputData, actual, n);
 
-  freeFlattenLayer(flatten);
+    freeFlattenLayer(flatten);
 }
 
 void testFlattenForwardSymInt32_PropagatesScaleAndValues(void) {
-  size_t n = 6;
-  float inputFloatData[] = {1.f, 2.f, 3.f, 4.f, 5.f, 6.f};
-  size_t inputDims[] = {1, 2, 3};
-  tensor_t *input = tensorInitSymInt32(inputFloatData, inputDims, 3, HTE, NULL);
+    size_t n = 6;
+    float inputFloatData[] = {1.f, 2.f, 3.f, 4.f, 5.f, 6.f};
+    size_t inputDims[] = {1, 2, 3};
+    tensor_t *input = tensorInitSymInt32(inputFloatData, inputDims, 3, HTE, NULL);
 
-  float outputFloatData[6] = {0};
-  size_t outputDims[] = {1, 6};
-  tensor_t *output = tensorInitSymInt32(outputFloatData, outputDims, 2, HTE, NULL);
+    float outputFloatData[6] = {0};
+    size_t outputDims[] = {1, 6};
+    tensor_t *output = tensorInitSymInt32(outputFloatData, outputDims, 2, HTE, NULL);
 
-  // Clobber the output's scale so we can verify flattenForward writes it.
-  symInt32QConfig_t *outputQC = output->quantization->qConfig;
-  outputQC->scale = 0.0f;
+    // Clobber the output's scale so we can verify flattenForward writes it.
+    symInt32QConfig_t *outputQC = output->quantization->qConfig;
+    outputQC->scale = 0.0f;
 
-  layer_t *flatten = flattenLayerInit();
-  flattenForward(flatten, input, output);
+    layer_t *flatten = flattenLayerInit();
+    flattenForward(flatten, input, output);
 
-  symInt32QConfig_t *inputQC = input->quantization->qConfig;
-  TEST_ASSERT_EQUAL_FLOAT(inputQC->scale, outputQC->scale);
+    symInt32QConfig_t *inputQC = input->quantization->qConfig;
+    TEST_ASSERT_EQUAL_FLOAT(inputQC->scale, outputQC->scale);
 
-  // Values round-trip through the same scale.
-  float roundTripData[6];
-  tensor_t *roundTrip = tensorInitFloat(roundTripData, outputDims, 2, NULL);
-  convertTensor(output, roundTrip);
-  float *actual = (float *)roundTrip->data;
-  for (size_t i = 0; i < n; i++) {
-    TEST_ASSERT_FLOAT_WITHIN(0.1f, inputFloatData[i], actual[i]);
-  }
+    // Values round-trip through the same scale.
+    float roundTripData[6];
+    tensor_t *roundTrip = tensorInitFloat(roundTripData, outputDims, 2, NULL);
+    convertTensor(output, roundTrip);
+    float *actual = (float *)roundTrip->data;
+    for (size_t i = 0; i < n; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(0.1f, inputFloatData[i], actual[i]);
+    }
 
-  freeFlattenLayer(flatten);
+    freeFlattenLayer(flatten);
 }
 
 void testFlattenBackwardFloat_CopiesGradsUnchanged(void) {
-  size_t n = 6;
+    size_t n = 6;
 
-  size_t forwardDims[] = {1, 2, 3};
-  float forwardData[] = {-1.f, 0.f, 1.f, 2.f, 5.f, -6.f};
-  tensor_t *forwardInput = tensorInitFloat(forwardData, forwardDims, 3, NULL);
+    size_t forwardDims[] = {1, 2, 3};
+    float forwardData[] = {-1.f, 0.f, 1.f, 2.f, 5.f, -6.f};
+    tensor_t *forwardInput = tensorInitFloat(forwardData, forwardDims, 3, NULL);
 
-  size_t lossDims[] = {1, 6};
-  float lossData[] = {0.1f, 0.2f, -0.3f, 0.4f, 0.5f, 0.6f};
-  tensor_t *loss = tensorInitFloat(lossData, lossDims, 2, NULL);
+    size_t lossDims[] = {1, 6};
+    float lossData[] = {0.1f, 0.2f, -0.3f, 0.4f, 0.5f, 0.6f};
+    tensor_t *loss = tensorInitFloat(lossData, lossDims, 2, NULL);
 
-  float propLossData[6] = {0};
-  tensor_t *propLoss = tensorInitFloat(propLossData, forwardDims, 3, NULL);
+    float propLossData[6] = {0};
+    tensor_t *propLoss = tensorInitFloat(propLossData, forwardDims, 3, NULL);
 
-  layer_t *flatten = flattenLayerInit();
-  flattenBackward(flatten, forwardInput, loss, propLoss);
+    layer_t *flatten = flattenLayerInit();
+    flattenBackward(flatten, forwardInput, loss, propLoss);
 
-  float *actual = (float *)propLoss->data;
-  TEST_ASSERT_EQUAL_FLOAT_ARRAY(lossData, actual, n);
+    float *actual = (float *)propLoss->data;
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(lossData, actual, n);
 
-  freeFlattenLayer(flatten);
+    freeFlattenLayer(flatten);
 }
 
 void testFlattenBackwardSymInt32_PropagatesScale(void) {
-  size_t n = 6;
+    size_t n = 6;
 
-  size_t forwardDims[] = {1, 2, 3};
-  float forwardData[] = {-1.f, 0.f, 1.f, 2.f, 5.f, -6.f};
-  tensor_t *forwardInput = tensorInitSymInt32(forwardData, forwardDims, 3, HTE, NULL);
+    size_t forwardDims[] = {1, 2, 3};
+    float forwardData[] = {-1.f, 0.f, 1.f, 2.f, 5.f, -6.f};
+    tensor_t *forwardInput = tensorInitSymInt32(forwardData, forwardDims, 3, HTE, NULL);
 
-  size_t lossDims[] = {1, 6};
-  float lossFloatData[] = {0.1f, 0.2f, -0.3f, 0.4f, 0.5f, 0.6f};
-  tensor_t *loss = tensorInitSymInt32(lossFloatData, lossDims, 2, HTE, NULL);
+    size_t lossDims[] = {1, 6};
+    float lossFloatData[] = {0.1f, 0.2f, -0.3f, 0.4f, 0.5f, 0.6f};
+    tensor_t *loss = tensorInitSymInt32(lossFloatData, lossDims, 2, HTE, NULL);
 
-  float propLossFloatData[6] = {0};
-  tensor_t *propLoss = tensorInitSymInt32(propLossFloatData, forwardDims, 3, HTE, NULL);
+    float propLossFloatData[6] = {0};
+    tensor_t *propLoss = tensorInitSymInt32(propLossFloatData, forwardDims, 3, HTE, NULL);
 
-  symInt32QConfig_t *propLossQC = propLoss->quantization->qConfig;
-  propLossQC->scale = 0.0f;
+    symInt32QConfig_t *propLossQC = propLoss->quantization->qConfig;
+    propLossQC->scale = 0.0f;
 
-  layer_t *flatten = flattenLayerInit();
-  flattenBackward(flatten, forwardInput, loss, propLoss);
+    layer_t *flatten = flattenLayerInit();
+    flattenBackward(flatten, forwardInput, loss, propLoss);
 
-  symInt32QConfig_t *lossQC = loss->quantization->qConfig;
-  TEST_ASSERT_EQUAL_FLOAT(lossQC->scale, propLossQC->scale);
+    symInt32QConfig_t *lossQC = loss->quantization->qConfig;
+    TEST_ASSERT_EQUAL_FLOAT(lossQC->scale, propLossQC->scale);
 
-  float roundTripData[6];
-  tensor_t *roundTrip = tensorInitFloat(roundTripData, forwardDims, 3, NULL);
-  convertTensor(propLoss, roundTrip);
-  float *actual = (float *)roundTrip->data;
-  for (size_t i = 0; i < n; i++) {
-    TEST_ASSERT_FLOAT_WITHIN(0.1f, lossFloatData[i], actual[i]);
-  }
+    float roundTripData[6];
+    tensor_t *roundTrip = tensorInitFloat(roundTripData, forwardDims, 3, NULL);
+    convertTensor(propLoss, roundTrip);
+    float *actual = (float *)roundTrip->data;
+    for (size_t i = 0; i < n; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(0.1f, lossFloatData[i], actual[i]);
+    }
 
-  freeFlattenLayer(flatten);
+    freeFlattenLayer(flatten);
 }
 
 void setUp(void) {}
 void tearDown(void) {}
 
 int main(void) {
-  UNITY_BEGIN();
-  RUN_TEST(testFlattenLayerInit_ReturnsFlattenTypedLayer);
-  RUN_TEST(testFlattenCalcOutputShape_NonSquareInput);
-  RUN_TEST(testFlattenForwardFloat_PreservesBytesAndReshapes);
-  RUN_TEST(testFlattenForwardSymInt32_PropagatesScaleAndValues);
-  RUN_TEST(testFlattenBackwardFloat_CopiesGradsUnchanged);
-  RUN_TEST(testFlattenBackwardSymInt32_PropagatesScale);
-  return UNITY_END();
+    UNITY_BEGIN();
+    RUN_TEST(testFlattenLayerInit_ReturnsFlattenTypedLayer);
+    RUN_TEST(testFlattenCalcOutputShape_NonSquareInput);
+    RUN_TEST(testFlattenForwardFloat_PreservesBytesAndReshapes);
+    RUN_TEST(testFlattenForwardSymInt32_PropagatesScaleAndValues);
+    RUN_TEST(testFlattenBackwardFloat_CopiesGradsUnchanged);
+    RUN_TEST(testFlattenBackwardSymInt32_PropagatesScale);
+    return UNITY_END();
 }

--- a/test/unit/layer/UnitTestFlatten.c
+++ b/test/unit/layer/UnitTestFlatten.c
@@ -66,6 +66,38 @@ void testFlattenForwardFloat_PreservesBytesAndReshapes(void) {
   freeFlattenLayer(flatten);
 }
 
+void testFlattenForwardSymInt32_PropagatesScaleAndValues(void) {
+  size_t n = 6;
+  float inputFloatData[] = {1.f, 2.f, 3.f, 4.f, 5.f, 6.f};
+  size_t inputDims[] = {1, 2, 3};
+  tensor_t *input = tensorInitSymInt32(inputFloatData, inputDims, 3, HTE, NULL);
+
+  float outputFloatData[6] = {0};
+  size_t outputDims[] = {1, 6};
+  tensor_t *output = tensorInitSymInt32(outputFloatData, outputDims, 2, HTE, NULL);
+
+  // Clobber the output's scale so we can verify flattenForward writes it.
+  symInt32QConfig_t *outputQC = output->quantization->qConfig;
+  outputQC->scale = 0.0f;
+
+  layer_t *flatten = flattenLayerInit();
+  flattenForward(flatten, input, output);
+
+  symInt32QConfig_t *inputQC = input->quantization->qConfig;
+  TEST_ASSERT_EQUAL_FLOAT(inputQC->scale, outputQC->scale);
+
+  // Values round-trip through the same scale.
+  float roundTripData[6];
+  tensor_t *roundTrip = tensorInitFloat(roundTripData, outputDims, 2, NULL);
+  convertTensor(output, roundTrip);
+  float *actual = (float *)roundTrip->data;
+  for (size_t i = 0; i < n; i++) {
+    TEST_ASSERT_FLOAT_WITHIN(0.1f, inputFloatData[i], actual[i]);
+  }
+
+  freeFlattenLayer(flatten);
+}
+
 void setUp(void) {}
 void tearDown(void) {}
 
@@ -74,5 +106,6 @@ int main(void) {
   RUN_TEST(testFlattenLayerInit_ReturnsFlattenTypedLayer);
   RUN_TEST(testFlattenCalcOutputShape_NonSquareInput);
   RUN_TEST(testFlattenForwardFloat_PreservesBytesAndReshapes);
+  RUN_TEST(testFlattenForwardSymInt32_PropagatesScaleAndValues);
   return UNITY_END();
 }

--- a/test/unit/layer/UnitTestFlatten.c
+++ b/test/unit/layer/UnitTestFlatten.c
@@ -121,6 +121,40 @@ void testFlattenBackwardFloat_CopiesGradsUnchanged(void) {
   freeFlattenLayer(flatten);
 }
 
+void testFlattenBackwardSymInt32_PropagatesScale(void) {
+  size_t n = 6;
+
+  size_t forwardDims[] = {1, 2, 3};
+  float forwardData[] = {-1.f, 0.f, 1.f, 2.f, 5.f, -6.f};
+  tensor_t *forwardInput = tensorInitSymInt32(forwardData, forwardDims, 3, HTE, NULL);
+
+  size_t lossDims[] = {1, 6};
+  float lossFloatData[] = {0.1f, 0.2f, -0.3f, 0.4f, 0.5f, 0.6f};
+  tensor_t *loss = tensorInitSymInt32(lossFloatData, lossDims, 2, HTE, NULL);
+
+  float propLossFloatData[6] = {0};
+  tensor_t *propLoss = tensorInitSymInt32(propLossFloatData, forwardDims, 3, HTE, NULL);
+
+  symInt32QConfig_t *propLossQC = propLoss->quantization->qConfig;
+  propLossQC->scale = 0.0f;
+
+  layer_t *flatten = flattenLayerInit();
+  flattenBackward(flatten, forwardInput, loss, propLoss);
+
+  symInt32QConfig_t *lossQC = loss->quantization->qConfig;
+  TEST_ASSERT_EQUAL_FLOAT(lossQC->scale, propLossQC->scale);
+
+  float roundTripData[6];
+  tensor_t *roundTrip = tensorInitFloat(roundTripData, forwardDims, 3, NULL);
+  convertTensor(propLoss, roundTrip);
+  float *actual = (float *)roundTrip->data;
+  for (size_t i = 0; i < n; i++) {
+    TEST_ASSERT_FLOAT_WITHIN(0.1f, lossFloatData[i], actual[i]);
+  }
+
+  freeFlattenLayer(flatten);
+}
+
 void setUp(void) {}
 void tearDown(void) {}
 
@@ -131,5 +165,6 @@ int main(void) {
   RUN_TEST(testFlattenForwardFloat_PreservesBytesAndReshapes);
   RUN_TEST(testFlattenForwardSymInt32_PropagatesScaleAndValues);
   RUN_TEST(testFlattenBackwardFloat_CopiesGradsUnchanged);
+  RUN_TEST(testFlattenBackwardSymInt32_PropagatesScale);
   return UNITY_END();
 }

--- a/test/unit/layer/UnitTestFlatten.c
+++ b/test/unit/layer/UnitTestFlatten.c
@@ -47,6 +47,25 @@ void testFlattenCalcOutputShape_NonSquareInput(void) {
   freeFlattenLayer(flatten);
 }
 
+void testFlattenForwardFloat_PreservesBytesAndReshapes(void) {
+  size_t n = 12; // 1 * 2 * 2 * 3
+  float inputData[] = {1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f, 10.f, 11.f, 12.f};
+  size_t inputDims[] = {1, 2, 2, 3};
+  tensor_t *input = tensorInitFloat(inputData, inputDims, 4, NULL);
+
+  float outputData[12] = {0};
+  size_t outputDims[] = {1, 12};
+  tensor_t *output = tensorInitFloat(outputData, outputDims, 2, NULL);
+
+  layer_t *flatten = flattenLayerInit();
+  flattenForward(flatten, input, output);
+
+  float *actual = (float *)output->data;
+  TEST_ASSERT_EQUAL_FLOAT_ARRAY(inputData, actual, n);
+
+  freeFlattenLayer(flatten);
+}
+
 void setUp(void) {}
 void tearDown(void) {}
 
@@ -54,5 +73,6 @@ int main(void) {
   UNITY_BEGIN();
   RUN_TEST(testFlattenLayerInit_ReturnsFlattenTypedLayer);
   RUN_TEST(testFlattenCalcOutputShape_NonSquareInput);
+  RUN_TEST(testFlattenForwardFloat_PreservesBytesAndReshapes);
   return UNITY_END();
 }

--- a/test/unit/layer/UnitTestFlatten.c
+++ b/test/unit/layer/UnitTestFlatten.c
@@ -1,0 +1,32 @@
+#define SOURCE_FILE "UNIT_TEST_FLATTEN"
+
+#include "DTypes.h"
+#include "Flatten.h"
+#include "FlattenApi.h"
+#include "Layer.h"
+#include "Quantization.h"
+#include "QuantizationApi.h"
+#include "Tensor.h"
+#include "TensorApi.h"
+#include "TensorConversion.h"
+#include "unity.h"
+
+void testFlattenLayerInit_ReturnsFlattenTypedLayer(void) {
+  layer_t *flattenLayer = flattenLayerInit();
+
+  TEST_ASSERT_NOT_NULL(flattenLayer);
+  TEST_ASSERT_EQUAL_INT(FLATTEN, flattenLayer->type);
+  TEST_ASSERT_NULL_MESSAGE(flattenLayer->config,
+                           "FLATTEN carries no per-layer config; layer->config must be NULL");
+
+  freeFlattenLayer(flattenLayer);
+}
+
+void setUp(void) {}
+void tearDown(void) {}
+
+int main(void) {
+  UNITY_BEGIN();
+  RUN_TEST(testFlattenLayerInit_ReturnsFlattenTypedLayer);
+  return UNITY_END();
+}

--- a/test/unit/layer/UnitTestFlatten.c
+++ b/test/unit/layer/UnitTestFlatten.c
@@ -98,6 +98,29 @@ void testFlattenForwardSymInt32_PropagatesScaleAndValues(void) {
   freeFlattenLayer(flatten);
 }
 
+void testFlattenBackwardFloat_CopiesGradsUnchanged(void) {
+  size_t n = 6;
+
+  size_t forwardDims[] = {1, 2, 3};
+  float forwardData[] = {-1.f, 0.f, 1.f, 2.f, 5.f, -6.f};
+  tensor_t *forwardInput = tensorInitFloat(forwardData, forwardDims, 3, NULL);
+
+  size_t lossDims[] = {1, 6};
+  float lossData[] = {0.1f, 0.2f, -0.3f, 0.4f, 0.5f, 0.6f};
+  tensor_t *loss = tensorInitFloat(lossData, lossDims, 2, NULL);
+
+  float propLossData[6] = {0};
+  tensor_t *propLoss = tensorInitFloat(propLossData, forwardDims, 3, NULL);
+
+  layer_t *flatten = flattenLayerInit();
+  flattenBackward(flatten, forwardInput, loss, propLoss);
+
+  float *actual = (float *)propLoss->data;
+  TEST_ASSERT_EQUAL_FLOAT_ARRAY(lossData, actual, n);
+
+  freeFlattenLayer(flatten);
+}
+
 void setUp(void) {}
 void tearDown(void) {}
 
@@ -107,5 +130,6 @@ int main(void) {
   RUN_TEST(testFlattenCalcOutputShape_NonSquareInput);
   RUN_TEST(testFlattenForwardFloat_PreservesBytesAndReshapes);
   RUN_TEST(testFlattenForwardSymInt32_PropagatesScaleAndValues);
+  RUN_TEST(testFlattenBackwardFloat_CopiesGradsUnchanged);
   return UNITY_END();
 }

--- a/test/unit/layer/UnitTestLinear.c
+++ b/test/unit/layer/UnitTestLinear.c
@@ -1,13 +1,15 @@
+#include <string.h>
+
 #include "DTypes.h"
 #include "Layer.h"
 #include "Linear.h"
+#include "LinearApi.h"
+#include "QuantizationApi.h"
 #include "Rounding.h"
 #include "Tensor.h"
+#include "TensorApi.h"
 #include "TensorConversion.h"
 #include "unity.h"
-#include "TensorApi.h"
-#include "QuantizationApi.h"
-#include "LinearApi.h"
 
 void setUp() {}
 void tearDown() {}
@@ -134,7 +136,8 @@ void testLinearBackwardFloat() {
                                  .numberOfDimensions = forwardInputNumberOfDims};
     quantization_t forwardInputQ;
     initFloat32Quantization(&forwardInputQ);
-    setTensorValues(&forwardInput, (uint8_t *)forwardInputData, &forwardInputShape, &forwardInputQ, NULL);
+    setTensorValues(&forwardInput, (uint8_t *)forwardInputData, &forwardInputShape, &forwardInputQ,
+                    NULL);
 
     tensor_t loss;
     float lossData[] = {-4.f, -3.f};
@@ -194,7 +197,8 @@ void testLinearForwardSymInt32() {
     float weightData[] = {-1.f, 2.f, -3.f, 4.f, 5.f, -6.f};
     size_t weightDims[] = {2, 3};
     size_t weightNumberOfDims = 2;
-    tensor_t *weightsParam = tensorInitSymInt32(weightData, weightDims, weightNumberOfDims, HTE, NULL);
+    tensor_t *weightsParam =
+        tensorInitSymInt32(weightData, weightDims, weightNumberOfDims, HTE, NULL);
     tensor_t *weightsGrad = gradInitSymInt32(weightsParam, HTE, NULL);
     parameter_t *weights = parameterInit(weightsParam, weightsGrad);
 
@@ -211,6 +215,7 @@ void testLinearForwardSymInt32() {
     tensor_t *input = tensorInitSymInt32(inputData, inputDims, inputNumberOfDims, HTE, NULL);
 
     float outputData[numberOfOutputs];
+    memset(outputData, 0, sizeof(outputData));
     size_t outputDims[] = {1, 2};
     size_t outputNumberOfDims = 2;
     tensor_t *output = tensorInitSymInt32(outputData, outputDims, outputNumberOfDims, HTE, NULL);
@@ -240,10 +245,10 @@ void testLinearBackwardSymInt32() {
     float weightFloatData[] = {-1.f, 2.f, -3.f, 4.f, 5.f, -6.f};
     size_t weightDims[] = {2, 3};
     size_t weightNumberOfDims = 2;
-    tensor_t *weightsParam = tensorInitSymInt32(weightFloatData, weightDims, weightNumberOfDims, HTE, NULL);
+    tensor_t *weightsParam =
+        tensorInitSymInt32(weightFloatData, weightDims, weightNumberOfDims, HTE, NULL);
     tensor_t *weightsGrad = gradInitSymInt32(weightsParam, HTE, NULL);
     parameter_t *weights = parameterInit(weightsParam, weightsGrad);
-
 
     float biasData[] = {-1, 3};
     size_t biasDims[] = {1, 2};
@@ -255,7 +260,8 @@ void testLinearBackwardSymInt32() {
     float forwardInputData[] = {0.f, 1.f, 2.f};
     size_t forwardInputDims[] = {1, 3};
     size_t forwardInputNumberOfDims = 2;
-    tensor_t *forwardInput = tensorInitSymInt32(forwardInputData, forwardInputDims, forwardInputNumberOfDims, HTE, NULL);
+    tensor_t *forwardInput =
+        tensorInitSymInt32(forwardInputData, forwardInputDims, forwardInputNumberOfDims, HTE, NULL);
 
     float lossData[] = {-4.f, -3.f};
     size_t lossDims[] = {1, 2};
@@ -263,9 +269,11 @@ void testLinearBackwardSymInt32() {
     tensor_t *loss = tensorInitSymInt32(lossData, lossDims, lossNumberOfDims, HTE, NULL);
 
     float propLossData[numberOfForwardInputs];
+    memset(propLossData, 0, sizeof(propLossData));
     size_t propLossDims[] = {numberOfForwardInputs};
     size_t propLossNumberOfDims = 1;
-    tensor_t *propLoss = tensorInitSymInt32(propLossData, propLossDims, propLossNumberOfDims, HTE, NULL);
+    tensor_t *propLoss =
+        tensorInitSymInt32(propLossData, propLossDims, propLossNumberOfDims, HTE, NULL);
 
     quantization_t *test = quantizationInitSymInt32(HTE);
     layer_t *linearLayer = linearLayerInit(weights, bias, test, test, test, test);
@@ -277,8 +285,8 @@ void testLinearBackwardSymInt32() {
     float weightGradFloatData[numberOfWeights];
     quantization_t weightGradFloatQ;
     initFloat32Quantization(&weightGradFloatQ);
-    setTensorValuesForConversion((uint8_t *)weightGradFloatData, &weightGradFloatQ, linearConfig->weights->grad,
-                                 &weightGradsFloat);
+    setTensorValuesForConversion((uint8_t *)weightGradFloatData, &weightGradFloatQ,
+                                 linearConfig->weights->grad, &weightGradsFloat);
     convertTensor(linearConfig->weights->grad, &weightGradsFloat);
 
     float expectedWeightGrads[] = {0.f, -4.f, -8.f, 0.f, -3.f, -6.f};
@@ -292,13 +300,13 @@ void testLinearBackwardSymInt32() {
     float biasGradFloatData[numberOfBiases];
     quantization_t biasGradFloatQ;
     initFloat32Quantization(&biasGradFloatQ);
-    setTensorValuesForConversion((uint8_t *)biasGradFloatData, &biasGradFloatQ, linearConfig->bias->grad,
-                                 &biasGradsFloat);
+    setTensorValuesForConversion((uint8_t *)biasGradFloatData, &biasGradFloatQ,
+                                 linearConfig->bias->grad, &biasGradsFloat);
     convertTensor(linearConfig->bias->grad, &biasGradsFloat);
 
     float expectedBiasGrads[] = {-4.f, -3.f};
     float *actualBiasGrads = (float *)biasGradsFloat.data;
-    for(size_t i = 0; i < numberOfBiases; i++) {
+    for (size_t i = 0; i < numberOfBiases; i++) {
         TEST_ASSERT_FLOAT_WITHIN(0.1f, expectedBiasGrads[i], actualBiasGrads[i]);
     }
 
@@ -306,7 +314,8 @@ void testLinearBackwardSymInt32() {
     float propLossFloatData[numberOfForwardInputs];
     quantization_t propLossFloatQ;
     initFloat32Quantization(&propLossFloatQ);
-    setTensorValuesForConversion((uint8_t *)propLossFloatData, &propLossFloatQ, propLoss, &propLossFloat);
+    setTensorValuesForConversion((uint8_t *)propLossFloatData, &propLossFloatQ, propLoss,
+                                 &propLossFloat);
     convertTensor(propLoss, &propLossFloat);
 
     float *propLossFloatArr = (float *)propLossFloat.data;
@@ -369,7 +378,8 @@ void testLinearBackwardFloatWithMismatchedQuantizations() {
                                  .numberOfDimensions = forwardInputNumberOfDims};
     quantization_t forwardInputQ;
     initFloat32Quantization(&forwardInputQ);
-    setTensorValues(&forwardInput, (uint8_t *)forwardInputData, &forwardInputShape, &forwardInputQ, NULL);
+    setTensorValues(&forwardInput, (uint8_t *)forwardInputData, &forwardInputShape, &forwardInputQ,
+                    NULL);
 
     tensor_t loss;
     float lossData[] = {-4.f, -3.f};
@@ -419,22 +429,21 @@ void testLinearBackwardFloatWithMismatchedQuantizations() {
     float expectedWeightGrad[] = {0.f, -4.f, -8.f, 0.f, -3.f, -6.f};
     float expectedBiasGrad[] = {-4.f, -3.f};
 
-
     size_t sizeWeights = calcNumberOfElementsByParameter(&weights);
     float *actualWeightGrad = (float *)linearConfig.linear->weights->grad->data;
-    for(size_t i = 0; i < sizeWeights; i++) {
+    for (size_t i = 0; i < sizeWeights; i++) {
         TEST_ASSERT_FLOAT_WITHIN(0.1f, expectedWeightGrad[i], actualWeightGrad[i]);
     }
 
     size_t sizeBias = calcNumberOfElementsByParameter(&bias);
     float *actualBiasGrad = (float *)linearConfig.linear->bias->grad->data;
-    for(size_t i = 0; i < sizeBias; i++) {
+    for (size_t i = 0; i < sizeBias; i++) {
         TEST_ASSERT_FLOAT_WITHIN(0.1f, expectedBiasGrad[i], actualBiasGrad[i]);
     }
 
     size_t sizePropLoss = calcNumberOfElementsByTensor(&propLoss);
     float *actualPropLoss = (float *)propLoss.data;
-    for(size_t i = 0; i < sizePropLoss; i++) {
+    for (size_t i = 0; i < sizePropLoss; i++) {
         TEST_ASSERT_FLOAT_WITHIN(0.1f, expectedPropagatedLoss[i], actualPropLoss[i]);
     }
 }

--- a/test/unit/layer/UnitTestRelu.c
+++ b/test/unit/layer/UnitTestRelu.c
@@ -1,12 +1,12 @@
-#include "Relu.h"
-#include "Quantization.h"
-#include "unity.h"
 #include "DTypes.h"
-#include "Tensor.h"
-#include "TensorConversion.h"
-#include "ReluApi.h"
-#include "TensorApi.h"
+#include "Quantization.h"
 #include "QuantizationApi.h"
+#include "Relu.h"
+#include "ReluApi.h"
+#include "Tensor.h"
+#include "TensorApi.h"
+#include "TensorConversion.h"
+#include "unity.h"
 
 void testReluForwardFloat() {
     size_t numberOfElements = 6;
@@ -16,26 +16,21 @@ void testReluForwardFloat() {
     size_t inputDims[] = {2, 3};
     size_t inputNumberOfDims = 2;
     size_t inputOrderOfDims[] = {0, 1};
-    shape_t inputShape = {
-        .dimensions = inputDims,
-        .orderOfDimensions = inputOrderOfDims,
-        .numberOfDimensions = inputNumberOfDims
-    };
+    shape_t inputShape = {.dimensions = inputDims,
+                          .orderOfDimensions = inputOrderOfDims,
+                          .numberOfDimensions = inputNumberOfDims};
     quantization_t inputQ;
     initFloat32Quantization(&inputQ);
-    setTensorValues(&input, (uint8_t *)inputData, &inputShape,
-                    &inputQ, NULL);
+    setTensorValues(&input, (uint8_t *)inputData, &inputShape, &inputQ, NULL);
 
     tensor_t output;
     float outputData[numberOfElements];
     size_t outputDims[] = {2, 3};
     size_t outputNumberOfDims = 2;
     size_t outputOrderOfDims[] = {0, 1};
-    shape_t outputShape = {
-        .dimensions = outputDims,
-        .orderOfDimensions = outputOrderOfDims,
-        .numberOfDimensions = outputNumberOfDims
-    };
+    shape_t outputShape = {.dimensions = outputDims,
+                           .orderOfDimensions = outputOrderOfDims,
+                           .numberOfDimensions = outputNumberOfDims};
     quantization_t outputQ;
     initFloat32Quantization(&outputQ);
     setTensorValues(&output, (uint8_t *)outputData, &outputShape, &outputQ, NULL);
@@ -62,7 +57,7 @@ void testReluForwardSymInt32() {
     float inputData[] = {-1.f, 0.f, 1.f, 2.f, 5.f, -6.f};
     tensor_t *input = tensorInitSymInt32(inputData, dims, numberOfDims, HTE, NULL);
 
-    float outputData[6];
+    float outputData[6] = {0};
     tensor_t *output = tensorInitSymInt32(outputData, dims, numberOfDims, HTE, NULL);
 
     quantization_t *symIntQ = quantizationInitSymInt32(HTE);
@@ -77,7 +72,7 @@ void testReluForwardSymInt32() {
     float expected[] = {0, 0, 1, 2, 5, 0};
     float *actual = (float *)outputFloat->data;
 
-    for(size_t i = 0; i < numberOfValues; i++) {
+    for (size_t i = 0; i < numberOfValues; i++) {
         TEST_ASSERT_FLOAT_WITHIN(0.1f, expected[i], actual[i]);
     }
 }
@@ -136,11 +131,10 @@ void testReluBackwardSymInt32() {
     convertTensor(propLoss, propLossFloat);
     float *actual = (float *)propLossFloat->data;
 
-    for(size_t i = 0; i < numberOfValues; i++) {
+    for (size_t i = 0; i < numberOfValues; i++) {
         TEST_ASSERT_FLOAT_WITHIN(0.1f, expected[i], actual[i]);
     }
 }
-
 
 void setUp() {}
 void tearDown() {}

--- a/test/unit/layer/UnitTestSoftmax.c
+++ b/test/unit/layer/UnitTestSoftmax.c
@@ -1,11 +1,12 @@
 #include <stdlib.h>
+#include <string.h>
 
+#include "QuantizationApi.h"
 #include "Softmax.h"
-#include "unity.h"
-#include "TensorConversion.h"
 #include "SoftmaxApi.h"
 #include "TensorApi.h"
-#include "QuantizationApi.h"
+#include "TensorConversion.h"
+#include "unity.h"
 
 void unitTestSoftmaxForwardFloat() {
     size_t inputSize = 6;
@@ -25,7 +26,8 @@ void unitTestSoftmaxForwardFloat() {
     layerFunctions_t softmaxFns = layerFunctions[SOFTMAX];
     softmaxFns.forward(softmaxLayer, input, output);
 
-    float expected[] = {2.3008e-03f, 6.2543e-03f, 1.7001e-02f, 4.6213e-02f, 9.2822e-01f, 1.5503e-05f};
+    float expected[] = {2.3008e-03f, 6.2543e-03f, 1.7001e-02f,
+                        4.6213e-02f, 9.2822e-01f, 1.5503e-05f};
 
     float *actual = (float *)output->data;
 
@@ -56,10 +58,11 @@ void unitTestSoftmaxForwardSymInt32() {
     tensor_t *outputFloat = tensorInitFloat(outputFloatData, dims, numberOfDims, NULL);
     convertTensor(output, outputFloat);
 
-    float expected[] = {2.3008e-03f, 6.2543e-03f, 1.7001e-02f, 4.6213e-02f, 9.2822e-01f, 1.5503e-05f};
+    float expected[] = {2.3008e-03f, 6.2543e-03f, 1.7001e-02f,
+                        4.6213e-02f, 9.2822e-01f, 1.5503e-05f};
     float *actual = (float *)outputFloat->data;
 
-    for(size_t i = 0; i < inputSize; i++) {
+    for (size_t i = 0; i < inputSize; i++) {
         TEST_ASSERT_FLOAT_WITHIN(0.1f, expected[i], actual[i]);
     }
 }
@@ -71,7 +74,6 @@ void unitTestSoftmaxBackwardFloat() {
     size_t inputDims[] = {2, 3};
     size_t inputNumberOfDims = 2;
     tensor_t *input = tensorInitFloat(inputData, inputDims, inputNumberOfDims, NULL);
-
 
     float lossData[] = {0.f, 2.f, -4.f, 6.f, 3.f, 2.f};
     size_t lossDims[] = {2, 3};
@@ -88,8 +90,8 @@ void unitTestSoftmaxBackwardFloat() {
     layerFunctions_t softmaxFns = layerFunctions[SOFTMAX];
     softmaxFns.backward(softmaxLayer, input, loss, propLoss);
 
-    float expected[] = {-6.9173e-03f, -6.2947e-03f, -1.1912e-01f, 1.3834e-01f, -5.9973e-03f,
-                        -1.5603e-05f};
+    float expected[] = {-6.9173e-03f, -6.2947e-03f, -1.1912e-01f,
+                        1.3834e-01f,  -5.9973e-03f, -1.5603e-05f};
 
     float *actual = (float *)propLoss->data;
 
@@ -101,7 +103,8 @@ void unitTestSoftmaxBackwardFloat() {
 void unitTestSoftmaxBackwardSymInt32() {
     size_t inputSize = 6;
 
-    float inputData[] = {2.3008e-03f, 6.2543e-03f, 1.7001e-02f, 4.6213e-02f, 9.2822e-01f, 1.5503e-05f};
+    float inputData[] = {2.3008e-03f, 6.2543e-03f, 1.7001e-02f,
+                         4.6213e-02f, 9.2822e-01f, 1.5503e-05f};
     size_t inputDims[] = {2, 3};
     size_t inputNumberOfDims = 2;
     tensor_t *input = tensorInitSymInt32(inputData, inputDims, inputNumberOfDims, HTE, NULL);
@@ -109,23 +112,26 @@ void unitTestSoftmaxBackwardSymInt32() {
     float lossData[] = {0.f, 2.f, -4.f, 6.f, 3.f, 2.f};
     size_t lossDims[] = {2, 3};
     size_t lossNumberOfDims = 2;
-    tensor_t *loss = tensorInitSymInt32(lossData, lossDims, lossNumberOfDims,HTE, NULL);
+    tensor_t *loss = tensorInitSymInt32(lossData, lossDims, lossNumberOfDims, HTE, NULL);
 
     float propLossData[inputSize];
+    memset(propLossData, 0, sizeof(propLossData));
     size_t propLossDims[] = {2, 3};
     size_t propLossNumberOfDims = 2;
-    tensor_t *propLoss = tensorInitSymInt32(propLossData, propLossDims, propLossNumberOfDims, HTE, NULL);
+    tensor_t *propLoss =
+        tensorInitSymInt32(propLossData, propLossDims, propLossNumberOfDims, HTE, NULL);
 
     quantization_t *symIntQ = quantizationInitSymInt32(HTE);
     layer_t *softmaxLayer = softmaxLayerInit(symIntQ, symIntQ);
     layerFunctions_t softmaxFns = layerFunctions[SOFTMAX];
     softmaxFns.backward(softmaxLayer, input, loss, propLoss);
 
-    float expected[] = {-6.9173e-03f, -6.2947e-03f, -1.1912e-01f, 1.3834e-01f, -5.9973e-03f,
-                        -1.5603e-05f};
+    float expected[] = {-6.9173e-03f, -6.2947e-03f, -1.1912e-01f,
+                        1.3834e-01f,  -5.9973e-03f, -1.5603e-05f};
 
     float propLossDataFloat[inputSize];
-    tensor_t *propLossFloat = tensorInitFloat(propLossDataFloat, propLossDims, propLossNumberOfDims, NULL);
+    tensor_t *propLossFloat =
+        tensorInitFloat(propLossDataFloat, propLossDims, propLossNumberOfDims, NULL);
     convertTensor(propLoss, propLossFloat);
     float *actual = (float *)propLossFloat->data;
 

--- a/test/unit/userAPI/CMakeLists.txt
+++ b/test/unit/userAPI/CMakeLists.txt
@@ -75,3 +75,21 @@ target_link_libraries(UnitTestMnistSmoke PRIVATE
         StorageApi
 )
 __register_target_as_unit_test(UnitTestMnistSmoke)
+
+add_executable(UnitTestFlattenIntegration UnitTestFlattenIntegration.c)
+target_link_libraries(UnitTestFlattenIntegration PRIVATE
+        unity
+        TrainingLoopApi
+        CalculateGradsSequential
+        CommonLayerLibs
+        FlattenApi
+        LinearApi
+        SoftmaxApi
+        TensorApi
+        QuantizationApi
+        LossFunction
+        InferenceApi
+        DataLoader
+        StorageApi
+)
+__register_target_as_unit_test(UnitTestFlattenIntegration)

--- a/test/unit/userAPI/UnitTestFlattenIntegration.c
+++ b/test/unit/userAPI/UnitTestFlattenIntegration.c
@@ -1,0 +1,65 @@
+#define SOURCE_FILE "UNIT_TEST_FLATTEN_INTEGRATION"
+
+#include <stdlib.h>
+
+#include "CalculateGradsSequential.h"
+#include "FlattenApi.h"
+#include "Layer.h"
+#include "LinearApi.h"
+#include "LossFunction.h"
+#include "QuantizationApi.h"
+#include "SoftmaxApi.h"
+#include "TensorApi.h"
+#include "unity.h"
+
+// Trains [Flatten → Linear(6,2) → Softmax] for one step with MSE loss.
+// Main point: initLayerOutputs FLATTEN case must derive output-Q from input tensor.
+// If that case is missing, initLayerOutputs hits `default: exit(1)`.
+void testCalculateGradsSequential_WithFlattenFirst_DoesNotCrash(void) {
+  quantization_t *q = quantizationInitFloat();
+
+  // Linear weights (6 -> 2)
+  static float w0Data[2 * 6] = {0};
+  static size_t w0Dims[] = {2, 6};
+  tensor_t *w0P = tensorInitWithDistribution(XAVIER_UNIFORM, w0Data, w0Dims, 2, q, NULL, 6, 2);
+  tensor_t *w0G = gradInitFloat(w0P, NULL);
+  parameter_t *w0 = parameterInit(w0P, w0G);
+
+  static float b0Data[2] = {0};
+  static size_t b0Dims[] = {1, 2};
+  tensor_t *b0P = tensorInitWithDistribution(ZEROS, b0Data, b0Dims, 2, q, NULL, 1, 2);
+  tensor_t *b0G = gradInitFloat(b0P, NULL);
+  parameter_t *b0 = parameterInit(b0P, b0G);
+
+  layer_t *model[3];
+  model[0] = flattenLayerInit();
+  model[1] = linearLayerInit(w0, b0, q, q, q, q);
+  model[2] = softmaxLayerInit(q, q);
+
+  // Input [1, 2, 3] = 6 elements
+  size_t inputDims[] = {1, 2, 3};
+  float inputData[] = {0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f};
+  tensor_t *input = tensorInitFloat(inputData, inputDims, 3, NULL);
+
+  // Label [1, 2]
+  size_t labelDims[] = {1, 2};
+  float labelData[] = {1.0f, 0.0f};
+  tensor_t *label = tensorInitFloat(labelData, labelDims, 2, NULL);
+
+  trainingStats_t *stats = calculateGradsSequential(model, 3, MSE, input, label);
+
+  TEST_ASSERT_NOT_NULL(stats);
+  TEST_ASSERT_NOT_NULL(stats->output);
+  TEST_ASSERT_EQUAL_UINT(2, stats->output->shape->numberOfDimensions);
+  TEST_ASSERT_EQUAL_UINT(1, stats->output->shape->dimensions[0]);
+  TEST_ASSERT_EQUAL_UINT(2, stats->output->shape->dimensions[1]);
+}
+
+void setUp(void) {}
+void tearDown(void) {}
+
+int main(void) {
+  UNITY_BEGIN();
+  RUN_TEST(testCalculateGradsSequential_WithFlattenFirst_DoesNotCrash);
+  return UNITY_END();
+}

--- a/test/unit/userAPI/UnitTestFlattenIntegration.c
+++ b/test/unit/userAPI/UnitTestFlattenIntegration.c
@@ -16,50 +16,98 @@
 // Main point: initLayerOutputs FLATTEN case must derive output-Q from input tensor.
 // If that case is missing, initLayerOutputs hits `default: exit(1)`.
 void testCalculateGradsSequential_WithFlattenFirst_DoesNotCrash(void) {
-  quantization_t *q = quantizationInitFloat();
+    quantization_t *q = quantizationInitFloat();
 
-  // Linear weights (6 -> 2)
-  static float w0Data[2 * 6] = {0};
-  static size_t w0Dims[] = {2, 6};
-  tensor_t *w0P = tensorInitWithDistribution(XAVIER_UNIFORM, w0Data, w0Dims, 2, q, NULL, 6, 2);
-  tensor_t *w0G = gradInitFloat(w0P, NULL);
-  parameter_t *w0 = parameterInit(w0P, w0G);
+    // Linear weights (6 -> 2)
+    static float w0Data[2 * 6] = {0};
+    static size_t w0Dims[] = {2, 6};
+    tensor_t *w0P = tensorInitWithDistribution(XAVIER_UNIFORM, w0Data, w0Dims, 2, q, NULL, 6, 2);
+    tensor_t *w0G = gradInitFloat(w0P, NULL);
+    parameter_t *w0 = parameterInit(w0P, w0G);
 
-  static float b0Data[2] = {0};
-  static size_t b0Dims[] = {1, 2};
-  tensor_t *b0P = tensorInitWithDistribution(ZEROS, b0Data, b0Dims, 2, q, NULL, 1, 2);
-  tensor_t *b0G = gradInitFloat(b0P, NULL);
-  parameter_t *b0 = parameterInit(b0P, b0G);
+    static float b0Data[2] = {0};
+    static size_t b0Dims[] = {1, 2};
+    tensor_t *b0P = tensorInitWithDistribution(ZEROS, b0Data, b0Dims, 2, q, NULL, 1, 2);
+    tensor_t *b0G = gradInitFloat(b0P, NULL);
+    parameter_t *b0 = parameterInit(b0P, b0G);
 
-  layer_t *model[3];
-  model[0] = flattenLayerInit();
-  model[1] = linearLayerInit(w0, b0, q, q, q, q);
-  model[2] = softmaxLayerInit(q, q);
+    layer_t *model[3];
+    model[0] = flattenLayerInit();
+    model[1] = linearLayerInit(w0, b0, q, q, q, q);
+    model[2] = softmaxLayerInit(q, q);
 
-  // Input [1, 2, 3] = 6 elements
-  size_t inputDims[] = {1, 2, 3};
-  float inputData[] = {0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f};
-  tensor_t *input = tensorInitFloat(inputData, inputDims, 3, NULL);
+    // Input [1, 2, 3] = 6 elements
+    size_t inputDims[] = {1, 2, 3};
+    float inputData[] = {0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f};
+    tensor_t *input = tensorInitFloat(inputData, inputDims, 3, NULL);
 
-  // Label [1, 2]
-  size_t labelDims[] = {1, 2};
-  float labelData[] = {1.0f, 0.0f};
-  tensor_t *label = tensorInitFloat(labelData, labelDims, 2, NULL);
+    // Label [1, 2]
+    size_t labelDims[] = {1, 2};
+    float labelData[] = {1.0f, 0.0f};
+    tensor_t *label = tensorInitFloat(labelData, labelDims, 2, NULL);
 
-  trainingStats_t *stats = calculateGradsSequential(model, 3, MSE, input, label);
+    trainingStats_t *stats = calculateGradsSequential(model, 3, MSE, input, label);
 
-  TEST_ASSERT_NOT_NULL(stats);
-  TEST_ASSERT_NOT_NULL(stats->output);
-  TEST_ASSERT_EQUAL_UINT(2, stats->output->shape->numberOfDimensions);
-  TEST_ASSERT_EQUAL_UINT(1, stats->output->shape->dimensions[0]);
-  TEST_ASSERT_EQUAL_UINT(2, stats->output->shape->dimensions[1]);
+    TEST_ASSERT_NOT_NULL(stats);
+    TEST_ASSERT_NOT_NULL(stats->output);
+    TEST_ASSERT_EQUAL_UINT(2, stats->output->shape->numberOfDimensions);
+    TEST_ASSERT_EQUAL_UINT(1, stats->output->shape->dimensions[0]);
+    TEST_ASSERT_EQUAL_UINT(2, stats->output->shape->dimensions[1]);
+}
+
+void testCalculateGradsSequential_FlattenRank1_DoesNotOOB(void) {
+    // Regression: initLayerOutputs sized output-shape buffers by INPUT rank, but
+    // flattenCalcOutputShape always writes 2 slots. For rank-1 input this is OOB.
+    size_t inputDims[] = {5};
+    float inputData[] = {1.f, 2.f, 3.f, 4.f, 5.f};
+    tensor_t *input = tensorInitFloat(inputData, inputDims, 1, NULL);
+
+    size_t labelDims[] = {5, 1};
+    float labelData[] = {0.f, 0.f, 0.f, 0.f, 0.f};
+    tensor_t *label = tensorInitFloat(labelData, labelDims, 2, NULL);
+
+    layer_t *model[1];
+    model[0] = flattenLayerInit();
+
+    trainingStats_t *stats = calculateGradsSequential(model, 1, MSE, input, label);
+
+    TEST_ASSERT_NOT_NULL(stats);
+    TEST_ASSERT_EQUAL_UINT(2, stats->output->shape->numberOfDimensions);
+    TEST_ASSERT_EQUAL_UINT(5, stats->output->shape->dimensions[0]);
+    TEST_ASSERT_EQUAL_UINT(1, stats->output->shape->dimensions[1]);
+}
+
+void testCalculateGradsSequential_FlattenOnly_PreservesValues(void) {
+    // FLATTEN is identity on values; stats->output must equal input, reshaped.
+    size_t inputDims[] = {1, 2, 3};
+    float inputData[] = {1.f, 2.f, 3.f, 4.f, 5.f, 6.f};
+    tensor_t *input = tensorInitFloat(inputData, inputDims, 3, NULL);
+
+    size_t labelDims[] = {1, 6};
+    float labelData[] = {0.f, 0.f, 0.f, 0.f, 0.f, 0.f};
+    tensor_t *label = tensorInitFloat(labelData, labelDims, 2, NULL);
+
+    layer_t *model[1];
+    model[0] = flattenLayerInit();
+
+    trainingStats_t *stats = calculateGradsSequential(model, 1, MSE, input, label);
+
+    TEST_ASSERT_NOT_NULL(stats);
+    TEST_ASSERT_EQUAL_UINT(2, stats->output->shape->numberOfDimensions);
+    TEST_ASSERT_EQUAL_UINT(1, stats->output->shape->dimensions[0]);
+    TEST_ASSERT_EQUAL_UINT(6, stats->output->shape->dimensions[1]);
+
+    float *actual = (float *)stats->output->data;
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(inputData, actual, 6);
 }
 
 void setUp(void) {}
 void tearDown(void) {}
 
 int main(void) {
-  UNITY_BEGIN();
-  RUN_TEST(testCalculateGradsSequential_WithFlattenFirst_DoesNotCrash);
-  return UNITY_END();
+    UNITY_BEGIN();
+    RUN_TEST(testCalculateGradsSequential_WithFlattenFirst_DoesNotCrash);
+    RUN_TEST(testCalculateGradsSequential_FlattenRank1_DoesNotOOB);
+    RUN_TEST(testCalculateGradsSequential_FlattenOnly_PreservesValues);
+    return UNITY_END();
 }


### PR DESCRIPTION
## Summary

- UBSan detected three manifestations of the same root cause: uninitialized stack-allocated float buffers passed to `tensorInitSymInt32()`, which unconditionally quantizes the buffer contents. Under ASan stack-poisoning, uninitialized floats parse as NaN, and `(int32_t)NaN` in `Rounding.c:12` is UB.
- Minimal fix: zero-initialize each of the three test-site buffer declarations. Two of them are VLAs (runtime-sized), for which ISO C forbids brace-initialization — those use `memset(buf, 0, sizeof(buf))` instead. The fixed-size one uses `= {0}`.
- The API design issue behind this pattern (input-quantize vs. output-storage conflation in `tensorInitSymInt32`) is tracked separately in #85 — this PR is scoped strictly to unblock the ASan/UBSan CI gate.

## Test plan

- [x] `ctest --preset unit_test_asan -R 'UnitTestLinear|UnitTestRelu|UnitTestSoftmax'` — target tests (`testLinearBackwardSymInt32`, `testReluForwardSymInt32`, `unitTestSoftmaxBackwardSymInt32`) all pass (no UBSan error)
- [x] `ctest --preset unit_test_debug -R 'UnitTestLinear|UnitTestRelu|UnitTestSoftmax'` — all pass (no regression)

## Notes

After this fix, AddressSanitizer surfaces a **separate, pre-existing** stack-buffer-overflow in `testLinearBackwardFloatWithMismatchedQuantizations` at `byteConversion` (`src/tensor/Tensor.c:170`) on the ASYM-conversion path. This is orthogonal to the UB fix here and is a candidate for a follow-up fix-PR under Phase 1B.

Part of #81 (AddressSanitizer + UBSan CI gate). Does NOT close #81; the CI gate will be added in a subsequent tooling PR.