### PR TITLE
test(#82): migrate UnitTestMultiLayerTraining + close freeOptimSgdM container leaks

### DIFF
--- a/src/userApi/optimizer/SgdApi.c
+++ b/src/userApi/optimizer/SgdApi.c
@@ -3,14 +3,13 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include "Tensor.h"
-#include "Layer.h"
-#include "SgdApi.h"
-#include "TensorApi.h"
-#include "Linear.h"
 #include "Common.h"
+#include "Layer.h"
+#include "Linear.h"
+#include "SgdApi.h"
 #include "StorageApi.h"
-
+#include "Tensor.h"
+#include "TensorApi.h"
 
 // IMPORTANT: Currently, the quantization for states are the same as the corresponding parameter
 optimizer_t *sgdMCreateOptim(float learningRate, float momentumFactor, float weightDecay,
@@ -79,6 +78,7 @@ void freeState(states_t *state) {
     for (size_t i = 0; i < state->statesPerParameter; i++) {
         freeTensor(state->stateBuffers[i]);
     }
+    freeReservedMemory(state->stateBuffers);
     freeReservedMemory(state);
 }
 
@@ -87,7 +87,10 @@ void freeOptimSgdM(optimizer_t *sgdM) {
         freeParameter(sgdM->parameter[i]);
         freeState(sgdM->states[i]);
     }
+    freeReservedMemory(sgdM->parameter);
+    freeReservedMemory(sgdM->states);
     sgd_t *sgdImpl = sgdM->impl->sgd;
     freeReservedMemory(sgdImpl);
+    freeReservedMemory(sgdM->impl);
     freeReservedMemory(sgdM);
 }

--- a/test/unit/userAPI/UnitTestMultiLayerTraining.c
+++ b/test/unit/userAPI/UnitTestMultiLayerTraining.c
@@ -2,59 +2,86 @@
 
 #include <stddef.h>
 
-#include "LossFunction.h"
-#include "TensorApi.h"
-#include "LinearApi.h"
-#include "ReluApi.h"
-#include "SoftmaxApi.h"
-#include "SgdApi.h"
-#include "unity.h"
-#include "TrainingLoopApi.h"
 #include "CalculateGradsSequential.h"
-#include "TrainingBatchDefault.h"
-#include "QuantizationApi.h"
-#include "Tensor.h"
-#include "StorageApi.h"
-#include "InferenceApi.h"
 #include "DataLoaderApi.h"
 #include "Dataset.h"
+#include "InferenceApi.h"
+#include "LinearApi.h"
+#include "LossFunction.h"
+#include "QuantizationApi.h"
+#include "ReluApi.h"
+#include "SgdApi.h"
+#include "SoftmaxApi.h"
+#include "StorageApi.h"
+#include "Tensor.h"
+#include "TensorApi.h"
+#include "TrainingBatchDefault.h"
+#include "TrainingLoopApi.h"
+#include "unity.h"
 
 void setUp() {}
 void tearDown() {}
 
 /*! Integration test: multi-layer model (Linear→ReLU→Linear→Softmax) with CrossEntropy.
  *  Reproduces the MnistExperiment structure at small scale (3→4→2).
- *  Uses tensorInitWithDistribution to init bias with ZEROS — exposes the += vs *= bug.
+ *  Uses initDistribution to init weights/biases with ZEROS — exposes the += vs *= bug.
  */
 void testMultiLayerBackward_WithCrossEntropy_DoesNotCrash() {
     quantization_t *q = quantizationInitFloat();
+    distribution_t zeros = {.type = ZEROS};
 
-    // Layer 0: Linear 3→4
-    float w0Data[4 * 3] = {0};
-    size_t w0Dims[] = {4, 3};
-    tensor_t *w0Param = tensorInitWithDistribution(ZEROS, w0Data, w0Dims, 2, q, NULL, 3, 4);
+    /* Layer 0 weights w0 (4x3, ZEROS). */
+    size_t *w0Dims = reserveMemory(2 * sizeof(size_t));
+    w0Dims[0] = 4;
+    w0Dims[1] = 3;
+    size_t *w0Order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, w0Order);
+    shape_t *w0Shape = reserveMemory(sizeof(shape_t));
+    setShape(w0Shape, w0Dims, 2, w0Order);
+    tensor_t *w0Param = initTensor(w0Shape, quantizationInitFloat(), NULL);
+    initDistribution(w0Param, &zeros);
     tensor_t *w0Grad = gradInitFloat(w0Param, NULL);
     parameter_t *w0 = parameterInit(w0Param, w0Grad);
 
-    float b0Data[4] = {0};
-    size_t b0Dims[] = {1, 4};
-    tensor_t *b0Param = tensorInitWithDistribution(ZEROS, b0Data, b0Dims, 2, q, NULL, 1, 4);
+    /* Layer 0 bias b0 (1x4, ZEROS). */
+    size_t *b0Dims = reserveMemory(2 * sizeof(size_t));
+    b0Dims[0] = 1;
+    b0Dims[1] = 4;
+    size_t *b0Order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, b0Order);
+    shape_t *b0Shape = reserveMemory(sizeof(shape_t));
+    setShape(b0Shape, b0Dims, 2, b0Order);
+    tensor_t *b0Param = initTensor(b0Shape, quantizationInitFloat(), NULL);
+    initDistribution(b0Param, &zeros);
     tensor_t *b0Grad = gradInitFloat(b0Param, NULL);
     parameter_t *b0 = parameterInit(b0Param, b0Grad);
 
     layer_t *linear0 = linearLayerInit(w0, b0, q, q, q, q);
     layer_t *relu = reluLayerInit(q, q);
 
