### PR TITLE
test(#82): migrate UnitTestInferenceApi + close inference outputNext leak

### DIFF
--- a/src/userApi/InferenceApi.c
+++ b/src/userApi/InferenceApi.c
@@ -140,6 +140,7 @@ tensor_t *inference(layer_t **model, size_t numberOfLayers, tensor_t *input) {
 
     tensor_t *output = getTensorLike(&outputNext);
     convertTensor(&outputNext, output);
+    deInitBuffer(&outputNext);
     return output;
 }
 
@@ -192,5 +193,6 @@ inferenceStats_t *inferenceWithLoss(layer_t **model, size_t numberOfLayers, tens
     float loss = lossFns.forward(&outputNext, label);
     inferenceStats->loss = loss;
 
+    deInitBuffer(&outputNext);
     return inferenceStats;
 }

--- a/test/unit/userAPI/UnitTestInferenceApi.c
+++ b/test/unit/userAPI/UnitTestInferenceApi.c
@@ -1,140 +1,253 @@
-#include "Layer.h"
-#include "TensorApi.h"
 #include "InferenceApi.h"
-#include "unity.h"
+#include "Layer.h"
 #include "LinearApi.h"
-#include "ReluApi.h"
-#include "QuantizationApi.h"
-#include "TensorConversion.h"
 #include "LossFunction.h"
+#include "QuantizationApi.h"
+#include "ReluApi.h"
+#include "StorageApi.h"
+#include "TensorApi.h"
+#include "TensorConversion.h"
+#include "unity.h"
 
 void testInferenceLinearReluFloat() {
+    /* 1. Build heap-allocated quantization (shared across both layers). */
+    quantization_t *q = quantizationInitFloat();
 
-    float weightData[] = {-1.f, 2.f, -3.f, 4.f, 5.f, 6.f};
-    size_t weightDims[] = {2, 3};
-    size_t weightNumberOfDims = 2;
-
-    tensor_t *weightParam = tensorInitFloat(weightData, weightDims, weightNumberOfDims, NULL);
-
+    /* 2. Build weights tensor (shape 2x3) and its grad. */
+    size_t *weightDims = reserveMemory(2 * sizeof(size_t));
+    weightDims[0] = 2;
+    weightDims[1] = 3;
+    size_t *weightOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, weightOrder);
+    shape_t *weightShape = reserveMemory(sizeof(shape_t));
+    setShape(weightShape, weightDims, 2, weightOrder);
+    tensor_t *weightParam = initTensor(weightShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(weightParam, (float[]){-1.f, 2.f, -3.f, 4.f, 5.f, 6.f}, 6);
     tensor_t *weightGrad = gradInitFloat(weightParam, NULL);
     parameter_t *weights = parameterInit(weightParam, weightGrad);
 
-    float biasData[] = {-1.f, 3.f};
-    size_t biasDims[] = {1, 2};
-    size_t biasNumberOfDims = 2;
-
-    tensor_t *biasParam = tensorInitFloat(biasData, biasDims, biasNumberOfDims, NULL);
+    /* 3. Build bias tensor (shape 1x2) and its grad. */
+    size_t *biasDims = reserveMemory(2 * sizeof(size_t));
+    biasDims[0] = 1;
+    biasDims[1] = 2;
+    size_t *biasOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, biasOrder);
+    shape_t *biasShape = reserveMemory(sizeof(shape_t));
+    setShape(biasShape, biasDims, 2, biasOrder);
+    tensor_t *biasParam = initTensor(biasShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(biasParam, (float[]){-1.f, 3.f}, 2);
     tensor_t *biasGrad = gradInitFloat(biasParam, NULL);
     parameter_t *bias = parameterInit(biasParam, biasGrad);
 
-    float inputData[] = {0.f, 1.f, 2.f};
-    size_t inputDims[] = {1, 3};
-    size_t inputNumberOfDims = 2;
-    tensor_t *input = tensorInitFloat(inputData, inputDims, inputNumberOfDims, NULL);
+    /* 4. Build input tensor (shape 1x3). */
+    size_t *inputDims = reserveMemory(2 * sizeof(size_t));
+    inputDims[0] = 1;
+    inputDims[1] = 3;
+    size_t *inputOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, inputOrder);
+    shape_t *inputShape = reserveMemory(sizeof(shape_t));
+    setShape(inputShape, inputDims, 2, inputOrder);
+    tensor_t *input = initTensor(inputShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(input, (float[]){0.f, 1.f, 2.f}, 3);
 
-    quantization_t *test = quantizationInitFloat();
-
-    layer_t *linear = linearLayerInit(weights, bias, test, test, test, test);
-
-    layer_t *relu = reluLayerInit(test, test);
-
+    /* 5. Build layers; both layers share the same q (no ownership transfer). */
+    layer_t *linear = linearLayerInit(weights, bias, q, q, q, q);
+    layer_t *relu = reluLayerInit(q, q);
     layer_t *model[] = {linear, relu};
 
+    /* 6. Exercise the system. */
     tensor_t *output = inference(model, 2, input);
 
-    float expected[] = {0.f, 20.f};
+    /* 7. CAPTURE assertion values into stack locals BEFORE frees. */
+    float capturedOutput[2];
+    capturedOutput[0] = ((float *)output->data)[0];
+    capturedOutput[1] = ((float *)output->data)[1];
 
-    TEST_ASSERT_EQUAL_FLOAT_ARRAY(expected, output->data, 2);
+    /* 8. FREE in reverse-init order.
+     *    - inference() returns a heap tensor (via getTensorLike) — caller owns it.
+     *    - freeReluLayer / freeLinearLayer release config wrappers but NOT shared q
+     *      and NOT the parameters.
+     *    - freeParameter cascades to param + grad via freeTensor (TensorApi.c:389).
+     *    - The shared q is freed exactly once at the end. */
+    freeTensor(output);
+    freeReluLayer(relu);
+    freeLinearLayer(linear);
+    freeTensor(input);
+    freeParameter(bias);
+    freeParameter(weights);
+    freeQuantization(q);
+
+    /* 9. ASSERT on captured locals. */
+    float expected[] = {0.f, 20.f};
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(expected, capturedOutput, 2);
 }
 
 void testInferenceLinearReluSymInt32() {
     size_t numberOfOutputs = 2;
 
-    float weightDataFloat[] = {-1.f, 2.f, -3.f, 4.f, 5.f, 6.f};
-    size_t weightDims[] = {2, 3};
-    size_t weightNumberOfDims = 2;
-    tensor_t *weightsParam = tensorInitSymInt32(weightDataFloat, weightDims, weightNumberOfDims,
-                                                HTE, NULL);
+    /* Shared SymInt32 quantization for layers. */
+    quantization_t *q = quantizationInitSymInt32(HTE);
+
+    /* Weights (2x3). */
+    size_t *weightDims = reserveMemory(2 * sizeof(size_t));
+    weightDims[0] = 2;
+    weightDims[1] = 3;
+    size_t *weightOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, weightOrder);
+    shape_t *weightShape = reserveMemory(sizeof(shape_t));
+    setShape(weightShape, weightDims, 2, weightOrder);
+    tensor_t *weightsParam = initTensor(weightShape, quantizationInitSymInt32(HTE), NULL);
+    tensorFillFromFloatBuffer(weightsParam, (float[]){-1.f, 2.f, -3.f, 4.f, 5.f, 6.f}, 6);
     tensor_t *weightGrad = gradInitSymInt32(weightsParam, HTE, NULL);
     parameter_t *weights = parameterInit(weightsParam, weightGrad);
 
-    float biasData[] = {-1, 3};
-    size_t biasDims[] = {1, 2};
-    size_t biasNumberOfDims = 2;
-    tensor_t *biasParam = tensorInitSymInt32(biasData, biasDims, biasNumberOfDims, HTE, NULL);
+    /* Bias (1x2). */
+    size_t *biasDims = reserveMemory(2 * sizeof(size_t));
+    biasDims[0] = 1;
+    biasDims[1] = 2;
+    size_t *biasOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, biasOrder);
+    shape_t *biasShape = reserveMemory(sizeof(shape_t));
+    setShape(biasShape, biasDims, 2, biasOrder);
+    tensor_t *biasParam = initTensor(biasShape, quantizationInitSymInt32(HTE), NULL);
+    tensorFillFromFloatBuffer(biasParam, (float[]){-1.f, 3.f}, 2);
     tensor_t *biasGrad = gradInitSymInt32(biasParam, HTE, NULL);
     parameter_t *bias = parameterInit(biasParam, biasGrad);
 
