### PR TITLE
test(#82): wave batch 4 — migrate UnitTestFlatten + UnitTestFlattenIntegration

### DIFF
--- a/test/unit/layer/CMakeLists.txt
+++ b/test/unit/layer/CMakeLists.txt
@@ -40,4 +40,5 @@ add_elastic_ai_unit_test(
         FlattenApi
         TensorApi
         QuantizationApi
+        StorageApi
 )

--- a/test/unit/layer/UnitTestFlatten.c
+++ b/test/unit/layer/UnitTestFlatten.c
@@ -1,11 +1,14 @@
 #define SOURCE_FILE "UNIT_TEST_FLATTEN"
 
+#include <stdbool.h>
+
 #include "DTypes.h"
 #include "Flatten.h"
 #include "FlattenApi.h"
 #include "Layer.h"
 #include "Quantization.h"
 #include "QuantizationApi.h"
+#include "StorageApi.h"
 #include "Tensor.h"
 #include "TensorApi.h"
 #include "TensorConversion.h"
@@ -14,12 +17,19 @@
 void testFlattenLayerInit_ReturnsFlattenTypedLayer(void) {
     layer_t *flattenLayer = flattenLayerInit();
 
-    TEST_ASSERT_NOT_NULL(flattenLayer);
-    TEST_ASSERT_EQUAL_INT(FLATTEN, flattenLayer->type);
-    TEST_ASSERT_NULL_MESSAGE(flattenLayer->config,
-                             "FLATTEN carries no per-layer config; layer->config must be NULL");
+    /* CAPTURE before frees. */
+    bool capturedNotNull = (flattenLayer != NULL);
+    int capturedType = flattenLayer ? (int)flattenLayer->type : -1;
+    bool capturedConfigNull = flattenLayer ? (flattenLayer->config == NULL) : false;
 
+    /* FREE. */
     freeFlattenLayer(flattenLayer);
+
+    /* ASSERT. */
+    TEST_ASSERT_TRUE(capturedNotNull);
+    TEST_ASSERT_EQUAL_INT(FLATTEN, capturedType);
+    TEST_ASSERT_TRUE_MESSAGE(capturedConfigNull,
+                             "FLATTEN carries no per-layer config; layer->config must be NULL");
 }
 
 void testFlattenCalcOutputShape_NonSquareInput(void) {
@@ -38,121 +48,275 @@ void testFlattenCalcOutputShape_NonSquareInput(void) {
     layer_t *flatten = flattenLayerInit();
     flattenCalcOutputShape(flatten, &inputShape, &outputShape);
 
-    TEST_ASSERT_EQUAL_UINT(2, outputShape.numberOfDimensions);
-    TEST_ASSERT_EQUAL_UINT(1, outputShape.dimensions[0]);
-    TEST_ASSERT_EQUAL_UINT(60, outputShape.dimensions[1]);
-    TEST_ASSERT_EQUAL_UINT(0, outputShape.orderOfDimensions[0]);
-    TEST_ASSERT_EQUAL_UINT(1, outputShape.orderOfDimensions[1]);
+    /* CAPTURE before frees. */
+    size_t capturedNumDims = outputShape.numberOfDimensions;
+    size_t capturedDim0 = outputShape.dimensions[0];
+    size_t capturedDim1 = outputShape.dimensions[1];
+    size_t capturedOrder0 = outputShape.orderOfDimensions[0];
+    size_t capturedOrder1 = outputShape.orderOfDimensions[1];
 
+    /* FREE. */
     freeFlattenLayer(flatten);
+
+    /* ASSERT. */
+    TEST_ASSERT_EQUAL_UINT(2, capturedNumDims);
+    TEST_ASSERT_EQUAL_UINT(1, capturedDim0);
+    TEST_ASSERT_EQUAL_UINT(60, capturedDim1);
+    TEST_ASSERT_EQUAL_UINT(0, capturedOrder0);
+    TEST_ASSERT_EQUAL_UINT(1, capturedOrder1);
 }
 
 void testFlattenForwardFloat_PreservesBytesAndReshapes(void) {
     size_t n = 12; // 1 * 2 * 2 * 3
     float inputData[] = {1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f, 10.f, 11.f, 12.f};
-    size_t inputDims[] = {1, 2, 2, 3};
-    tensor_t *input = tensorInitFloat(inputData, inputDims, 4, NULL);
 
-    float outputData[12] = {0};
-    size_t outputDims[] = {1, 12};
-    tensor_t *output = tensorInitFloat(outputData, outputDims, 2, NULL);
+    /* 1. Build heap input tensor (shape 1x2x2x3). */
+    size_t *inputDims = reserveMemory(4 * sizeof(size_t));
+    inputDims[0] = 1;
+    inputDims[1] = 2;
+    inputDims[2] = 2;
+    inputDims[3] = 3;
+    size_t *inputOrder = reserveMemory(4 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(4, inputOrder);
+    shape_t *inputShape = reserveMemory(sizeof(shape_t));
+    setShape(inputShape, inputDims, 4, inputOrder);
+    tensor_t *input = initTensor(inputShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(input, inputData, n);
 
+    /* 2. Build heap output tensor (shape 1x12). */
+    size_t *outputDims = reserveMemory(2 * sizeof(size_t));
+    outputDims[0] = 1;
+    outputDims[1] = 12;
+    size_t *outputOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, outputOrder);
+    shape_t *outputShape = reserveMemory(sizeof(shape_t));
+    setShape(outputShape, outputDims, 2, outputOrder);
+    tensor_t *output = initTensor(outputShape, quantizationInitFloat(), NULL);
+
+    /* 3. Build flatten layer. */
     layer_t *flatten = flattenLayerInit();
     flattenForward(flatten, input, output);
 
-    float *actual = (float *)output->data;
-    TEST_ASSERT_EQUAL_FLOAT_ARRAY(inputData, actual, n);
+    /* 4. CAPTURE assertion values before frees. */
+    float captured[12];
+    for (size_t i = 0; i < n; i++) {
+        captured[i] = ((float *)output->data)[i];
+    }
 
+    /* 5. FREE in reverse-init order. */
     freeFlattenLayer(flatten);
+    freeTensor(output);
+    freeTensor(input);
+
+    /* 6. ASSERT on captured. */
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(inputData, captured, n);
 }
 
 void testFlattenForwardSymInt32_PropagatesScaleAndValues(void) {
     size_t n = 6;
     float inputFloatData[] = {1.f, 2.f, 3.f, 4.f, 5.f, 6.f};
-    size_t inputDims[] = {1, 2, 3};
-    tensor_t *input = tensorInitSymInt32(inputFloatData, inputDims, 3, HTE, NULL);
 
-    float outputFloatData[6] = {0};
-    size_t outputDims[] = {1, 6};
-    tensor_t *output = tensorInitSymInt32(outputFloatData, outputDims, 2, HTE, NULL);
+    /* 1. Build heap input tensor (SymInt32, shape 1x2x3). */
+    size_t *inputDims = reserveMemory(3 * sizeof(size_t));
+    inputDims[0] = 1;
+    inputDims[1] = 2;
+    inputDims[2] = 3;
+    size_t *inputOrder = reserveMemory(3 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(3, inputOrder);
+    shape_t *inputShape = reserveMemory(sizeof(shape_t));
+    setShape(inputShape, inputDims, 3, inputOrder);
+    tensor_t *input = initTensor(inputShape, quantizationInitSymInt32(HTE), NULL);
+    tensorFillFromFloatBuffer(input, inputFloatData, n);
 
-    // Clobber the output's scale so we can verify flattenForward writes it.
+    /* 2. Build heap output tensor (SymInt32, shape 1x6). */
+    size_t *outputDims = reserveMemory(2 * sizeof(size_t));
+    outputDims[0] = 1;
+    outputDims[1] = 6;
+    size_t *outputOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, outputOrder);
+    shape_t *outputShape = reserveMemory(sizeof(shape_t));
+    setShape(outputShape, outputDims, 2, outputOrder);
+    tensor_t *output = initTensor(outputShape, quantizationInitSymInt32(HTE), NULL);
+
+    /* Clobber the output's scale so we can verify flattenForward writes it. */
     symInt32QConfig_t *outputQC = output->quantization->qConfig;
     outputQC->scale = 0.0f;
 
     layer_t *flatten = flattenLayerInit();
     flattenForward(flatten, input, output);
 
+    /* 3. Capture scale-propagation observation before frees. */
     symInt32QConfig_t *inputQC = input->quantization->qConfig;
-    TEST_ASSERT_EQUAL_FLOAT(inputQC->scale, outputQC->scale);
+    float capturedInputScale = inputQC->scale;
+    float capturedOutputScale = outputQC->scale;
 
-    // Values round-trip through the same scale.
-    float roundTripData[6];
-    tensor_t *roundTrip = tensorInitFloat(roundTripData, outputDims, 2, NULL);
+    /* 4. Build heap roundtrip Float tensor (shape 1x6) and convert. */
+    size_t *roundTripDims = reserveMemory(2 * sizeof(size_t));
+    roundTripDims[0] = 1;
+    roundTripDims[1] = 6;
+    size_t *roundTripOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, roundTripOrder);
+    shape_t *roundTripShape = reserveMemory(sizeof(shape_t));
+    setShape(roundTripShape, roundTripDims, 2, roundTripOrder);
+    tensor_t *roundTrip = initTensor(roundTripShape, quantizationInitFloat(), NULL);
     convertTensor(output, roundTrip);
-    float *actual = (float *)roundTrip->data;
+
+    /* 5. CAPTURE roundtrip values before frees. */
+    float captured[6];
     for (size_t i = 0; i < n; i++) {
-        TEST_ASSERT_FLOAT_WITHIN(0.1f, inputFloatData[i], actual[i]);
+        captured[i] = ((float *)roundTrip->data)[i];
     }
 
+    /* 6. FREE in reverse-init order. */
+    freeTensor(roundTrip);
     freeFlattenLayer(flatten);
+    freeTensor(output);
+    freeTensor(input);
+
+    /* 7. ASSERT. */
+    TEST_ASSERT_EQUAL_FLOAT(capturedInputScale, capturedOutputScale);
+    for (size_t i = 0; i < n; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(0.1f, inputFloatData[i], captured[i]);
+    }
 }
 
 void testFlattenBackwardFloat_CopiesGradsUnchanged(void) {
     size_t n = 6;
-
-    size_t forwardDims[] = {1, 2, 3};
-    float forwardData[] = {-1.f, 0.f, 1.f, 2.f, 5.f, -6.f};
-    tensor_t *forwardInput = tensorInitFloat(forwardData, forwardDims, 3, NULL);
-
-    size_t lossDims[] = {1, 6};
     float lossData[] = {0.1f, 0.2f, -0.3f, 0.4f, 0.5f, 0.6f};
-    tensor_t *loss = tensorInitFloat(lossData, lossDims, 2, NULL);
 
-    float propLossData[6] = {0};
-    tensor_t *propLoss = tensorInitFloat(propLossData, forwardDims, 3, NULL);
+    /* 1. Build heap forwardInput tensor (shape 1x2x3). */
+    size_t *forwardDims = reserveMemory(3 * sizeof(size_t));
+    forwardDims[0] = 1;
+    forwardDims[1] = 2;
+    forwardDims[2] = 3;
+    size_t *forwardOrder = reserveMemory(3 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(3, forwardOrder);
+    shape_t *forwardShape = reserveMemory(sizeof(shape_t));
+    setShape(forwardShape, forwardDims, 3, forwardOrder);
+    tensor_t *forwardInput = initTensor(forwardShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(forwardInput, (float[]){-1.f, 0.f, 1.f, 2.f, 5.f, -6.f}, 6);
+
+    /* 2. Build heap loss tensor (shape 1x6). */
+    size_t *lossDims = reserveMemory(2 * sizeof(size_t));
+    lossDims[0] = 1;
+    lossDims[1] = 6;
+    size_t *lossOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, lossOrder);
+    shape_t *lossShape = reserveMemory(sizeof(shape_t));
+    setShape(lossShape, lossDims, 2, lossOrder);
+    tensor_t *loss = initTensor(lossShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(loss, lossData, n);
+
+    /* 3. Build heap propLoss tensor (shape 1x2x3 — same as forwardInput). */
+    size_t *propLossDims = reserveMemory(3 * sizeof(size_t));
+    propLossDims[0] = 1;
+    propLossDims[1] = 2;
+    propLossDims[2] = 3;
+    size_t *propLossOrder = reserveMemory(3 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(3, propLossOrder);
+    shape_t *propLossShape = reserveMemory(sizeof(shape_t));
+    setShape(propLossShape, propLossDims, 3, propLossOrder);
+    tensor_t *propLoss = initTensor(propLossShape, quantizationInitFloat(), NULL);
 
     layer_t *flatten = flattenLayerInit();
     flattenBackward(flatten, forwardInput, loss, propLoss);
 
-    float *actual = (float *)propLoss->data;
-    TEST_ASSERT_EQUAL_FLOAT_ARRAY(lossData, actual, n);
+    /* 4. CAPTURE before frees. */
+    float captured[6];
+    for (size_t i = 0; i < n; i++) {
+        captured[i] = ((float *)propLoss->data)[i];
+    }
 
+    /* 5. FREE. */
     freeFlattenLayer(flatten);
+    freeTensor(propLoss);
+    freeTensor(loss);
+    freeTensor(forwardInput);
+
+    /* 6. ASSERT. */
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(lossData, captured, n);
 }
 
 void testFlattenBackwardSymInt32_PropagatesScale(void) {
     size_t n = 6;
-
-    size_t forwardDims[] = {1, 2, 3};
-    float forwardData[] = {-1.f, 0.f, 1.f, 2.f, 5.f, -6.f};
-    tensor_t *forwardInput = tensorInitSymInt32(forwardData, forwardDims, 3, HTE, NULL);
-
-    size_t lossDims[] = {1, 6};
     float lossFloatData[] = {0.1f, 0.2f, -0.3f, 0.4f, 0.5f, 0.6f};
-    tensor_t *loss = tensorInitSymInt32(lossFloatData, lossDims, 2, HTE, NULL);
 
-    float propLossFloatData[6] = {0};
-    tensor_t *propLoss = tensorInitSymInt32(propLossFloatData, forwardDims, 3, HTE, NULL);
+    /* 1. Build heap forwardInput tensor (SymInt32, shape 1x2x3). */
+    size_t *forwardDims = reserveMemory(3 * sizeof(size_t));
+    forwardDims[0] = 1;
+    forwardDims[1] = 2;
+    forwardDims[2] = 3;
+    size_t *forwardOrder = reserveMemory(3 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(3, forwardOrder);
+    shape_t *forwardShape = reserveMemory(sizeof(shape_t));
+    setShape(forwardShape, forwardDims, 3, forwardOrder);
+    tensor_t *forwardInput = initTensor(forwardShape, quantizationInitSymInt32(HTE), NULL);
+    tensorFillFromFloatBuffer(forwardInput, (float[]){-1.f, 0.f, 1.f, 2.f, 5.f, -6.f}, 6);
 
+    /* 2. Build heap loss tensor (SymInt32, shape 1x6). */
+    size_t *lossDims = reserveMemory(2 * sizeof(size_t));
+    lossDims[0] = 1;
+    lossDims[1] = 6;
+    size_t *lossOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, lossOrder);
+    shape_t *lossShape = reserveMemory(sizeof(shape_t));
+    setShape(lossShape, lossDims, 2, lossOrder);
+    tensor_t *loss = initTensor(lossShape, quantizationInitSymInt32(HTE), NULL);
+    tensorFillFromFloatBuffer(loss, lossFloatData, n);
+
+    /* 3. Build heap propLoss tensor (SymInt32, shape 1x2x3). */
+    size_t *propLossDims = reserveMemory(3 * sizeof(size_t));
+    propLossDims[0] = 1;
+    propLossDims[1] = 2;
+    propLossDims[2] = 3;
+    size_t *propLossOrder = reserveMemory(3 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(3, propLossOrder);
+    shape_t *propLossShape = reserveMemory(sizeof(shape_t));
+    setShape(propLossShape, propLossDims, 3, propLossOrder);
+    tensor_t *propLoss = initTensor(propLossShape, quantizationInitSymInt32(HTE), NULL);
+
+    /* Clobber propLoss scale so we can verify flattenBackward writes it. */
     symInt32QConfig_t *propLossQC = propLoss->quantization->qConfig;
     propLossQC->scale = 0.0f;
 
     layer_t *flatten = flattenLayerInit();
     flattenBackward(flatten, forwardInput, loss, propLoss);
 
+    /* 4. Capture scale-propagation observation before frees. */
     symInt32QConfig_t *lossQC = loss->quantization->qConfig;
-    TEST_ASSERT_EQUAL_FLOAT(lossQC->scale, propLossQC->scale);
+    float capturedLossScale = lossQC->scale;
+    float capturedPropLossScale = propLossQC->scale;
 
-    float roundTripData[6];
-    tensor_t *roundTrip = tensorInitFloat(roundTripData, forwardDims, 3, NULL);
+    /* 5. Build heap roundtrip Float tensor (shape 1x2x3) and convert. */
+    size_t *roundTripDims = reserveMemory(3 * sizeof(size_t));
+    roundTripDims[0] = 1;
+    roundTripDims[1] = 2;
+    roundTripDims[2] = 3;
+    size_t *roundTripOrder = reserveMemory(3 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(3, roundTripOrder);
+    shape_t *roundTripShape = reserveMemory(sizeof(shape_t));
+    setShape(roundTripShape, roundTripDims, 3, roundTripOrder);
+    tensor_t *roundTrip = initTensor(roundTripShape, quantizationInitFloat(), NULL);
     convertTensor(propLoss, roundTrip);
-    float *actual = (float *)roundTrip->data;
+
+    /* 6. CAPTURE roundtrip values before frees. */
+    float captured[6];
     for (size_t i = 0; i < n; i++) {
-        TEST_ASSERT_FLOAT_WITHIN(0.1f, lossFloatData[i], actual[i]);
+        captured[i] = ((float *)roundTrip->data)[i];
     }
 
+    /* 7. FREE in reverse-init order. */
+    freeTensor(roundTrip);
     freeFlattenLayer(flatten);
+    freeTensor(propLoss);
+    freeTensor(loss);
+    freeTensor(forwardInput);
+
+    /* 8. ASSERT. */
+    TEST_ASSERT_EQUAL_FLOAT(capturedLossScale, capturedPropLossScale);
+    for (size_t i = 0; i < n; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(0.1f, lossFloatData[i], captured[i]);
+    }
 }
 
 void setUp(void) {}

--- a/test/unit/userAPI/CMakeLists.txt
+++ b/test/unit/userAPI/CMakeLists.txt
@@ -91,6 +91,7 @@ target_link_libraries(UnitTestFlattenIntegration PRIVATE
         FlattenApi
         LinearApi
         SoftmaxApi
+        SgdApi
         TensorApi
         QuantizationApi
         LossFunction

--- a/test/unit/userAPI/UnitTestFlattenIntegration.c
+++ b/test/unit/userAPI/UnitTestFlattenIntegration.c
@@ -1,5 +1,6 @@
 #define SOURCE_FILE "UNIT_TEST_FLATTEN_INTEGRATION"
 
+#include <stdbool.h>
 #include <stdlib.h>
 
 #include "CalculateGradsSequential.h"
@@ -9,96 +10,204 @@
 #include "LossFunction.h"
 #include "QuantizationApi.h"
 #include "SoftmaxApi.h"
+#include "StorageApi.h"
 #include "TensorApi.h"
 #include "unity.h"
 
-// Trains [Flatten → Linear(6,2) → Softmax] for one step with MSE loss.
+// Trains [Flatten -> Linear(6,2) -> Softmax] for one step with MSE loss.
 // Main point: initLayerOutputs FLATTEN case must derive output-Q from input tensor.
 // If that case is missing, initLayerOutputs hits `default: exit(1)`.
 void testCalculateGradsSequential_WithFlattenFirst_DoesNotCrash(void) {
     quantization_t *q = quantizationInitFloat();
 
-    // Linear weights (6 -> 2)
-    static float w0Data[2 * 6] = {0};
-    static size_t w0Dims[] = {2, 6};
-    tensor_t *w0P = tensorInitWithDistribution(XAVIER_UNIFORM, w0Data, w0Dims, 2, q, NULL, 6, 2);
-    tensor_t *w0G = gradInitFloat(w0P, NULL);
-    parameter_t *w0 = parameterInit(w0P, w0G);
+    /* Linear weights w0 (2x6, XAVIER_UNIFORM). */
+    size_t *w0Dims = reserveMemory(2 * sizeof(size_t));
+    w0Dims[0] = 2;
+    w0Dims[1] = 6;
+    size_t *w0Order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, w0Order);
+    shape_t *w0Shape = reserveMemory(sizeof(shape_t));
+    setShape(w0Shape, w0Dims, 2, w0Order);
+    tensor_t *w0Param = initTensor(w0Shape, quantizationInitFloat(), NULL);
+    distribution_t xavier = {.type = XAVIER_UNIFORM,
+                             .params.xavier = {.gain = 1.0f, .fanIn = 6, .fanOut = 2}};
+    initDistribution(w0Param, &xavier);
+    tensor_t *w0Grad = gradInitFloat(w0Param, NULL);
+    parameter_t *w0 = parameterInit(w0Param, w0Grad);
 
-    static float b0Data[2] = {0};
-    static size_t b0Dims[] = {1, 2};
-    tensor_t *b0P = tensorInitWithDistribution(ZEROS, b0Data, b0Dims, 2, q, NULL, 1, 2);
-    tensor_t *b0G = gradInitFloat(b0P, NULL);
-    parameter_t *b0 = parameterInit(b0P, b0G);
+    /* Linear bias b0 (1x2, ZEROS). */
+    size_t *b0Dims = reserveMemory(2 * sizeof(size_t));
+    b0Dims[0] = 1;
+    b0Dims[1] = 2;
+    size_t *b0Order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, b0Order);
+    shape_t *b0Shape = reserveMemory(sizeof(shape_t));
+    setShape(b0Shape, b0Dims, 2, b0Order);
+    tensor_t *b0Param = initTensor(b0Shape, quantizationInitFloat(), NULL);
+    distribution_t zeros = {.type = ZEROS};
+    initDistribution(b0Param, &zeros);
+    tensor_t *b0Grad = gradInitFloat(b0Param, NULL);
+    parameter_t *b0 = parameterInit(b0Param, b0Grad);
 
-    layer_t *model[3];
-    model[0] = flattenLayerInit();
-    model[1] = linearLayerInit(w0, b0, q, q, q, q);
-    model[2] = softmaxLayerInit(q, q);
+    layer_t *flatten = flattenLayerInit();
+    layer_t *linear = linearLayerInit(w0, b0, q, q, q, q);
+    layer_t *softmax = softmaxLayerInit(q, q);
+    layer_t *model[3] = {flatten, linear, softmax};
 
-    // Input [1, 2, 3] = 6 elements
-    size_t inputDims[] = {1, 2, 3};
-    float inputData[] = {0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f};
-    tensor_t *input = tensorInitFloat(inputData, inputDims, 3, NULL);
+    /* Input [1, 2, 3] = 6 elements. */
+    size_t *inputDims = reserveMemory(3 * sizeof(size_t));
+    inputDims[0] = 1;
+    inputDims[1] = 2;
+    inputDims[2] = 3;
+    size_t *inputOrder = reserveMemory(3 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(3, inputOrder);
+    shape_t *inputShape = reserveMemory(sizeof(shape_t));
+    setShape(inputShape, inputDims, 3, inputOrder);
+    tensor_t *input = initTensor(inputShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(input, (float[]){0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f}, 6);
 
-    // Label [1, 2]
-    size_t labelDims[] = {1, 2};
-    float labelData[] = {1.0f, 0.0f};
-    tensor_t *label = tensorInitFloat(labelData, labelDims, 2, NULL);
+    /* Label [1, 2]. */
+    size_t *labelDims = reserveMemory(2 * sizeof(size_t));
+    labelDims[0] = 1;
+    labelDims[1] = 2;
+    size_t *labelOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, labelOrder);
+    shape_t *labelShape = reserveMemory(sizeof(shape_t));
+    setShape(labelShape, labelDims, 2, labelOrder);
+    tensor_t *label = initTensor(labelShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(label, (float[]){1.0f, 0.0f}, 2);
 
     trainingStats_t *stats = calculateGradsSequential(model, 3, MSE, input, label);
 
-    TEST_ASSERT_NOT_NULL(stats);
-    TEST_ASSERT_NOT_NULL(stats->output);
-    TEST_ASSERT_EQUAL_UINT(2, stats->output->shape->numberOfDimensions);
-    TEST_ASSERT_EQUAL_UINT(1, stats->output->shape->dimensions[0]);
-    TEST_ASSERT_EQUAL_UINT(2, stats->output->shape->dimensions[1]);
+    /* CAPTURE before frees. */
+    bool capturedStatsNotNull = (stats != NULL);
+    bool capturedOutputNotNull = (stats && stats->output != NULL);
+    size_t capturedNumDims =
+        (stats && stats->output) ? stats->output->shape->numberOfDimensions : 0;
+    size_t capturedDim0 = (stats && stats->output) ? stats->output->shape->dimensions[0] : 0;
+    size_t capturedDim1 = (stats && stats->output) ? stats->output->shape->dimensions[1] : 0;
+
+    /* FREE in reverse-init order. */
+    freeTrainingStats(stats);
+    freeTensor(label);
+    freeTensor(input);
+    freeSoftmaxLayer(softmax);
+    freeLinearLayer(linear);
+    freeFlattenLayer(flatten);
+    freeParameter(b0);
+    freeParameter(w0);
+    freeQuantization(q);
+
+    /* ASSERT. */
+    TEST_ASSERT_TRUE(capturedStatsNotNull);
+    TEST_ASSERT_TRUE(capturedOutputNotNull);
+    TEST_ASSERT_EQUAL_UINT(2, capturedNumDims);
+    TEST_ASSERT_EQUAL_UINT(1, capturedDim0);
+    TEST_ASSERT_EQUAL_UINT(2, capturedDim1);
 }
 
 void testCalculateGradsSequential_FlattenRank1_DoesNotOOB(void) {
     // Regression: initLayerOutputs sized output-shape buffers by INPUT rank, but
     // flattenCalcOutputShape always writes 2 slots. For rank-1 input this is OOB.
-    size_t inputDims[] = {5};
-    float inputData[] = {1.f, 2.f, 3.f, 4.f, 5.f};
-    tensor_t *input = tensorInitFloat(inputData, inputDims, 1, NULL);
+    size_t *inputDims = reserveMemory(1 * sizeof(size_t));
+    inputDims[0] = 5;
+    size_t *inputOrder = reserveMemory(1 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(1, inputOrder);
+    shape_t *inputShape = reserveMemory(sizeof(shape_t));
+    setShape(inputShape, inputDims, 1, inputOrder);
+    tensor_t *input = initTensor(inputShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(input, (float[]){1.f, 2.f, 3.f, 4.f, 5.f}, 5);
 
-    size_t labelDims[] = {5, 1};
-    float labelData[] = {0.f, 0.f, 0.f, 0.f, 0.f};
-    tensor_t *label = tensorInitFloat(labelData, labelDims, 2, NULL);
+    size_t *labelDims = reserveMemory(2 * sizeof(size_t));
+    labelDims[0] = 5;
+    labelDims[1] = 1;
+    size_t *labelOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, labelOrder);
+    shape_t *labelShape = reserveMemory(sizeof(shape_t));
+    setShape(labelShape, labelDims, 2, labelOrder);
+    tensor_t *label = initTensor(labelShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(label, (float[]){0.f, 0.f, 0.f, 0.f, 0.f}, 5);
 
-    layer_t *model[1];
-    model[0] = flattenLayerInit();
+    layer_t *flatten = flattenLayerInit();
+    layer_t *model[1] = {flatten};
 
     trainingStats_t *stats = calculateGradsSequential(model, 1, MSE, input, label);
 
-    TEST_ASSERT_NOT_NULL(stats);
-    TEST_ASSERT_EQUAL_UINT(2, stats->output->shape->numberOfDimensions);
-    TEST_ASSERT_EQUAL_UINT(5, stats->output->shape->dimensions[0]);
-    TEST_ASSERT_EQUAL_UINT(1, stats->output->shape->dimensions[1]);
+    /* CAPTURE before frees. */
+    bool capturedStatsNotNull = (stats != NULL);
+    size_t capturedNumDims =
+        (stats && stats->output) ? stats->output->shape->numberOfDimensions : 0;
+    size_t capturedDim0 = (stats && stats->output) ? stats->output->shape->dimensions[0] : 0;
+    size_t capturedDim1 = (stats && stats->output) ? stats->output->shape->dimensions[1] : 0;
+
+    /* FREE in reverse-init order. */
+    freeTrainingStats(stats);
+    freeTensor(label);
+    freeTensor(input);
+    freeFlattenLayer(flatten);
+
+    /* ASSERT. */
+    TEST_ASSERT_TRUE(capturedStatsNotNull);
+    TEST_ASSERT_EQUAL_UINT(2, capturedNumDims);
+    TEST_ASSERT_EQUAL_UINT(5, capturedDim0);
+    TEST_ASSERT_EQUAL_UINT(1, capturedDim1);
 }
 
 void testCalculateGradsSequential_FlattenOnly_PreservesValues(void) {
     // FLATTEN is identity on values; stats->output must equal input, reshaped.
-    size_t inputDims[] = {1, 2, 3};
     float inputData[] = {1.f, 2.f, 3.f, 4.f, 5.f, 6.f};
-    tensor_t *input = tensorInitFloat(inputData, inputDims, 3, NULL);
 
-    size_t labelDims[] = {1, 6};
-    float labelData[] = {0.f, 0.f, 0.f, 0.f, 0.f, 0.f};
-    tensor_t *label = tensorInitFloat(labelData, labelDims, 2, NULL);
+    size_t *inputDims = reserveMemory(3 * sizeof(size_t));
+    inputDims[0] = 1;
+    inputDims[1] = 2;
+    inputDims[2] = 3;
+    size_t *inputOrder = reserveMemory(3 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(3, inputOrder);
+    shape_t *inputShape = reserveMemory(sizeof(shape_t));
+    setShape(inputShape, inputDims, 3, inputOrder);
+    tensor_t *input = initTensor(inputShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(input, inputData, 6);
 
-    layer_t *model[1];
-    model[0] = flattenLayerInit();
+    size_t *labelDims = reserveMemory(2 * sizeof(size_t));
+    labelDims[0] = 1;
+    labelDims[1] = 6;
+    size_t *labelOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, labelOrder);
+    shape_t *labelShape = reserveMemory(sizeof(shape_t));
+    setShape(labelShape, labelDims, 2, labelOrder);
+    tensor_t *label = initTensor(labelShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(label, (float[]){0.f, 0.f, 0.f, 0.f, 0.f, 0.f}, 6);
+
+    layer_t *flatten = flattenLayerInit();
+    layer_t *model[1] = {flatten};
 
     trainingStats_t *stats = calculateGradsSequential(model, 1, MSE, input, label);
 
-    TEST_ASSERT_NOT_NULL(stats);
-    TEST_ASSERT_EQUAL_UINT(2, stats->output->shape->numberOfDimensions);
-    TEST_ASSERT_EQUAL_UINT(1, stats->output->shape->dimensions[0]);
-    TEST_ASSERT_EQUAL_UINT(6, stats->output->shape->dimensions[1]);
+    /* CAPTURE before frees. */
+    bool capturedStatsNotNull = (stats != NULL);
+    size_t capturedNumDims =
+        (stats && stats->output) ? stats->output->shape->numberOfDimensions : 0;
+    size_t capturedDim0 = (stats && stats->output) ? stats->output->shape->dimensions[0] : 0;
+    size_t capturedDim1 = (stats && stats->output) ? stats->output->shape->dimensions[1] : 0;
+    float capturedValues[6] = {0};
+    if (stats && stats->output && stats->output->data) {
+        for (size_t i = 0; i < 6; i++) {
+            capturedValues[i] = ((float *)stats->output->data)[i];
+        }
+    }
 
-    float *actual = (float *)stats->output->data;
-    TEST_ASSERT_EQUAL_FLOAT_ARRAY(inputData, actual, 6);
+    /* FREE in reverse-init order. */
+    freeTrainingStats(stats);
+    freeTensor(label);
+    freeTensor(input);
+    freeFlattenLayer(flatten);
+
+    /* ASSERT. */
+    TEST_ASSERT_TRUE(capturedStatsNotNull);
+    TEST_ASSERT_EQUAL_UINT(2, capturedNumDims);
+    TEST_ASSERT_EQUAL_UINT(1, capturedDim0);
+    TEST_ASSERT_EQUAL_UINT(6, capturedDim1);
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(inputData, capturedValues, 6);
 }
 
 void setUp(void) {}


### PR DESCRIPTION
**Stack position:** `develop ← #109 ← #110 ← #111 ← #112 ← #114 ← #115 ← #116 ← #THIS`

Stacked on #116. Per `codebase_stacked_pr_merge_trap.md`: do not merge before #116.

---

## Summary

Wave batch 4. Migrates the flatten-layer tests to the Phase 2 explicit-free + assert-last idiom.

## Test-side changes

- `test/unit/layer/UnitTestFlatten.c`: 4 forward/backward x Float/SymInt32 tests rewritten with post-#106 primitives + assert-last. The two layer-only tests reordered to assert-last (existing structure had assertions before `freeFlattenLayer`).
- `test/unit/userAPI/UnitTestFlattenIntegration.c`: 3 `calculateGradsSequential` tests rewritten with heap shapes + `initDistribution` (replacing deprecated `tensorInitWithDistribution`) + `freeTrainingStats` and reverse-init cleanup of layers/parameters/tensors/quantization.

## CMake bundle

- `test/unit/userAPI/CMakeLists.txt`: add `SgdApi` to `UnitTestFlattenIntegration`'s link list. The migration introduces a reference to `freeTrainingStats`, which pulls in `TrainingLoopApi.c.o`, which transitively requires `Optimizer.c.o`'s static `optimizerFunctions[]` table — this references `sgdStep`/`sgdStepM`/`sgdZeroGrad` from the `Sgd` archive. GNU ld is strict about static-archive ordering and refuses to resolve those references unless `Sgd` is on the link line. macOS ld8 was permissive. The fix matches the precedent set by `UnitTestTrainingLoopApi` and `UnitTestMultiLayerTraining`, both of which already link `SgdApi`.
- `test/unit/layer/CMakeLists.txt`: add `StorageApi` to `UnitTestFlatten`'s `MORE_LIBS` (matches the batch-3 precedent for the migrated layer tests).

## Verification

- macOS: 6/6 in `UnitTestFlatten`, 3/3 in `UnitTestFlattenIntegration`. Zero deprecation warnings.
- LSan in `odt-lsan-recon:2026-04-22`: both binaries report `All heap blocks were freed -- no leaks are possible` (84 allocs/84 frees and 164 allocs/164 frees respectively). The `UnitTestFlattenIntegration` log additionally surfaces two non-leak `memcpy(self, self, ...)` warnings inside `convertTensorsWithSameType` (TensorConversion.c:379) reachable via Linear's backward path; these are pre-existing production-side undefined-behavior issues unrelated to the test migration and out of scope here.

Spec: `docs/superpowers/specs/2026-04-25-phase-2-teardown-idiom-design.md`
Plan: `docs/superpowers/plans/2026-04-27-phase-2-teardown-idiom.md`