-    // Layer 1: Linear 4→2
-    float w1Data[2 * 4] = {0};
-    size_t w1Dims[] = {2, 4};
-    tensor_t *w1Param = tensorInitWithDistribution(ZEROS, w1Data, w1Dims, 2, q, NULL, 4, 2);
+    /* Layer 1 weights w1 (2x4, ZEROS). */
+    size_t *w1Dims = reserveMemory(2 * sizeof(size_t));
+    w1Dims[0] = 2;
+    w1Dims[1] = 4;
+    size_t *w1Order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, w1Order);
+    shape_t *w1Shape = reserveMemory(sizeof(shape_t));
+    setShape(w1Shape, w1Dims, 2, w1Order);
+    tensor_t *w1Param = initTensor(w1Shape, quantizationInitFloat(), NULL);
+    initDistribution(w1Param, &zeros);
     tensor_t *w1Grad = gradInitFloat(w1Param, NULL);
     parameter_t *w1 = parameterInit(w1Param, w1Grad);
 
-    float b1Data[2] = {0};
-    size_t b1Dims[] = {1, 2};
-    tensor_t *b1Param = tensorInitWithDistribution(ZEROS, b1Data, b1Dims, 2, q, NULL, 1, 2);
+    /* Layer 1 bias b1 (1x2, ZEROS). */
+    size_t *b1Dims = reserveMemory(2 * sizeof(size_t));
+    b1Dims[0] = 1;
+    b1Dims[1] = 2;
+    size_t *b1Order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, b1Order);
+    shape_t *b1Shape = reserveMemory(sizeof(shape_t));
+    setShape(b1Shape, b1Dims, 2, b1Order);
+    tensor_t *b1Param = initTensor(b1Shape, quantizationInitFloat(), NULL);
+    initDistribution(b1Param, &zeros);
     tensor_t *b1Grad = gradInitFloat(b1Param, NULL);
     parameter_t *b1 = parameterInit(b1Param, b1Grad);
 
