### PR TITLE
test(#82): assert-last in UnitTestTensorApi.testInitDistribution_*

### DIFF
--- a/test/unit/tensor/UnitTestTensorApi.c
+++ b/test/unit/tensor/UnitTestTensorApi.c
@@ -134,10 +134,17 @@ void testInitDistribution_Zeros_AllValuesAreZero(void) {
     distribution_t d = {.type = ZEROS};
     initDistribution(t, &d);
 
+    /* CAPTURE values before free. */
+    float captured[12];
     for (size_t i = 0; i < 12; ++i) {
-        TEST_ASSERT_FLOAT_WITHIN(1e-9f, 0.0f, vals[i]);
+        captured[i] = vals[i];
     }
     freeTensor(t);
+
+    /* ASSERT on captured. */
+    for (size_t i = 0; i < 12; ++i) {
+        TEST_ASSERT_FLOAT_WITHIN(1e-9f, 0.0f, captured[i]);
+    }
 }
 
 void testInitDistribution_Ones_AllValuesAreOne(void) {
@@ -145,10 +152,18 @@ void testInitDistribution_Ones_AllValuesAreOne(void) {
     distribution_t d = {.type = ONES};
     initDistribution(t, &d);
     float *vals = (float *)t->data;
+
+    /* CAPTURE. */
+    float captured[12];
     for (size_t i = 0; i < 12; ++i) {
-        TEST_ASSERT_FLOAT_WITHIN(1e-9f, 1.0f, vals[i]);
+        captured[i] = vals[i];
     }
     freeTensor(t);
+
+    /* ASSERT. */
+    for (size_t i = 0; i < 12; ++i) {
+        TEST_ASSERT_FLOAT_WITHIN(1e-9f, 1.0f, captured[i]);
+    }
 }
 
 void testInitDistribution_Uniform_AllValuesInRange(void) {
@@ -156,15 +171,23 @@ void testInitDistribution_Uniform_AllValuesInRange(void) {
     distribution_t d = {.type = UNIFORM, .params.uniform = {-0.5f, 0.5f}};
     initDistribution(t, &d);
     float *vals = (float *)t->data;
+
+    /* CAPTURE values + derived bool flag. */
+    float captured[20];
     bool any_nonzero = false;
     for (size_t i = 0; i < 20; ++i) {
-        TEST_ASSERT_TRUE(vals[i] >= -0.5f && vals[i] <= 0.5f);
+        captured[i] = vals[i];
         if (vals[i] != 0.0f) {
             any_nonzero = true;
         }
     }
-    TEST_ASSERT_TRUE(any_nonzero);
     freeTensor(t);
+
+    /* ASSERT on captured. */
+    for (size_t i = 0; i < 20; ++i) {
+        TEST_ASSERT_TRUE(captured[i] >= -0.5f && captured[i] <= 0.5f);
+    }
+    TEST_ASSERT_TRUE(any_nonzero);
 }
 
 void testInitDistribution_Normal_NotAllSentinel(void) {
@@ -175,14 +198,18 @@ void testInitDistribution_Normal_NotAllSentinel(void) {
     }
     distribution_t d = {.type = NORMAL, .params.normal = {0.0f, 0.01f}};
     initDistribution(t, &d);
+
+    /* CAPTURE the derived sentinel count. */
     size_t sentinelCount = 0;
     for (size_t i = 0; i < 20; ++i) {
         if (vals[i] == -999.0f) {
             sentinelCount++;
         }
     }
-    TEST_ASSERT_EQUAL_UINT(0, sentinelCount);
     freeTensor(t);
+
+    /* ASSERT on captured. */
+    TEST_ASSERT_EQUAL_UINT(0, sentinelCount);
 }
 
 void testInitDistribution_XavierUniform_NotAllZero(void) {
@@ -191,6 +218,8 @@ void testInitDistribution_XavierUniform_NotAllZero(void) {
                         .params.xavier = {.gain = 1.0f, .fanIn = 4, .fanOut = 5}};
     initDistribution(t, &d);
     float *vals = (float *)t->data;
+
+    /* CAPTURE the derived bool flag. */
     bool any_nonzero = false;
     for (size_t i = 0; i < 20; ++i) {
         if (vals[i] != 0.0f) {
@@ -198,8 +227,10 @@ void testInitDistribution_XavierUniform_NotAllZero(void) {
             break;
         }
     }
-    TEST_ASSERT_TRUE(any_nonzero);
     freeTensor(t);
+
+    /* ASSERT on captured. */
+    TEST_ASSERT_TRUE(any_nonzero);
 }
 
 void testInitDistribution_XavierNormal_NotAllZero(void) {
@@ -208,6 +239,8 @@ void testInitDistribution_XavierNormal_NotAllZero(void) {
                         .params.xavier = {.gain = 1.0f, .fanIn = 4, .fanOut = 5}};
     initDistribution(t, &d);
     float *vals = (float *)t->data;
+
+    /* CAPTURE. */
     bool any_nonzero = false;
     for (size_t i = 0; i < 20; ++i) {
         if (vals[i] != 0.0f) {
@@ -215,8 +248,10 @@ void testInitDistribution_XavierNormal_NotAllZero(void) {
             break;
         }
     }
-    TEST_ASSERT_TRUE(any_nonzero);
     freeTensor(t);
+
+    /* ASSERT. */
+    TEST_ASSERT_TRUE(any_nonzero);
 }
 
 void testInitDistribution_KaimingUniform_NotAllZero(void) {
@@ -225,6 +260,8 @@ void testInitDistribution_KaimingUniform_NotAllZero(void) {
                         .params.kaiming = {.gain = sqrtf(2.0f), .fanMode = 4}};
     initDistribution(t, &d);
     float *vals = (float *)t->data;
+
+    /* CAPTURE. */
     bool any_nonzero = false;
     for (size_t i = 0; i < 20; ++i) {
         if (vals[i] != 0.0f) {
@@ -232,8 +269,10 @@ void testInitDistribution_KaimingUniform_NotAllZero(void) {
             break;
         }
     }
-    TEST_ASSERT_TRUE(any_nonzero);
     freeTensor(t);
+
+    /* ASSERT. */
+    TEST_ASSERT_TRUE(any_nonzero);
 }
 
 void testInitDistribution_KaimingNormal_NotAllZero(void) {
@@ -242,6 +281,8 @@ void testInitDistribution_KaimingNormal_NotAllZero(void) {
                         .params.kaiming = {.gain = sqrtf(2.0f), .fanMode = 4}};
     initDistribution(t, &d);
     float *vals = (float *)t->data;
+
+    /* CAPTURE. */
     bool any_nonzero = false;
     for (size_t i = 0; i < 20; ++i) {
         if (vals[i] != 0.0f) {
@@ -249,8 +290,10 @@ void testInitDistribution_KaimingNormal_NotAllZero(void) {
             break;
         }
     }
-    TEST_ASSERT_TRUE(any_nonzero);
     freeTensor(t);
+
+    /* ASSERT. */
+    TEST_ASSERT_TRUE(any_nonzero);
 }
 
 static void fillTensorFromStackArrayThatGoesOutOfScope(tensor_t *t) {


### PR DESCRIPTION
**Stack position:** `develop ← #109 ← #110 ← #111 (this) ← #112`

This PR is **based on #110**. Merge order: #109 → #110 → this → #112.

---

## Summary

Reorders 8 `testInitDistribution_*` tests in `UnitTestTensorApi.c` to follow the Phase 2 assert-last rule. The construction primitives were already correct (file uses heap-allocated tensors via `makeFloatTensorForDistTest` + `initTensor`); only the assert/free order needed flipping.

Parallel to #109 and #110.

## Test-side changes

Each migrated test now:
- Captures asserted values (full data array, derived bool flag, or derived counter) into stack locals BEFORE `freeTensor(t)`.
- Frees the tensor.
- Asserts on the captured locals.

8 tests touched: `Zeros`, `Ones`, `Uniform`, `Normal`, `XavierUniform`, `XavierNormal`, `KaimingUniform`, `KaimingNormal`.

## Verification

- macOS: `cmake --build --preset unit_test_debug --target UnitTestTensorApi && build/unit_test_debug/test/unit/tensor/UnitTestTensorApi` — green, all 20 tests pass.
- LSan in `odt-lsan-recon:2026-04-22`: zero residual attributable to `testInitDistribution_*`. Log at `docs/superpowers/reports/UnitTestTensorApi.after.log`.

## Out of scope

Other tests in `UnitTestTensorApi.c` are not migrated by this PR — they ship in the per-file migration wave that follows the framework PRs.

The file-level LSan summary still reports `128 bytes definitely lost in 4 blocks + 160 bytes indirectly lost in 8 blocks`, but every loss-record stack trace originates in one of the 4 `testTensorInitWithDistribution_*` tests (the deprecated API path scheduled for removal in Phase 2). Zero records trace back to any `testInitDistribution_*` function.

## Test plan

- [ ] CI green (c-build-and-test + python-test).

Spec: `docs/superpowers/specs/2026-04-25-phase-2-teardown-idiom-design.md`
Plan: `docs/superpowers/plans/2026-04-27-phase-2-teardown-idiom.md`

Closes #82
