### PR TITLE
test(#82): wave batch 1 — migrate UnitTestMSE.testMSEForward + UnitTestCrossEntropy

### DIFF
--- a/test/unit/loss_functions/CMakeLists.txt
+++ b/test/unit/loss_functions/CMakeLists.txt
@@ -6,6 +6,7 @@ add_elastic_ai_unit_test(
         Log
         SoftmaxApi
         QuantizationApi
+        TensorApi
 )
 
 add_elastic_ai_unit_test(
@@ -14,4 +15,6 @@ add_elastic_ai_unit_test(
         MORE_LIBS
         CommonLayerLibs
         TensorApi
+        StorageApi
+        QuantizationApi
 )

--- a/test/unit/loss_functions/UnitTestCrossEntropy.c
+++ b/test/unit/loss_functions/UnitTestCrossEntropy.c
@@ -1,9 +1,9 @@
-#include "unity.h"
-#include "Softmax.h"
 #include "CrossEntropy.h"
 #include "QuantizationApi.h"
+#include "Softmax.h"
 #include "SoftmaxApi.h"
-
+#include "TensorApi.h"
+#include "unity.h"
 
 void unitTestCrossEntropyForward() {
     tensor_t logits;
@@ -44,11 +44,18 @@ void unitTestCrossEntropyForward() {
     initFloat32Quantization(&distQ);
     setTensorValues(&distribution, (uint8_t *)distData, &distShape, &distQ, NULL);
 
+    /* CAPTURE. */
+    float capturedActual = crossEntropyForwardFloat(&softmaxOutput, &distribution);
+
+    /* FREE. freeSoftmaxLayer releases the layer config wrapper only; it does
+     * NOT touch the stored forwardQ/backwardQ pointer (which is floatQ). So
+     * floatQ is safe to free after. */
+    freeSoftmaxLayer(softmaxLayer);
+    freeQuantization(floatQ);
+
+    /* ASSERT. */
     float expected = 0.5170299410820007f;
-    float actual = crossEntropyForwardFloat(&softmaxOutput, &distribution);
-
-    TEST_ASSERT_EQUAL_FLOAT(expected, actual);
-
+    TEST_ASSERT_EQUAL_FLOAT(expected, capturedActual);
 }
 
 void unitTestCrossEntropySoftmaxBackward() {
@@ -106,14 +113,23 @@ void unitTestCrossEntropySoftmaxBackward() {
 
     crossEntropySoftmaxBackward(&softmaxOutput, &distribution, &propLoss);
 
-    float expected[] = {-0.2410f, 0.1424f, 0.0986f};
-
-    float *actual = (float *)propLoss.data;
-
+    /* CAPTURE. propLoss.data is stack memory (propLossData[]); copy into a
+     * dedicated capture array so the assertions read from a buffer that
+     * doesn't depend on freeing softmaxLayer/floatQ first. */
+    float capturedActual[3];
     for (size_t i = 0; i < inputSize; i++) {
-        TEST_ASSERT_FLOAT_WITHIN(0.0001f, expected[i], actual[i]);
+        capturedActual[i] = ((float *)propLoss.data)[i];
     }
 
+    /* FREE. */
+    freeSoftmaxLayer(softmaxLayer);
+    freeQuantization(floatQ);
+
+    /* ASSERT. */
+    float expected[] = {-0.2410f, 0.1424f, 0.0986f};
+    for (size_t i = 0; i < inputSize; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(0.0001f, expected[i], capturedActual[i]);
+    }
 }
 
 void setUp() {}

--- a/test/unit/loss_functions/UnitTestMSE.c
+++ b/test/unit/loss_functions/UnitTestMSE.c
@@ -1,26 +1,43 @@
-#include "Tensor.h"
-#include "Rounding.h"
 #include "MSE.h"
-#include "unity.h"
-#include "TensorConversion.h"
+#include "QuantizationApi.h"
+#include "Rounding.h"
+#include "StorageApi.h"
+#include "Tensor.h"
 #include "TensorApi.h"
+#include "TensorConversion.h"
+#include "unity.h"
 
 void testMSEForward() {
-    float outputData[] = {1.f, 2.f, 3.f};
-    size_t outputDims[] = {3};
-    size_t outputNumberOfDims = 1;
-    tensor_t *output = tensorInitFloat(outputData, outputDims, outputNumberOfDims, NULL);
+    /* Output (1D, 3 elements). */
+    size_t *outputDims = reserveMemory(1 * sizeof(size_t));
+    outputDims[0] = 3;
+    size_t *outputOrder = reserveMemory(1 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(1, outputOrder);
+    shape_t *outputShape = reserveMemory(sizeof(shape_t));
+    setShape(outputShape, outputDims, 1, outputOrder);
+    tensor_t *output = initTensor(outputShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(output, (float[]){1.f, 2.f, 3.f}, 3);
 
-    float labelData[] = {2.f, 4.f, 6.f};
-    size_t labelDims[] = {3};
-    size_t labelNumberOfDims = 1;
-    tensor_t *label = tensorInitFloat(labelData, labelDims, labelNumberOfDims, NULL);
+    /* Label (1D, 3 elements). */
+    size_t *labelDims = reserveMemory(1 * sizeof(size_t));
+    labelDims[0] = 3;
+    size_t *labelOrder = reserveMemory(1 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(1, labelOrder);
+    shape_t *labelShape = reserveMemory(sizeof(shape_t));
+    setShape(labelShape, labelDims, 1, labelOrder);
+    tensor_t *label = initTensor(labelShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(label, (float[]){2.f, 4.f, 6.f}, 3);
 
-    float loss = mseLossForward(output, label);
+    /* CAPTURE. */
+    float capturedLoss = mseLossForward(output, label);
 
+    /* FREE. */
+    freeTensor(label);
+    freeTensor(output);
+
+    /* ASSERT. */
     float expected = 4.67f;
-
-    TEST_ASSERT_FLOAT_WITHIN(0.01f, expected, loss);
+    TEST_ASSERT_FLOAT_WITHIN(0.01f, expected, capturedLoss);
 }
 
 void testMSELossBackwardFloat() {
@@ -30,10 +47,7 @@ void testMSELossBackwardFloat() {
     size_t numberOfDims = 1;
     size_t orderOfDims[] = {0};
     shape_t shape = {
-        .dimensions = dims,
-        .orderOfDimensions = orderOfDims,
-        .numberOfDimensions = numberOfDims
-    };
+        .dimensions = dims, .orderOfDimensions = orderOfDims, .numberOfDimensions = numberOfDims};
 
     tensor_t modelOutput;
     quantization_t modelOutputQ;
@@ -59,7 +73,7 @@ void testMSELossBackwardFloat() {
 
     float *actual = (float *)result.data;
 
-    for(size_t i = 0; i < 3; i++) {
+    for (size_t i = 0; i < 3; i++) {
         TEST_ASSERT_FLOAT_WITHIN(0.0001f, expected[i], actual[i]);
     }
 }
@@ -71,10 +85,7 @@ void testMSELossBackwardSymInt32() {
     size_t numberOfDims = 1;
     size_t orderOfDims[] = {0};
     shape_t shape = {
-        .dimensions = dims,
-        .orderOfDimensions = orderOfDims,
-        .numberOfDimensions = numberOfDims
-    };
+        .dimensions = dims, .orderOfDimensions = orderOfDims, .numberOfDimensions = numberOfDims};
 
     tensor_t modelOutput;
     quantization_t modelOutputQ;
@@ -88,7 +99,8 @@ void testMSELossBackwardSymInt32() {
     quantization_t modelOutputSymInt32Q;
     initSymInt32Quantization(&modelOutputSymInt32QC, &modelOutputSymInt32Q);
     uint8_t modelOutputSymInt32Data[numberOfElements * sizeof(int32_t)];
-    setTensorValuesForConversion(modelOutputSymInt32Data, &modelOutputSymInt32Q, &modelOutput, &modelOutputSymInt32);
+    setTensorValuesForConversion(modelOutputSymInt32Data, &modelOutputSymInt32Q, &modelOutput,
+                                 &modelOutputSymInt32);
     convertTensor(&modelOutput, &modelOutputSymInt32);
 
     tensor_t label;
@@ -106,7 +118,6 @@ void testMSELossBackwardSymInt32() {
     setTensorValuesForConversion(labelSymInt32Data, &labelSymInt32Q, &label, &labelSymInt32);
     convertTensor(&label, &labelSymInt32);
 
-
     tensor_t result;
     quantization_t resultQ;
     initFloat32Quantization(&resultQ);
@@ -122,7 +133,6 @@ void testMSELossBackwardSymInt32() {
     setTensorValuesForConversion(resultSymInt32Data, &resultSymInt32Q, &result, &resultSymInt32);
     convertTensor(&result, &resultSymInt32);
 
-
     mseLossBackward(&modelOutputSymInt32, &labelSymInt32, &resultSymInt32);
 
     convertTensor(&resultSymInt32, &result);
@@ -131,13 +141,13 @@ void testMSELossBackwardSymInt32() {
 
     float *actual = (float *)result.data;
 
-    for(size_t i = 0; i < numberOfElements; i++) {
+    for (size_t i = 0; i < numberOfElements; i++) {
         TEST_ASSERT_FLOAT_WITHIN(0.5f, expected[i], actual[i]);
     }
 }
 
-void setUp(){}
-void tearDown(){}
+void setUp() {}
+void tearDown() {}
 
 int main(void) {
     UNITY_BEGIN();


### PR DESCRIPTION
**Stack position:** `develop ← #109 ← #110 ← #111 ← #112 ← #THIS`

Stacked on #112. Per `codebase_stacked_pr_merge_trap.md`: do not merge before #112.

---

## Summary

Wave batch 1 of the per-file migration following the framework PRs (#109/#110/#111/#112). Migrates three test bodies in two files to the Phase 2 explicit-free + assert-last idiom.

## Test-side changes

- `test/unit/loss_functions/UnitTestMSE.c::testMSEForward` — full body rewrite: replaces deprecated `tensorInitFloat` with the post-#106 chain (`reserveMemory` + `setShape` + `initTensor` + `tensorFillFromFloatBuffer`), pairs each tensor with `freeTensor`, captures `loss` into a stack local before frees.
- `test/unit/loss_functions/UnitTestCrossEntropy.c::unitTestCrossEntropyForward` — adds the missing `freeSoftmaxLayer` + `freeQuantization` pair; captures the float result before frees.
- `test/unit/loss_functions/UnitTestCrossEntropy.c::unitTestCrossEntropySoftmaxBackward` — same pattern; captures the `propLoss` output array before frees.

The stack-only tests in `UnitTestMSE.c` (`testMSELossBackwardFloat`/`testMSELossBackwardSymInt32`) are unchanged per the self-enforcing tier boundary documented in #112.

## Bundled test-build fix

Per the PRIVATE-link convention (CMake include propagation), `MORE_LIBS` extended for the two test targets so the new symbols resolve:

- `UnitTestMSE` += `StorageApi` (for `reserveMemory`) + `QuantizationApi` (for `quantizationInitFloat`)
- `UnitTestCrossEntropy` += `TensorApi` (for `freeQuantization`)

No production-code change.

## Verification

- macOS: both binaries pass all tests, zero deprecation warnings.
  - `UnitTestMSE`: 3 Tests 0 Failures 0 Ignored — OK
  - `UnitTestCrossEntropy`: 2 Tests 0 Failures 0 Ignored — OK
- LSan in `odt-lsan-recon:2026-04-22`: zero residual on both files.
  - `UnitTestMSE`: "All heap blocks were freed -- no leaks are possible" (9 pre-existing uninit-value errors in untouched stack-only `testMSELossBackwardSymInt32`; not introduced by this migration)
  - `UnitTestCrossEntropy`: "All heap blocks were freed -- no leaks are possible" + "ERROR SUMMARY: 0 errors from 0 contexts"
  - Logs at `docs/superpowers/reports/UnitTest{MSE,CrossEntropy}.after.log`.

Spec: `docs/superpowers/specs/2026-04-25-phase-2-teardown-idiom-design.md`
Plan: `docs/superpowers/plans/2026-04-27-phase-2-teardown-idiom.md`