@@ -64,165 +91,308 @@ void testMultiLayerBackward_WithCrossEntropy_DoesNotCrash() {
     layer_t *model[] = {linear0, relu, linear1, softmax};
     size_t sizeModel = 4;
 
-    // Input: [1, 3], Label: [1, 2] (one-hot)
-    float inputData[] = {1.0f, 2.0f, 3.0f};
-    size_t inputDims[] = {1, 3};
-    tensor_t *input = tensorInitFloat(inputData, inputDims, 2, NULL);
+    /* Input (1x3). */
+    size_t *inputDims = reserveMemory(2 * sizeof(size_t));
+    inputDims[0] = 1;
+    inputDims[1] = 3;
+    size_t *inputOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, inputOrder);
+    shape_t *inputShape = reserveMemory(sizeof(shape_t));
+    setShape(inputShape, inputDims, 2, inputOrder);
+    tensor_t *input = initTensor(inputShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(input, (float[]){1.0f, 2.0f, 3.0f}, 3);
 
-    float labelData[] = {1.0f, 0.0f};
-    size_t labelDims[] = {1, 2};
-    tensor_t *label = tensorInitFloat(labelData, labelDims, 2, NULL);
+    /* Label (1x2 one-hot). */
+    size_t *labelDims = reserveMemory(2 * sizeof(size_t));
+    labelDims[0] = 1;
+    labelDims[1] = 2;
+    size_t *labelOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, labelOrder);
+    shape_t *labelShape = reserveMemory(sizeof(shape_t));
+    setShape(labelShape, labelDims, 2, labelOrder);
+    tensor_t *label = initTensor(labelShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(label, (float[]){1.0f, 0.0f}, 2);
 
-    // This is the call that crashes in the MnistExperiment
-    trainingStats_t *stats = calculateGradsSequential(model, sizeModel, CROSS_ENTROPY,
-                                                       input, label);
+    trainingStats_t *stats =
+        calculateGradsSequential(model, sizeModel, CROSS_ENTROPY, input, label);
 
-    TEST_ASSERT_NOT_NULL(stats);
-    // Loss should be finite and non-negative
-    TEST_ASSERT_TRUE(stats->loss >= 0.0f);
+    /* CAPTURE. */
+    bool capturedNotNull = (stats != NULL);
+    float capturedLoss = stats ? stats->loss : -1.0f;
 
+    /* FREE in reverse-init order. */
     freeTrainingStats(stats);
+    freeTensor(label);
+    freeTensor(input);
+    freeSoftmaxLayer(softmax);
+    freeLinearLayer(linear1);
+    freeParameter(b1);
+    freeParameter(w1);
+    freeReluLayer(relu);
+    freeLinearLayer(linear0);
+    freeParameter(b0);
+    freeParameter(w0);
+    freeQuantization(q);
+
+    /* ASSERT on captured. */
+    TEST_ASSERT_TRUE(capturedNotNull);
+    TEST_ASSERT_TRUE(capturedLoss >= 0.0f);
 }
 
