### PR TITLE
fix(#99): drop StorageApi handle indirection to close the leak

### DIFF
--- a/src/userApi/InferenceApi.c
+++ b/src/userApi/InferenceApi.c
@@ -39,9 +39,9 @@ static void initBufferOutput(tensor_t *buffer, layer_t *currentLayer, shape_t *i
 
     size_t sizeDims = inputShape->numberOfDimensions;
 
-    shape_t *outShape = *reserveMemory(sizeof(shape_t));
-    size_t *outDims = *reserveMemory(sizeDims * sizeof(size_t));
-    size_t *outOrder = *reserveMemory(sizeDims * sizeof(size_t));
+    shape_t *outShape = reserveMemory(sizeof(shape_t));
+    size_t *outDims = reserveMemory(sizeDims * sizeof(size_t));
+    size_t *outOrder = reserveMemory(sizeDims * sizeof(size_t));
 
     outShape->dimensions = outDims;
     outShape->numberOfDimensions = sizeDims;
@@ -53,16 +53,16 @@ static void initBufferOutput(tensor_t *buffer, layer_t *currentLayer, shape_t *i
     size_t numValues =
         calcNumberOfElementsByShape(outShape);
     size_t sizeData = calcNumberOfBytesForData(currentQ, numValues);
-    uint8_t *data = *reserveMemory(sizeData);
+    uint8_t *data = reserveMemory(sizeData);
 
-    quantization_t *q = *reserveMemory(sizeof(quantization_t));
+    quantization_t *q = reserveMemory(sizeof(quantization_t));
     switch (currentQ->type) {
     case FLOAT32:
         initFloat32Quantization(q);
         break;
     case SYM_INT32:
         symInt32QConfig_t *currentQC = currentQ->qConfig;
-        symInt32QConfig_t *symInt32QC = *reserveMemory(sizeof(symInt32QConfig_t));
+        symInt32QConfig_t *symInt32QC = reserveMemory(sizeof(symInt32QConfig_t));
 
         initSymInt32QConfig(currentQC->roundingMode, symInt32QC);
         initSymInt32Quantization(symInt32QC, q);
@@ -81,9 +81,9 @@ static void initBufferInput(tensor_t *input, tensor_t *buffer) {
 
     size_t sizeDims = input->shape->numberOfDimensions;
 
-    shape_t *outShape = *reserveMemory(sizeof(shape_t));
-    size_t *outDims = *reserveMemory(sizeDims * sizeof(size_t));
-    size_t *outOrder = *reserveMemory(sizeDims * sizeof(size_t));
+    shape_t *outShape = reserveMemory(sizeof(shape_t));
+    size_t *outDims = reserveMemory(sizeDims * sizeof(size_t));
+    size_t *outOrder = reserveMemory(sizeDims * sizeof(size_t));
 
     outShape->dimensions = outDims;
     outShape->numberOfDimensions = sizeDims;
@@ -91,9 +91,9 @@ static void initBufferInput(tensor_t *input, tensor_t *buffer) {
 
     size_t numValues = calcNumberOfElementsByTensor(input);
     size_t sizeData = calcNumberOfBytesForData(currentQ, numValues);
-    uint8_t *data = *reserveMemory(sizeData);
+    uint8_t *data = reserveMemory(sizeData);
 
-    quantization_t *q = *reserveMemory(sizeof(quantization_t));
+    quantization_t *q = reserveMemory(sizeof(quantization_t));
     switch (currentQ->type) {
     case FLOAT32:
         q->type = FLOAT32;
@@ -102,7 +102,7 @@ static void initBufferInput(tensor_t *input, tensor_t *buffer) {
     case SYM_INT32:
         q->type = SYM_INT32;
         symInt32QConfig_t *currentQC = currentQ->qConfig;
-        symInt32QConfig_t *symInt32QC = *reserveMemory(sizeof(symInt32QConfig_t));
+        symInt32QConfig_t *symInt32QC = reserveMemory(sizeof(symInt32QConfig_t));
         symInt32QC->roundingMode = currentQC->roundingMode;
         q->qConfig = symInt32QC;
         break;
@@ -146,7 +146,7 @@ tensor_t *inference(layer_t **model, size_t numberOfLayers, tensor_t *input) {
 }
 
 tensor_t **inferenceBatched(layer_t **model, size_t numberOfLayers, batch_t *batch) {
-    tensor_t **tensorArr = *reserveMemory(batch->size * sizeof(tensor_t));
+    tensor_t **tensorArr = reserveMemory(batch->size * sizeof(tensor_t));
 
     for (size_t i = 0; i < batch->size; i++) {
         tensorArr[i] = inference(model, numberOfLayers, batch->samples[i]->item);
@@ -156,13 +156,13 @@ tensor_t **inferenceBatched(layer_t **model, size_t numberOfLayers, batch_t *bat
 }
 
 inferenceStats_t *reserveInferenceStats(tensor_t *label) {
-    inferenceStats_t *inferenceStats = *reserveMemory(sizeof(inferenceStats_t));
+    inferenceStats_t *inferenceStats = reserveMemory(sizeof(inferenceStats_t));
 
     size_t sizeOutput = calcNumberOfElementsByTensor(label);
 
-    float *outputData = *reserveMemory(sizeOutput * sizeof(float));
+    float *outputData = reserveMemory(sizeOutput * sizeof(float));
     size_t outputNumberOfDims = label->shape->numberOfDimensions;
-    size_t *outputDims = *reserveMemory(outputNumberOfDims * sizeof(size_t));
+    size_t *outputDims = reserveMemory(outputNumberOfDims * sizeof(size_t));
     quantization_t *outputQ = getQLike(label->quantization);
     tensor_t *output = tensorInit(outputData, outputDims, outputNumberOfDims, outputQ, NULL);
 

--- a/src/userApi/StorageApi.c
+++ b/src/userApi/StorageApi.c
@@ -4,15 +4,10 @@
 
 #include "StorageApi.h"
 
-
-void **reserveMemory(size_t numberOfBytes) {
-    void *ptr = calloc(1, numberOfBytes);
-    void **handle = malloc(sizeof(void *));
-    *handle = ptr;
-    return handle;
+void *reserveMemory(size_t numberOfBytes) {
+    return calloc(1, numberOfBytes);
 }
 
 void freeReservedMemory(void *ptr) {
     free(ptr);
 }
-

--- a/src/userApi/data_loader/DataLoaderApi.c
+++ b/src/userApi/data_loader/DataLoaderApi.c
@@ -23,10 +23,10 @@ dataLoader_t *dataLoaderInit(getSampleFn_t getSample,
         exit(1);
     }
 
-    dataLoader_t *dataLoader = *reserveMemory(sizeof(dataLoader_t));
+    dataLoader_t *dataLoader = reserveMemory(sizeof(dataLoader_t));
 
     size_t numberOfIndices = getDatasetSize();
-    size_t *indices = *reserveMemory(numberOfIndices * sizeof(size_t));
+    size_t *indices = reserveMemory(numberOfIndices * sizeof(size_t));
 
     initDataLoader(dataLoader, getSample, getDatasetSize, getBatch, batchSize, transform,
                    targetTransform, shuffle,
@@ -57,11 +57,11 @@ static sample_t *getSampleByIndex(dataLoader_t *dataLoader, size_t index) {
 }
 
 static batch_t *getBatch(dataLoader_t *dataLoader, size_t index) {
-    batch_t *batch = *reserveMemory(sizeof(batch_t));
+    batch_t *batch = reserveMemory(sizeof(batch_t));
 
     size_t batchSize = dataLoader->batchSize;
     batch->size = batchSize;
-    batch->samples = *reserveMemory(batchSize * sizeof(sample_t *));
+    batch->samples = reserveMemory(batchSize * sizeof(sample_t *));
 
     size_t sampleIndex = index * batchSize;
 

--- a/src/userApi/data_loader/NPYLoaderApi.c
+++ b/src/userApi/data_loader/NPYLoaderApi.c
@@ -19,7 +19,7 @@ tensorArray_t *npyLoad(char *path) {
     checkMagic(f);
 
     uint32_t headerSize = readHeaderSize(f);
-    char *header = *reserveMemory(headerSize + 1);
+    char *header = reserveMemory(headerSize + 1);
     readHeader(header, headerSize, f);
 
     dtype_t dtype = getDTypeFromHeader(header);
@@ -45,14 +45,14 @@ tensorArray_t *npyLoad(char *path) {
     size_t bytesPerValue = calcBytesPerElement(q);
     size_t numberOfValuesInRow = calcNumberOfElementsByShape(&rowShape);
 
-    tensorArray_t *tensorArr = *reserveMemory(sizeof(tensorArray_t));
-    tensor_t **arr = *reserveMemory(numberOfTensors * sizeof(tensor_t *));
+    tensorArray_t *tensorArr = reserveMemory(sizeof(tensorArray_t));
+    tensor_t **arr = reserveMemory(numberOfTensors * sizeof(tensor_t *));
     tensorArr->array = arr;
     tensorArr->size = numberOfTensors;
 
     for (size_t i = 0; i < numberOfTensors; i++) {
-        float *data = *reserveMemory(numberOfValuesInRow * bytesPerValue);
-        size_t *dims = *reserveMemory(numberOfDims * sizeof(size_t));
+        float *data = reserveMemory(numberOfValuesInRow * bytesPerValue);
+        size_t *dims = reserveMemory(numberOfDims * sizeof(size_t));
         memcpy(dims, rowDims, rowNumberOfDims * sizeof(size_t));
 
         size_t n = fread(data, bytesPerValue, numberOfValuesInRow, f);
@@ -69,7 +69,7 @@ tensorArray_t *npyLoad(char *path) {
 }
 
 sample_t *npyGetSample(dataset_t *dataset, size_t index) {
-    sample_t *sample = *reserveMemory(sizeof(sample_t));
+    sample_t *sample = reserveMemory(sizeof(sample_t));
     sample->item = dataset->items->array[index];
     sample->label = dataset->labels->array[index];
 

--- a/src/userApi/include/StorageApi.h
+++ b/src/userApi/include/StorageApi.h
@@ -3,11 +3,9 @@
 
 #include <stddef.h>
 
+void *reserveMemory(size_t numberOfBytes);
 
-void **reserveMemory(size_t numberOfBytes);
-
+/* NULL-safe (mirrors free(NULL)). */
 void freeReservedMemory(void *ptr);
 
-
-
-#endif //STORAGEAPI_H
+#endif // STORAGEAPI_H

--- a/src/userApi/layer/FlattenApi.c
+++ b/src/userApi/layer/FlattenApi.c
@@ -4,7 +4,7 @@
 #include "StorageApi.h"
 
 layer_t *flattenLayerInit(void) {
-    layer_t *flattenLayer = *reserveMemory(sizeof(layer_t));
+    layer_t *flattenLayer = reserveMemory(sizeof(layer_t));
     flattenLayer->type = FLATTEN;
     // Load-bearing: initLayerOutputs' FLATTEN case never reads config.
     flattenLayer->config = NULL;

--- a/src/userApi/layer/LinearApi.c
+++ b/src/userApi/layer/LinearApi.c
@@ -10,12 +10,12 @@
 #include "Linear.h"
 
 layer_t *linearLayerInit(parameter_t *weights, parameter_t *bias, quantization_t *forwardQ, quantization_t *weightGradsQ, quantization_t *biasGradsQ, quantization_t *propLossQ) {
-    layer_t *linearLayer = *reserveMemory(sizeof(layer_t));
+    layer_t *linearLayer = reserveMemory(sizeof(layer_t));
 
     linearLayer->type = LINEAR;
 
-    layerConfig_t *layerConfig = *reserveMemory(sizeof(layerConfig_t));
-    linearConfig_t *linearConfig = *reserveMemory(sizeof(linearConfig_t));
+    layerConfig_t *layerConfig = reserveMemory(sizeof(layerConfig_t));
+    linearConfig_t *linearConfig = reserveMemory(sizeof(linearConfig_t));
     layerConfig->linear = linearConfig;
 
     linearConfig->weights = weights;
@@ -31,12 +31,12 @@ layer_t *linearLayerInit(parameter_t *weights, parameter_t *bias, quantization_t
 }
 
 layer_t *linearLayerInitNonTrainable(tensor_t *weights, tensor_t *bias, quantization_t *forwardQ) {
-    layer_t *linearLayer = *reserveMemory(sizeof(layer_t));
+    layer_t *linearLayer = reserveMemory(sizeof(layer_t));
 
     linearLayer->type = LINEAR;
 
-    layerConfig_t *layerConfig = *reserveMemory(sizeof(layerConfig_t));
-    linearConfig_t *linearConfig = *reserveMemory(sizeof(linearConfig_t));
+    layerConfig_t *layerConfig = reserveMemory(sizeof(layerConfig_t));
+    linearConfig_t *linearConfig = reserveMemory(sizeof(linearConfig_t));
     layerConfig->linear = linearConfig;
 
     linearConfig->weights = parameterInit(weights, NULL);

--- a/src/userApi/layer/ReluApi.c
+++ b/src/userApi/layer/ReluApi.c
@@ -6,13 +6,13 @@
 
 
 layer_t *reluLayerInit(quantization_t *forwardQ, quantization_t *backwardQ) {
-    layer_t *reluLayer = *reserveMemory(sizeof(layer_t));
+    layer_t *reluLayer = reserveMemory(sizeof(layer_t));
 
     reluLayer->type = RELU;
 
-    layerConfig_t *reluConfig = *reserveMemory(sizeof(layerConfig_t));
+    layerConfig_t *reluConfig = reserveMemory(sizeof(layerConfig_t));
 
-    reluConfig_t *reluCfg = *reserveMemory(sizeof(reluConfig_t));
+    reluConfig_t *reluCfg = reserveMemory(sizeof(reluConfig_t));
     reluConfig->relu = reluCfg;
     reluCfg->forwardQ = forwardQ;
     reluCfg->backwardQ = backwardQ;

--- a/src/userApi/layer/SoftmaxApi.c
+++ b/src/userApi/layer/SoftmaxApi.c
@@ -5,12 +5,12 @@
 #include "SoftmaxApi.h"
 
 layer_t *softmaxLayerInit(quantization_t *forwardQ, quantization_t *backwardQ) {
-    layer_t *softmaxLayer = *reserveMemory(sizeof(layer_t));
+    layer_t *softmaxLayer = reserveMemory(sizeof(layer_t));
 
     softmaxLayer->type = SOFTMAX;
 
-    layerConfig_t *layerConfig = *reserveMemory(sizeof(layerConfig_t));
-    softmaxConfig_t *softmaxConfig = *reserveMemory(sizeof(softmaxConfig_t));
+    layerConfig_t *layerConfig = reserveMemory(sizeof(layerConfig_t));
+    softmaxConfig_t *softmaxConfig = reserveMemory(sizeof(softmaxConfig_t));
     layerConfig->softmax = softmaxConfig;
 
     softmaxConfig->forwardQ = forwardQ;

--- a/src/userApi/optimizer/SgdApi.c
+++ b/src/userApi/optimizer/SgdApi.c
@@ -15,21 +15,21 @@
 // IMPORTANT: Currently, the quantization for states are the same as the corresponding parameter
 optimizer_t *sgdMCreateOptim(float learningRate, float momentumFactor, float weightDecay,
                              layer_t **model, size_t sizeModel, qtype_t qType) {
-    optimizer_t *optim = *reserveMemory(sizeof(optimizer_t));
+    optimizer_t *optim = reserveMemory(sizeof(optimizer_t));
     optim->type = SGD_M;
     optim->qtype = qType;
 
-    optimImpl_t *sgdImpl = *reserveMemory(sizeof(optimImpl_t));
-    sgd_t *sgd = *reserveMemory(sizeof(sgd_t));
+    optimImpl_t *sgdImpl = reserveMemory(sizeof(optimImpl_t));
+    sgd_t *sgd = reserveMemory(sizeof(sgd_t));
     sgdInit(sgd, learningRate, momentumFactor, weightDecay);
     sgdImpl->sgd = sgd;
     optim->impl = sgdImpl;
 
     size_t sizeStates = calcTotalNumberOfStates(model, sizeModel);
     optim->sizeStates = sizeStates;
-    states_t **states = *reserveMemory(sizeStates * sizeof(states_t *));
+    states_t **states = reserveMemory(sizeStates * sizeof(states_t *));
     optim->states = states;
-    parameter_t **parameter = *reserveMemory(sizeStates * sizeof(parameter_t *));
+    parameter_t **parameter = reserveMemory(sizeStates * sizeof(parameter_t *));
     optim->parameter = parameter;
     size_t statesPerParam = 1;
 
@@ -50,14 +50,14 @@ optimizer_t *sgdMCreateOptim(float learningRate, float momentumFactor, float wei
             optim->parameter[i + 1] = bias;
             tensor_t *biasStateBuffer = getTensorLike(bias->param);
 
-            states_t *weightStates = *reserveMemory(sizeof(states_t));
+            states_t *weightStates = reserveMemory(sizeof(states_t));
             weightStates->statesPerParameter = statesPerParam;
-            weightStates->stateBuffers = *reserveMemory(sizeof(tensor_t));
+            weightStates->stateBuffers = reserveMemory(sizeof(tensor_t));
             weightStates->stateBuffers[0] = weightStateBuffer;
 
-            states_t *biasStates = *reserveMemory(sizeof(states_t));
+            states_t *biasStates = reserveMemory(sizeof(states_t));
             biasStates->statesPerParameter = statesPerParam;
-            biasStates->stateBuffers = *reserveMemory(sizeof(tensor_t));
+            biasStates->stateBuffers = reserveMemory(sizeof(tensor_t));
             biasStates->stateBuffers[0] = biasStateBuffer;
 
             states[i] = weightStates;

--- a/src/userApi/tensor/QuantizationApi.c
+++ b/src/userApi/tensor/QuantizationApi.c
@@ -6,28 +6,28 @@
 
 
 quantization_t *quantizationInitFloat() {
-    quantization_t *q = *reserveMemory(sizeof(quantization_t));
+    quantization_t *q = reserveMemory(sizeof(quantization_t));
     initFloat32Quantization(q);
     return q;
 }
 
 quantization_t *quantizationInitInt32() {
-    quantization_t *q = *reserveMemory(sizeof(quantization_t));
+    quantization_t *q = reserveMemory(sizeof(quantization_t));
     initInt32Quantization(q);
     return q;
 }
 
 quantization_t *quantizationInitSymInt32(roundingMode_t roundingMode) {
-    quantization_t *q = *reserveMemory(sizeof(quantization_t));
-    symInt32QConfig_t *qC = *reserveMemory(sizeof(symInt32QConfig_t));
+    quantization_t *q = reserveMemory(sizeof(quantization_t));
+    symInt32QConfig_t *qC = reserveMemory(sizeof(symInt32QConfig_t));
     initSymInt32QConfig(roundingMode, qC);
     initSymInt32Quantization(qC, q);
     return q;
 }
 
 quantization_t *quantizationInitAsym(uint8_t qBits, roundingMode_t roundingMode) {
-    quantization_t *q = *reserveMemory(sizeof(quantization_t));
-    asymQConfig_t *qC = *reserveMemory(sizeof(asymQConfig_t));
+    quantization_t *q = reserveMemory(sizeof(quantization_t));
+    asymQConfig_t *qC = reserveMemory(sizeof(asymQConfig_t));
     initAsymQConfig(qBits, roundingMode, qC);
     initAsymQuantization(qC, q);
     return q;

--- a/src/userApi/tensor/TensorApi.c
+++ b/src/userApi/tensor/TensorApi.c
@@ -19,14 +19,14 @@
 // tensor inits
 
 tensor_t *tensorInitInt32(int32_t *data, size_t *dims, size_t numberOfDims, sparsity_t *sparsity) {
-    quantization_t *q = *reserveMemory(sizeof(quantization_t));
+    quantization_t *q = reserveMemory(sizeof(quantization_t));
     initInt32Quantization(q);
 
     return initTensorWithQInt32(data, dims, numberOfDims, q, sparsity);
 }
 
 tensor_t *tensorInitFloat(float *data, size_t *dims, size_t numberOfDims, sparsity_t *sparsity) {
-    quantization_t *q = *reserveMemory(sizeof(quantization_t));
+    quantization_t *q = reserveMemory(sizeof(quantization_t));
     initFloat32Quantization(q);
 
     return initTensorWithQFloat(data, dims, numberOfDims, q, sparsity);
@@ -34,8 +34,8 @@ tensor_t *tensorInitFloat(float *data, size_t *dims, size_t numberOfDims, sparsi
 
 tensor_t *tensorInitSymInt32(float *data, size_t *dims, size_t numberOfDims,
                              roundingMode_t roundingMode, sparsity_t *sparsity) {
-    quantization_t *symInt32Q = *reserveMemory(sizeof(quantization_t));
-    symInt32QConfig_t *symInt32QC = *reserveMemory(sizeof(symInt32QConfig_t));
+    quantization_t *symInt32Q = reserveMemory(sizeof(quantization_t));
+    symInt32QConfig_t *symInt32QC = reserveMemory(sizeof(symInt32QConfig_t));
     initSymInt32QConfig(roundingMode, symInt32QC);
     initSymInt32Quantization(symInt32QC, symInt32Q);
 
@@ -44,10 +44,10 @@ tensor_t *tensorInitSymInt32(float *data, size_t *dims, size_t numberOfDims,
 
 tensor_t *tensorInitAsym(float *data, size_t *dims, size_t numberOfDims, uint8_t qBits,
                          roundingMode_t roundingMode, sparsity_t *sparsity) {
-    asymQConfig_t *asymQC = *reserveMemory(sizeof(asymQConfig_t));
+    asymQConfig_t *asymQC = reserveMemory(sizeof(asymQConfig_t));
     asymQC->qBits = qBits;
     asymQC->roundingMode = roundingMode;
-    quantization_t *asymQ = *reserveMemory(sizeof(quantization_t));
+    quantization_t *asymQ = reserveMemory(sizeof(quantization_t));
     asymQ->type = ASYM;
     asymQ->qConfig = asymQC;
 
@@ -64,7 +64,7 @@ tensor_t *tensorInit(float *data, size_t *dims, size_t numberOfDims, quantizatio
         for (size_t i = 0; i < numberOfDims; i++) {
             size += dims[i];
         }
-        int32_t *dataInt = *reserveMemory(size * sizeof(int32_t));
+        int32_t *dataInt = reserveMemory(size * sizeof(int32_t));
         for (size_t i = 0; i < size; i++) {
             dataInt[i] = (int32_t)data[i];
         }
@@ -140,16 +140,16 @@ tensor_t *tensorInitWithDistribution(distributionType_t distributionType, float 
 // grad inits
 
 tensor_t *gradInitInt32(tensor_t *param, sparsity_t *sparsity) {
-    tensor_t *grad = *reserveMemory(sizeof(tensor_t));
+    tensor_t *grad = reserveMemory(sizeof(tensor_t));
 
     grad->shape = param->shape;
-    quantization_t *gradQ = *reserveMemory(sizeof(quantization_t));
+    quantization_t *gradQ = reserveMemory(sizeof(quantization_t));
     initInt32Quantization(gradQ);
     grad->quantization = gradQ;
 
     size_t numberOfValues = calcNumberOfElementsByTensor(param);
     size_t bytesPerElement = sizeof(int32_t);
-    uint8_t *data = *reserveMemory(numberOfValues * bytesPerElement);
+    uint8_t *data = reserveMemory(numberOfValues * bytesPerElement);
     grad->data = data;
 
     grad->sparsity = sparsity;
@@ -158,16 +158,16 @@ tensor_t *gradInitInt32(tensor_t *param, sparsity_t *sparsity) {
 }
 
 tensor_t *gradInitFloat(tensor_t *param, sparsity_t *sparsity) {
-    tensor_t *grad = *reserveMemory(sizeof(tensor_t));
+    tensor_t *grad = reserveMemory(sizeof(tensor_t));
 
     grad->shape = param->shape;
-    quantization_t *gradQ = *reserveMemory(sizeof(quantization_t));
+    quantization_t *gradQ = reserveMemory(sizeof(quantization_t));
     initFloat32Quantization(gradQ);
     grad->quantization = gradQ;
 
     size_t numberOfValues = calcNumberOfElementsByTensor(param);
     size_t bytesPerElement = sizeof(float);
-    uint8_t *data = *reserveMemory(numberOfValues * bytesPerElement);
+    uint8_t *data = reserveMemory(numberOfValues * bytesPerElement);
     grad->data = data;
 
     grad->sparsity = sparsity;
@@ -176,18 +176,18 @@ tensor_t *gradInitFloat(tensor_t *param, sparsity_t *sparsity) {
 }
 
 tensor_t *gradInitSymInt32(tensor_t *param, roundingMode_t roundingMode, sparsity_t *sparsity) {
-    tensor_t *grad = *reserveMemory(sizeof(tensor_t));
+    tensor_t *grad = reserveMemory(sizeof(tensor_t));
 
     grad->shape = param->shape;
-    symInt32QConfig_t *gradQC = *reserveMemory(sizeof(symInt32QConfig_t));
+    symInt32QConfig_t *gradQC = reserveMemory(sizeof(symInt32QConfig_t));
     initSymInt32QConfig(roundingMode, gradQC);
-    quantization_t *gradQ = *reserveMemory(sizeof(quantization_t));
+    quantization_t *gradQ = reserveMemory(sizeof(quantization_t));
     initSymInt32Quantization(gradQC, gradQ);
     grad->quantization = gradQ;
 
     size_t numberOfValues = calcNumberOfElementsByTensor(param);
     size_t bytesPerElement = sizeof(float);
-    uint8_t *data = *reserveMemory(numberOfValues * bytesPerElement);
+    uint8_t *data = reserveMemory(numberOfValues * bytesPerElement);
     grad->data = data;
 
     grad->sparsity = sparsity;
@@ -197,18 +197,18 @@ tensor_t *gradInitSymInt32(tensor_t *param, roundingMode_t roundingMode, sparsit
 
 tensor_t *gradInitAsym(tensor_t *param, uint8_t qBits, roundingMode_t roundingMode,
                        sparsity_t *sparsity) {
-    tensor_t *grad = *reserveMemory(sizeof(tensor_t));
+    tensor_t *grad = reserveMemory(sizeof(tensor_t));
 
     grad->shape = param->shape;
-    asymQConfig_t *gradQC = *reserveMemory(sizeof(asymQConfig_t));
+    asymQConfig_t *gradQC = reserveMemory(sizeof(asymQConfig_t));
     initAsymQConfig(qBits, roundingMode, gradQC);
-    quantization_t *gradQ = *reserveMemory(sizeof(quantization_t));
+    quantization_t *gradQ = reserveMemory(sizeof(quantization_t));
     initAsymQuantization(gradQC, gradQ);
     grad->quantization = gradQ;
 
     size_t numberOfValues = calcNumberOfElementsByTensor(param);
     size_t bytesPerElement = sizeof(float);
-    uint8_t *data = *reserveMemory(numberOfValues * bytesPerElement);
+    uint8_t *data = reserveMemory(numberOfValues * bytesPerElement);
     grad->data = data;
 
     grad->sparsity = sparsity;
@@ -219,14 +219,14 @@ tensor_t *gradInitAsym(tensor_t *param, uint8_t qBits, roundingMode_t roundingMo
 // getLike
 
 shape_t *getShapeLike(shape_t *shape) {
-    shape_t *likeShape = *reserveMemory(sizeof(shape_t));
+    shape_t *likeShape = reserveMemory(sizeof(shape_t));
 
     size_t numberOfDims = shape->numberOfDimensions;
 
-    size_t *likeDims = *reserveMemory(numberOfDims * sizeof(size_t));
+    size_t *likeDims = reserveMemory(numberOfDims * sizeof(size_t));
     memcpy(likeDims, shape->dimensions, numberOfDims * sizeof(size_t));
 
-    size_t *likeOrder = *reserveMemory(numberOfDims * sizeof(size_t));
+    size_t *likeOrder = reserveMemory(numberOfDims * sizeof(size_t));
     setOrderOfDimsForNewTensor(numberOfDims, likeOrder);
 
     setShape(likeShape, likeDims, numberOfDims, likeOrder);
@@ -235,7 +235,7 @@ shape_t *getShapeLike(shape_t *shape) {
 }
 
 quantization_t *getQLike(quantization_t *quantization) {
-    quantization_t *likeQ = *reserveMemory(sizeof(quantization_t));
+    quantization_t *likeQ = reserveMemory(sizeof(quantization_t));
     switch (quantization->type) {
     case FLOAT32:
         initFloat32Quantization(likeQ);
@@ -244,14 +244,14 @@ quantization_t *getQLike(quantization_t *quantization) {
         initInt32Quantization(likeQ);
         break;
     case SYM_INT32:
-        symInt32QConfig_t *likeSymInt32QC = *reserveMemory(sizeof(symInt32QConfig_t));
+        symInt32QConfig_t *likeSymInt32QC = reserveMemory(sizeof(symInt32QConfig_t));
         symInt32QConfig_t *symInt32QC = quantization->qConfig;
 
         initSymInt32QConfig(symInt32QC->roundingMode, likeSymInt32QC);
         initSymInt32Quantization(likeSymInt32QC, likeQ);
         break;
     case ASYM:
-        asymQConfig_t *likeAsymQC = *reserveMemory(sizeof(asymQConfig_t));
+        asymQConfig_t *likeAsymQC = reserveMemory(sizeof(asymQConfig_t));
         asymQConfig_t *asymQC = quantization->qConfig;
 
         initAsymQConfig(asymQC->qBits, asymQC->roundingMode, likeAsymQC);
@@ -267,16 +267,16 @@ quantization_t *getQLike(quantization_t *quantization) {
 uint8_t *getDataLike(quantization_t *quantization, size_t numberOfValues) {
     switch (quantization->type) {
     case FLOAT32:
-        return *reserveMemory(numberOfValues * sizeof(float));
+        return reserveMemory(numberOfValues * sizeof(float));
     case INT32:
-        return *reserveMemory(numberOfValues * sizeof(int32_t));
+        return reserveMemory(numberOfValues * sizeof(int32_t));
     case SYM_INT32:
-        return *reserveMemory(numberOfValues * sizeof(int32_t));
+        return reserveMemory(numberOfValues * sizeof(int32_t));
     case ASYM:
         asymQConfig_t *asymQC = quantization->qConfig;
         size_t totalBits = numberOfValues * asymQC->qBits;
         size_t totalBytes = ceilf(totalBits / 8);
-        return *reserveMemory(totalBytes);
+        return reserveMemory(totalBytes);
     default:
         PRINT_ERROR("Unknown QType");
         exit(1);
@@ -285,13 +285,13 @@ uint8_t *getDataLike(quantization_t *quantization, size_t numberOfValues) {
 
 sparsity_t *getSparsityLike(sparsity_t *sparsity) {
     if (sparsity != NULL) {
-        return *reserveMemory(sizeof(sparsity_t));
+        return reserveMemory(sizeof(sparsity_t));
     }
     return NULL;
 }
 
 tensor_t *getTensorLike(tensor_t *tensor) {
-    tensor_t *likeTensor = *reserveMemory(sizeof(tensor_t));
+    tensor_t *likeTensor = reserveMemory(sizeof(tensor_t));
     size_t numberOfValues = calcNumberOfElementsByShape(tensor->shape);
     likeTensor->data = getDataLike(tensor->quantization, numberOfValues);
     likeTensor->quantization = getQLike(tensor->quantization);
@@ -304,7 +304,7 @@ tensor_t *getTensorLike(tensor_t *tensor) {
 // Free Functions
 
 parameter_t *parameterInit(tensor_t *param, tensor_t *grad) {
-    parameter_t *parameter = *reserveMemory(sizeof(parameter_t));
+    parameter_t *parameter = reserveMemory(sizeof(parameter_t));
     parameter->param = param;
     parameter->grad = grad;
 
@@ -349,8 +349,8 @@ static tensor_t *initTensorWithQInt32(int32_t *data, size_t *dims, size_t number
                                       quantization_t *quantization, sparsity_t *sparsity) {
     tensor_t *tensor = malloc(sizeof(tensor_t));
     tensor->data = (uint8_t *)data;
-    shape_t *shape = *reserveMemory(sizeof(shape_t));
-    size_t *order = *reserveMemory(numberOfDims * sizeof(size_t));
+    shape_t *shape = reserveMemory(sizeof(shape_t));
+    size_t *order = reserveMemory(numberOfDims * sizeof(size_t));
     setOrderOfDimsForNewTensor(numberOfDims, order);
     setShape(shape, dims, numberOfDims, order);
     tensor->shape = shape;
@@ -362,12 +362,12 @@ static tensor_t *initTensorWithQInt32(int32_t *data, size_t *dims, size_t number
 
 static tensor_t *initTensorWithQFloat(float *data, size_t *dims, size_t numberOfDims,
                                       quantization_t *quantization, sparsity_t *sparsity) {
-    tensor_t *tensor = *reserveMemory(sizeof(tensor_t));
+    tensor_t *tensor = reserveMemory(sizeof(tensor_t));
 
     tensor->data = (uint8_t *)data;
 
-    shape_t *shape = *reserveMemory(sizeof(shape_t));
-    size_t *order = *reserveMemory(numberOfDims * sizeof(size_t));
+    shape_t *shape = reserveMemory(sizeof(shape_t));
+    size_t *order = reserveMemory(numberOfDims * sizeof(size_t));
     setOrderOfDimsForNewTensor(numberOfDims, order);
     setShape(shape, dims, numberOfDims, order);
     tensor->shape = shape;
@@ -380,8 +380,8 @@ static tensor_t *initTensorWithQFloat(float *data, size_t *dims, size_t numberOf
 static tensor_t *initTensorWithQSymInt32(float *data, size_t *dims, size_t numberOfDims,
                                          quantization_t *quantization, sparsity_t *sparsity) {
 
-    shape_t *shape = *reserveMemory(sizeof(shape_t));
-    size_t *order = *reserveMemory(numberOfDims * sizeof(size_t));
+    shape_t *shape = reserveMemory(sizeof(shape_t));
+    size_t *order = reserveMemory(numberOfDims * sizeof(size_t));
     setOrderOfDimsForNewTensor(numberOfDims, order);
     setShape(shape, dims, numberOfDims, order);
 
@@ -394,10 +394,10 @@ static tensor_t *initTensorWithQSymInt32(float *data, size_t *dims, size_t numbe
     floatTensor.quantization = &floatQ;
     floatTensor.sparsity = sparsity;
 
-    tensor_t *symInt32Tensor = *reserveMemory(sizeof(tensor_t));
+    tensor_t *symInt32Tensor = reserveMemory(sizeof(tensor_t));
 
     size_t numberOfValues = calcNumberOfElementsByTensor(&floatTensor);
-    int32_t *symInt32Data = *reserveMemory(numberOfValues * sizeof(int32_t));
+    int32_t *symInt32Data = reserveMemory(numberOfValues * sizeof(int32_t));
 
     symInt32Tensor->data = (uint8_t *)symInt32Data;
     symInt32Tensor->shape = shape;
@@ -411,8 +411,8 @@ static tensor_t *initTensorWithQSymInt32(float *data, size_t *dims, size_t numbe
 static tensor_t *initTensorWithQAsym(float *data, size_t *dims, size_t numberOfDims,
                                      quantization_t *quantization, sparsity_t *sparsity) {
 
-    shape_t *shape = *reserveMemory(sizeof(shape_t));
-    size_t *order = *reserveMemory(numberOfDims * sizeof(size_t));
+    shape_t *shape = reserveMemory(sizeof(shape_t));
+    size_t *order = reserveMemory(numberOfDims * sizeof(size_t));
     setOrderOfDimsForNewTensor(numberOfDims, order);
     setShape(shape, dims, numberOfDims, order);
 
@@ -425,13 +425,13 @@ static tensor_t *initTensorWithQAsym(float *data, size_t *dims, size_t numberOfD
     floatTensor.quantization = &floatQ;
     floatTensor.sparsity = sparsity;
 
-    tensor_t *asymTensor = *reserveMemory(sizeof(tensor_t));
+    tensor_t *asymTensor = reserveMemory(sizeof(tensor_t));
 
     asymQConfig_t *asymQC = quantization->qConfig;
     size_t bitsPerElement = asymQC->qBits;
     size_t numberOfValues = calcNumberOfElementsByShape(shape);
     size_t sizeData = ceilf((float)(numberOfValues * bitsPerElement / 8));
-    uint8_t *asymData = *reserveMemory(sizeData);
+    uint8_t *asymData = reserveMemory(sizeData);
 
     asymTensor->data = asymData;
     asymTensor->shape = shape;

--- a/src/userApi/training_loop/TrainingLoopApi.c
+++ b/src/userApi/training_loop/TrainingLoopApi.c
@@ -139,9 +139,9 @@ static epochStats_t evaluateEpochInternal(layer_t **model, size_t modelSize, los
     size_t datasetSize = dataLoader->getDatasetSize();
     size_t numberOfBatches = datasetSize / dataLoader->batchSize;
 
-    size_t *tp = *reserveMemory(numClasses * sizeof(size_t));
-    size_t *predCount = *reserveMemory(numClasses * sizeof(size_t));
-    size_t *actualCount = *reserveMemory(numClasses * sizeof(size_t));
+    size_t *tp = reserveMemory(numClasses * sizeof(size_t));
+    size_t *predCount = reserveMemory(numClasses * sizeof(size_t));
+    size_t *actualCount = reserveMemory(numClasses * sizeof(size_t));
 
     for (size_t c = 0; c < numClasses; c++) {
         tp[c] = 0;

--- a/src/userApi/training_loop/calculate_grads/CalculateGradsSequential.c
+++ b/src/userApi/training_loop/calculate_grads/CalculateGradsSequential.c
@@ -102,9 +102,9 @@ static void initLayerOutputs(tensor_t **layerOutputs, layer_t **model, size_t si
             numberOfDims = 2;
         }
 
-        size_t *dims = *reserveMemory(numberOfDims * sizeof(size_t));
-        size_t *order = *reserveMemory(numberOfDims * sizeof(size_t));
-        shape_t *outShape = *reserveMemory(sizeof(shape_t));
+        size_t *dims = reserveMemory(numberOfDims * sizeof(size_t));
+        size_t *order = reserveMemory(numberOfDims * sizeof(size_t));
+        shape_t *outShape = reserveMemory(sizeof(shape_t));
 
         outShape->dimensions = dims;
         outShape->numberOfDimensions = numberOfDims;
@@ -114,9 +114,9 @@ static void initLayerOutputs(tensor_t **layerOutputs, layer_t **model, size_t si
 
         size_t numberOfValues = calcNumberOfElementsByShape(outShape);
         size_t sizeData = calcNumberOfBytesForData(currentQ, numberOfValues);
-        uint8_t *data = *reserveMemory(sizeData);
+        uint8_t *data = reserveMemory(sizeData);
 
-        quantization_t *q = *reserveMemory(sizeof(quantization_t));
+        quantization_t *q = reserveMemory(sizeof(quantization_t));
         switch (currentQ->type) {
         case FLOAT32:
             initFloat32Quantization(q);
@@ -124,7 +124,7 @@ static void initLayerOutputs(tensor_t **layerOutputs, layer_t **model, size_t si
         case SYM_INT32:
             q->type = SYM_INT32;
             symInt32QConfig_t *currentQC = currentQ->qConfig;
-            symInt32QConfig_t *qC = *reserveMemory(sizeof(symInt32QConfig_t));
+            symInt32QConfig_t *qC = reserveMemory(sizeof(symInt32QConfig_t));
             initSymInt32QConfig(currentQC->roundingMode, qC);
             initSymInt32Quantization(qC, q);
             break;
@@ -133,14 +133,14 @@ static void initLayerOutputs(tensor_t **layerOutputs, layer_t **model, size_t si
             exit(1);
         }
 
-        tensor_t *tensor = *reserveMemory(sizeof(tensor_t));
+        tensor_t *tensor = reserveMemory(sizeof(tensor_t));
         tensor->data = data;
         tensor->quantization = q;
         tensor->shape = outShape;
 
         tensor->sparsity = NULL;
         if (layerOutputs[i]->sparsity != NULL) {
-            sparsity_t *sparsity = *reserveMemory(sizeof(sparsity_t));
+            sparsity_t *sparsity = reserveMemory(sizeof(sparsity_t));
             tensor->sparsity = sparsity;
         }
 
@@ -158,9 +158,9 @@ static void initGradTensor(tensor_t *grad, tensor_t *layerOutput) {
     shape_t *currentShape = layerOutput->shape;
     quantization_t *currentQ = layerOutput->quantization;
 
-    size_t *dims = *reserveMemory(currentShape->numberOfDimensions * sizeof(size_t));
-    size_t *order = *reserveMemory(currentShape->numberOfDimensions * sizeof(size_t));
-    shape_t *inShape = *reserveMemory(sizeof(shape_t));
+    size_t *dims = reserveMemory(currentShape->numberOfDimensions * sizeof(size_t));
+    size_t *order = reserveMemory(currentShape->numberOfDimensions * sizeof(size_t));
+    shape_t *inShape = reserveMemory(sizeof(shape_t));
 
     inShape->dimensions = dims;
     inShape->numberOfDimensions = currentShape->numberOfDimensions;
@@ -175,16 +175,16 @@ static void initGradTensor(tensor_t *grad, tensor_t *layerOutput) {
 
     size_t numberOfValues = calcNumberOfElementsByShape(currentShape);
     size_t sizeData = calcNumberOfBytesForData(currentQ, numberOfValues);
-    uint8_t *data = *reserveMemory(sizeData);
+    uint8_t *data = reserveMemory(sizeData);
 
-    quantization_t *q = *reserveMemory(sizeof(quantization_t));
+    quantization_t *q = reserveMemory(sizeof(quantization_t));
     switch (currentQ->type) {
     case FLOAT32:
         initFloat32Quantization(q);
         break;
     case SYM_INT32:
         symInt32QConfig_t *currentQC = currentQ->qConfig;
-        symInt32QConfig_t *qC = *reserveMemory(sizeof(symInt32QConfig_t));
+        symInt32QConfig_t *qC = reserveMemory(sizeof(symInt32QConfig_t));
         initSymInt32QConfig(currentQC->roundingMode, qC);
         initSymInt32Quantization(qC, q);
         break;
@@ -199,7 +199,7 @@ static void initGradTensor(tensor_t *grad, tensor_t *layerOutput) {
 
     grad->sparsity = NULL;
     if (layerOutput->sparsity != NULL) {
-        sparsity_t *sparsity = *reserveMemory(sizeof(sparsity_t));
+        sparsity_t *sparsity = reserveMemory(sizeof(sparsity_t));
         grad->sparsity = sparsity;
     }
 }
@@ -211,7 +211,7 @@ static void deInitGradTensor(tensor_t *tensor) {
 }
 
 static trainingStats_t *initTrainingStats(tensor_t *output) {
-    trainingStats_t *trainingStats = *reserveMemory(sizeof(trainingStats_t));
+    trainingStats_t *trainingStats = reserveMemory(sizeof(trainingStats_t));
 
     tensor_t *o = getTensorLike(output);
     trainingStats->output = o;

--- a/test/unit/data_loader/UnitTestDataLoader.c
+++ b/test/unit/data_loader/UnitTestDataLoader.c
@@ -57,7 +57,7 @@ static void initProxyDataset() {
 }
 
 static sample_t *getProxySample(size_t id) {
-    sample_t *s = *reserveMemory(sizeof(sample_t));
+    sample_t *s = reserveMemory(sizeof(sample_t));
     s->item = proxyDataset.items->array[id];
     s->label = proxyDataset.labels->array[id];
     return s;

--- a/test/unit/userAPI/CMakeLists.txt
+++ b/test/unit/userAPI/CMakeLists.txt
@@ -1,5 +1,11 @@
 add_elastic_ai_unit_test(
         LIB_UNDER_TEST
+        StorageApi
+)
+
+
+add_elastic_ai_unit_test(
+        LIB_UNDER_TEST
         InferenceApi
         MORE_LIBS
         CommonLayerLibs

--- a/test/unit/userAPI/UnitTestMnistSmoke.c
+++ b/test/unit/userAPI/UnitTestMnistSmoke.c
@@ -62,7 +62,7 @@ static void initDataset() {
 }
 
 static sample_t *getSample(size_t id) {
-    sample_t *sample = *reserveMemory(sizeof(sample_t));
+    sample_t *sample = reserveMemory(sizeof(sample_t));
     sample->item = items[id];
     sample->label = labels[id];
     return sample;

--- a/test/unit/userAPI/UnitTestStorageApi.c
+++ b/test/unit/userAPI/UnitTestStorageApi.c
@@ -1,0 +1,55 @@
+#include <stddef.h>
+#include <stdint.h>
+
+#include "StorageApi.h"
+#include "unity.h"
+
+/* Compile-time contract: reserveMemory returns the allocated payload
+ * directly (void *), and freeReservedMemory accepts that same payload.
+ * The old void ** handle-indirection is removed; see issue #99 comment
+ * for the design rationale (a real handle-table allocator will reintroduce
+ * a typed opaque handle type later, not void **). */
+_Static_assert(_Generic((&reserveMemory), void *(*)(size_t): 1, default: 0),
+               "reserveMemory must return void * (payload), not void ** (handle)");
+_Static_assert(_Generic((&freeReservedMemory), void (*)(void *): 1, default: 0),
+               "freeReservedMemory must take void * (payload)");
+
+void testReserveMemoryReturnsZeroedWritablePayload(void) {
+    uint8_t *payload = reserveMemory(64);
+    TEST_ASSERT_NOT_NULL(payload);
+
+    for (size_t i = 0; i < 64; ++i) {
+        TEST_ASSERT_EQUAL_UINT8(0, payload[i]);
+    }
+    payload[0] = 0xAA;
+    payload[63] = 0x55;
+    TEST_ASSERT_EQUAL_UINT8(0xAA, payload[0]);
+    TEST_ASSERT_EQUAL_UINT8(0x55, payload[63]);
+
+    freeReservedMemory(payload);
+}
+
+void testReserveAndFreeRoundTrip(void) {
+    int *payload = reserveMemory(sizeof(int));
+    TEST_ASSERT_NOT_NULL(payload);
+
+    *payload = 42;
+    TEST_ASSERT_EQUAL_INT(42, *payload);
+
+    freeReservedMemory(payload);
+}
+
+void testFreeReservedMemoryIsNullSafe(void) {
+    freeReservedMemory(NULL);
+}
+
+void setUp() {}
+void tearDown() {}
+
+int main(void) {
+    UNITY_BEGIN();
+    RUN_TEST(testReserveMemoryReturnsZeroedWritablePayload);
+    RUN_TEST(testReserveAndFreeRoundTrip);
+    RUN_TEST(testFreeReservedMemoryIsNullSafe);
+    return UNITY_END();
+}

--- a/test/unit/userAPI/UnitTestTrainingLoopApi.c
+++ b/test/unit/userAPI/UnitTestTrainingLoopApi.c
@@ -188,7 +188,7 @@ static void initEpochDataset() {
 }
 
 static sample_t *getEpochSample(size_t id) {
-    sample_t *s = *reserveMemory(sizeof(sample_t));
+    sample_t *s = reserveMemory(sizeof(sample_t));
     s->item = epochDataset.items->array[id];
     s->label = epochDataset.labels->array[id];
     return s;
@@ -607,7 +607,7 @@ static void initPartialDataset() {
 }
 
 static sample_t *getPartialSample(size_t id) {
-    sample_t *s = *reserveMemory(sizeof(sample_t));
+    sample_t *s = reserveMemory(sizeof(sample_t));
     s->item = partialDataset.items->array[id];
     s->label = partialDataset.labels->array[id];
     return s;
@@ -697,7 +697,7 @@ static void initZeroPredDataset() {
 }
 
 static sample_t *getZeroPredSample(size_t id) {
-    sample_t *s = *reserveMemory(sizeof(sample_t));
+    sample_t *s = reserveMemory(sizeof(sample_t));
     s->item = zeroPredDataset.items->array[id];
     s->label = zeroPredDataset.labels->array[id];
     return s;


### PR DESCRIPTION
Closes #99

## Summary

`reserveMemory` used to do a `calloc` for the payload **plus** a separate `malloc` for an indirection handle (`void **`). Every caller immediately did `T *t = *reserveMemory(...)`, dropping the handle pointer; the matching `freeReservedMemory` only freed the payload. The handle malloc was permanently lost — Phase 1 LSan recon attributed 99+ unique leak signatures to that single line of `StorageApi.c`.

Option β from the brainstorm (caller keeps the handle, `freeReservedMemory(void **)`) turned out to be infeasible in this codebase: the dominant pattern is init/free pairs separated by user code (`reluLayerInit`/`freeReluLayer`, `tensorInit*`/`freeTensor`, …), where the free function only sees the payload pointer. Finishing β would have required struct-internal handle fields, a `payload→handle` side-table inside StorageApi, or threading handles through every public init/free signature — all of which are larger than the eventual handle-table allocator will be when it lands. See [issue #99 comment](https://github.com/es-ude/OnDeviceTraining/issues/99#issuecomment-4317217469) for the full design rationale.

The `void **` indirection is a placeholder, not a step toward the planned typed-handle allocator (`project_storage_api_handle_vision`); the real handle will be opaque, not a double pointer. So this PR removes the indirection entirely:

```c
void *reserveMemory(size_t)      // calloc, no handle malloc
void freeReservedMemory(void *)  // free, NULL-safe
```

All call-sites in `src/userApi/` migrated mechanically (`*reserveMemory(...)` → `reserveMemory(...)`); three test files outside `src/userApi/` that were also dereferencing `reserveMemory` directly migrated the same way.

## Phase 1 LSan sweep delta (Linux Valgrind run)

| Category | Baseline | After fix | Δ |
|---|---:|---:|---:|
| definitely lost | 126,686 B | 18,432 B | **−85 %** |
| indirectly lost | 47,094 B | 28,684 B | **−39 %** |
| still reachable | 4,744 B | 4,744 B | 0 |
| **total lost** | **173,780 B** | **47,116 B** | **−73 %** |

The remaining ~47 KB are pre-existing deinit gaps (e.g. `freeLinearLayer` not releasing all sub-allocations). Those are Phase 2 territory and are tracked separately in the LSan recon report.

## TDD

`test/unit/userAPI/UnitTestStorageApi.c` (new) pins the flat signatures at compile time via `_Static_assert` + `_Generic`, plus runtime tests for the round-trip and NULL-safety contract. Verified failing against the original (handle-indirection) StorageApi.c, then green after the flat implementation landed.

## Test plan

- [x] `cmake --build --preset unit_test_debug` clean
- [x] `ctest --preset unit_test_debug`: 32/32 pass (UnitTestStorageApi added)
- [x] `uv run pytest python/`: 3/3 pass
- [x] Phase 1 LSan sweep run after the change confirms the per-test "lost" totals drop as above
- [x] No new warnings introduced
- [x] `_Static_assert` verified to fail against the original signatures (TDD red proven)

## Stacking note

Based on `81-fix-npy-vla-memcpy` because three of the migrated files (`NPYLoaderApi.c`, `FlattenApi.c`, plus the rest of the chain) only exist or were last-modified on that branch and PR #77 (flatten). When #89 (and #77 if needed) merge first, this PR's base auto-rolls forward to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)