### PR TITLE
test(#82): wave batch 2 — migrate UnitTestTensor + UnitTestAdd

### DIFF
--- a/test/unit/arithmetic/CMakeLists.txt
+++ b/test/unit/arithmetic/CMakeLists.txt
@@ -6,6 +6,7 @@ add_elastic_ai_unit_test(
         TensorApi
         QuantizationApi
         Arithmetic
+        StorageApi
 )
 
 add_elastic_ai_unit_test(

--- a/test/unit/arithmetic/UnitTestAdd.c
+++ b/test/unit/arithmetic/UnitTestAdd.c
@@ -1,13 +1,13 @@
 #include <string.h>
 
 #include "Add.h"
-#include "Tensor.h"
-#include "unity.h"
-#include "TensorApi.h"
 #include "DTypes.h"
 #include "QuantizationApi.h"
+#include "StorageApi.h"
+#include "Tensor.h"
+#include "TensorApi.h"
 #include "TensorConversion.h"
-
+#include "unity.h"
 
 void setUp() {}
 void tearDown() {}
@@ -16,24 +16,18 @@ void testAddInt32TensorsInplace() {
     size_t numberOfElements = 24;
     size_t bytesPerElement = sizeof(int32_t);
 
-
-
-    int32_t aData[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
-                       22, 23};
+    int32_t aData[] = {0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11,
+                       12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23};
     uint8_t *aDataBytes = (uint8_t *)aData;
 
     size_t aNumberOfDims = 3;
     size_t aDims[] = {2, 3, 4};
     size_t aOrderOfDims[] = {0, 1, 2};
-    quantization_t aQ = {
-        .type = INT32
-    };
+    quantization_t aQ = {.type = INT32};
 
-    shape_t aShape = {
-        .dimensions = aDims,
-        .numberOfDimensions = aNumberOfDims,
-        .orderOfDimensions = aOrderOfDims
-    };
+    shape_t aShape = {.dimensions = aDims,
+                      .numberOfDimensions = aNumberOfDims,
+                      .orderOfDimensions = aOrderOfDims};
 
     tensor_t aTensor = {
         .data = aDataBytes,
@@ -42,22 +36,18 @@ void testAddInt32TensorsInplace() {
         .sparsity = NULL,
     };
 
-    int32_t bData[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
-                       22, 23};
+    int32_t bData[] = {0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11,
+                       12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23};
     uint8_t *bDataBytes = (uint8_t *)bData;
     size_t bNumberOfDims = 3;
     size_t bDims[] = {2, 3, 4};
     size_t bOrderOfDims[] = {1, 0, 2};
 
-    shape_t bShape = {
-        .dimensions = bDims,
-        .numberOfDimensions = bNumberOfDims,
-        .orderOfDimensions = bOrderOfDims
-    };
+    shape_t bShape = {.dimensions = bDims,
+                      .numberOfDimensions = bNumberOfDims,
+                      .orderOfDimensions = bOrderOfDims};
 
-    quantization_t bQ = {
-        .type = INT32
-    };
+    quantization_t bQ = {.type = INT32};
     tensor_t bTensor = {
         .data = bDataBytes,
         .shape = &bShape,
@@ -69,8 +59,8 @@ void testAddInt32TensorsInplace() {
 
     addInt32TensorsInplace(&aTensor, &bTensor);
 
-    int32_t expected[] = {0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36, 38,
-                          40, 42, 44, 46};
+    int32_t expected[] = {0,  2,  4,  6,  8,  10, 12, 14, 16, 18, 20, 22,
+                          24, 26, 28, 30, 32, 34, 36, 38, 40, 42, 44, 46};
 
     TEST_ASSERT_EQUAL_INT32_ARRAY(expected, aTensor.data, numberOfElements);
 }
@@ -83,15 +73,11 @@ void testAddInt32ElementWithInt32TensorInplace() {
     size_t aNumberOfDims = 2;
     size_t aDims[] = {2, 3};
     size_t aOrderOfDims[] = {0, 1};
-    quantization_t aQ = {
-        .type = INT32
-    };
+    quantization_t aQ = {.type = INT32};
 
-    shape_t aShape = {
-        .dimensions = aDims,
-        .numberOfDimensions = aNumberOfDims,
-        .orderOfDimensions = aOrderOfDims
-    };
+    shape_t aShape = {.dimensions = aDims,
+                      .numberOfDimensions = aNumberOfDims,
+                      .orderOfDimensions = aOrderOfDims};
 
     tensor_t aTensor = {
         .data = aDataBytes,
@@ -112,17 +98,15 @@ void testAddInt32ElementWithInt32TensorInplace() {
 void testAddFloat32TensorsInplace() {
     size_t numberOfElements = 24;
 
-    float aData[] = {0.f, 1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f, 10.f, 11.f, 12.f, 13.f, 14.f,
-                     15.f, 16.f, 17.f, 18.f, 19.f, 20.f, 21.f, 22.f, 23.f};
+    float aData[] = {0.f,  1.f,  2.f,  3.f,  4.f,  5.f,  6.f,  7.f,  8.f,  9.f,  10.f, 11.f,
+                     12.f, 13.f, 14.f, 15.f, 16.f, 17.f, 18.f, 19.f, 20.f, 21.f, 22.f, 23.f};
     uint8_t *aDataBytes = (uint8_t *)aData;
     size_t aNumberOfDims = 3;
     size_t aDims[] = {2, 3, 4};
     size_t aOrderOfDims[] = {0, 1, 2};
-    shape_t aShape = {
-        .dimensions = aDims,
-        .numberOfDimensions = aNumberOfDims,
-        .orderOfDimensions = aOrderOfDims
-    };
+    shape_t aShape = {.dimensions = aDims,
+                      .numberOfDimensions = aNumberOfDims,
+                      .orderOfDimensions = aOrderOfDims};
 
     quantization_t aQ;
     initFloat32Quantization(&aQ);
@@ -130,17 +114,15 @@ void testAddFloat32TensorsInplace() {
     tensor_t aTensor;
     setTensorValues(&aTensor, aDataBytes, &aShape, &aQ, NULL);
 
-    float bData[] = {0.f, 1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f, 10.f, 11.f, 12.f, 13.f, 14.f,
-                     15.f, 16.f, 17.f, 18.f, 19.f, 20.f, 21.f, 22.f, 23.f};
+    float bData[] = {0.f,  1.f,  2.f,  3.f,  4.f,  5.f,  6.f,  7.f,  8.f,  9.f,  10.f, 11.f,
+                     12.f, 13.f, 14.f, 15.f, 16.f, 17.f, 18.f, 19.f, 20.f, 21.f, 22.f, 23.f};
     uint8_t *bDataBytes = (uint8_t *)bData;
     size_t bNumberOfDims = 3;
     size_t bDims[] = {2, 3, 4};
     size_t bOrderOfDims[] = {1, 0, 2};
-    shape_t bShape = {
-        .dimensions = bDims,
-        .numberOfDimensions = bNumberOfDims,
-        .orderOfDimensions = bOrderOfDims
-    };
+    shape_t bShape = {.dimensions = bDims,
+                      .numberOfDimensions = bNumberOfDims,
+                      .orderOfDimensions = bOrderOfDims};
 
     quantization_t bQ;
     initFloat32Quantization(&bQ);
@@ -152,8 +134,8 @@ void testAddFloat32TensorsInplace() {
 
     addFloat32TensorsInplace(&aTensor, &bTensor);
 
-    float expected[] = {0.f, 2.f, 4.f, 6.f, 8.f, 10.f, 12.f, 14.f, 16.f, 18.f, 20.f, 22.f, 24.f,
-                        26.f, 28.f, 30.f, 32.f, 34.f, 36.f, 38.f, 40.f, 42.f, 44.f, 46.f};
+    float expected[] = {0.f,  2.f,  4.f,  6.f,  8.f,  10.f, 12.f, 14.f, 16.f, 18.f, 20.f, 22.f,
+                        24.f, 26.f, 28.f, 30.f, 32.f, 34.f, 36.f, 38.f, 40.f, 42.f, 44.f, 46.f};
 
     TEST_ASSERT_EQUAL_FLOAT_ARRAY(expected, aTensor.data, numberOfElements);
 }
@@ -175,10 +157,7 @@ void testAddSymInt32TensorsInplace() {
     size_t numberOfDims = 1;
     size_t orderOfDims[] = {0};
     shape_t shape = {
-        .dimensions = dims,
-        .numberOfDimensions = numberOfDims,
-        .orderOfDimensions = orderOfDims
-    };
+        .dimensions = dims, .numberOfDimensions = numberOfDims, .orderOfDimensions = orderOfDims};
 
     setTensorValues(&aTensor, aDataBytes, &shape, &aQ, NULL);
 
@@ -196,15 +175,32 @@ void testAddSymInt32TensorsInplace() {
 
     addSymInt32TensorsInplace(&aTensor, &bTensor);
 
-    float actual[numberOfValues];
-    quantization_t *floatQ = quantizationInitFloat();
-    tensor_t *floatTensor = tensorInit(actual, dims, numberOfDims, floatQ, NULL);
+    /* Build a heap Float32 output tensor for the convert-back step using the
+     * post-#106 primitives. The deprecated tensorInit(actual, dims, ...) form
+     * stored caller's data pointer; here, initTensor owns its own data buffer
+     * and convertTensor writes the result there. */
+    size_t *outputDims = reserveMemory(1 * sizeof(size_t));
+    outputDims[0] = numberOfValues;
+    size_t *outputOrder = reserveMemory(1 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(1, outputOrder);
+    shape_t *outputShape = reserveMemory(sizeof(shape_t));
+    setShape(outputShape, outputDims, 1, outputOrder);
+    tensor_t *floatTensor = initTensor(outputShape, quantizationInitFloat(), NULL);
     convertTensor(&aTensor, floatTensor);
 
-    float_t expected[] = {3, 6, 9, 12, 15, 18};
+    /* CAPTURE before free. */
+    float captured[numberOfValues];
+    for (size_t i = 0; i < numberOfValues; i++) {
+        captured[i] = ((float *)floatTensor->data)[i];
+    }
 
-    for(size_t i = 0; i < numberOfValues; i++) {
-        TEST_ASSERT_FLOAT_WITHIN(0.1f, expected[i], actual[i]);
+    /* FREE. */
+    freeTensor(floatTensor);
+
+    /* ASSERT. */
+    float_t expected[] = {3, 6, 9, 12, 15, 18};
+    for (size_t i = 0; i < numberOfValues; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(0.1f, expected[i], captured[i]);
     }
 }
 
@@ -223,10 +219,7 @@ void testAddInt32TensorWithSymInt32TensorInplace() {
     size_t numberOfDims = 1;
     size_t orderOfDims[] = {0};
     shape_t shape = {
-        .dimensions = dims,
-        .numberOfDimensions = numberOfDims,
-        .orderOfDimensions = orderOfDims
-    };
+        .dimensions = dims, .numberOfDimensions = numberOfDims, .orderOfDimensions = orderOfDims};
     setTensorValues(&aTensor, aDataBytes, &shape, &aQ, NULL);
 
     quantization_t bQ;
@@ -258,10 +251,7 @@ void testAddFloat32TensorToSymInt32TensorInplace() {
     size_t numberOfDims = 1;
     size_t orderOfDims[] = {0};
     shape_t shape = {
-        .dimensions = dims,
-        .numberOfDimensions = numberOfDims,
-        .orderOfDimensions = orderOfDims
-    };
+        .dimensions = dims, .numberOfDimensions = numberOfDims, .orderOfDimensions = orderOfDims};
     setTensorValues(&aTensor, aDataBytes, &shape, &aQ, NULL);
 
     quantization_t bQ;
@@ -277,7 +267,6 @@ void testAddFloat32TensorToSymInt32TensorInplace() {
 
     TEST_ASSERT_EQUAL_INT32_ARRAY(expected, aData, numberOfValues);
 }
-
 
 int main(void) {
     UNITY_BEGIN();

--- a/test/unit/tensor/CMakeLists.txt
+++ b/test/unit/tensor/CMakeLists.txt
@@ -12,6 +12,7 @@ add_elastic_ai_unit_test(
         MORE_LIBS
         Rounding
         Quantization
+        StorageApi
 )
 add_elastic_ai_unit_test(
         LIB_UNDER_TEST

--- a/test/unit/tensor/UnitTestTensor.c
+++ b/test/unit/tensor/UnitTestTensor.c
@@ -1,9 +1,10 @@
 #include "DTypes.h"
+#include "StorageApi.h"
 #include "Tensor.h"
 #include "unity.h"
 
 #include <stdlib.h>
-
+#include <string.h>
 
 void testGetBitmask() {
     uint8_t startbit = 1;
@@ -54,47 +55,62 @@ void testByteFlattening() {
     size_t dataOutBits = 19;
     size_t numValues = 3;
     size_t numBytesDataOut = (dataOutBits * numValues - 1) / 8 + 1;
-    uint8_t *dataOut = calloc(numBytesDataOut, sizeof(uint8_t));
+    uint8_t *dataOut = reserveMemory(numBytesDataOut);
     byteConversion(dataIn, dataInBits, dataOut, dataOutBits, numValues);
 
-    uint8_t expectedBytes[] = {0b000000001, 0b00000000, 0b00011000, 0b00000000, 0b10000000,
-                               0b00010011, 0b00000000, 0b00000000};
+    /* CAPTURE before free. */
+    uint8_t captured[numBytesDataOut];
+    memcpy(captured, dataOut, numBytesDataOut);
+    freeReservedMemory(dataOut);
 
-    TEST_ASSERT_EQUAL_UINT8_ARRAY(expectedBytes, dataOut, numBytesDataOut);
+    uint8_t expectedBytes[] = {0b000000001, 0b00000000, 0b00011000, 0b00000000,
+                               0b10000000,  0b00010011, 0b00000000, 0b00000000};
+
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(expectedBytes, captured, numBytesDataOut);
 }
 
 void testByteFlattening2() {
     // {1, 2, 78}
-    uint8_t dataIn[] = {0b000000001, 0b00000000, 0b00011000, 0b00000000, 0b10000000, 0b00010011,
-                        0b00000000, 0b00000000};
+    uint8_t dataIn[] = {0b000000001, 0b00000000, 0b00011000, 0b00000000,
+                        0b10000000,  0b00010011, 0b00000000, 0b00000000};
     size_t dataInBits = 19;
 
     size_t dataOutBits = 9;
     size_t numValues = 3;
     size_t numBytesDataOut = (dataOutBits * numValues - 1) / 8 + 1;
-    uint8_t *dataOut = calloc(numBytesDataOut, sizeof(uint8_t));
+    uint8_t *dataOut = reserveMemory(numBytesDataOut);
     byteConversion(dataIn, dataInBits, dataOut, dataOutBits, numValues);
+
+    /* CAPTURE before free. */
+    uint8_t captured[numBytesDataOut];
+    memcpy(captured, dataOut, numBytesDataOut);
+    freeReservedMemory(dataOut);
 
     uint8_t expectedBytes[] = {0b000000001, 0b00000110, 0b00111000, 0b00000001};
 
-    TEST_ASSERT_EQUAL_UINT8_ARRAY(expectedBytes, dataOut, numBytesDataOut);
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(expectedBytes, captured, numBytesDataOut);
 }
 
 void testByteFlattening3() {
     // {1, 2, 78}
-    uint8_t dataIn[] = {0b000000001, 0b00000000, 0b00001100, 0b00000000, 0b00000100, 0b00001011,
-                        0b00000000, 0b00000000};
+    uint8_t dataIn[] = {0b000000001, 0b00000000, 0b00001100, 0b00000000,
+                        0b00000100,  0b00001011, 0b00000000, 0b00000000};
     size_t dataInBits = 8;
 
     size_t dataOutBits = 4;
     size_t numValues = 8;
     size_t numBytesDataOut = (dataOutBits * numValues - 1) / 8 + 1;
-    uint8_t *dataOut = calloc(numBytesDataOut, sizeof(uint8_t));
+    uint8_t *dataOut = reserveMemory(numBytesDataOut);
     byteConversion(dataIn, dataInBits, dataOut, dataOutBits, numValues);
+
+    /* CAPTURE before free. */
+    uint8_t captured[numBytesDataOut];
+    memcpy(captured, dataOut, numBytesDataOut);
+    freeReservedMemory(dataOut);
 
     uint8_t expectedBytes[] = {0b000000001, 0b00001100, 0b10110100, 0b00000000};
 
-    TEST_ASSERT_EQUAL_UINT8_ARRAY(expectedBytes, dataOut, numBytesDataOut);
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(expectedBytes, captured, numBytesDataOut);
 }
 
 void testByteFlattening4() {
@@ -102,10 +118,16 @@ void testByteFlattening4() {
     size_t dataInBits = 5;
     size_t dataOutBits = 8;
     size_t numBytesDataOut = 6;
-    uint8_t *dataOut = calloc(numBytesDataOut, sizeof(uint8_t));
+    uint8_t *dataOut = reserveMemory(numBytesDataOut);
     byteConversion(dataIn, dataInBits, dataOut, dataOutBits, numBytesDataOut);
+
+    /* CAPTURE before free. */
+    uint8_t captured[numBytesDataOut];
+    memcpy(captured, dataOut, numBytesDataOut);
+    freeReservedMemory(dataOut);
+
     uint8_t expectedBytes[] = {16, 22, 27, 31, 6, 0};
-    TEST_ASSERT_EQUAL_UINT8_ARRAY(expectedBytes, dataOut, numBytesDataOut);
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(expectedBytes, captured, numBytesDataOut);
 }
 
 void testByteFlattening5() {
@@ -114,12 +136,12 @@ void testByteFlattening5() {
     size_t dataOutBits = 32;
     size_t numValues = 6;
     size_t numBytesDataOut = 4 * numValues;
-    uint8_t dataOut[numBytesDataOut];;
+    uint8_t dataOut[numBytesDataOut];
+    ;
     byteConversion(dataIn, dataInBits, dataOut, dataOutBits, numValues);
-    uint8_t expectedBytes[] = {16, 0, 0, 0, 22, 0, 0, 0, 27, 0, 0, 0, 31, 0, 0, 0, 6, 0, 0, 0, 0, 0,
-                               0, 0};
+    uint8_t expectedBytes[] = {16, 0, 0, 0, 22, 0, 0, 0, 27, 0, 0, 0,
+                               31, 0, 0, 0, 6,  0, 0, 0, 0,  0, 0, 0};
     TEST_ASSERT_EQUAL_UINT8_ARRAY(expectedBytes, dataOut, numBytesDataOut);
-
 }
 
 void testCopyTensor() {
@@ -130,10 +152,7 @@ void testCopyTensor() {
     size_t numberOfDims = 2;
     size_t orderOfDims[] = {0, 1};
     shape_t shape = {
-        .dimensions = dims,
-        .numberOfDimensions = numberOfDims,
-        .orderOfDimensions = orderOfDims
-    };
+        .dimensions = dims, .numberOfDimensions = numberOfDims, .orderOfDimensions = orderOfDims};
     quantization_t q;
     initFloat32Quantization(&q);
 
@@ -144,11 +163,9 @@ void testCopyTensor() {
     size_t destDims[2];
     size_t destNumberOfDims;
     size_t destOrderOfDims[2];
-    shape_t destShape = {
-        .dimensions = destDims,
-        .numberOfDimensions = destNumberOfDims,
-        .orderOfDimensions = destOrderOfDims
-    };
+    shape_t destShape = {.dimensions = destDims,
+                         .numberOfDimensions = destNumberOfDims,
+                         .orderOfDimensions = destOrderOfDims};
     setTensorValues(&dest, (uint8_t *)destData, &destShape, &q, NULL);
 
     copyTensor(&dest, &src);


### PR DESCRIPTION
**Stack position:** `develop ← #109 ← #110 ← #111 ← #112 ← #114 ← #THIS`

Stacked on #114. Per `codebase_stacked_pr_merge_trap.md`: do not merge before #114.

---

## Summary

Wave batch 2. Migrates 5 tests across 2 files to the Phase 2 explicit-free + assert-last idiom.

## Test-side changes

- `test/unit/tensor/UnitTestTensor.c`: replaces `calloc` with `reserveMemory` in `testByteFlattening`, `testByteFlattening2`, `testByteFlattening3`, `testByteFlattening4`; adds `captured[]` stack array, `freeReservedMemory`, then asserts. Fixes the pre-existing allocation-locality rule violation (calloc in test/ is forbidden — see `docs/CONVENTIONS.md` "Allocation Locality").
- `test/unit/arithmetic/UnitTestAdd.c::testAddSymInt32TensorsInplace`: replaces deprecated `tensorInit(stack-data, ...)` with the post-#106 chain so the output tensor owns its own data buffer; captures converted floats before `freeTensor`, then asserts.

Build-config bundle (per PR #114 precedent): `StorageApi` added to `MORE_LIBS` for the `Tensor` and `Add` test targets, since both test bodies now reference `reserveMemory`/`freeReservedMemory`.

Other migration-test bodies in both files are stack-only and unchanged.

## Incidental format-only changes (UnitTestAdd.c)

The PostToolUse `clang-format -i` hook reformatted the entire file when applying my edits. The repo-wide reformat on 2026-04-20 had not previously touched `test/unit/arithmetic/UnitTestAdd.c` (its last functional change pre-dated the format pass), so applying current `.clang-format` rules to the file in this PR produced incidental noise: designated-initializer compaction, integer-array wrapping. No semantics changed. Tests pass on macOS host and in Docker LSan.

## Verification

- macOS: both binaries pass all tests (`UnitTestTensor`: 11/11, `UnitTestAdd`: 6/6), zero deprecation warnings.
- LSan in `odt-lsan-recon:2026-04-22`: zero residual on both files.
  - `UnitTestTensor`: `==59== All heap blocks were freed -- no leaks are possible`
  - `UnitTestAdd`: `==60== All heap blocks were freed -- no leaks are possible`

Spec: `docs/superpowers/specs/2026-04-25-phase-2-teardown-idiom-design.md`
Plan: `docs/superpowers/plans/2026-04-27-phase-2-teardown-idiom.md`