-/*! Integration test: same as above but using tensorInitFloat (no distribution).
- *  This should always work — validates the backward pass logic itself is correct.
+/*! Integration test: same as above but with manually filled weights.
+ *  Validates the backward pass logic itself is correct.
  */
 void testMultiLayerBackward_WithManualInit_DoesNotCrash() {
-    quantization_t testQ;
-    initFloat32Quantization(&testQ);
+    quantization_t *q = quantizationInitFloat();
 
-    // Layer 0: Linear 3→4
-    float w0Data[] = {0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f,
-                      0.7f, 0.8f, 0.9f, 1.0f, 1.1f, 1.2f};
-    size_t w0Dims[] = {4, 3};
-    tensor_t *w0Param = tensorInitFloat(w0Data, w0Dims, 2, NULL);
-    float w0GradData[12] = {0};
-    tensor_t *w0Grad = tensorInitFloat(w0GradData, w0Dims, 2, NULL);
+    /* Layer 0 weights w0 (4x3, manual values). */
+    size_t *w0Dims = reserveMemory(2 * sizeof(size_t));
+    w0Dims[0] = 4;
+    w0Dims[1] = 3;
+    size_t *w0Order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, w0Order);
+    shape_t *w0Shape = reserveMemory(sizeof(shape_t));
+    setShape(w0Shape, w0Dims, 2, w0Order);
+    tensor_t *w0Param = initTensor(w0Shape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(
+        w0Param, (float[]){0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f, 0.7f, 0.8f, 0.9f, 1.0f, 1.1f, 1.2f},
+        12);
+    tensor_t *w0Grad = gradInitFloat(w0Param, NULL);
     parameter_t *w0 = parameterInit(w0Param, w0Grad);
 
-    float b0Data[] = {0.0f, 0.0f, 0.0f, 0.0f};
-    size_t b0Dims[] = {1, 4};
-    tensor_t *b0Param = tensorInitFloat(b0Data, b0Dims, 2, NULL);
-    float b0GradData[] = {0.0f, 0.0f, 0.0f, 0.0f};
-    tensor_t *b0Grad = tensorInitFloat(b0GradData, b0Dims, 2, NULL);
+    /* Layer 0 bias b0 (1x4, zeros). */
+    size_t *b0Dims = reserveMemory(2 * sizeof(size_t));
+    b0Dims[0] = 1;
+    b0Dims[1] = 4;
+    size_t *b0Order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, b0Order);
+    shape_t *b0Shape = reserveMemory(sizeof(shape_t));
+    setShape(b0Shape, b0Dims, 2, b0Order);
+    tensor_t *b0Param = initTensor(b0Shape, quantizationInitFloat(), NULL);
+    /* initTensor zero-initializes data per TensorApi.c:81-92, so no explicit fill. */
+    tensor_t *b0Grad = gradInitFloat(b0Param, NULL);
     parameter_t *b0 = parameterInit(b0Param, b0Grad);
 
-    layer_t *linear0 = linearLayerInit(w0, b0, &testQ, &testQ, &testQ, &testQ);
-    layer_t *relu = reluLayerInit(&testQ, &testQ);
+    layer_t *linear0 = linearLayerInit(w0, b0, q, q, q, q);
+    layer_t *relu = reluLayerInit(q, q);
 
-    // Layer 1: Linear 4→2
-    float w1Data[] = {0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f, 0.7f, 0.8f};
-    size_t w1Dims[] = {2, 4};
-    tensor_t *w1Param = tensorInitFloat(w1Data, w1Dims, 2, NULL);
-    float w1GradData[8] = {0};
-    tensor_t *w1Grad = tensorInitFloat(w1GradData, w1Dims, 2, NULL);
+    /* Layer 1 weights w1 (2x4, manual). */
+    size_t *w1Dims = reserveMemory(2 * sizeof(size_t));
+    w1Dims[0] = 2;
+    w1Dims[1] = 4;
+    size_t *w1Order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, w1Order);
+    shape_t *w1Shape = reserveMemory(sizeof(shape_t));
+    setShape(w1Shape, w1Dims, 2, w1Order);
+    tensor_t *w1Param = initTensor(w1Shape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(w1Param, (float[]){0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f, 0.7f, 0.8f},
+                              8);
+    tensor_t *w1Grad = gradInitFloat(w1Param, NULL);
     parameter_t *w1 = parameterInit(w1Param, w1Grad);
 
-    float b1Data[] = {0.0f, 0.0f};
-    size_t b1Dims[] = {1, 2};
-    tensor_t *b1Param = tensorInitFloat(b1Data, b1Dims, 2, NULL);
-    float b1GradData[] = {0.0f, 0.0f};
-    tensor_t *b1Grad = tensorInitFloat(b1GradData, b1Dims, 2, NULL);
+    /* Layer 1 bias b1 (1x2, zeros). */
+    size_t *b1Dims = reserveMemory(2 * sizeof(size_t));
+    b1Dims[0] = 1;
+    b1Dims[1] = 2;
+    size_t *b1Order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, b1Order);
+    shape_t *b1Shape = reserveMemory(sizeof(shape_t));
+    setShape(b1Shape, b1Dims, 2, b1Order);
+    tensor_t *b1Param = initTensor(b1Shape, quantizationInitFloat(), NULL);
+    tensor_t *b1Grad = gradInitFloat(b1Param, NULL);
     parameter_t *b1 = parameterInit(b1Param, b1Grad);
 