-    float inputDataFloat[] = {0.f, 1.f, 2.f};
-    size_t inputDims[] = {1, 3};
-    size_t inputNumberOfDims = 2;
-    tensor_t *input = tensorInitSymInt32(inputDataFloat, inputDims, inputNumberOfDims, HTE, NULL);
+    /* Input (1x3). */
+    size_t *inputDims = reserveMemory(2 * sizeof(size_t));
+    inputDims[0] = 1;
+    inputDims[1] = 3;
+    size_t *inputOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, inputOrder);
+    shape_t *inputShape = reserveMemory(sizeof(shape_t));
+    setShape(inputShape, inputDims, 2, inputOrder);
+    tensor_t *input = initTensor(inputShape, quantizationInitSymInt32(HTE), NULL);
+    tensorFillFromFloatBuffer(input, (float[]){0.f, 1.f, 2.f}, 3);
 
-    quantization_t *test = quantizationInitSymInt32(HTE);
-    layer_t *linear = linearLayerInit(weights, bias, test, test, test, test);
-
-    layer_t *relu = reluLayerInit(test, test);
-
+    /* Layers. */
+    layer_t *linear = linearLayerInit(weights, bias, q, q, q, q);
+    layer_t *relu = reluLayerInit(q, q);
     layer_t *model[] = {linear, relu};
 
