### PR TITLE
fix(#81): prevent VLA overread in npyLoad per-row dim copy

### DIFF
--- a/src/userApi/data_loader/NPYLoaderApi.c
+++ b/src/userApi/data_loader/NPYLoaderApi.c
@@ -53,7 +53,7 @@ tensorArray_t *npyLoad(char *path) {
     for (size_t i = 0; i < numberOfTensors; i++) {
         float *data = *reserveMemory(numberOfValuesInRow * bytesPerValue);
         size_t *dims = *reserveMemory(numberOfDims * sizeof(size_t));
-        memcpy(dims, rowDims, numberOfDims * sizeof(size_t));
+        memcpy(dims, rowDims, rowNumberOfDims * sizeof(size_t));
 
         size_t n = fread(data, bytesPerValue, numberOfValuesInRow, f);
         tensorArr->array[i] = tensorInit(data, dims, rowShape.numberOfDimensions, q, NULL);

--- a/src/userApi/data_loader/NPYLoaderApi.c
+++ b/src/userApi/data_loader/NPYLoaderApi.c
@@ -3,16 +3,15 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include "TensorApi.h"
-#include "Tensor.h"
 #include "Common.h"
-#include "StorageApi.h"
 #include "Dataset.h"
-#include "NPYLoaderApiInternal.h"
 #include "NPYLoader.h"
-#include "QuantizationApi.h"
+#include "NPYLoaderApiInternal.h"
 #include "Quantization.h"
-
+#include "QuantizationApi.h"
+#include "StorageApi.h"
+#include "Tensor.h"
+#include "TensorApi.h"
 
 tensorArray_t *npyLoad(char *path) {
     FILE *f = openNPYFile(path);
@@ -57,11 +56,7 @@ tensorArray_t *npyLoad(char *path) {
         memcpy(dims, rowDims, numberOfDims * sizeof(size_t));
 
         size_t n = fread(data, bytesPerValue, numberOfValuesInRow, f);
-        tensorArr->array[i] = tensorInit(data,
-                                         dims,
-                                         rowShape.numberOfDimensions,
-                                         q,
-                                         NULL);
+        tensorArr->array[i] = tensorInit(data, dims, rowShape.numberOfDimensions, q, NULL);
         if (n != numberOfValuesInRow) {
             PRINT_ERROR("fread did not read the correct number of bytes!");
             exit(1);
@@ -80,7 +75,6 @@ sample_t *npyGetSample(dataset_t *dataset, size_t index) {
 
     return sample;
 }
-
 
 static void getRowShape(shape_t *totalShape, shape_t *rowShape) {
     for (size_t i = 0; i < rowShape->numberOfDimensions; i++) {


### PR DESCRIPTION
## Summary

- After PR #84 fixes the NPY header OOB, AddressSanitizer surfaces a second, distinct bug in the same loader path: `npyLoad` copies `numberOfDims * sizeof(size_t)` bytes from `rowDims`, but `rowDims` is a VLA sized `rowNumberOfDims = numberOfDims - 1` — a 1-element overread per iteration.
- Fix: copy `rowNumberOfDims * sizeof(size_t)` instead, matching the actual source size. The destination `dims` allocation stays at `numberOfDims * sizeof(size_t)` (trailing slot left uninitialized; it corresponds to the stripped batch dimension and is not read by `tensorInit`, which is passed `rowShape.numberOfDimensions`).

## Commits

1. `style: alphabetize includes in NPYLoaderApi.c` — cosmetic, applied by the repo clang-format hook as a side effect of touching the file; separated into its own commit for clean review.
2. `fix(#81): copy only rowNumberOfDims elements from rowDims VLA in npyLoad` — the one-line semantic fix.

## Dependency

Runtime verification under ASan depends on PR #84 landing first — before that fix, `readHeader` aborts earlier with its own heap OOB and the VLA overread never executes. The fix here is a local correctness fix and passes the standard (`unit_test_debug`) suite on its own.

## Test plan

- [x] `ctest --preset unit_test_debug -R UnitTestDataLoader` — passes (no regression)
- [ ] `ctest --preset unit_test_asan -R UnitTestDataLoader` — run after #84 + #87 land to confirm the dynamic-stack-buffer-overflow at `NPYLoaderApi.c:57` no longer reports

Part of #81. Does NOT close #81.