-    layer_t *linear1 = linearLayerInit(w1, b1, &testQ, &testQ, &testQ, &testQ);
-    layer_t *softmax = softmaxLayerInit(&testQ, &testQ);
+    layer_t *linear1 = linearLayerInit(w1, b1, q, q, q, q);
+    layer_t *softmax = softmaxLayerInit(q, q);
 
     layer_t *model[] = {linear0, relu, linear1, softmax};
     size_t sizeModel = 4;
 
-    float inputData[] = {1.0f, 2.0f, 3.0f};
-    size_t inputDims[] = {1, 3};
-    tensor_t *input = tensorInitFloat(inputData, inputDims, 2, NULL);
+    /* Input (1x3). */
+    size_t *inputDims = reserveMemory(2 * sizeof(size_t));
+    inputDims[0] = 1;
+    inputDims[1] = 3;
+    size_t *inputOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, inputOrder);
+    shape_t *inputShape = reserveMemory(sizeof(shape_t));
+    setShape(inputShape, inputDims, 2, inputOrder);
+    tensor_t *input = initTensor(inputShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(input, (float[]){1.0f, 2.0f, 3.0f}, 3);
 
-    float labelData[] = {1.0f, 0.0f};
-    size_t labelDims[] = {1, 2};
-    tensor_t *label = tensorInitFloat(labelData, labelDims, 2, NULL);
+    /* Label (1x2). */
+    size_t *labelDims = reserveMemory(2 * sizeof(size_t));
+    labelDims[0] = 1;
+    labelDims[1] = 2;
+    size_t *labelOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, labelOrder);
+    shape_t *labelShape = reserveMemory(sizeof(shape_t));
+    setShape(labelShape, labelDims, 2, labelOrder);
+    tensor_t *label = initTensor(labelShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(label, (float[]){1.0f, 0.0f}, 2);
 
-    trainingStats_t *stats = calculateGradsSequential(model, sizeModel, CROSS_ENTROPY,
-                                                       input, label);
+    trainingStats_t *stats =
+        calculateGradsSequential(model, sizeModel, CROSS_ENTROPY, input, label);
 
-    TEST_ASSERT_NOT_NULL(stats);
-    TEST_ASSERT_TRUE(stats->loss >= 0.0f);
-
-    // Verify bias grads were accumulated (not zero after backward)
-    float *b1GradValues = (float *)b1Grad->data;
-    bool anyNonZero = false;
-    for (size_t i = 0; i < 2; i++) {
-        if (b1GradValues[i] != 0.0f) {
-            anyNonZero = true;
-            break;
+    /* CAPTURE. The original test checks that b1Grad has at least one nonzero
+     * value AFTER the backward pass; we capture that boolean before frees so
+     * the post-free freeParameter(b1) doesn't zero or invalidate b1Grad. */
+    bool capturedNotNull = (stats != NULL);
+    float capturedLoss = stats ? stats->loss : -1.0f;
+    bool capturedAnyNonZero = false;
+    if (b1Grad && b1Grad->data) {
+        float *vals = (float *)b1Grad->data;
+        for (size_t i = 0; i < 2; i++) {
+            if (vals[i] != 0.0f) {
+                capturedAnyNonZero = true;
+                break;
+            }
         }
     }
-    TEST_ASSERT_TRUE(anyNonZero);
 
+    /* FREE in reverse-init order. */
     freeTrainingStats(stats);
+    freeTensor(label);
+    freeTensor(input);
+    freeSoftmaxLayer(softmax);
+    freeLinearLayer(linear1);
+    freeParameter(b1);
+    freeParameter(w1);
+    freeReluLayer(relu);
+    freeLinearLayer(linear0);
+    freeParameter(b0);
+    freeParameter(w0);
+    freeQuantization(q);
+
+    /* ASSERT on captured. */
+    TEST_ASSERT_TRUE(capturedNotNull);
+    TEST_ASSERT_TRUE(capturedLoss >= 0.0f);
+    TEST_ASSERT_TRUE(capturedAnyNonZero);
 }
 
 /*! Integration test: run multiple training steps to verify grad accumulation is stable. */
 void testMultiLayerTraining_MultipleSteps_GradsAccumulate() {
-    quantization_t testQ;
-    initFloat32Quantization(&testQ);
+    quantization_t *q = quantizationInitFloat();
 
-    float w0Data[] = {0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f,
-                      0.7f, 0.8f, 0.9f, 1.0f, 1.1f, 1.2f};
-    size_t w0Dims[] = {4, 3};
-    tensor_t *w0Param = tensorInitFloat(w0Data, w0Dims, 2, NULL);
-    float w0GradData[12] = {0};
-    tensor_t *w0Grad = tensorInitFloat(w0GradData, w0Dims, 2, NULL);
+    /* Layer 0 weights w0 (4x3). */
+    size_t *w0Dims = reserveMemory(2 * sizeof(size_t));
+    w0Dims[0] = 4;
+    w0Dims[1] = 3;
+    size_t *w0Order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, w0Order);
+    shape_t *w0Shape = reserveMemory(sizeof(shape_t));
+    setShape(w0Shape, w0Dims, 2, w0Order);
+    tensor_t *w0Param = initTensor(w0Shape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(
+        w0Param, (float[]){0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f, 0.7f, 0.8f, 0.9f, 1.0f, 1.1f, 1.2f},
+        12);
+    tensor_t *w0Grad = gradInitFloat(w0Param, NULL);
     parameter_t *w0 = parameterInit(w0Param, w0Grad);
 
-    float b0Data[] = {0.0f, 0.0f, 0.0f, 0.0f};
-    size_t b0Dims[] = {1, 4};
-    tensor_t *b0Param = tensorInitFloat(b0Data, b0Dims, 2, NULL);
-    float b0GradData[] = {0.0f, 0.0f, 0.0f, 0.0f};
-    tensor_t *b0Grad = tensorInitFloat(b0GradData, b0Dims, 2, NULL);
+    /* Layer 0 bias b0 (1x4, zeros). */
+    size_t *b0Dims = reserveMemory(2 * sizeof(size_t));
+    b0Dims[0] = 1;
+    b0Dims[1] = 4;
+    size_t *b0Order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, b0Order);
+    shape_t *b0Shape = reserveMemory(sizeof(shape_t));
+    setShape(b0Shape, b0Dims, 2, b0Order);
+    tensor_t *b0Param = initTensor(b0Shape, quantizationInitFloat(), NULL);
+    tensor_t *b0Grad = gradInitFloat(b0Param, NULL);
     parameter_t *b0 = parameterInit(b0Param, b0Grad);
 
-    layer_t *linear0 = linearLayerInit(w0, b0, &testQ, &testQ, &testQ, &testQ);
-    layer_t *relu = reluLayerInit(&testQ, &testQ);
+    layer_t *linear0 = linearLayerInit(w0, b0, q, q, q, q);
+    layer_t *relu = reluLayerInit(q, q);
 
-    float w1Data[] = {0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f, 0.7f, 0.8f};
-    size_t w1Dims[] = {2, 4};
-    tensor_t *w1Param = tensorInitFloat(w1Data, w1Dims, 2, NULL);
-    float w1GradData[8] = {0};
-    tensor_t *w1Grad = tensorInitFloat(w1GradData, w1Dims, 2, NULL);
+    /* Layer 1 weights w1 (2x4). */
+    size_t *w1Dims = reserveMemory(2 * sizeof(size_t));
+    w1Dims[0] = 2;
+    w1Dims[1] = 4;
+    size_t *w1Order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, w1Order);
+    shape_t *w1Shape = reserveMemory(sizeof(shape_t));
+    setShape(w1Shape, w1Dims, 2, w1Order);
+    tensor_t *w1Param = initTensor(w1Shape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(w1Param, (float[]){0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f, 0.7f, 0.8f},
+                              8);
+    tensor_t *w1Grad = gradInitFloat(w1Param, NULL);
     parameter_t *w1 = parameterInit(w1Param, w1Grad);
 
-    float b1Data[] = {0.0f, 0.0f};
-    size_t b1Dims[] = {1, 2};
-    tensor_t *b1Param = tensorInitFloat(b1Data, b1Dims, 2, NULL);
-    float b1GradData[] = {0.0f, 0.0f};
-    tensor_t *b1Grad = tensorInitFloat(b1GradData, b1Dims, 2, NULL);
+    /* Layer 1 bias b1 (1x2). */
+    size_t *b1Dims = reserveMemory(2 * sizeof(size_t));
+    b1Dims[0] = 1;
+    b1Dims[1] = 2;
+    size_t *b1Order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, b1Order);
+    shape_t *b1Shape = reserveMemory(sizeof(shape_t));
+    setShape(b1Shape, b1Dims, 2, b1Order);
+    tensor_t *b1Param = initTensor(b1Shape, quantizationInitFloat(), NULL);
+    tensor_t *b1Grad = gradInitFloat(b1Param, NULL);
     parameter_t *b1 = parameterInit(b1Param, b1Grad);
 
-    layer_t *linear1 = linearLayerInit(w1, b1, &testQ, &testQ, &testQ, &testQ);
-    layer_t *softmax = softmaxLayerInit(&testQ, &testQ);
+    layer_t *linear1 = linearLayerInit(w1, b1, q, q, q, q);
+    layer_t *softmax = softmaxLayerInit(q, q);
 
     layer_t *model[] = {linear0, relu, linear1, softmax};
     size_t sizeModel = 4;
 
+    /* Optimizer takes references to w0/b0/w1/b1 — its free will cascade. */
     optimizer_t *sgd = sgdMCreateOptim(0.01f, 0.f, 0.f, model, sizeModel, FLOAT32);
     optimizerFunctions_t sgdFns = optimizerFunctions[SGD_M];
 
-    float inputData[] = {1.0f, 2.0f, 3.0f};
-    size_t inputDims[] = {1, 3};
-    tensor_t *input = tensorInitFloat(inputData, inputDims, 2, NULL);
+    /* Input (1x3). */
+    size_t *inputDims = reserveMemory(2 * sizeof(size_t));
+    inputDims[0] = 1;
+    inputDims[1] = 3;
+    size_t *inputOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, inputOrder);
+    shape_t *inputShape = reserveMemory(sizeof(shape_t));
+    setShape(inputShape, inputDims, 2, inputOrder);
+    tensor_t *input = initTensor(inputShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(input, (float[]){1.0f, 2.0f, 3.0f}, 3);
 
-    float labelData[] = {1.0f, 0.0f};
-    size_t labelDims[] = {1, 2};
-    tensor_t *label = tensorInitFloat(labelData, labelDims, 2, NULL);
+    /* Label (1x2). */
+    size_t *labelDims = reserveMemory(2 * sizeof(size_t));
+    labelDims[0] = 1;
+    labelDims[1] = 2;
+    size_t *labelOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, labelOrder);
+    shape_t *labelShape = reserveMemory(sizeof(shape_t));
+    setShape(labelShape, labelDims, 2, labelOrder);
+    tensor_t *label = initTensor(labelShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(label, (float[]){1.0f, 0.0f}, 2);
 
-    // Run 3 training steps
+    /* Run 3 training steps. CAPTURE per-step assertions into a per-step
+     * tracking array; assert at end after all frees. */
+    bool capturedNotNull[3];
+    float capturedLoss[3];
     for (size_t step = 0; step < 3; step++) {
-        trainingStats_t *stats = calculateGradsSequential(model, sizeModel, CROSS_ENTROPY,
-                                                           input, label);
-        TEST_ASSERT_NOT_NULL(stats);
-        TEST_ASSERT_TRUE(stats->loss >= 0.0f);
+        trainingStats_t *stats =
+            calculateGradsSequential(model, sizeModel, CROSS_ENTROPY, input, label);
+        capturedNotNull[step] = (stats != NULL);
+        capturedLoss[step] = stats ? stats->loss : -1.0f;
         freeTrainingStats(stats);
 
         sgdFns.step(sgd);
         sgdFns.zero(sgd);
+    }
+
+    /* FREE in reverse-init order.
+     * NOTE: freeOptimSgdM cascades to w0, b0, w1, b1 via freeParameter (per
+     * SgdApi.c:85-93). Do NOT also call freeParameter(w0/b0/w1/b1) here — it
+     * would be a double-free. */
+    freeTensor(label);
+    freeTensor(input);
+    freeOptimSgdM(sgd);
+    freeSoftmaxLayer(softmax);
+    freeLinearLayer(linear1);
+    freeReluLayer(relu);
+    freeLinearLayer(linear0);
+    freeQuantization(q);
+
+    /* ASSERT on captured. */
+    for (size_t step = 0; step < 3; step++) {
+        TEST_ASSERT_TRUE(capturedNotNull[step]);
+        TEST_ASSERT_TRUE(capturedLoss[step] >= 0.0f);
     }
 }
 