+    /* Run inference (returns a heap tensor in SymInt32 form). */
     tensor_t *outputSymInt32 = inference(model, 2, input);
 
-    float expected[] = {0.f, 20.f};
-    float outputData[numberOfOutputs];
-    tensor_t *outputFloat = tensorInitFloat(outputData, biasDims, biasNumberOfDims, NULL);
+    /* Convert SymInt32 → Float32 view for comparison. The output buffer is
+     * heap-allocated to keep us in the heap-tier idiom. */
+    size_t *outDims = reserveMemory(2 * sizeof(size_t));
+    outDims[0] = 1;
+    outDims[1] = numberOfOutputs;
+    size_t *outOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, outOrder);
+    shape_t *outShape = reserveMemory(sizeof(shape_t));
+    setShape(outShape, outDims, 2, outOrder);
+    tensor_t *outputFloat = initTensor(outShape, quantizationInitFloat(), NULL);
     convertTensor(outputSymInt32, outputFloat);
-    float *actual = (float *)outputFloat->data;
 
+    /* CAPTURE assertion values. */
+    float capturedActual[2];
+    capturedActual[0] = ((float *)outputFloat->data)[0];
+    capturedActual[1] = ((float *)outputFloat->data)[1];
+
+    /* FREE in reverse-init order. */
+    freeTensor(outputFloat);
+    freeTensor(outputSymInt32);
+    freeReluLayer(relu);
+    freeLinearLayer(linear);
+    freeTensor(input);
+    freeParameter(bias);
+    freeParameter(weights);
+    freeQuantization(q);
+
+    /* ASSERT on captured. */
+    float expected[] = {0.f, 20.f};
     for (size_t i = 0; i < numberOfOutputs; i++) {
-        TEST_ASSERT_FLOAT_WITHIN(0.1f, expected[i], actual[i]);
+        TEST_ASSERT_FLOAT_WITHIN(0.1f, expected[i], capturedActual[i]);
     }
 }
 
 void testInferenceWithLossLinearReluFloat() {
+    quantization_t *q = quantizationInitFloat();
 
-    float weightData[] = {-1.f, 2.f, -3.f, 4.f, 5.f, 6.f};
-    size_t weightDims[] = {2, 3};
-    size_t weightNumberOfDims = 2;
-
-    tensor_t *weightParam = tensorInitFloat(weightData, weightDims, weightNumberOfDims, NULL);
+    /* Weights (2x3). */
+    size_t *weightDims = reserveMemory(2 * sizeof(size_t));
+    weightDims[0] = 2;
+    weightDims[1] = 3;
+    size_t *weightOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, weightOrder);
+    shape_t *weightShape = reserveMemory(sizeof(shape_t));
+    setShape(weightShape, weightDims, 2, weightOrder);
+    tensor_t *weightParam = initTensor(weightShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(weightParam, (float[]){-1.f, 2.f, -3.f, 4.f, 5.f, 6.f}, 6);
     tensor_t *weightGrad = gradInitFloat(weightParam, NULL);
     parameter_t *weights = parameterInit(weightParam, weightGrad);
 
-    float biasData[] = {-1.f, 3.f};
-    size_t biasDims[] = {1, 2};
-    size_t biasNumberOfDims = 2;
-
-    tensor_t *biasParam = tensorInitFloat(biasData, biasDims, biasNumberOfDims, NULL);
+    /* Bias (1x2). */
+    size_t *biasDims = reserveMemory(2 * sizeof(size_t));
+    biasDims[0] = 1;
+    biasDims[1] = 2;
+    size_t *biasOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, biasOrder);
+    shape_t *biasShape = reserveMemory(sizeof(shape_t));
+    setShape(biasShape, biasDims, 2, biasOrder);
+    tensor_t *biasParam = initTensor(biasShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(biasParam, (float[]){-1.f, 3.f}, 2);
     tensor_t *biasGrad = gradInitFloat(biasParam, NULL);
     parameter_t *bias = parameterInit(biasParam, biasGrad);
 
-    float inputData[] = {0.f, 1.f, 2.f};
-    size_t inputDims[] = {1, 3};
-    size_t inputNumberOfDims = 2;
-    tensor_t *input = tensorInitFloat(inputData, inputDims, inputNumberOfDims, NULL);
+    /* Input (1x3). */
+    size_t *inputDims = reserveMemory(2 * sizeof(size_t));
+    inputDims[0] = 1;
+    inputDims[1] = 3;
+    size_t *inputOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, inputOrder);
+    shape_t *inputShape = reserveMemory(sizeof(shape_t));
+    setShape(inputShape, inputDims, 2, inputOrder);
+    tensor_t *input = initTensor(inputShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(input, (float[]){0.f, 1.f, 2.f}, 3);
 
-    quantization_t *test = quantizationInitFloat();
+    /* Label0 (1x2). */
+    size_t *label0Dims = reserveMemory(2 * sizeof(size_t));
+    label0Dims[0] = 1;
+    label0Dims[1] = 2;
+    size_t *label0Order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, label0Order);
+    shape_t *label0Shape = reserveMemory(sizeof(shape_t));
+    setShape(label0Shape, label0Dims, 2, label0Order);
+    tensor_t *label0 = initTensor(label0Shape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(label0, (float[]){59.f, -23.f}, 2);
 
-    layer_t *linear = linearLayerInit(weights, bias, test, test, test, test);
-
-    layer_t *relu = reluLayerInit(test, test);
-
+    /* Layers. */
+    layer_t *linear = linearLayerInit(weights, bias, q, q, q, q);
+    layer_t *relu = reluLayerInit(q, q);
     layer_t *model[] = {linear, relu};
 
-    float label0Data[] = {59.f, -23.f};
-    size_t label0Dims[] = {1, 2};
-    size_t label0NumberOfDims = 2;
-    tensor_t *label0 = tensorInitFloat(label0Data, label0Dims, label0NumberOfDims, NULL);
-
+    /* Run inferenceWithLoss. inferenceStats owns its `output` tensor; its
+     * matching free is freeInferenceStats. */
     inferenceStats_t *inferenceStats = inferenceWithLoss(model, 2, input, label0, MSE);
 
-    float expectedOutput[] = {0.f, 20.f};
-    float expectedLoss = 2665.f;
+    /* CAPTURE. */
+    float capturedLoss = inferenceStats->loss;
+    float capturedOutput[2];
+    capturedOutput[0] = ((float *)inferenceStats->output->data)[0];
+    capturedOutput[1] = ((float *)inferenceStats->output->data)[1];
 
-    TEST_ASSERT_EQUAL_FLOAT(expectedLoss, inferenceStats->loss);
-    TEST_ASSERT_EQUAL_FLOAT_ARRAY(expectedOutput, inferenceStats->output->data, 2);
-
+    /* FREE in reverse-init order. */
     freeInferenceStats(inferenceStats);
+    freeReluLayer(relu);
+    freeLinearLayer(linear);
+    freeTensor(label0);
+    freeTensor(input);
+    freeParameter(bias);
+    freeParameter(weights);
+    freeQuantization(q);
+
+    /* ASSERT on captured. */
+    float expectedLoss = 2665.f;
+    float expectedOutput[] = {0.f, 20.f};
+    TEST_ASSERT_EQUAL_FLOAT(expectedLoss, capturedLoss);
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(expectedOutput, capturedOutput, 2);
 }
 
 void setUp() {}


