### PR TITLE
test(#82): wave batch 5 — migrate UnitTestSgd + fix three pre-existing bugs

### DIFF
--- a/test/unit/optimizer/CMakeLists.txt
+++ b/test/unit/optimizer/CMakeLists.txt
@@ -5,6 +5,8 @@ add_elastic_ai_unit_test(
         CommonLayerLibs
         SgdApi
         TensorApi
+        QuantizationApi
+        StorageApi
         LinearApi
         ReluApi
 )

--- a/test/unit/optimizer/UnitTestSgd.c
+++ b/test/unit/optimizer/UnitTestSgd.c
@@ -1,15 +1,17 @@
 #define SOURCE_FILE "SGD-UTEST"
 #include <stdlib.h>
 
-#include "Linear.h"
-#include "unity.h"
 #include "Layer.h"
-#include "Tensor.h"
+#include "Linear.h"
+#include "LinearApi.h"
+#include "OptimizerApi.h"
+#include "QuantizationApi.h"
 #include "Sgd.h"
 #include "SgdApi.h"
-#include "LinearApi.h"
+#include "StorageApi.h"
+#include "Tensor.h"
 #include "TensorApi.h"
-#include "OptimizerApi.h"
+#include "unity.h"
 
 #include <ReluApi.h>
 
@@ -17,30 +19,70 @@ void setUp() {}
 void tearDown() {}
 
 void testSgdMCreateOptim() {
+    /* Shared layer-config quantization (caller-owned). */
+    quantization_t *layerQ = quantizationInitFloat();
 
-    float weightData[] = {0.f, 1.f, 2.f};
-    size_t weightDims[] = {1, 3};
-    size_t weightNumberOfDims = 2;
-    tensor_t *weightParam = tensorInitFloat(weightData, weightDims, weightNumberOfDims, NULL);
-    float weightGradData[] = {0.f, 0.f, 0.f};
-    tensor_t *weightGrad = tensorInitFloat(weightGradData, weightDims, weightNumberOfDims, NULL);
-    parameter_t *weights = parameterInit(weightParam, weightGrad);
+    /* linear0 weights (heap shape, FLOAT32, dims {1, 3}, ndims=2). */
+    size_t *w0Dims = reserveMemory(2 * sizeof(size_t));
+    w0Dims[0] = 1;
+    w0Dims[1] = 3;
+    size_t *w0Order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, w0Order);
+    shape_t *w0Shape = reserveMemory(sizeof(shape_t));
+    setShape(w0Shape, w0Dims, 2, w0Order);
+    tensor_t *w0Param = initTensor(w0Shape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(w0Param, (float[]){0.f, 1.f, 2.f}, 3);
+    tensor_t *w0Grad = gradInitFloat(w0Param, NULL);
+    tensorFillFromFloatBuffer(w0Grad, (float[]){0.f, 0.f, 0.f}, 3);
+    parameter_t *weights0 = parameterInit(w0Param, w0Grad);
 
-    float biasData[] = {0.f, 1.f, -1.f};
-    size_t biasDims[] = {1, 3};
-    size_t biasNumberOfDims = 1;
-    tensor_t *biasParam = tensorInitFloat(biasData, biasDims, biasNumberOfDims, NULL);
-    float biasGradData[] = {0.f, 0.f, 0.f};
-    tensor_t *biasGrad = tensorInitFloat(biasGradData, biasDims, biasNumberOfDims, NULL);
-    parameter_t *bias = parameterInit(biasParam, biasGrad);
+    /* linear0 bias (heap shape, FLOAT32, dims {1, 3}, ndims=1 -> 1 element). */
+    size_t *b0Dims = reserveMemory(1 * sizeof(size_t));
+    b0Dims[0] = 1;
+    size_t *b0Order = reserveMemory(1 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(1, b0Order);
+    shape_t *b0Shape = reserveMemory(sizeof(shape_t));
+    setShape(b0Shape, b0Dims, 1, b0Order);
+    tensor_t *b0Param = initTensor(b0Shape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(b0Param, (float[]){0.f}, 1);
+    tensor_t *b0Grad = gradInitFloat(b0Param, NULL);
+    tensorFillFromFloatBuffer(b0Grad, (float[]){0.f}, 1);
+    parameter_t *bias0 = parameterInit(b0Param, b0Grad);
 
-    quantization_t testQ;
-    initFloat32Quantization(&testQ);
-    layer_t *linear0 = linearLayerInit(weights, bias, &testQ, &testQ, &testQ, &testQ);
+    /* linear1 needs its OWN weights/bias parameters (Bug 1 fix): freeOptimSgdM
+     * will walk optim->parameter[] and freeParameter each entry once. Sharing
+     * the same parameter_t pointers across linear0 and linear1 would cause a
+     * double-free. The pointer-equality assertions below still hold because
+     * they compare layer config slots against optim->parameter slots, both
+     * of which now point to whichever parameter object the layer was given. */
+    size_t *w1Dims = reserveMemory(2 * sizeof(size_t));
+    w1Dims[0] = 1;
+    w1Dims[1] = 3;
+    size_t *w1Order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, w1Order);
+    shape_t *w1Shape = reserveMemory(sizeof(shape_t));
+    setShape(w1Shape, w1Dims, 2, w1Order);
+    tensor_t *w1Param = initTensor(w1Shape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(w1Param, (float[]){0.f, 1.f, 2.f}, 3);
+    tensor_t *w1Grad = gradInitFloat(w1Param, NULL);
+    tensorFillFromFloatBuffer(w1Grad, (float[]){0.f, 0.f, 0.f}, 3);
+    parameter_t *weights1 = parameterInit(w1Param, w1Grad);
 
-    layer_t *relu0 = reluLayerInit(&testQ, &testQ);
+    size_t *b1Dims = reserveMemory(1 * sizeof(size_t));
+    b1Dims[0] = 1;
+    size_t *b1Order = reserveMemory(1 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(1, b1Order);
+    shape_t *b1Shape = reserveMemory(sizeof(shape_t));
+    setShape(b1Shape, b1Dims, 1, b1Order);
+    tensor_t *b1Param = initTensor(b1Shape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(b1Param, (float[]){0.f}, 1);
+    tensor_t *b1Grad = gradInitFloat(b1Param, NULL);
+    tensorFillFromFloatBuffer(b1Grad, (float[]){0.f}, 1);
+    parameter_t *bias1 = parameterInit(b1Param, b1Grad);
 
-    layer_t *linear1 = linearLayerInit(weights, bias, &testQ, &testQ, &testQ, &testQ);
+    layer_t *linear0 = linearLayerInit(weights0, bias0, layerQ, layerQ, layerQ, layerQ);
+    layer_t *relu0 = reluLayerInit(layerQ, layerQ);
+    layer_t *linear1 = linearLayerInit(weights1, bias1, layerQ, layerQ, layerQ, layerQ);
 
     layer_t *model[] = {linear0, relu0, linear1};
     size_t sizeModel = sizeof(model) / sizeof(model[0]);
@@ -48,60 +90,121 @@ void testSgdMCreateOptim() {
     float momentumFactor = 0.9f;
     float weightDecay = 0.5f;
 
-    optimizer_t *optim = sgdMCreateOptim(lr, momentumFactor, weightDecay, model, sizeModel, FLOAT32);
+    optimizer_t *optim =
+        sgdMCreateOptim(lr, momentumFactor, weightDecay, model, sizeModel, FLOAT32);
     sgd_t *sgd = optim->impl->sgd;
 
     linearConfig_t *linear0Conf = linear0->config->linear;
     linearConfig_t *linear1Conf = linear1->config->linear;
 
-    TEST_ASSERT_EQUAL_FLOAT(lr, sgd->learningRate);
-    TEST_ASSERT_EQUAL_FLOAT(momentumFactor, sgd->momentumFactor);
-    TEST_ASSERT_EQUAL_FLOAT(weightDecay, sgd->weightDecay);
-    TEST_ASSERT_EQUAL_size_t(4, optim->sizeStates);
+    /* CAPTURE before frees. */
+    float capturedLr = sgd->learningRate;
+    float capturedMomentum = sgd->momentumFactor;
+    float capturedWeightDecay = sgd->weightDecay;
+    size_t capturedSizeStates = optim->sizeStates;
 
-    TEST_ASSERT_EQUAL_PTR(linear0Conf->weights, optim->parameter[0]);
-    TEST_ASSERT_EQUAL_PTR(linear0Conf->bias, optim->parameter[1]);
-    TEST_ASSERT_EQUAL_PTR(linear1Conf->weights, optim->parameter[2]);
-    TEST_ASSERT_EQUAL_PTR(linear1Conf->bias, optim->parameter[3]);
+    parameter_t *capturedL0Weights = linear0Conf->weights;
+    parameter_t *capturedL0Bias = linear0Conf->bias;
+    parameter_t *capturedL1Weights = linear1Conf->weights;
+    parameter_t *capturedL1Bias = linear1Conf->bias;
+    parameter_t *capturedOptimP0 = optim->parameter[0];
+    parameter_t *capturedOptimP1 = optim->parameter[1];
+    parameter_t *capturedOptimP2 = optim->parameter[2];
+    parameter_t *capturedOptimP3 = optim->parameter[3];
 
-    TEST_ASSERT_EQUAL_FLOAT_ARRAY(linear0Conf->weights->grad->data,
-                                  optim->states[0]->stateBuffers[0]->data,
-                                  calcNumberOfElementsByParameter(linear0Conf->weights));
+    size_t l0WeightsN = calcNumberOfElementsByParameter(linear0Conf->weights);
+    size_t l0BiasN = calcNumberOfElementsByParameter(linear0Conf->bias);
+    size_t l1WeightsN = calcNumberOfElementsByParameter(linear1Conf->weights);
+    size_t l1BiasN = calcNumberOfElementsByParameter(linear1Conf->bias);
 
-    TEST_ASSERT_EQUAL_FLOAT_ARRAY(linear0Conf->bias->grad->data,
-                                  optim->states[1]->stateBuffers[0]->data,
-                                  calcNumberOfElementsByParameter(linear0Conf->bias));
+    /* l0WeightsN=3, l0BiasN=1, l1WeightsN=3, l1BiasN=1 (per shape semantics above). */
+    float capturedL0WGrad[3];
+    float capturedL0WState[3];
+    for (size_t i = 0; i < l0WeightsN; i++) {
+        capturedL0WGrad[i] = ((float *)linear0Conf->weights->grad->data)[i];
+        capturedL0WState[i] = ((float *)optim->states[0]->stateBuffers[0]->data)[i];
+    }
 
-    TEST_ASSERT_EQUAL_FLOAT_ARRAY(linear1Conf->weights->grad->data,
-                                  optim->states[2]->stateBuffers[0]->data,
-                                  calcNumberOfElementsByParameter(linear1Conf->weights));
-    TEST_ASSERT_EQUAL_FLOAT_ARRAY(linear1Conf->bias->grad->data,
-                                  optim->states[3]->stateBuffers[0]->data,
-                                  calcNumberOfElementsByParameter(linear1Conf->bias));
+    float capturedL0BGrad[1];
+    float capturedL0BState[1];
+    for (size_t i = 0; i < l0BiasN; i++) {
+        capturedL0BGrad[i] = ((float *)linear0Conf->bias->grad->data)[i];
+        capturedL0BState[i] = ((float *)optim->states[1]->stateBuffers[0]->data)[i];
+    }
+
+    float capturedL1WGrad[3];
+    float capturedL1WState[3];
+    for (size_t i = 0; i < l1WeightsN; i++) {
+        capturedL1WGrad[i] = ((float *)linear1Conf->weights->grad->data)[i];
+        capturedL1WState[i] = ((float *)optim->states[2]->stateBuffers[0]->data)[i];
+    }
+
+    float capturedL1BGrad[1];
+    float capturedL1BState[1];
+    for (size_t i = 0; i < l1BiasN; i++) {
+        capturedL1BGrad[i] = ((float *)linear1Conf->bias->grad->data)[i];
+        capturedL1BState[i] = ((float *)optim->states[3]->stateBuffers[0]->data)[i];
+    }
+
+    /* FREE in reverse-init order. freeOptimSgdM cascades to all parameters
+     * (and their grads) registered with the optimizer (per SgdApi.c:85-93,
+     * mirroring the post-#110 ownership contract). */
+    freeOptimSgdM(optim);
+    freeLinearLayer(linear1);
+    freeReluLayer(relu0);
+    freeLinearLayer(linear0);
+    freeQuantization(layerQ);
+
+    /* ASSERT. */
+    TEST_ASSERT_EQUAL_FLOAT(lr, capturedLr);
+    TEST_ASSERT_EQUAL_FLOAT(momentumFactor, capturedMomentum);
+    TEST_ASSERT_EQUAL_FLOAT(weightDecay, capturedWeightDecay);
+    TEST_ASSERT_EQUAL_size_t(4, capturedSizeStates);
+
+    TEST_ASSERT_EQUAL_PTR(capturedL0Weights, capturedOptimP0);
+    TEST_ASSERT_EQUAL_PTR(capturedL0Bias, capturedOptimP1);
+    TEST_ASSERT_EQUAL_PTR(capturedL1Weights, capturedOptimP2);
+    TEST_ASSERT_EQUAL_PTR(capturedL1Bias, capturedOptimP3);
+
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(capturedL0WGrad, capturedL0WState, l0WeightsN);
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(capturedL0BGrad, capturedL0BState, l0BiasN);
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(capturedL1WGrad, capturedL1WState, l1WeightsN);
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(capturedL1BGrad, capturedL1BState, l1BiasN);
 }
 
 void testSGDStep() {
-    float weightData[] = {1.f, 2.f, -3.f};
-    size_t weightDims[] = {3, 1};
-    size_t weightNumberOfDims = 1;
-    tensor_t *weightParam = tensorInitFloat(weightData, weightDims, weightNumberOfDims, NULL);
+    quantization_t *layerQ = quantizationInitFloat();
+
+    /* weights (heap shape, FLOAT32, dims {3, 1}, ndims=1 -> 3 elements). */
+    size_t *wDims = reserveMemory(1 * sizeof(size_t));
+    wDims[0] = 3;
+    size_t *wOrder = reserveMemory(1 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(1, wOrder);
+    shape_t *wShape = reserveMemory(sizeof(shape_t));
+    setShape(wShape, wDims, 1, wOrder);
+    tensor_t *weightParam = initTensor(wShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(weightParam, (float[]){1.f, 2.f, -3.f}, 3);
     tensor_t *weightGrad = gradInitFloat(weightParam, NULL);
-    float weightGradData[] = {1.f, -1.f, 2.f};
-    weightGrad->data = (uint8_t *)weightGradData;
+    /* Bug 2 fix: populate the heap-allocated grad buffer rather than
+     * overwriting weightGrad->data with a stack pointer (which would leak
+     * the heap buffer and make freeTensor UB on the dangling stack ptr). */
+    tensorFillFromFloatBuffer(weightGrad, (float[]){1.f, -1.f, 2.f}, 3);
     parameter_t *weights = parameterInit(weightParam, weightGrad);
 
-    float biasData[] = {-1.f, 3.f};
-    size_t biasDims[] = {2, 1};
-    size_t biasNumberOfDims = 1;
-    tensor_t *biasParam = tensorInitFloat(biasData, biasDims, biasNumberOfDims, NULL);
+    /* bias (heap shape, FLOAT32, dims {2, 1}, ndims=1 -> 2 elements). */
+    size_t *bDims = reserveMemory(1 * sizeof(size_t));
+    bDims[0] = 2;
+    size_t *bOrder = reserveMemory(1 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(1, bOrder);
+    shape_t *bShape = reserveMemory(sizeof(shape_t));
+    setShape(bShape, bDims, 1, bOrder);
+    tensor_t *biasParam = initTensor(bShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(biasParam, (float[]){-1.f, 3.f}, 2);
     tensor_t *biasGrad = gradInitFloat(biasParam, NULL);
-    float biasGradData[] = {1.f, 3.f};
-    biasGrad->data = (uint8_t *) biasGradData;
+    tensorFillFromFloatBuffer(biasGrad, (float[]){1.f, 3.f}, 2);
     parameter_t *bias = parameterInit(biasParam, biasGrad);
 
-    quantization_t testQ;
-    initFloat32Quantization(&testQ);
-    layer_t *linear = linearLayerInit(weights, bias, &testQ, &testQ, &testQ, &testQ);
+    layer_t *linear = linearLayerInit(weights, bias, layerQ, layerQ, layerQ, layerQ);
 
     layer_t *model[] = {linear};
     size_t modelSize = 1;
@@ -114,48 +217,80 @@ void testSGDStep() {
     optimizerFunctions_t sgdFns = optimizerFunctions[sgd->type];
     sgdFns.step(sgd);
 
-    float wPExpected[] = {0.899f, 2.098f, -3.197f};
-    float bPExpected[] = {-1.099f, 2.697f};
-
-    TEST_ASSERT_EQUAL_FLOAT_ARRAY(wPExpected, linear->config->linear->weights->param->data,
-                                  sizeof(wPExpected)/sizeof(float));
-    TEST_ASSERT_EQUAL_FLOAT_ARRAY(bPExpected, linear->config->linear->bias->param->data,
-                                  sizeof(bPExpected)/sizeof(float));
+    /* CAPTURE first-step values before second step. */
+    float capturedWAfterStep1[3];
+    for (size_t i = 0; i < 3; i++) {
+        capturedWAfterStep1[i] = ((float *)linear->config->linear->weights->param->data)[i];
+    }
+    float capturedBAfterStep1[2];
+    for (size_t i = 0; i < 2; i++) {
+        capturedBAfterStep1[i] = ((float *)linear->config->linear->bias->param->data)[i];
+    }
 
     sgdFns.step(sgd);
 
+    /* CAPTURE second-step values before frees. */
+    float capturedWAfterStep2[3];
+    for (size_t i = 0; i < 3; i++) {
+        capturedWAfterStep2[i] = ((float *)linear->config->linear->weights->param->data)[i];
+    }
+    float capturedBAfterStep2[2];
+    for (size_t i = 0; i < 2; i++) {
+        capturedBAfterStep2[i] = ((float *)linear->config->linear->bias->param->data)[i];
+    }
+
+    /* FREE in reverse-init order. */
+    freeOptimSgdM(sgd);
+    freeLinearLayer(linear);
+    freeQuantization(layerQ);
+
+    /* ASSERT. */
+    float wPExpected[] = {0.899f, 2.098f, -3.197f};
+    float bPExpected[] = {-1.099f, 2.697f};
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(wPExpected, capturedWAfterStep1, 3);
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(bPExpected, capturedBAfterStep1, 2);
+
     float wPExpected2[] = {0.707201f, 2.284102f, -3.571103f};
     float bPExpected2[] = {-1.287001f, 2.121603f};
-
-    TEST_ASSERT_EQUAL_FLOAT_ARRAY(wPExpected2, linear->config->linear->weights->param->data,
-                                  sizeof(wPExpected2)/sizeof(float));
-    TEST_ASSERT_EQUAL_FLOAT_ARRAY(bPExpected2, linear->config->linear->bias->param->data,
-                                  sizeof(bPExpected2)/sizeof(float));
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(wPExpected2, capturedWAfterStep2, 3);
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(bPExpected2, capturedBAfterStep2, 2);
 }
 
 void testSGDZeroGrad() {
-    float weightData[] = {1.f, 2.f, -3.f};
-    size_t weightDims[] = {3, 1};
-    size_t weightNumberOfDims = 2;
-    tensor_t *weightParam = tensorInitFloat(weightData, weightDims, weightNumberOfDims, NULL);
+    quantization_t *layerQ = quantizationInitFloat();
+
+    /* weights (heap shape, FLOAT32, dims {3, 1}, ndims=2 -> 3 elements). */
+    size_t *wDims = reserveMemory(2 * sizeof(size_t));
+    wDims[0] = 3;
+    wDims[1] = 1;
+    size_t *wOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, wOrder);
+    shape_t *wShape = reserveMemory(sizeof(shape_t));
+    setShape(wShape, wDims, 2, wOrder);
+    tensor_t *weightParam = initTensor(wShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(weightParam, (float[]){1.f, 2.f, -3.f}, 3);
     tensor_t *weightGrad = gradInitFloat(weightParam, NULL);
-    float weightGradData[] = {1.f, -1.f, 2.f};
-    weightGrad->data = (uint8_t *)weightGradData;
+    /* Bug 2 fix: same as testSGDStep. */
+    tensorFillFromFloatBuffer(weightGrad, (float[]){1.f, -1.f, 2.f}, 3);
     parameter_t *weights = parameterInit(weightParam, weightGrad);
 
-
-    float biasData[] = {-1.f, 3.f};
-    size_t biasDims[] = {2, 1};
-    size_t biasNumberOfDims = 2;
-    tensor_t *biasParam = tensorInitFloat(biasData, biasDims, biasNumberOfDims, NULL);
-    tensor_t *biasGrad = gradInitFloat(weightParam, NULL);
-    float biasGradData[] = {1.f, 3.f};
-    biasGrad->data = (uint8_t *)biasGradData;
+    /* bias (heap shape, FLOAT32, dims {2, 1}, ndims=2 -> 2 elements). */
+    size_t *bDims = reserveMemory(2 * sizeof(size_t));
+    bDims[0] = 2;
+    bDims[1] = 1;
+    size_t *bOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, bOrder);
+    shape_t *bShape = reserveMemory(sizeof(shape_t));
+    setShape(bShape, bDims, 2, bOrder);
+    tensor_t *biasParam = initTensor(bShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(biasParam, (float[]){-1.f, 3.f}, 2);
+    /* Bug 3 fix: gradInitFloat must take biasParam (not weightParam) so the
+     * grad's shape matches bias (2 elements), not weight (3 elements). */
+    tensor_t *biasGrad = gradInitFloat(biasParam, NULL);
+    tensorFillFromFloatBuffer(biasGrad, (float[]){1.f, 3.f}, 2);
     parameter_t *bias = parameterInit(biasParam, biasGrad);
 
-    quantization_t testQ;
-    initFloat32Quantization(&testQ);
-    layer_t *linear = linearLayerInit(weights, bias, &testQ, &testQ, &testQ, &testQ);
+    layer_t *linear = linearLayerInit(weights, bias, layerQ, layerQ, layerQ, layerQ);
 
     layer_t *model[] = {linear};
     size_t modelSize = 1;
@@ -166,14 +301,27 @@ void testSGDZeroGrad() {
     optimizer_t *sgd = sgdMCreateOptim(lr, momentumFactor, weightDecay, model, modelSize, FLOAT32);
 
     sgdZeroGrad(sgd);
+
+    /* CAPTURE before frees. */
+    float capturedWGrad[3];
+    for (size_t i = 0; i < 3; i++) {
+        capturedWGrad[i] = ((float *)weights->grad->data)[i];
+    }
+    float capturedBGrad[2];
+    for (size_t i = 0; i < 2; i++) {
+        capturedBGrad[i] = ((float *)bias->grad->data)[i];
+    }
+
+    /* FREE in reverse-init order. */
+    freeOptimSgdM(sgd);
+    freeLinearLayer(linear);
+    freeQuantization(layerQ);
+
+    /* ASSERT. */
     float wGradExpected[] = {0.f, 0.f, 0.f};
     float bGradExpected[] = {0.f, 0.f};
-
-    TEST_ASSERT_EQUAL_FLOAT_ARRAY(wGradExpected, weights->grad->data,
-                                  sizeof(wGradExpected)/sizeof(float));
-    TEST_ASSERT_EQUAL_FLOAT_ARRAY(bGradExpected, bias->grad->data,
-                                  sizeof(bGradExpected)/sizeof(float));
-
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(wGradExpected, capturedWGrad, 3);
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(bGradExpected, capturedBGrad, 2);
 }
 
 int main() {


### PR DESCRIPTION
**Stack position:** `develop ← #109 ← #110 ← #111 ← #112 ← #114 ← #115 ← #116 ← #117 ← #THIS`

Stacked on #117. Per `codebase_stacked_pr_merge_trap.md`: do not merge before #117.

---

## Summary

Wave batch 5. Migrates the SGD optimizer tests AND fixes three pre-existing correctness bugs that the migration's ownership-stricter cleanup surfaces.

## Test-side changes

- `test/unit/optimizer/UnitTestSgd.c` — all three tests rewritten with post-#106 primitives and freed via the `freeOptimSgdM` cascade (no manual `freeParameter` on registered parameters, per #110 / SgdApi.c:85-93).

## Bugs fixed alongside the migration

- **Bug 1**: `testSgdMCreateOptim` reused the same `weights` and `bias` parameters across `linear0` and `linear1`, double-freeing under `freeOptimSgdM`. Fix: give `linear1` its own `weights1` / `bias1` with identical content.
- **Bug 2**: `testSGDStep` and `testSGDZeroGrad` overwrote heap-allocated `->data` pointers with stack arrays, leaking the heap buffer and making `freeTensor` UB. Fix: populate via `tensorFillFromFloatBuffer` instead of pointer reassignment.
- **Bug 3**: `testSGDZeroGrad` called `gradInitFloat(weightParam, NULL)` for `biasGrad`, producing a 3-element grad in a place that should be 2-element. The assertion only read 2 elements, masking the bug. Fix: `gradInitFloat(biasParam, NULL)`.

## CMake

- `test/unit/optimizer/CMakeLists.txt` — adds `QuantizationApi` and `StorageApi` to `MORE_LIBS` since the migrated test now references `quantizationInitFloat`, `reserveMemory`, etc. directly.

## Verification

- macOS: `UnitTestSgd` passes 3/3, zero deprecation warnings.
- LSan in `odt-lsan-recon:2026-04-22`: zero residual. ERROR SUMMARY: 0 errors. "All heap blocks were freed -- no leaks are possible".

Spec: `docs/superpowers/specs/2026-04-25-phase-2-teardown-idiom-design.md`
Plan: `docs/superpowers/plans/2026-04-27-phase-2-teardown-idiom.md`