### PR DESCRIPTION
**Stack position:** `develop ← #109 ← #110 (this) ← #111 ← #112`

This PR is **based on #109**, not directly on `develop`. Per `codebase_stacked_pr_merge_trap.md`: do not merge this PR before #109 — merging now would target the inferenceapi branch, not develop. After #109 merges, this PR's base auto-rebases to develop.

---

## Summary

Migrates UnitTestMultiLayerTraining (3 multi-layer training tests, ~15-20 inits each) to the Phase 2 explicit-free + assert-last idiom, **and** closes a previously-undetected production leak in `freeOptimSgdM` / `freeState` that the migration spike surfaced.

Same bundling pattern as #109 (Task 1).

## Test-side changes

`test/unit/userAPI/UnitTestMultiLayerTraining.c` — all 3 tests rewritten to:
- Build heap dependencies via `reserveMemory` + `setShape` + `quantizationInit*` + `initTensor` + `tensorFillFromFloatBuffer` (or `initDistribution(ZEROS)` in test 1).
- Capture assertion values into stack locals before frees.
- Free in reverse-init order via `freeTensor` / `freeParameter` / `free*Layer` / `freeQuantization` / `freeTrainingStats` / `freeOptimSgdM`.
- Assert on captured locals last.
- Test 3: free through `freeOptimSgdM` (which cascades to registered parameters) rather than calling `freeParameter` on each `w*`/`b*` to avoid double-free.