### PR DESCRIPTION
**Stack position:** `develop ← #109 (this) ← #110 ← #111 ← #112`

Merge order: this PR first; once merged, GitHub will auto-rebase #110 onto `develop`.

---

## Summary

Migrates UnitTestInferenceApi (3 tests, 1.3KB pre-migration leak) to the Phase 2 explicit-free + assert-last idiom, **and** closes a previously-undetected production leak in inference() / inferenceWithLoss() that the migration spike surfaced. Spike-validates the idiom for the rest of the framework migration.

## Test-side changes

`test/unit/userAPI/UnitTestInferenceApi.c` — all 3 tests rewritten to:
- Build heap dependencies via `reserveMemory` + `setShape` + `quantizationInit*` + `initTensor` + `tensorFillFromFloatBuffer`.
- Capture every value the assertions need into stack locals before any free.
- Free in reverse-init order via `freeTensor` / `freeParameter` / `free*Layer` / `freeQuantization` / `freeInferenceStats`.
- Assert on the captured locals last.

## Production-side fix

`src/userApi/InferenceApi.c` — `inference()` and `inferenceWithLoss()` both terminate their forward-pass loop with `outputNext` aliasing the last layer's heap-allocated `outputCurr`. The loop body's `deInitBuffer(&outputNext)` only freed the previous iteration's tensor, so the last layer's allocations leaked on every call. Two-line fix: invoke `deInitBuffer(&outputNext)` after the loop, before the function returns.

This was not in the original Phase 1.5 prerequisite list. The Phase 1 recon report saw the signatures (#17–#21 in the dedupe table) but classified them under generic `initBufferOutput` traces rather than escalating to a "missing destructor at call site" category.

## Verification

- macOS: `cmake --build --preset unit_test_debug --target UnitTestInferenceApi && build/unit_test_debug/test/unit/userAPI/UnitTestInferenceApi` — 3/3 PASS, zero deprecation warnings.
- LSan in `odt-lsan-recon:2026-04-22`: `definitely lost = indirectly lost = possibly lost = still reachable = 0 bytes in 0 blocks`. Logs at `docs/superpowers/reports/UnitTestInferenceApi.{before,after}.log` (gitignored).

## Test plan

- [ ] CI green (c-build-and-test + python-test).
- [ ] Reviewer LSan smoke check on Linux.

Spec: `docs/superpowers/specs/2026-04-25-phase-2-teardown-idiom-design.md`
Plan: `docs/superpowers/plans/2026-04-27-phase-2-teardown-idiom.md`

Closes #82
