### PR TITLE
build(#81): add unit_test_asan CMake preset for Clang ASan + UBSan

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -45,6 +45,15 @@
       "cacheVariables": {
         "DEBUG_MODE_DEBUG": "ON"
       }
+    },
+    {
+      "name": "unit_test_asan",
+      "displayName": "Unit-Test-ASan",
+      "inherits": "host",
+      "cacheVariables": {
+        "CMAKE_C_FLAGS": "-fsanitize=address,undefined -fno-sanitize=function -fno-omit-frame-pointer -fno-sanitize-recover=all -g -O1",
+        "CMAKE_EXE_LINKER_FLAGS": "-fsanitize=address,undefined"
+      }
     }
   ],
   "buildPresets": [
@@ -76,6 +85,12 @@
       "name": "unit_test_debug",
       "inherits": "host",
       "configurePreset": "unit_test_debug",
+      "targets": "all_unit_tests"
+    },
+    {
+      "name": "unit_test_asan",
+      "inherits": "host",
+      "configurePreset": "unit_test_asan",
       "targets": "all_unit_tests"
     }
   ],
@@ -134,6 +149,24 @@
         "include": {
           "label": "unit"
         }
+      }
+    },
+    {
+      "name": "unit_test_asan",
+      "displayName": "Unit Tests (ASan + UBSan)",
+      "configurePreset": "unit_test_asan",
+      "output": {
+        "outputJUnitFile": "unit-test-asan.junit",
+        "outputOnFailure": true
+      },
+      "filter": {
+        "include": {
+          "label": "unit"
+        }
+      },
+      "environment": {
+        "ASAN_OPTIONS": "detect_leaks=0:abort_on_error=1:halt_on_error=1:strict_string_checks=1:check_initialization_order=1",
+        "UBSAN_OPTIONS": "print_stacktrace=1:halt_on_error=1"
       }
     }
   ]


### PR DESCRIPTION
## Summary

- Adds `unit_test_asan` CMake preset (configurePreset + buildPreset + testPreset) that enables Clang AddressSanitizer + UndefinedBehaviorSanitizer on the existing unit test suite.
- Compile flags: `-fsanitize=address,undefined -fno-sanitize=function -fno-omit-frame-pointer -fno-sanitize-recover=all -g -O1`.
- Runtime env via `environment`: `ASAN_OPTIONS=detect_leaks=0:abort_on_error=1:halt_on_error=1:strict_string_checks=1:check_initialization_order=1` and `UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1`.

## Why `-fno-sanitize=function`

Clang's UBSan `function` check triggers spuriously on Unity's `RUN_TEST` dispatch under macOS-ARM64 pointer authentication (PAC). GCC has no `function` check so the flag is a no-op on CI; locally it's needed with the Clang toolchain shipped in our devenv.

## Scope

This PR lands the preset **only**. It does not:

- wire the preset into CI (Phase 2 of #81 — follow-up PR)
- fix any sanitizer failures the preset uncovers (Phase 1B of #81 — PRs #83, #84, and a follow-up VLA fix)

After this lands, running `ctest --preset unit_test_asan` locally produces the expected failure set documented in #81. The fix-PRs in Phase 1B address those failures independently.

## Test plan

- [x] `cmake --preset unit_test_asan` configures cleanly
- [x] `cmake --build --preset unit_test_asan` builds all unit test targets
- [x] `ctest --preset unit_test_asan` runs and produces the documented failure set (25/29 pass; 4 failing with the two known root causes from #81)

Part of #81. Does NOT close #81; the CI gate lands in a separate tooling PR.