### PR TITLE
fix(#101): close three free-API gaps surfaced by Phase 1 LSan recon

### DIFF
--- a/src/userApi/layer/LinearApi.c
+++ b/src/userApi/layer/LinearApi.c
@@ -3,13 +3,15 @@
 #include <stdlib.h>
 
 #include "Layer.h"
-#include "Tensor.h"
-#include "StorageApi.h"
-#include "TensorApi.h"
-#include "LinearApi.h"
 #include "Linear.h"
+#include "LinearApi.h"
+#include "StorageApi.h"
+#include "Tensor.h"
+#include "TensorApi.h"
 
-layer_t *linearLayerInit(parameter_t *weights, parameter_t *bias, quantization_t *forwardQ, quantization_t *weightGradsQ, quantization_t *biasGradsQ, quantization_t *propLossQ) {
+layer_t *linearLayerInit(parameter_t *weights, parameter_t *bias, quantization_t *forwardQ,
+                         quantization_t *weightGradsQ, quantization_t *biasGradsQ,
+                         quantization_t *propLossQ) {
     layer_t *linearLayer = reserveMemory(sizeof(layer_t));
 
     linearLayer->type = LINEAR;
@@ -49,7 +51,7 @@ layer_t *linearLayerInitNonTrainable(tensor_t *weights, tensor_t *bias, quantiza
 }
 
 void freeLinearLayer(layer_t *linearLayer) {
-    linearConfig_t *linearConfig = linearLayer->config->linear;
-    freeReservedMemory(linearConfig);
+    freeReservedMemory(linearLayer->config->linear);
+    freeReservedMemory(linearLayer->config);
     freeReservedMemory(linearLayer);
 }

--- a/src/userApi/layer/ReluApi.c
+++ b/src/userApi/layer/ReluApi.c
@@ -1,9 +1,8 @@
 #define SOURCE_FILE "RELU_API"
 
-#include "StorageApi.h"
 #include "ReluApi.h"
 #include "Relu.h"
-
+#include "StorageApi.h"
 
 layer_t *reluLayerInit(quantization_t *forwardQ, quantization_t *backwardQ) {
     layer_t *reluLayer = reserveMemory(sizeof(layer_t));
@@ -23,6 +22,7 @@ layer_t *reluLayerInit(quantization_t *forwardQ, quantization_t *backwardQ) {
 }
 
 void freeReluLayer(layer_t *reluLayer) {
+    freeReservedMemory(reluLayer->config->relu);
     freeReservedMemory(reluLayer->config);
     freeReservedMemory(reluLayer);
 }

--- a/src/userApi/layer/SoftmaxApi.c
+++ b/src/userApi/layer/SoftmaxApi.c
@@ -1,8 +1,8 @@
 #define SOURCE_FILE "SOFTMAX_API"
 
-#include "StorageApi.h"
-#include "Softmax.h"
 #include "SoftmaxApi.h"
+#include "Softmax.h"
+#include "StorageApi.h"
 
 layer_t *softmaxLayerInit(quantization_t *forwardQ, quantization_t *backwardQ) {
     layer_t *softmaxLayer = reserveMemory(sizeof(layer_t));
@@ -17,5 +17,11 @@ layer_t *softmaxLayerInit(quantization_t *forwardQ, quantization_t *backwardQ) {
     softmaxConfig->backwardQ = backwardQ;
     softmaxLayer->config = layerConfig;
 
-    return  softmaxLayer;
+    return softmaxLayer;
+}
+
+void freeSoftmaxLayer(layer_t *softmaxLayer) {
+    freeReservedMemory(softmaxLayer->config->softmax);
+    freeReservedMemory(softmaxLayer->config);
+    freeReservedMemory(softmaxLayer);
 }

--- a/src/userApi/layer/include/SoftmaxApi.h
+++ b/src/userApi/layer/include/SoftmaxApi.h
@@ -1,9 +1,11 @@
 #ifndef SOFTMAXAPI_H
 #define SOFTMAXAPI_H
 
-#include "Tensor.h"
 #include "Layer.h"
+#include "Tensor.h"
 
 layer_t *softmaxLayerInit(quantization_t *forwardQ, quantization_t *backwardQ);
 
-#endif //SOFTMAXAPI_H
+void freeSoftmaxLayer(layer_t *softmaxLayer);
+
+#endif // SOFTMAXAPI_H

--- a/test/unit/layer/UnitTestLinear.c
+++ b/test/unit/layer/UnitTestLinear.c
@@ -484,6 +484,27 @@ void testLinearLayerInitNonTrainable(void) {
     TEST_ASSERT_FLOAT_WITHIN(0.001f, -4.f, actual[1]);
 }
 
+void testLinearLayerInitAndFreeRoundTrip(void) {
+    /* Roundtrip: linearLayerInit allocates layer + outer layerConfig +
+     * inner linearConfig (3 reserveMemory calls). freeLinearLayer must
+     * release all three. Pre-fix this test runs to completion but leaks
+     * the outer layerConfig wrapper; post-fix it is leak-clean (verified
+     * via the LSan sweep).
+     *
+     * linearLayerInit only stores the parameter and quantization pointers
+     * without dereferencing them, and freeLinearLayer does not touch
+     * parameters/quantization (those are externally owned). So NULL is a
+     * valid stand-in here — keeps the test focused on the StorageApi
+     * lifecycle, not on tensor ownership. */
+    layer_t *linearLayer = linearLayerInit(NULL, NULL, NULL, NULL, NULL, NULL);
+    TEST_ASSERT_NOT_NULL(linearLayer);
+    TEST_ASSERT_EQUAL_INT(LINEAR, linearLayer->type);
+    TEST_ASSERT_NOT_NULL(linearLayer->config);
+    TEST_ASSERT_NOT_NULL(linearLayer->config->linear);
+
+    freeLinearLayer(linearLayer);
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(testLinearForwardFloat);
@@ -491,6 +512,7 @@ int main(void) {
 
     RUN_TEST(testLinearForwardSymInt32);
     RUN_TEST(testLinearBackwardSymInt32);
+    RUN_TEST(testLinearLayerInitAndFreeRoundTrip);
 
     RUN_TEST(testLinearBackwardFloatWithMismatchedQuantizations);
     RUN_TEST(testLinearLayerInitNonTrainable);

--- a/test/unit/layer/UnitTestRelu.c
+++ b/test/unit/layer/UnitTestRelu.c
@@ -136,6 +136,22 @@ void testReluBackwardSymInt32() {
     }
 }
 
+void testReluLayerInitAndFreeRoundTrip(void) {
+    /* Roundtrip: reluLayerInit allocates layer + outer layerConfig +
+     * inner reluConfig (3 reserveMemory calls). freeReluLayer must
+     * release all three. Pre-fix this test runs to completion but leaks
+     * the inner reluConfig; post-fix it is leak-clean (verified via the
+     * LSan sweep). NULL is acceptable for the quantization arguments —
+     * reluLayerInit only stores them, freeReluLayer doesn't touch them. */
+    layer_t *reluLayer = reluLayerInit(NULL, NULL);
+    TEST_ASSERT_NOT_NULL(reluLayer);
+    TEST_ASSERT_EQUAL_INT(RELU, reluLayer->type);
+    TEST_ASSERT_NOT_NULL(reluLayer->config);
+    TEST_ASSERT_NOT_NULL(reluLayer->config->relu);
+
+    freeReluLayer(reluLayer);
+}
+
 void setUp() {}
 void tearDown() {}
 
@@ -146,5 +162,7 @@ int main(void) {
 
     RUN_TEST(testReluBackwardFloat);
     RUN_TEST(testReluBackwardSymInt32);
+
+    RUN_TEST(testReluLayerInitAndFreeRoundTrip);
     return UNITY_END();
 }

--- a/test/unit/layer/UnitTestSoftmax.c
+++ b/test/unit/layer/UnitTestSoftmax.c
@@ -140,6 +140,26 @@ void unitTestSoftmaxBackwardSymInt32() {
     }
 }
 
+void testSoftmaxLayerInitAndFreeRoundTrip(void) {
+    /* Roundtrip: softmaxLayerInit allocates layer + outer layerConfig +
+     * inner softmaxConfig (3 reserveMemory calls). freeSoftmaxLayer must
+     * release all three. Leak verification is delegated to the LSan
+     * sweep — this test asserts only that the round-trip completes
+     * without a crash and that the layer was wired correctly. */
+    quantization_t *floatQ = quantizationInitFloat();
+    layer_t *softmaxLayer = softmaxLayerInit(floatQ, floatQ);
+    TEST_ASSERT_NOT_NULL(softmaxLayer);
+    TEST_ASSERT_EQUAL_INT(SOFTMAX, softmaxLayer->type);
+    TEST_ASSERT_NOT_NULL(softmaxLayer->config);
+    TEST_ASSERT_NOT_NULL(softmaxLayer->config->softmax);
+
+    freeSoftmaxLayer(softmaxLayer);
+
+    /* floatQ is owned by the test; freeSoftmaxLayer must not have freed
+     * it (quantization configs are externally owned and shared). */
+    freeQuantization(floatQ);
+}
+
 void setUp() {}
 void tearDown() {}
 
@@ -150,5 +170,7 @@ int main() {
 
     RUN_TEST(unitTestSoftmaxBackwardFloat);
     RUN_TEST(unitTestSoftmaxBackwardSymInt32);
+
+    RUN_TEST(testSoftmaxLayerInitAndFreeRoundTrip);
     return UNITY_END();
 }


### PR DESCRIPTION
Closes #101

## Summary

Three independent fixes to layer free-functions in `src/userApi/layer/`, prerequisite for Phase 2's leak discipline.

| Gap | Before | After |
|---|---|---|
| 1: `softmaxLayerInit` had no matching free | 3 internal structs always leaked | Adds `freeSoftmaxLayer` (header + impl) |
| 2: `freeLinearLayer` leaked outer `layerConfig` | Freed inner `linearConfig` + layer | Now also frees outer `layerConfig` |
| 3: `freeReluLayer` leaked inner `reluConfig` | Freed outer `layerConfig` + layer | Now also frees inner `reluConfig` |

## Recon notes (also in [issue comment](https://github.com/es-ude/OnDeviceTraining/issues/101#issuecomment-4317312070))

- **No "free-vtable" exists today.** `layerFunctions_t` has only `forward`, `backward`, `calcOutputShape`. `freeReluLayer` and `freeLinearLayer` are direct functions, not vtable entries. The new `freeSoftmaxLayer` follows the same convention; adding a free vtable slot is a separate design decision not driven by any current caller.
- **`freeReluLayer` / `freeLinearLayer` are never called today.** Only `freeFlattenLayer` has callers (`UnitTestFlatten.c`). The LSan signatures from these inits won't disappear in the existing test suite until Phase 2 migrates the tests to call the free functions. The fixes are still real (the free functions become correct, ready for Phase 2 to call them).

## TDD

Each gap has a small init+free roundtrip test in the matching `test/unit/layer/UnitTest{Softmax,Linear,Relu}.c`:

- `testSoftmaxLayerInitAndFreeRoundTrip` — Gap 1: compile-RED (function didn't exist), green after the new symbol lands.
- `testLinearLayerInitAndFreeRoundTrip` — Gap 2: passed pre-fix and post-fix at the Unity layer (the missing free is invisible to a Unity assertion); LSan-clean post-fix because all three allocations get released.
- `testReluLayerInitAndFreeRoundTrip` — Gap 3: same shape as Gap 2.

The tests pass `NULL` for the externally-owned `parameter_t` and `quantization_t` arguments. `linearLayerInit` and `reluLayerInit` only store these pointers (don't dereference), and the corresponding free functions don't touch them — so NULL is the cleanest stand-in to keep the test focused on StorageApi lifecycle, not tensor ownership.

## LSan sweep

| Test binary | def lost (#99 → #101) | ind lost (#99 → #101) |
|---|---:|---:|
| UnitTestLinear   | 304 → 304 | 1832 → 1832 |
| UnitTestRelu     | 384 → 384 |  852 → 852 |
| UnitTestSoftmax  | 448 → 448 | 1036 → 1036 |
| **suite total**  | **49,868 B → 49,868 B** | (Δ = 0) |

This is the predicted result given that existing tests don't call the new free functions; the new round-trip tests are leak-clean in their isolated paths but their footprint is masked by the still-leaking older tests in the same binary. Phase 2 will resolve this by migrating tests onto a teardown idiom that calls the free functions.

## Test plan

- [x] `cmake --build --preset unit_test_debug` clean
- [x] `ctest --preset unit_test_debug`: 32/32 pass (3 new tests added)
- [x] `uv run pytest python/`: 3/3 pass
- [x] LSan sweep run; result matches prediction

## Stacking note

Based on `99-storage-api-flat-alloc` (PR #103). When #99 merges first, this PR's base auto-rolls forward to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)