## Production-side fix

`src/userApi/optimizer/SgdApi.c` — `freeOptimSgdM` and `freeState` previously freed the children of arrays/structs but not the containers themselves. Five gaps per call:
- `sgdM->impl` wrapper (only inner `sgd_t` was freed via `sgdM->impl->sgd`).
- `sgdM->parameter` array container.
- `sgdM->states` array container.
- `state->stateBuffers` array container (per state).

Adds the four matching `freeReservedMemory` calls. Structurally identical to the `inference()` `outputNext` leak fixed in #109.

There is also a latent over-allocation at `SgdApi.c:55,60` (`reserveMemory(sizeof(tensor_t))` should be `sizeof(tensor_t *)`). Closing the leak makes it harmless; out of scope for this PR.

## Verification

- macOS: `cmake --build --preset unit_test_debug --target UnitTestMultiLayerTraining && build/unit_test_debug/test/unit/userAPI/UnitTestMultiLayerTraining` — 3/3 PASS, zero deprecation warnings.
- LSan in `odt-lsan-recon:2026-04-22`: all four LEAK SUMMARY categories at 0 bytes / 0 blocks. Log at `docs/superpowers/reports/UnitTestMultiLayerTraining.after.log`.

## Test plan

- [ ] CI green (c-build-and-test + python-test).
- [ ] Reviewer LSan smoke check on Linux.

Spec: `docs/superpowers/specs/2026-04-25-phase-2-teardown-idiom-design.md`
Plan: `docs/superpowers/plans/2026-04-27-phase-2-teardown-idiom.md`

Closes #82
