### PR TITLE
refactor(#100): split tensor init from data populate (initTensor + initDistribution + tensorFillFromBuffer)

### DIFF
--- a/src/arithmetic/include/Distributions.h
+++ b/src/arithmetic/include/Distributions.h
@@ -3,8 +3,7 @@
 
 #include <stddef.h>
 
-typedef enum
-{
+typedef enum {
     ZEROS,
     ONES,
     UNIFORM,
@@ -14,6 +13,33 @@ typedef enum
     KAIMING_UNIFORM,
     KAIMING_NORMAL
 } distributionType_t;
+
+/*! Carries both the kind of distribution and the kind-specific parameters
+ * needed to draw values. Used by initDistribution() (TensorApi.h) and by
+ * future layer factories that take an initialization recipe.
+ *
+ * Discriminant: `type`. Read the union member matching that discriminant.
+ * ZEROS and ONES need no params; their union slot is unused.
+ */
+typedef struct {
+    distributionType_t type;
+    union {
+        struct {
+            float min, max;
+        } uniform;
+        struct {
+            float mean, stddev;
+        } normal;
+        struct {
+            float gain;
+            size_t fanIn, fanOut;
+        } xavier;
+        struct {
+            float gain;
+            size_t fanMode;
+        } kaiming;
+    } params;
+} distribution_t;
 
 /*! Gets random value from normal distribution.\n
  * Uses the Box-Muller transform.
@@ -61,7 +87,6 @@ float kaimingUniform(float gain, size_t fanMode);
  * @returns Float value
  */
 float xavierNormal(float gain, size_t fanIn, size_t fanOut);
-
 
 /*! Gets random value from Xavier distribution using the uniform distribution.
  *

--- a/src/tensor/Tensor.c
+++ b/src/tensor/Tensor.c
@@ -1,15 +1,15 @@
 #define SOURCE_FILE "TENSOR"
 
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
 #include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
-#include "Tensor.h"
-#include "Quantization.h"
-#include "MinMax.h"
-#include "DTypes.h"
 #include "Common.h"
+#include "DTypes.h"
+#include "MinMax.h"
+#include "Quantization.h"
+#include "Tensor.h"
 
 size_t calcNumberOfElementsByShape(shape_t *shape) {
     size_t numElem = 1;
@@ -79,6 +79,8 @@ size_t calcNumberOfBytesForData(quantization_t *q, size_t numberOfElements) {
     switch (q->type) {
     case FLOAT32:
         return numberOfElements * sizeof(float);
+    case INT32:
+        return numberOfElements * sizeof(int32_t);
     case SYM_INT32:
         return numberOfElements * sizeof(int32_t);
     case ASYM:
@@ -116,8 +118,8 @@ uint32_t getBitmask(uint32_t startbit, uint32_t endbit) {
         }
         value *= 2;
     }
-    //printf("bitmask ");
-    //print_binary_uint8(counter);
+    // printf("bitmask ");
+    // print_binary_uint8(counter);
     return counter;
 }
 
@@ -133,12 +135,12 @@ uint8_t writeByte(uint8_t existingData, uint8_t data, uint8_t startbit, uint8_t 
     uint8_t endbitInternal = endbit - (startbit / 8) * 8;
     uint8_t bitmask = getBitmask(startbitInternal, endbitInternal);
     data <<= startbitInternal;
-    //print_binary_uint8(data);
+    // print_binary_uint8(data);
     uint8_t intermediate = data & bitmask;
-    //print_binary_uint8(bitmask);
-    //print_binary_uint8(intermediate);
+    // print_binary_uint8(bitmask);
+    // print_binary_uint8(intermediate);
     existingData = intermediate | existingData;
-    //print_binary_uint8(existingData);
+    // print_binary_uint8(existingData);
     return existingData;
 }
 
@@ -149,7 +151,6 @@ int max(int a, int b) {
 int min(int a, int b) {
     return (a < b) ? a : b;
 }
-
 
 void byteConversion(uint8_t *dataIn, size_t dataInBits, uint8_t *dataOut, size_t dataOutBits,
                     size_t numValues) {
@@ -167,8 +168,8 @@ void byteConversion(uint8_t *dataIn, size_t dataInBits, uint8_t *dataOut, size_t
         printf("Value %i\n", i);*/
         while ((dataInStartbit < dataInEndbit) | (dataOutStartbit < dataOutEndbit)) {
             uint8_t data = readByte(dataIn[dataInIndex], dataInStartbit, dataInEndbit);
-            dataOut[dataOutIndex] = writeByte(dataOut[dataOutIndex], data, dataOutStartbit,
-                                              dataOutEndbit);
+            dataOut[dataOutIndex] =
+                writeByte(dataOut[dataOutIndex], data, dataOutStartbit, dataOutEndbit);
 
             /*
             printf("dataInStartbit %d\n", dataInStartbit);
@@ -213,17 +214,14 @@ void byteConversion(uint8_t *dataIn, size_t dataInBits, uint8_t *dataOut, size_t
             if (dataOutStartbit / 8 > (dataOutStartbit - deltaOut) / 8) {
                 dataOutIndex += 1;
             }
-            //printf("\n");
-
+            // printf("\n");
         }
         dataInStartbit = dataInEndbit % 8;
         dataInEndbit = dataInStartbit + dataInBits;
         dataOutStartbit = dataOutEndbit % 8;
         dataOutEndbit = dataOutStartbit + dataOutBits;
-
     }
 }
-
 
 tensor_t *getParamFromParameter(parameter_t *parameter) {
     return parameter->param;
@@ -242,7 +240,6 @@ void transposeTensor(tensor_t *tensor, size_t dim0Index, size_t dim1Index) {
     tensor->shape->orderOfDimensions[dim1Index] = temp;
 }
 
-
 void setTensorValuesForConversion(uint8_t *data, quantization_t *q, tensor_t *originalTensor,
                                   tensor_t *outputTensor) {
     outputTensor->data = data;
@@ -251,8 +248,8 @@ void setTensorValuesForConversion(uint8_t *data, quantization_t *q, tensor_t *or
     outputTensor->sparsity = originalTensor->sparsity;
 }
 
-void setTensorValues(tensor_t *tensor, uint8_t *data, shape_t *shape,
-                     quantization_t *quantization, sparsity_t *sparsity) {
+void setTensorValues(tensor_t *tensor, uint8_t *data, shape_t *shape, quantization_t *quantization,
+                     sparsity_t *sparsity) {
     tensor->data = data;
     tensor->shape = shape;
     tensor->quantization = quantization;

--- a/src/userApi/InferenceApi.c
+++ b/src/userApi/InferenceApi.c
@@ -1,20 +1,19 @@
 #define SOURCE_FILE "INFERENCE_Api"
 
-#include <stdio.h>
 #include <stdbool.h>
+#include <stdio.h>
 #include <stdlib.h>
 
-#include "Tensor.h"
-#include "Layer.h"
+#include "Common.h"
 #include "InferenceApi.h"
-#include "TensorApi.h"
-#include "StorageApi.h"
+#include "Layer.h"
 #include "Linear.h"
 #include "Relu.h"
-#include "TensorConversion.h"
-#include "Common.h"
 #include "Softmax.h"
-
+#include "StorageApi.h"
+#include "Tensor.h"
+#include "TensorApi.h"
+#include "TensorConversion.h"
 
 // Initializes buffer to match output
 static void initBufferOutput(tensor_t *buffer, layer_t *currentLayer, shape_t *inputShape,
@@ -50,8 +49,7 @@ static void initBufferOutput(tensor_t *buffer, layer_t *currentLayer, shape_t *i
     calcOutputShapeFn_t calcOutputShape = layerFunctions[currentLayerType].calcOutputShape;
     calcOutputShape(currentLayer, inputShape, outShape);
 
-    size_t numValues =
-        calcNumberOfElementsByShape(outShape);
+    size_t numValues = calcNumberOfElementsByShape(outShape);
     size_t sizeData = calcNumberOfBytesForData(currentQ, numValues);
     uint8_t *data = reserveMemory(sizeData);
 
@@ -158,15 +156,9 @@ tensor_t **inferenceBatched(layer_t **model, size_t numberOfLayers, batch_t *bat
 inferenceStats_t *reserveInferenceStats(tensor_t *label) {
     inferenceStats_t *inferenceStats = reserveMemory(sizeof(inferenceStats_t));
 
-    size_t sizeOutput = calcNumberOfElementsByTensor(label);
-
-    float *outputData = reserveMemory(sizeOutput * sizeof(float));
-    size_t outputNumberOfDims = label->shape->numberOfDimensions;
-    size_t *outputDims = reserveMemory(outputNumberOfDims * sizeof(size_t));
+    shape_t *outputShape = getShapeLike(label->shape);
     quantization_t *outputQ = getQLike(label->quantization);
-    tensor_t *output = tensorInit(outputData, outputDims, outputNumberOfDims, outputQ, NULL);
-
-    inferenceStats->output = output;
+    inferenceStats->output = initTensor(outputShape, outputQ, NULL);
 
     return inferenceStats;
 }

--- a/src/userApi/data_loader/NPYLoaderApi.c
+++ b/src/userApi/data_loader/NPYLoaderApi.c
@@ -73,6 +73,9 @@ tensorArray_t *npyLoad(char *path) {
         }
     }
 
+    /* `q` was deep-copied per tensor via getQLike; free the original. */
+    freeQuantization(q);
+
     fclose(f);
 
     return tensorArr;

--- a/src/userApi/data_loader/NPYLoaderApi.c
+++ b/src/userApi/data_loader/NPYLoaderApi.c
@@ -51,12 +51,22 @@ tensorArray_t *npyLoad(char *path) {
     tensorArr->size = numberOfTensors;
 
     for (size_t i = 0; i < numberOfTensors; i++) {
-        float *data = reserveMemory(numberOfValuesInRow * bytesPerValue);
-        size_t *dims = reserveMemory(numberOfDims * sizeof(size_t));
+        size_t *dims = reserveMemory(rowNumberOfDims * sizeof(size_t));
         memcpy(dims, rowDims, rowNumberOfDims * sizeof(size_t));
+        size_t *order = reserveMemory(rowNumberOfDims * sizeof(size_t));
+        setOrderOfDimsForNewTensor(rowNumberOfDims, order);
+        shape_t *shape = reserveMemory(sizeof(shape_t));
+        setShape(shape, dims, rowNumberOfDims, order);
 
-        size_t n = fread(data, bytesPerValue, numberOfValuesInRow, f);
-        tensorArr->array[i] = tensorInit(data, dims, rowShape.numberOfDimensions, q, NULL);
+        /* Fresh quantization clone per tensor: every array entry now owns its
+         * own quantization, so freeTensor on any one doesn't double-free a
+         * shared `q`. */
+        quantization_t *rowQ = getQLike(q);
+
+        tensor_t *t = initTensor(shape, rowQ, NULL);
+        tensorArr->array[i] = t;
+
+        size_t n = fread(t->data, bytesPerValue, numberOfValuesInRow, f);
         if (n != numberOfValuesInRow) {
             PRINT_ERROR("fread did not read the correct number of bytes!");
             exit(1);

--- a/src/userApi/tensor/CMakeLists.txt
+++ b/src/userApi/tensor/CMakeLists.txt
@@ -16,4 +16,5 @@ target_link_libraries(TensorApi PRIVATE
         Common
         TensorConversion
         Distributions
+        QuantizationApi
 )

--- a/src/userApi/tensor/TensorApi.c
+++ b/src/userApi/tensor/TensorApi.c
@@ -240,80 +240,21 @@ tensor_t *tensorInitWithDistribution(distributionType_t distributionType, float 
 // grad inits
 
 tensor_t *gradInitInt32(tensor_t *param, sparsity_t *sparsity) {
-    tensor_t *grad = reserveMemory(sizeof(tensor_t));
-
-    grad->shape = param->shape;
-    quantization_t *gradQ = reserveMemory(sizeof(quantization_t));
-    initInt32Quantization(gradQ);
-    grad->quantization = gradQ;
-
-    size_t numberOfValues = calcNumberOfElementsByTensor(param);
-    size_t bytesPerElement = sizeof(int32_t);
-    uint8_t *data = reserveMemory(numberOfValues * bytesPerElement);
-    grad->data = data;
-
-    grad->sparsity = sparsity;
-
-    return grad;
+    return initTensor(getShapeLike(param->shape), quantizationInitInt32(), sparsity);
 }
 
 tensor_t *gradInitFloat(tensor_t *param, sparsity_t *sparsity) {
-    tensor_t *grad = reserveMemory(sizeof(tensor_t));
-
-    grad->shape = param->shape;
-    quantization_t *gradQ = reserveMemory(sizeof(quantization_t));
-    initFloat32Quantization(gradQ);
-    grad->quantization = gradQ;
-
-    size_t numberOfValues = calcNumberOfElementsByTensor(param);
-    size_t bytesPerElement = sizeof(float);
-    uint8_t *data = reserveMemory(numberOfValues * bytesPerElement);
-    grad->data = data;
-
-    grad->sparsity = sparsity;
-
-    return grad;
+    return initTensor(getShapeLike(param->shape), quantizationInitFloat(), sparsity);
 }
 
 tensor_t *gradInitSymInt32(tensor_t *param, roundingMode_t roundingMode, sparsity_t *sparsity) {
-    tensor_t *grad = reserveMemory(sizeof(tensor_t));
-
-    grad->shape = param->shape;
-    symInt32QConfig_t *gradQC = reserveMemory(sizeof(symInt32QConfig_t));
-    initSymInt32QConfig(roundingMode, gradQC);
-    quantization_t *gradQ = reserveMemory(sizeof(quantization_t));
-    initSymInt32Quantization(gradQC, gradQ);
-    grad->quantization = gradQ;
-
-    size_t numberOfValues = calcNumberOfElementsByTensor(param);
-    size_t bytesPerElement = sizeof(float);
-    uint8_t *data = reserveMemory(numberOfValues * bytesPerElement);
-    grad->data = data;
-
-    grad->sparsity = sparsity;
-
-    return grad;
+    return initTensor(getShapeLike(param->shape), quantizationInitSymInt32(roundingMode), sparsity);
 }
 
 tensor_t *gradInitAsym(tensor_t *param, uint8_t qBits, roundingMode_t roundingMode,
                        sparsity_t *sparsity) {
-    tensor_t *grad = reserveMemory(sizeof(tensor_t));
-
-    grad->shape = param->shape;
-    asymQConfig_t *gradQC = reserveMemory(sizeof(asymQConfig_t));
-    initAsymQConfig(qBits, roundingMode, gradQC);
-    quantization_t *gradQ = reserveMemory(sizeof(quantization_t));
-    initAsymQuantization(gradQC, gradQ);
-    grad->quantization = gradQ;
-
-    size_t numberOfValues = calcNumberOfElementsByTensor(param);
-    size_t bytesPerElement = sizeof(float);
-    uint8_t *data = reserveMemory(numberOfValues * bytesPerElement);
-    grad->data = data;
-
-    grad->sparsity = sparsity;
-
-    return grad;
+    return initTensor(getShapeLike(param->shape), quantizationInitAsym(qBits, roundingMode),
+                      sparsity);
 }
 
 // getLike

--- a/src/userApi/tensor/TensorApi.c
+++ b/src/userApi/tensor/TensorApi.c
@@ -91,6 +91,67 @@ tensor_t *initTensor(shape_t *shape, quantization_t *quantization, sparsity_t *s
     return tensor;
 }
 
+void initDistribution(tensor_t *tensor, const distribution_t *distribution) {
+    if (tensor->quantization->type != FLOAT32) {
+        PRINT_ERROR("initDistribution only supports FLOAT32 in this iteration");
+        exit(1);
+    }
+    float *vals = (float *)tensor->data;
+    size_t n = calcNumberOfElementsByTensor(tensor);
+
+    switch (distribution->type) {
+    case ZEROS:
+        memset(vals, 0, n * sizeof(float));
+        break;
+    case ONES:
+        for (size_t i = 0; i < n; ++i) {
+            vals[i] = 1.0f;
+        }
+        break;
+    case UNIFORM:
+        for (size_t i = 0; i < n; ++i) {
+            vals[i] =
+                randomUniform(distribution->params.uniform.min, distribution->params.uniform.max);
+        }
+        break;
+    case NORMAL:
+        for (size_t i = 0; i < n; ++i) {
+            vals[i] =
+                randomNormal(distribution->params.normal.mean, distribution->params.normal.stddev);
+        }
+        break;
+    case XAVIER_UNIFORM:
+        for (size_t i = 0; i < n; ++i) {
+            vals[i] =
+                xavierUniform(distribution->params.xavier.gain, distribution->params.xavier.fanIn,
+                              distribution->params.xavier.fanOut);
+        }
+        break;
+    case XAVIER_NORMAL:
+        for (size_t i = 0; i < n; ++i) {
+            vals[i] =
+                xavierNormal(distribution->params.xavier.gain, distribution->params.xavier.fanIn,
+                             distribution->params.xavier.fanOut);
+        }
+        break;
+    case KAIMING_UNIFORM:
+        for (size_t i = 0; i < n; ++i) {
+            vals[i] = kaimingUniform(distribution->params.kaiming.gain,
+                                     distribution->params.kaiming.fanMode);
+        }
+        break;
+    case KAIMING_NORMAL:
+        for (size_t i = 0; i < n; ++i) {
+            vals[i] = kaimingNormal(distribution->params.kaiming.gain,
+                                    distribution->params.kaiming.fanMode);
+        }
+        break;
+    default:
+        PRINT_ERROR("Unknown distribution type!");
+        exit(1);
+    }
+}
+
 tensor_t *tensorInitWithDistribution(distributionType_t distributionType, float *data, size_t *dims,
                                      size_t numberOfDims, quantization_t *quantization,
                                      sparsity_t *sparsity, size_t inputFeatures,

--- a/src/userApi/tensor/TensorApi.c
+++ b/src/userApi/tensor/TensorApi.c
@@ -384,7 +384,9 @@ void freeTensor(tensor_t *tensor) {
 
 void freeParameter(parameter_t *parameter) {
     freeTensor(parameter->param);
-    freeTensor(parameter->grad);
+    if (parameter->grad != NULL) {
+        freeTensor(parameter->grad);
+    }
     freeReservedMemory(parameter);
 }
 

--- a/src/userApi/tensor/TensorApi.c
+++ b/src/userApi/tensor/TensorApi.c
@@ -91,6 +91,33 @@ tensor_t *initTensor(shape_t *shape, quantization_t *quantization, sparsity_t *s
     return tensor;
 }
 
+void tensorFillFromFloatBuffer(tensor_t *tensor, const float *source, size_t count) {
+    size_t expected = calcNumberOfElementsByTensor(tensor);
+    if (count != expected) {
+        PRINT_ERROR("tensorFillFromFloatBuffer count mismatch (expected vs given)");
+        exit(1);
+    }
+
+    if (tensor->quantization->type == FLOAT32) {
+        memcpy(tensor->data, source, count * sizeof(float));
+        return;
+    }
+
+    /* Non-FLOAT32: route through convertTensor, mirroring the pattern in
+     * initTensorWithQSymInt32. Build a temporary FLOAT32 view over `source`
+     * and convert into `tensor`. The const-cast is safe: convertTensor only
+     * reads from inputTensor->data. */
+    quantization_t floatQ;
+    initFloat32Quantization(&floatQ);
+    tensor_t srcView;
+    srcView.data = (uint8_t *)(uintptr_t)source;
+    srcView.shape = tensor->shape;
+    srcView.quantization = &floatQ;
+    srcView.sparsity = NULL;
+
+    convertTensor(&srcView, tensor);
+}
+
 void initDistribution(tensor_t *tensor, const distribution_t *distribution) {
     if (tensor->quantization->type != FLOAT32) {
         PRINT_ERROR("initDistribution only supports FLOAT32 in this iteration");

--- a/src/userApi/tensor/TensorApi.c
+++ b/src/userApi/tensor/TensorApi.c
@@ -105,11 +105,15 @@ void tensorFillFromFloatBuffer(tensor_t *tensor, const float *source, size_t cou
 
     /* Non-FLOAT32: route through convertTensor, mirroring the pattern in
      * initTensorWithQSymInt32. Build a temporary FLOAT32 view over `source`
-     * and convert into `tensor`. The const-cast is safe because the only
-     * write convertTensor's helpers do back into `inputTensor` is through
-     * `copyDimsAndSparsityToTensor`, which assigns `outputTensor->shape =
-     * inputTensor->shape` — given that we set `srcView.shape = tensor->shape`,
-     * that write is a self-assignment of the same pointer back into tensor. */
+     * and convert into `tensor`. The const-cast is safe per converter:
+     *   - SYM_INT32: convertFloatTensorToSymInt32Tensor writes only to
+     *     outputTensor->data and outputTensor->quantization->qConfig->scale.
+     *   - INT32 / ASYM: convertFloatTensorTo{Int32,Asym}Tensor end with
+     *     copyDimsAndSparsityToTensor(input, output), which writes
+     *     outputTensor->shape = inputTensor->shape. Since we set
+     *     srcView.shape = tensor->shape, that write self-assigns the same
+     *     pointer back into tensor — harmless. srcView.sparsity is NULL so
+     *     the sparsity memcpy branch is skipped. */
     quantization_t floatQ;
     initFloat32Quantization(&floatQ);
     tensor_t srcView;

--- a/src/userApi/tensor/TensorApi.c
+++ b/src/userApi/tensor/TensorApi.c
@@ -1,20 +1,19 @@
 #define SOURCE_FILE "TENSOR_API"
 
 #include <math.h>
-#include <stdlib.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
-#include "Rounding.h"
-#include "TensorConversion.h"
-#include "TensorApiInternal.h"
-#include "TensorApi.h"
-#include "StorageApi.h"
-#include "QuantizationApi.h"
 #include "Common.h"
 #include "Distributions.h"
-
+#include "QuantizationApi.h"
+#include "Rounding.h"
+#include "StorageApi.h"
+#include "TensorApi.h"
+#include "TensorApiInternal.h"
+#include "TensorConversion.h"
 
 // tensor inits
 
@@ -77,6 +76,19 @@ tensor_t *tensorInit(float *data, size_t *dims, size_t numberOfDims, quantizatio
         PRINT_ERROR("Unknown QType");
         exit(1);
     }
+}
+
+tensor_t *initTensor(shape_t *shape, quantization_t *quantization, sparsity_t *sparsity) {
+    tensor_t *tensor = reserveMemory(sizeof(tensor_t));
+    tensor->shape = shape;
+    tensor->quantization = quantization;
+    tensor->sparsity = sparsity;
+
+    size_t numberOfElements = calcNumberOfElementsByShape(shape);
+    size_t bytes = calcNumberOfBytesForData(quantization, numberOfElements);
+    tensor->data = reserveMemory(bytes);
+
+    return tensor;
 }
 
 tensor_t *tensorInitWithDistribution(distributionType_t distributionType, float *data, size_t *dims,
@@ -343,7 +355,6 @@ void freeParameter(parameter_t *parameter) {
     freeTensor(parameter->grad);
     freeReservedMemory(parameter);
 }
-
 
 static tensor_t *initTensorWithQInt32(int32_t *data, size_t *dims, size_t numberOfDims,
                                       quantization_t *quantization, sparsity_t *sparsity) {

--- a/src/userApi/tensor/TensorApi.c
+++ b/src/userApi/tensor/TensorApi.c
@@ -105,8 +105,11 @@ void tensorFillFromFloatBuffer(tensor_t *tensor, const float *source, size_t cou
 
     /* Non-FLOAT32: route through convertTensor, mirroring the pattern in
      * initTensorWithQSymInt32. Build a temporary FLOAT32 view over `source`
-     * and convert into `tensor`. The const-cast is safe: convertTensor only
-     * reads from inputTensor->data. */
+     * and convert into `tensor`. The const-cast is safe because the only
+     * write convertTensor's helpers do back into `inputTensor` is through
+     * `copyDimsAndSparsityToTensor`, which assigns `outputTensor->shape =
+     * inputTensor->shape` — given that we set `srcView.shape = tensor->shape`,
+     * that write is a self-assignment of the same pointer back into tensor. */
     quantization_t floatQ;
     initFloat32Quantization(&floatQ);
     tensor_t srcView;

--- a/src/userApi/tensor/include/TensorApi.h
+++ b/src/userApi/tensor/include/TensorApi.h
@@ -96,6 +96,19 @@ tensor_t *tensorInitWithDistribution(distributionType_t distributionType, float 
  */
 tensor_t *initTensor(shape_t *shape, quantization_t *quantization, sparsity_t *sparsity);
 
+/*! Populates an already-initialized tensor's data buffer with values drawn
+ * from the given distribution. Tensor must be FLOAT32-quantized in this
+ * iteration; non-FLOAT32 support is a follow-up.
+ *
+ * The tensor must have its data buffer already allocated (via initTensor).
+ * The distribution value is read by `distribution->type`; the matching
+ * union member supplies the kind-specific parameters.
+ *
+ * \param tensor: Pre-initialized FLOAT32 tensor.
+ * \param distribution: Recipe for value generation. Read-only.
+ */
+void initDistribution(tensor_t *tensor, const distribution_t *distribution);
+
 /*! Initializes int32 gradient tensor to match given param tensor.
  *
  * \param param: Pointer to param tensor

--- a/src/userApi/tensor/include/TensorApi.h
+++ b/src/userApi/tensor/include/TensorApi.h
@@ -109,6 +109,16 @@ tensor_t *initTensor(shape_t *shape, quantization_t *quantization, sparsity_t *s
  */
 void initDistribution(tensor_t *tensor, const distribution_t *distribution);
 
+/*! Copies `count` floats from a caller-owned source into a tensor's data
+ * buffer. Caller retains ownership of `source`. If the tensor is non-FLOAT32
+ * quantized, values are converted via the tensor's quantization.
+ *
+ * \param tensor: Pre-initialized tensor.
+ * \param source: Caller-owned float array (any storage class).
+ * \param count: Number of floats; must equal the tensor's element count.
+ */
+void tensorFillFromFloatBuffer(tensor_t *tensor, const float *source, size_t count);
+
 /*! Initializes int32 gradient tensor to match given param tensor.
  *
  * \param param: Pointer to param tensor

--- a/src/userApi/tensor/include/TensorApi.h
+++ b/src/userApi/tensor/include/TensorApi.h
@@ -1,9 +1,8 @@
 #ifndef TENSOR_H
 #define TENSOR_H
 
-#include "Tensor.h"
 #include "Distributions.h"
-
+#include "Tensor.h"
 
 /*! Initializes int32 tensor with given data and shape.
  *
@@ -14,7 +13,7 @@
  *
  * \returns Pointer to initialized tensor
  */
-tensor_t* tensorInitInt32(int32_t* data, size_t* dims, size_t numberOfDims, sparsity_t* sparsity);
+tensor_t *tensorInitInt32(int32_t *data, size_t *dims, size_t numberOfDims, sparsity_t *sparsity);
 /*! Initializes float tensor with given data and shape.
  *
  * \param data: Data of tensor
@@ -24,7 +23,7 @@ tensor_t* tensorInitInt32(int32_t* data, size_t* dims, size_t numberOfDims, spar
  *
  * \returns Pointer to initialized tensor
  */
-tensor_t* tensorInitFloat(float* data, size_t* dims, size_t numberOfDims, sparsity_t* sparsity);
+tensor_t *tensorInitFloat(float *data, size_t *dims, size_t numberOfDims, sparsity_t *sparsity);
 /*! Initializes symInt32 tensor with given data and shape.
  *
  * \param data: Data of tensor
@@ -35,8 +34,8 @@ tensor_t* tensorInitFloat(float* data, size_t* dims, size_t numberOfDims, sparsi
  *
  * \returns Pointer to initialized tensor
  */
-tensor_t* tensorInitSymInt32(float* data, size_t* dims, size_t numberOfDims,
-                             roundingMode_t roundingMode, sparsity_t* sparsity);
+tensor_t *tensorInitSymInt32(float *data, size_t *dims, size_t numberOfDims,
+                             roundingMode_t roundingMode, sparsity_t *sparsity);
 /*! Initializes asym tensor with given data and shape.
  *
  * \param data: Data of tensor
@@ -48,8 +47,8 @@ tensor_t* tensorInitSymInt32(float* data, size_t* dims, size_t numberOfDims,
  *
  * \returns Pointer to initialized tensor
  */
-tensor_t* tensorInitAsym(float* data, size_t* dims, size_t numberOfDims, uint8_t qBits,
-                         roundingMode_t roundingMode, sparsity_t* sparsity);
+tensor_t *tensorInitAsym(float *data, size_t *dims, size_t numberOfDims, uint8_t qBits,
+                         roundingMode_t roundingMode, sparsity_t *sparsity);
 /*! Initializes tensor to match given quantization.
  *
  * \param data: Data of tensor
@@ -60,8 +59,8 @@ tensor_t* tensorInitAsym(float* data, size_t* dims, size_t numberOfDims, uint8_t
  *
  * \returns Pointer to initialized tensor
  */
-tensor_t* tensorInit(float* data, size_t* dims, size_t numberOfDims, quantization_t* quantization,
-                     sparsity_t* sparsity);
+tensor_t *tensorInit(float *data, size_t *dims, size_t numberOfDims, quantization_t *quantization,
+                     sparsity_t *sparsity);
 /*! Initializes tensor with distribution to match given quantization.
  *
  * \param distributionType: Type of distribution to be used
@@ -80,6 +79,23 @@ tensor_t *tensorInitWithDistribution(distributionType_t distributionType, float 
                                      sparsity_t *sparsity, size_t inputFeatures,
                                      size_t outputFeatures);
 
+/*! Initializes a tensor that owns its data buffer.
+ *
+ * The tensor takes ownership of `shape`, `quantization`, and `sparsity` (if non-NULL).
+ * The data buffer is allocated by initTensor itself (size derived from shape and
+ * quantization) and is zero-initialized.
+ *
+ * After this call, freeTensor(t) is unconditionally safe and frees all four
+ * ownership domains (data, shape, quantization, sparsity).
+ *
+ * \param shape: Caller-allocated shape; ownership transferred to the tensor.
+ * \param quantization: Caller-allocated quantization; ownership transferred.
+ * \param sparsity: Optional; ownership transferred (NULL means no sparsity).
+ *
+ * \returns Pointer to an initialized tensor with own-allocated zero data.
+ */
+tensor_t *initTensor(shape_t *shape, quantization_t *quantization, sparsity_t *sparsity);
+
 /*! Initializes int32 gradient tensor to match given param tensor.
  *
  * \param param: Pointer to param tensor
@@ -87,7 +103,7 @@ tensor_t *tensorInitWithDistribution(distributionType_t distributionType, float 
  *
  * \returns Pointer to initialized gradient tensor
  */
-tensor_t* gradInitInt32(tensor_t* param, sparsity_t* sparsity);
+tensor_t *gradInitInt32(tensor_t *param, sparsity_t *sparsity);
 /*! Initializes float gradient tensor to match given param tensor.
  *
  * \param param: Pointer to param tensor
@@ -95,7 +111,7 @@ tensor_t* gradInitInt32(tensor_t* param, sparsity_t* sparsity);
  *
  * \returns Pointer to initialized gradient tensor
  */
-tensor_t* gradInitFloat(tensor_t* param, sparsity_t* sparsity);
+tensor_t *gradInitFloat(tensor_t *param, sparsity_t *sparsity);
 /*! Initializes symInt32 gradient tensor to match given param tensor.
  *
  * \param param: Pointer to param tensor
@@ -103,7 +119,7 @@ tensor_t* gradInitFloat(tensor_t* param, sparsity_t* sparsity);
  *
  * \returns Pointer to initialized gradient tensor
  */
-tensor_t* gradInitSymInt32(tensor_t* param, roundingMode_t roundingMode, sparsity_t* sparsity);
+tensor_t *gradInitSymInt32(tensor_t *param, roundingMode_t roundingMode, sparsity_t *sparsity);
 /*! Initializes asym gradient tensor to match given param tensor.
  *
  * \param param: Pointer to param tensor
@@ -111,7 +127,8 @@ tensor_t* gradInitSymInt32(tensor_t* param, roundingMode_t roundingMode, sparsit
  *
  * \returns Pointer to initialized gradient tensor
  */
-tensor_t* gradInitAsym(tensor_t* param, uint8_t qBits, roundingMode_t roundingMode, sparsity_t* sparsity);
+tensor_t *gradInitAsym(tensor_t *param, uint8_t qBits, roundingMode_t roundingMode,
+                       sparsity_t *sparsity);
 
 /*! Initializes parameter with given param and graident tensor.
  *
@@ -120,7 +137,7 @@ tensor_t* gradInitAsym(tensor_t* param, uint8_t qBits, roundingMode_t roundingMo
  *
  * \returns Pointer to initialized parameter
  */
-parameter_t* parameterInit(tensor_t* param, tensor_t* grad);
+parameter_t *parameterInit(tensor_t *param, tensor_t *grad);
 
 /*! Gets quantization that matches a given quantization.
  *
@@ -128,14 +145,14 @@ parameter_t* parameterInit(tensor_t* param, tensor_t* grad);
  *
  * \returns Pointer to quantization with matching type and config
  */
-quantization_t* getQLike(quantization_t* quantization);
+quantization_t *getQLike(quantization_t *quantization);
 /*! Gets tensor that matches a given tensor.
  *
  * \param tensor: Pointer to tensor
  *
  * \returns Pointer to tensor with matching shape, sparsity and quantization
  */
-tensor_t* getTensorLike(tensor_t* tensor);
+tensor_t *getTensorLike(tensor_t *tensor);
 /*! Gets shape that matches a given shape.
  *
  * \param shape: Pointer to shape
@@ -159,34 +176,33 @@ uint8_t *getDataLike(quantization_t *quantization, size_t numberOfValues);
  */
 sparsity_t *getSparsityLike(sparsity_t *sparsity);
 
-
-
-// IMPORTANT: these are needed for trainingAPI.c to free gradTensors without freeing the actual Pointer
+// IMPORTANT: these are needed for trainingAPI.c to free gradTensors without freeing the actual
+// Pointer
 /*! Frees data of tensor.
  *
  * \param tensor: Pointer to tensor
  */
-void freeData(tensor_t* tensor);
+void freeData(tensor_t *tensor);
 /*! Frees shape of tensor.
  *
  * \param shape: Pointer to shape
  */
-void freeShape(shape_t* shape);
+void freeShape(shape_t *shape);
 /*! Frees quantization of tensor.
  *
  * \param quantization: Pointer to quantization
  */
-void freeQuantization(quantization_t* quantization);
+void freeQuantization(quantization_t *quantization);
 
 /*! Frees tensor.
  *
  * \param tensor: Pointer to tensor
  */
-void freeTensor(tensor_t* tensor);
+void freeTensor(tensor_t *tensor);
 /*! Frees parameter.
  *
  * \param parameter: Pointer to parameter
  */
 void freeParameter(parameter_t *parameter);
 
-#endif //TENSOR_H
+#endif // TENSOR_H

--- a/src/userApi/tensor/include/TensorApi.h
+++ b/src/userApi/tensor/include/TensorApi.h
@@ -13,7 +13,10 @@
  *
  * \returns Pointer to initialized tensor
  */
-tensor_t *tensorInitInt32(int32_t *data, size_t *dims, size_t numberOfDims, sparsity_t *sparsity);
+__attribute__((deprecated("Use initTensor(shape, quantization, sparsity) + "
+                          "tensorFillFromFloatBuffer or initDistribution instead. "
+                          "Old API will be removed in Phase 2."))) tensor_t *
+tensorInitInt32(int32_t *data, size_t *dims, size_t numberOfDims, sparsity_t *sparsity);
 /*! Initializes float tensor with given data and shape.
  *
  * \param data: Data of tensor
@@ -23,7 +26,10 @@ tensor_t *tensorInitInt32(int32_t *data, size_t *dims, size_t numberOfDims, spar
  *
  * \returns Pointer to initialized tensor
  */
-tensor_t *tensorInitFloat(float *data, size_t *dims, size_t numberOfDims, sparsity_t *sparsity);
+__attribute__((deprecated("Use initTensor(shape, quantization, sparsity) + "
+                          "tensorFillFromFloatBuffer or initDistribution instead. "
+                          "Old API will be removed in Phase 2."))) tensor_t *
+tensorInitFloat(float *data, size_t *dims, size_t numberOfDims, sparsity_t *sparsity);
 /*! Initializes symInt32 tensor with given data and shape.
  *
  * \param data: Data of tensor
@@ -34,8 +40,11 @@ tensor_t *tensorInitFloat(float *data, size_t *dims, size_t numberOfDims, sparsi
  *
  * \returns Pointer to initialized tensor
  */
-tensor_t *tensorInitSymInt32(float *data, size_t *dims, size_t numberOfDims,
-                             roundingMode_t roundingMode, sparsity_t *sparsity);
+__attribute__((deprecated("Use initTensor(shape, quantization, sparsity) + "
+                          "tensorFillFromFloatBuffer or initDistribution instead. "
+                          "Old API will be removed in Phase 2."))) tensor_t *
+tensorInitSymInt32(float *data, size_t *dims, size_t numberOfDims, roundingMode_t roundingMode,
+                   sparsity_t *sparsity);
 /*! Initializes asym tensor with given data and shape.
  *
  * \param data: Data of tensor
@@ -47,8 +56,11 @@ tensor_t *tensorInitSymInt32(float *data, size_t *dims, size_t numberOfDims,
  *
  * \returns Pointer to initialized tensor
  */
-tensor_t *tensorInitAsym(float *data, size_t *dims, size_t numberOfDims, uint8_t qBits,
-                         roundingMode_t roundingMode, sparsity_t *sparsity);
+__attribute__((deprecated("Use initTensor(shape, quantization, sparsity) + "
+                          "tensorFillFromFloatBuffer or initDistribution instead. "
+                          "Old API will be removed in Phase 2."))) tensor_t *
+tensorInitAsym(float *data, size_t *dims, size_t numberOfDims, uint8_t qBits,
+               roundingMode_t roundingMode, sparsity_t *sparsity);
 /*! Initializes tensor to match given quantization.
  *
  * \param data: Data of tensor
@@ -59,8 +71,11 @@ tensor_t *tensorInitAsym(float *data, size_t *dims, size_t numberOfDims, uint8_t
  *
  * \returns Pointer to initialized tensor
  */
-tensor_t *tensorInit(float *data, size_t *dims, size_t numberOfDims, quantization_t *quantization,
-                     sparsity_t *sparsity);
+__attribute__((deprecated("Use initTensor(shape, quantization, sparsity) + "
+                          "tensorFillFromFloatBuffer or initDistribution instead. "
+                          "Old API will be removed in Phase 2."))) tensor_t *
+tensorInit(float *data, size_t *dims, size_t numberOfDims, quantization_t *quantization,
+           sparsity_t *sparsity);
 /*! Initializes tensor with distribution to match given quantization.
  *
  * \param distributionType: Type of distribution to be used
@@ -74,10 +89,12 @@ tensor_t *tensorInit(float *data, size_t *dims, size_t numberOfDims, quantizatio
  *
  * \returns Pointer to initialized tensor
  */
-tensor_t *tensorInitWithDistribution(distributionType_t distributionType, float *data, size_t *dims,
-                                     size_t numberOfDims, quantization_t *quantization,
-                                     sparsity_t *sparsity, size_t inputFeatures,
-                                     size_t outputFeatures);
+__attribute__((deprecated("Use initTensor(shape, quantization, sparsity) + "
+                          "initDistribution(t, &distribution) instead. "
+                          "Old API will be removed in Phase 2."))) tensor_t *
+tensorInitWithDistribution(distributionType_t distributionType, float *data, size_t *dims,
+                           size_t numberOfDims, quantization_t *quantization, sparsity_t *sparsity,
+                           size_t inputFeatures, size_t outputFeatures);
 
 /*! Initializes a tensor that owns its data buffer.
  *

--- a/test/unit/tensor/CMakeLists.txt
+++ b/test/unit/tensor/CMakeLists.txt
@@ -28,5 +28,6 @@ add_elastic_ai_unit_test(
         Tensor
         Rounding
         Quantization
+        QuantizationApi
         StorageApi
 )

--- a/test/unit/tensor/UnitTestTensorApi.c
+++ b/test/unit/tensor/UnitTestTensorApi.c
@@ -1,5 +1,7 @@
 #define SOURCE_FILE "UNIT_TEST_TENSOR_API"
 
+#include <math.h>
+#include <stdbool.h>
 #include <stddef.h>
 #include <string.h>
 
@@ -16,6 +18,12 @@ _Static_assert(_Generic((&initTensor),
                    tensor_t *(*)(shape_t *, quantization_t *, sparsity_t *): 1,
                    default: 0),
                "initTensor must take (shape_t *, quantization_t *, sparsity_t *)");
+
+/* Compile-time contract: initDistribution takes tensor_t * and const distribution_t *. */
+_Static_assert(_Generic((&initDistribution),
+                   void (*)(tensor_t *, const distribution_t *): 1,
+                   default: 0),
+               "initDistribution must take (tensor_t *, const distribution_t *)");
 
 void setUp() {}
 void tearDown() {}
@@ -98,6 +106,147 @@ void testTensorInitWithDistribution_ShapeIsCorrect() {
     TEST_ASSERT_EQUAL_UINT(6, numElements);
 }
 
+static tensor_t *makeFloatTensorForDistTest(size_t d0, size_t d1) {
+    size_t *dims = reserveMemory(2 * sizeof(size_t));
+    dims[0] = d0;
+    dims[1] = d1;
+    size_t *order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, order);
+    shape_t *shape = reserveMemory(sizeof(shape_t));
+    setShape(shape, dims, 2, order);
+    return initTensor(shape, quantizationInitFloat(), NULL);
+}
+
+void testInitDistribution_Zeros_AllValuesAreZero(void) {
+    tensor_t *t = makeFloatTensorForDistTest(3, 4);
+    /* Pre-write a sentinel so we can prove ZEROS overwrites. */
+    float *vals = (float *)t->data;
+    for (size_t i = 0; i < 12; ++i) {
+        vals[i] = 42.0f;
+    }
+
+    distribution_t d = {.type = ZEROS};
+    initDistribution(t, &d);
+
+    for (size_t i = 0; i < 12; ++i) {
+        TEST_ASSERT_FLOAT_WITHIN(1e-9f, 0.0f, vals[i]);
+    }
+    freeTensor(t);
+}
+
+void testInitDistribution_Ones_AllValuesAreOne(void) {
+    tensor_t *t = makeFloatTensorForDistTest(3, 4);
+    distribution_t d = {.type = ONES};
+    initDistribution(t, &d);
+    float *vals = (float *)t->data;
+    for (size_t i = 0; i < 12; ++i) {
+        TEST_ASSERT_FLOAT_WITHIN(1e-9f, 1.0f, vals[i]);
+    }
+    freeTensor(t);
+}
+
+void testInitDistribution_Uniform_AllValuesInRange(void) {
+    tensor_t *t = makeFloatTensorForDistTest(4, 5);
+    distribution_t d = {.type = UNIFORM, .params.uniform = {-0.5f, 0.5f}};
+    initDistribution(t, &d);
+    float *vals = (float *)t->data;
+    bool any_nonzero = false;
+    for (size_t i = 0; i < 20; ++i) {
+        TEST_ASSERT_TRUE(vals[i] >= -0.5f && vals[i] <= 0.5f);
+        if (vals[i] != 0.0f) {
+            any_nonzero = true;
+        }
+    }
+    TEST_ASSERT_TRUE(any_nonzero);
+    freeTensor(t);
+}
+
+void testInitDistribution_Normal_NotAllSentinel(void) {
+    tensor_t *t = makeFloatTensorForDistTest(4, 5);
+    float *vals = (float *)t->data;
+    for (size_t i = 0; i < 20; ++i) {
+        vals[i] = -999.0f;
+    }
+    distribution_t d = {.type = NORMAL, .params.normal = {0.0f, 0.01f}};
+    initDistribution(t, &d);
+    size_t sentinelCount = 0;
+    for (size_t i = 0; i < 20; ++i) {
+        if (vals[i] == -999.0f) {
+            sentinelCount++;
+        }
+    }
+    TEST_ASSERT_EQUAL_UINT(0, sentinelCount);
+    freeTensor(t);
+}
+
+void testInitDistribution_XavierUniform_NotAllZero(void) {
+    tensor_t *t = makeFloatTensorForDistTest(4, 5);
+    distribution_t d = {.type = XAVIER_UNIFORM,
+                        .params.xavier = {.gain = 1.0f, .fanIn = 4, .fanOut = 5}};
+    initDistribution(t, &d);
+    float *vals = (float *)t->data;
+    bool any_nonzero = false;
+    for (size_t i = 0; i < 20; ++i) {
+        if (vals[i] != 0.0f) {
+            any_nonzero = true;
+            break;
+        }
+    }
+    TEST_ASSERT_TRUE(any_nonzero);
+    freeTensor(t);
+}
+
+void testInitDistribution_XavierNormal_NotAllZero(void) {
+    tensor_t *t = makeFloatTensorForDistTest(4, 5);
+    distribution_t d = {.type = XAVIER_NORMAL,
+                        .params.xavier = {.gain = 1.0f, .fanIn = 4, .fanOut = 5}};
+    initDistribution(t, &d);
+    float *vals = (float *)t->data;
+    bool any_nonzero = false;
+    for (size_t i = 0; i < 20; ++i) {
+        if (vals[i] != 0.0f) {
+            any_nonzero = true;
+            break;
+        }
+    }
+    TEST_ASSERT_TRUE(any_nonzero);
+    freeTensor(t);
+}
+
+void testInitDistribution_KaimingUniform_NotAllZero(void) {
+    tensor_t *t = makeFloatTensorForDistTest(4, 5);
+    distribution_t d = {.type = KAIMING_UNIFORM,
+                        .params.kaiming = {.gain = sqrtf(2.0f), .fanMode = 4}};
+    initDistribution(t, &d);
+    float *vals = (float *)t->data;
+    bool any_nonzero = false;
+    for (size_t i = 0; i < 20; ++i) {
+        if (vals[i] != 0.0f) {
+            any_nonzero = true;
+            break;
+        }
+    }
+    TEST_ASSERT_TRUE(any_nonzero);
+    freeTensor(t);
+}
+
+void testInitDistribution_KaimingNormal_NotAllZero(void) {
+    tensor_t *t = makeFloatTensorForDistTest(4, 5);
+    distribution_t d = {.type = KAIMING_NORMAL,
+                        .params.kaiming = {.gain = sqrtf(2.0f), .fanMode = 4}};
+    initDistribution(t, &d);
+    float *vals = (float *)t->data;
+    bool any_nonzero = false;
+    for (size_t i = 0; i < 20; ++i) {
+        if (vals[i] != 0.0f) {
+            any_nonzero = true;
+            break;
+        }
+    }
+    TEST_ASSERT_TRUE(any_nonzero);
+    freeTensor(t);
+}
+
 void testInitTensor_AllocatesOwnZeroDataBuffer_FreeTensorIsSafe(void) {
     /* Build shape via reserveMemory so caller doesn't bypass the locality rule. */
     size_t *dims = reserveMemory(2 * sizeof(size_t));
@@ -137,5 +286,13 @@ int main(void) {
     RUN_TEST(testTensorInitWithDistribution_Normal_InitializesAllValues);
     RUN_TEST(testTensorInitWithDistribution_ShapeIsCorrect);
     RUN_TEST(testInitTensor_AllocatesOwnZeroDataBuffer_FreeTensorIsSafe);
+    RUN_TEST(testInitDistribution_Zeros_AllValuesAreZero);
+    RUN_TEST(testInitDistribution_Ones_AllValuesAreOne);
+    RUN_TEST(testInitDistribution_Uniform_AllValuesInRange);
+    RUN_TEST(testInitDistribution_Normal_NotAllSentinel);
+    RUN_TEST(testInitDistribution_XavierUniform_NotAllZero);
+    RUN_TEST(testInitDistribution_XavierNormal_NotAllZero);
+    RUN_TEST(testInitDistribution_KaimingUniform_NotAllZero);
+    RUN_TEST(testInitDistribution_KaimingNormal_NotAllZero);
     return UNITY_END();
 }

--- a/test/unit/tensor/UnitTestTensorApi.c
+++ b/test/unit/tensor/UnitTestTensorApi.c
@@ -247,6 +247,30 @@ void testInitDistribution_KaimingNormal_NotAllZero(void) {
     freeTensor(t);
 }
 
+void testInitTensor_Int32_AllocatesFourBytesPerElement(void) {
+    /* Closes the calcNumberOfBytesForData gap surfaced by code-review on Task A:
+     * the INT32 arm was missing, which would have made gradInitInt32 (Task D)
+     * exit(1) on its first call. */
+    size_t *dims = reserveMemory(2 * sizeof(size_t));
+    dims[0] = 2;
+    dims[1] = 3;
+    size_t *order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, order);
+    shape_t *shape = reserveMemory(sizeof(shape_t));
+    setShape(shape, dims, 2, order);
+
+    quantization_t *q = quantizationInitInt32();
+    tensor_t *t = initTensor(shape, q, NULL);
+
+    TEST_ASSERT_NOT_NULL(t);
+    TEST_ASSERT_NOT_NULL(t->data);
+    /* 6 elements × 4 bytes = 24 bytes; all zero. */
+    for (size_t i = 0; i < 24; ++i) {
+        TEST_ASSERT_EQUAL_UINT8(0, t->data[i]);
+    }
+    freeTensor(t);
+}
+
 void testInitTensor_AllocatesOwnZeroDataBuffer_FreeTensorIsSafe(void) {
     /* Build shape via reserveMemory so caller doesn't bypass the locality rule. */
     size_t *dims = reserveMemory(2 * sizeof(size_t));
@@ -286,6 +310,7 @@ int main(void) {
     RUN_TEST(testTensorInitWithDistribution_Normal_InitializesAllValues);
     RUN_TEST(testTensorInitWithDistribution_ShapeIsCorrect);
     RUN_TEST(testInitTensor_AllocatesOwnZeroDataBuffer_FreeTensorIsSafe);
+    RUN_TEST(testInitTensor_Int32_AllocatesFourBytesPerElement);
     RUN_TEST(testInitDistribution_Zeros_AllValuesAreZero);
     RUN_TEST(testInitDistribution_Ones_AllValuesAreOne);
     RUN_TEST(testInitDistribution_Uniform_AllValuesInRange);

--- a/test/unit/tensor/UnitTestTensorApi.c
+++ b/test/unit/tensor/UnitTestTensorApi.c
@@ -288,6 +288,92 @@ void testTensorFillFromFloatBuffer_CopiesValues_SourceCanGoOutOfScope(void) {
     freeTensor(t);
 }
 
+void testGradInitFloat_DoesNotAliasParentShape(void) {
+    /* H2 regression: gradInit* must allocate a fresh shape instead of aliasing
+     * the parent tensor's shape. */
+    size_t *dims = reserveMemory(2 * sizeof(size_t));
+    dims[0] = 3;
+    dims[1] = 4;
+    size_t *order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, order);
+    shape_t *shape = reserveMemory(sizeof(shape_t));
+    setShape(shape, dims, 2, order);
+
+    tensor_t *param = initTensor(shape, quantizationInitFloat(), NULL);
+
+    tensor_t *grad = gradInitFloat(param, NULL);
+
+    TEST_ASSERT_TRUE_MESSAGE(grad->shape != param->shape,
+                             "gradInitFloat aliases parent shape (H2 hazard)");
+
+    /* Free grad first — must not corrupt parent. */
+    freeTensor(grad);
+
+    /* Parent's shape must still be readable. */
+    TEST_ASSERT_EQUAL_UINT(2, param->shape->numberOfDimensions);
+    TEST_ASSERT_EQUAL_UINT(3, param->shape->dimensions[0]);
+    TEST_ASSERT_EQUAL_UINT(4, param->shape->dimensions[1]);
+
+    freeTensor(param);
+}
+
+void testGradInitInt32_DoesNotAliasParentShape(void) {
+    size_t *dims = reserveMemory(2 * sizeof(size_t));
+    dims[0] = 3;
+    dims[1] = 4;
+    size_t *order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, order);
+    shape_t *shape = reserveMemory(sizeof(shape_t));
+    setShape(shape, dims, 2, order);
+
+    tensor_t *param = initTensor(shape, quantizationInitInt32(), NULL);
+    tensor_t *grad = gradInitInt32(param, NULL);
+
+    TEST_ASSERT_TRUE_MESSAGE(grad->shape != param->shape,
+                             "gradInitInt32 aliases parent shape (H2 hazard)");
+    freeTensor(grad);
+    TEST_ASSERT_EQUAL_UINT(3, param->shape->dimensions[0]);
+    freeTensor(param);
+}
+
+void testGradInitSymInt32_DoesNotAliasParentShape(void) {
+    size_t *dims = reserveMemory(2 * sizeof(size_t));
+    dims[0] = 3;
+    dims[1] = 4;
+    size_t *order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, order);
+    shape_t *shape = reserveMemory(sizeof(shape_t));
+    setShape(shape, dims, 2, order);
+
+    tensor_t *param = initTensor(shape, quantizationInitSymInt32(HTE), NULL);
+    tensor_t *grad = gradInitSymInt32(param, HTE, NULL);
+
+    TEST_ASSERT_TRUE_MESSAGE(grad->shape != param->shape,
+                             "gradInitSymInt32 aliases parent shape (H2 hazard)");
+    freeTensor(grad);
+    TEST_ASSERT_EQUAL_UINT(3, param->shape->dimensions[0]);
+    freeTensor(param);
+}
+
+void testGradInitAsym_DoesNotAliasParentShape(void) {
+    size_t *dims = reserveMemory(2 * sizeof(size_t));
+    dims[0] = 3;
+    dims[1] = 4;
+    size_t *order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, order);
+    shape_t *shape = reserveMemory(sizeof(shape_t));
+    setShape(shape, dims, 2, order);
+
+    tensor_t *param = initTensor(shape, quantizationInitAsym(8, HTE), NULL);
+    tensor_t *grad = gradInitAsym(param, 8, HTE, NULL);
+
+    TEST_ASSERT_TRUE_MESSAGE(grad->shape != param->shape,
+                             "gradInitAsym aliases parent shape (H2 hazard)");
+    freeTensor(grad);
+    TEST_ASSERT_EQUAL_UINT(3, param->shape->dimensions[0]);
+    freeTensor(param);
+}
+
 void testInitTensor_Int32_AllocatesFourBytesPerElement(void) {
     /* Closes the calcNumberOfBytesForData gap surfaced by code-review on Task A:
      * the INT32 arm was missing, which would have made gradInitInt32 (Task D)
@@ -353,6 +439,10 @@ int main(void) {
     RUN_TEST(testInitTensor_AllocatesOwnZeroDataBuffer_FreeTensorIsSafe);
     RUN_TEST(testInitTensor_Int32_AllocatesFourBytesPerElement);
     RUN_TEST(testTensorFillFromFloatBuffer_CopiesValues_SourceCanGoOutOfScope);
+    RUN_TEST(testGradInitFloat_DoesNotAliasParentShape);
+    RUN_TEST(testGradInitInt32_DoesNotAliasParentShape);
+    RUN_TEST(testGradInitSymInt32_DoesNotAliasParentShape);
+    RUN_TEST(testGradInitAsym_DoesNotAliasParentShape);
     RUN_TEST(testInitDistribution_Zeros_AllValuesAreZero);
     RUN_TEST(testInitDistribution_Ones_AllValuesAreOne);
     RUN_TEST(testInitDistribution_Uniform_AllValuesInRange);

--- a/test/unit/tensor/UnitTestTensorApi.c
+++ b/test/unit/tensor/UnitTestTensorApi.c
@@ -3,10 +3,19 @@
 #include <stddef.h>
 #include <string.h>
 
-#include "TensorApi.h"
-#include "Tensor.h"
 #include "Quantization.h"
+#include "QuantizationApi.h"
+#include "StorageApi.h"
+#include "Tensor.h"
+#include "TensorApi.h"
 #include "unity.h"
+
+/* Compile-time contract: initTensor takes shape_t *, quantization_t *,
+ * sparsity_t * and returns tensor_t *. No data buffer parameter. */
+_Static_assert(_Generic((&initTensor),
+                   tensor_t *(*)(shape_t *, quantization_t *, sparsity_t *): 1,
+                   default: 0),
+               "initTensor must take (shape_t *, quantization_t *, sparsity_t *)");
 
 void setUp() {}
 void tearDown() {}
@@ -89,11 +98,44 @@ void testTensorInitWithDistribution_ShapeIsCorrect() {
     TEST_ASSERT_EQUAL_UINT(6, numElements);
 }
 
+void testInitTensor_AllocatesOwnZeroDataBuffer_FreeTensorIsSafe(void) {
+    /* Build shape via reserveMemory so caller doesn't bypass the locality rule. */
+    size_t *dims = reserveMemory(2 * sizeof(size_t));
+    dims[0] = 3;
+    dims[1] = 4;
+    size_t *order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, order);
+    shape_t *shape = reserveMemory(sizeof(shape_t));
+    setShape(shape, dims, 2, order);
+
+    quantization_t *q = quantizationInitFloat();
+
+    tensor_t *t = initTensor(shape, q, NULL);
+
+    TEST_ASSERT_NOT_NULL(t);
+    TEST_ASSERT_NOT_NULL(t->data);
+    TEST_ASSERT_EQUAL_PTR(shape, t->shape);
+    TEST_ASSERT_EQUAL_PTR(q, t->quantization);
+    TEST_ASSERT_NULL(t->sparsity);
+
+    /* All bytes of the data buffer must be zero (calloc semantics). */
+    size_t bytes = calcBytesPerTensor(t);
+    for (size_t i = 0; i < bytes; ++i) {
+        TEST_ASSERT_EQUAL_UINT8(0, t->data[i]);
+    }
+
+    /* freeTensor must release everything cleanly without external buffers. */
+    freeTensor(t);
+    /* If we reach here without an abort/segfault, freeTensor is unconditional-safe
+     * for an initTensor-allocated tensor. */
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(testTensorInitWithDistribution_Zeros_InitializesProductOfDimsValues);
     RUN_TEST(testTensorInitWithDistribution_Ones_InitializesAllValues);
     RUN_TEST(testTensorInitWithDistribution_Normal_InitializesAllValues);
     RUN_TEST(testTensorInitWithDistribution_ShapeIsCorrect);
+    RUN_TEST(testInitTensor_AllocatesOwnZeroDataBuffer_FreeTensorIsSafe);
     return UNITY_END();
 }

--- a/test/unit/tensor/UnitTestTensorApi.c
+++ b/test/unit/tensor/UnitTestTensorApi.c
@@ -288,6 +288,25 @@ void testTensorFillFromFloatBuffer_CopiesValues_SourceCanGoOutOfScope(void) {
     freeTensor(t);
 }
 
+void testFreeParameter_NullGrad_DoesNotSegfault(void) {
+    /* H3 regression: linearLayerInitNonTrainable passes NULL for grad into
+     * parameterInit; today freeParameter dereferences it and crashes. */
+    size_t *dims = reserveMemory(2 * sizeof(size_t));
+    dims[0] = 1;
+    dims[1] = 2;
+    size_t *order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, order);
+    shape_t *shape = reserveMemory(sizeof(shape_t));
+    setShape(shape, dims, 2, order);
+
+    tensor_t *param = initTensor(shape, quantizationInitFloat(), NULL);
+    parameter_t *p = parameterInit(param, NULL);
+
+    freeParameter(p);
+    /* If we reach here, the H3 fix worked. */
+    TEST_PASS();
+}
+
 void testGradInitFloat_DoesNotAliasParentShape(void) {
     /* H2 regression: gradInit* must allocate a fresh shape instead of aliasing
      * the parent tensor's shape. */
@@ -439,6 +458,7 @@ int main(void) {
     RUN_TEST(testInitTensor_AllocatesOwnZeroDataBuffer_FreeTensorIsSafe);
     RUN_TEST(testInitTensor_Int32_AllocatesFourBytesPerElement);
     RUN_TEST(testTensorFillFromFloatBuffer_CopiesValues_SourceCanGoOutOfScope);
+    RUN_TEST(testFreeParameter_NullGrad_DoesNotSegfault);
     RUN_TEST(testGradInitFloat_DoesNotAliasParentShape);
     RUN_TEST(testGradInitInt32_DoesNotAliasParentShape);
     RUN_TEST(testGradInitSymInt32_DoesNotAliasParentShape);

--- a/test/unit/tensor/UnitTestTensorApi.c
+++ b/test/unit/tensor/UnitTestTensorApi.c
@@ -25,6 +25,12 @@ _Static_assert(_Generic((&initDistribution),
                    default: 0),
                "initDistribution must take (tensor_t *, const distribution_t *)");
 
+/* Compile-time contract: tensorFillFromFloatBuffer takes (tensor_t *, const float *, size_t). */
+_Static_assert(_Generic((&tensorFillFromFloatBuffer),
+                   void (*)(tensor_t *, const float *, size_t): 1,
+                   default: 0),
+               "tensorFillFromFloatBuffer must take (tensor_t *, const float *, size_t)");
+
 void setUp() {}
 void tearDown() {}
 
@@ -247,6 +253,41 @@ void testInitDistribution_KaimingNormal_NotAllZero(void) {
     freeTensor(t);
 }
 
+static void fillTensorFromStackArrayThatGoesOutOfScope(tensor_t *t) {
+    /* Local stack array — exits scope when this function returns. */
+    float src[6] = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
+    tensorFillFromFloatBuffer(t, src, 6);
+    /* `src` goes out of scope on return; tensor must keep its own copy. */
+}
+
+void testTensorFillFromFloatBuffer_CopiesValues_SourceCanGoOutOfScope(void) {
+    size_t *dims = reserveMemory(2 * sizeof(size_t));
+    dims[0] = 2;
+    dims[1] = 3;
+    size_t *order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, order);
+    shape_t *shape = reserveMemory(sizeof(shape_t));
+    setShape(shape, dims, 2, order);
+
+    tensor_t *t = initTensor(shape, quantizationInitFloat(), NULL);
+
+    fillTensorFromStackArrayThatGoesOutOfScope(t);
+
+    /* Force stack reuse — analogous to issue #93's regression pattern. */
+    for (int i = 0; i < 100; ++i) {
+        volatile float junk[6] = {(float)i, (float)~i, 0, 0, 0, 0};
+        (void)junk;
+    }
+
+    float *vals = (float *)t->data;
+    float expected[6] = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
+    for (size_t i = 0; i < 6; ++i) {
+        TEST_ASSERT_FLOAT_WITHIN(1e-9f, expected[i], vals[i]);
+    }
+
+    freeTensor(t);
+}
+
 void testInitTensor_Int32_AllocatesFourBytesPerElement(void) {
     /* Closes the calcNumberOfBytesForData gap surfaced by code-review on Task A:
      * the INT32 arm was missing, which would have made gradInitInt32 (Task D)
@@ -311,6 +352,7 @@ int main(void) {
     RUN_TEST(testTensorInitWithDistribution_ShapeIsCorrect);
     RUN_TEST(testInitTensor_AllocatesOwnZeroDataBuffer_FreeTensorIsSafe);
     RUN_TEST(testInitTensor_Int32_AllocatesFourBytesPerElement);
+    RUN_TEST(testTensorFillFromFloatBuffer_CopiesValues_SourceCanGoOutOfScope);
     RUN_TEST(testInitDistribution_Zeros_AllValuesAreZero);
     RUN_TEST(testInitDistribution_Ones_AllValuesAreOne);
     RUN_TEST(testInitDistribution_Uniform_AllValuesInRange);


### PR DESCRIPTION
Closes #100

## Summary

Three Phase-1 LSan ownership hazards close together because the underlying API was wrong. `tensorInit*` used to wrap a caller-owned `data` buffer (H1) and `gradInit*` aliased the parent tensor's `shape` pointer (H2); `linearLayerInitNonTrainable` produced a `parameter_t` with `grad = NULL` that `freeParameter` later dereferenced (H3). Splitting init into "allocate the tensor" and "populate the data" makes the tensor the unconditional owner of all four memory domains (data, shape, quantization, sparsity), so `freeTensor` becomes safe under the new model.

## New API

- `initTensor(shape, quantization, sparsity)` — allocates the tensor and its data buffer; transfers ownership of shape/q/sparsity into the tensor. Data buffer is calloc-zeroed via `reserveMemory` (contract: caller must populate before use).
- `distribution_t` (in `Distributions.h`) — typed-union value carrying both the distribution kind and its kind-specific parameters.
- `initDistribution(tensor, &distribution)` — populates a FLOAT32 tensor's data buffer; covers all 8 distribution variants (ZEROS, ONES, UNIFORM, NORMAL, XAVIER_*, KAIMING_*) through one dispatcher.
- `tensorFillFromFloatBuffer(tensor, source, count)` — copies `count` floats from a caller-owned (potentially stack) buffer; tensor keeps an independent copy. Non-FLOAT32 paths route through `convertTensor`.

## Internal changes

- `gradInitFloat / Int32 / SymInt32 / Asym` rewired through `getShapeLike + initTensor` (closes H2).
- `freeParameter` now NULL-safe on `parameter->grad` (closes H3 segfault path; the broader question of who owns parameters built by `linearLayerInitNonTrainable` is left to Issue Draft A's layer-factory work).
- `InferenceApi.reserveInferenceStats` migrated to `initTensor` (also fixes a latent uninitialized-dims bug).
- `NPYLoaderApi.npyLoad` migrated to `initTensor` + `fread`-into-owned-buffer; per-tensor `getQLike(q)` clone closes the shared-quantization hazard; outer `q` now `freeQuantization`-d after the loop.
- `calcNumberOfBytesForData` (in `src/tensor/Tensor.c`) gained an INT32 arm — previously the only function in the byte-count cluster that didn't cover INT32, surfaced by code review.
- `TensorApi` now PRIVATE-links `QuantizationApi` (its sibling under `src/userApi/tensor/`).

## Old API

`tensorInitFloat`, `tensorInitInt32`, `tensorInitSymInt32`, `tensorInitAsym`, `tensorInitWithDistribution`, `tensorInit` marked `__attribute__((deprecated))`. All `src/` callers are migrated; `src/` build is warning-free. The ~205 `test/` and `experiments/` call-sites continue to compile (with `-Wdeprecated-declarations` warnings) until Phase 2's test migration.

## Phase 1 LSan recon delta

Generated via `docs/superpowers/tools/lsan-recon/` (host=clang-21 in odt-lsan-recon container).

| Metric | Pre-refactor | Post-refactor | Δ |
|---|---:|---:|---:|
| Total unique leak signatures | 605 | 295 | **−51%** |
| UnitTestMnistSmoke definitely-lost | 86,024 B | 10,360 B | **−88%** |
| UnitTestMultiLayerTraining | 3,624 B | 424 B | **−88%** |
| UnitTestInferenceApi | 1,328 B | 464 B | **−65%** |
| UnitTestLinear | 880 B | 304 B | **−65%** |
| Top `initTensorWithQFloat` signature occurrences | 99 | 88 | −11 |

The remaining `initTensorWithQFloat` signatures are reached only through the deprecated `test/` wrappers; Phase 2's test migration takes them to zero.

## Cross-repo note

The `training-implementation-provider` branch in [es-ude/elastic-ai.creator](https://github.com/es-ude/elastic-ai.creator) (per the two-repo pipeline in CLAUDE.md) is an upcoming caller of this API once the IR-to-C provider lands. No upstream issue is filed yet — the provider work is in flux and the deprecation messages give the next provider PR cycle a clear migration target.

## Test plan

- [x] `cmake --build --preset unit_test_debug` clean (4 pre-existing C23-extension warnings unchanged)
- [x] `ctest --preset unit_test_debug` 32/32 green
- [x] `uv run pytest python/` 3/3 green (via `ci` devenv script)
- [x] Allocation-locality CI grep gate passes (no new malloc/calloc/free outside `src/userApi/`)
- [x] Phase 1 LSan recon shows H1 signatures drop 88% in `MnistSmoke` definitely-lost and 51% in unique-signature count
- [x] `src/` is warning-free for `-Wdeprecated-declarations`; deprecation warnings present in `test/` and `experiments/` as expected
- [x] H2 regression test (`testGradInitFloat_DoesNotAliasParentShape` and three siblings) reproduce shape-aliasing before fix and pass after
- [x] H3 regression test (`testFreeParameter_NullGrad_DoesNotSegfault`) reproduces SEGFAULT on `freeParameter(parameterInit(p, NULL))` before fix and passes after

🤖 Generated with [Claude Code](https://claude.com/claude-code)