### PR TITLE
test(#82): wave batch 6 — UnitTestTensorApi remaining + DataLoader + Deserialize

### DIFF
--- a/src/userApi/data_loader/NPYLoaderApi.c
+++ b/src/userApi/data_loader/NPYLoaderApi.c
@@ -31,6 +31,9 @@ tensorArray_t *npyLoad(char *path) {
     size_t orderOfDims[numberOfDims];
     getShapeFromHeader(&totalShape, totalDims, orderOfDims, header, numberOfDims);
 
+    /* Header is fully consumed; release before the per-tensor loop runs. */
+    freeReservedMemory(header);
+
     size_t numberOfTensors = totalShape.dimensions[0];
 
     shape_t rowShape;
@@ -87,6 +90,18 @@ sample_t *npyGetSample(dataset_t *dataset, size_t index) {
     sample->label = dataset->labels->array[index];
 
     return sample;
+}
+
+void freeTensorArray(tensorArray_t *tensorArr) {
+    /* Walk every entry and freeTensor it; freeTensor cascades to data,
+     * shape (+ dims, + order), quantization, sparsity, and the tensor
+     * struct. Then release the array buffer and the tensorArray_t struct
+     * itself, both reservedMemory-allocated by npyLoad. */
+    for (size_t i = 0; i < tensorArr->size; i++) {
+        freeTensor(tensorArr->array[i]);
+    }
+    freeReservedMemory(tensorArr->array);
+    freeReservedMemory(tensorArr);
 }
 
 static void getRowShape(shape_t *totalShape, shape_t *rowShape) {

--- a/src/userApi/data_loader/include/NPYLoaderApi.h
+++ b/src/userApi/data_loader/include/NPYLoaderApi.h
@@ -1,6 +1,8 @@
 #ifndef NPYLOADERAPI_H
 #define NPYLOADERAPI_H
 
+#include "Dataset.h"
+
 /*!
  * Loads a .npy file as a tensor array.
  *
@@ -20,4 +22,14 @@ tensorArray_t *npyLoad(char *path);
  */
 sample_t *npyGetSample(dataset_t *dataset, size_t index);
 
-#endif //NPYLOADERAPI_H
+/*!
+ * Frees a tensorArray_t allocated by npyLoad: walks the inner array,
+ * freeTensor()s every entry, then releases the array buffer and the
+ * tensorArray_t struct itself. Stack- or static-allocated tensorArray_t
+ * values must not be passed here.
+ *
+ * \param tensorArr: Pointer returned by npyLoad
+ */
+void freeTensorArray(tensorArray_t *tensorArr);
+
+#endif // NPYLOADERAPI_H

--- a/test/unit/data_loader/UnitTestDataLoader.c
+++ b/test/unit/data_loader/UnitTestDataLoader.c
@@ -1,88 +1,119 @@
+#include <stdbool.h>
 #include <stdlib.h>
 
-#include "Tensor.h"
-#include "TensorApi.h"
-#include "DataLoaderApi.h"
-#include "unity.h"
-#include "RNG.h"
 #include "DataLoader.h"
-#include "StorageApi.h"
+#include "DataLoaderApi.h"
 #include "Dataset.h"
 #include "NPYLoaderApi.h"
+#include "QuantizationApi.h"
+#include "RNG.h"
+#include "StorageApi.h"
+#include "Tensor.h"
+#include "TensorApi.h"
+#include "unity.h"
 
 #define PROXY_DATASET_SIZE 4
 #define PROXY_FEATURES 2
 
-static tensor_t *proxyItems[PROXY_DATASET_SIZE];
-static tensor_t *proxyLabels[PROXY_DATASET_SIZE];
-static tensorArray_t proxyItemsArr;
-static tensorArray_t proxyLabelsArr;
-static dataset_t proxyDataset;
-static bool proxyInit = false;
+/* Per-test fixture handle. Each test calls makeProxyDataset() at the start
+ * and freeProxyDataset() once it's captured every assertion value, in line
+ * with docs/CONVENTIONS.md "Test memory discipline" (heap-tier idiom). */
+typedef struct proxyFixture {
+    tensor_t *items[PROXY_DATASET_SIZE];
+    tensor_t *labels[PROXY_DATASET_SIZE];
+    tensorArray_t itemsArr;
+    tensorArray_t labelsArr;
+    dataset_t dataset;
+} proxyFixture_t;
 
-static void initProxyDataset() {
-    if (proxyInit) return;
+static proxyFixture_t g_proxy;
 
-    static float in0[] = {1.f, 2.f};
-    static float in1[] = {3.f, 4.f};
-    static float in2[] = {5.f, 6.f};
-    static float in3[] = {7.f, 8.f};
+static tensor_t *makeProxyTensor(const float *src, size_t count) {
+    /* Heap-tier construction per CONVENTIONS Rule 1: shape via reserveMemory,
+     * data populated by tensorFillFromFloatBuffer (caller-buffer-safe). */
+    size_t *dims = reserveMemory(2 * sizeof(size_t));
+    dims[0] = 1;
+    dims[1] = PROXY_FEATURES;
+    size_t *order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, order);
+    shape_t *shape = reserveMemory(sizeof(shape_t));
+    setShape(shape, dims, 2, order);
 
-    static float lb0[] = {0.f, 1.f};
-    static float lb1[] = {1.f, 0.f};
-    static float lb2[] = {0.f, 1.f};
-    static float lb3[] = {1.f, 0.f};
+    tensor_t *t = initTensor(shape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(t, src, count);
+    return t;
+}
 
-    static size_t inDims[] = {1, PROXY_FEATURES};
-    static size_t lbDims[] = {1, PROXY_FEATURES};
+static void makeProxyDataset(void) {
+    static const float in0[] = {1.f, 2.f};
+    static const float in1[] = {3.f, 4.f};
+    static const float in2[] = {5.f, 6.f};
+    static const float in3[] = {7.f, 8.f};
+    static const float lb0[] = {0.f, 1.f};
+    static const float lb1[] = {1.f, 0.f};
+    static const float lb2[] = {0.f, 1.f};
+    static const float lb3[] = {1.f, 0.f};
 
-    proxyItems[0] = tensorInitFloat(in0, inDims, 2, NULL);
-    proxyItems[1] = tensorInitFloat(in1, inDims, 2, NULL);
-    proxyItems[2] = tensorInitFloat(in2, inDims, 2, NULL);
-    proxyItems[3] = tensorInitFloat(in3, inDims, 2, NULL);
+    g_proxy.items[0] = makeProxyTensor(in0, PROXY_FEATURES);
+    g_proxy.items[1] = makeProxyTensor(in1, PROXY_FEATURES);
+    g_proxy.items[2] = makeProxyTensor(in2, PROXY_FEATURES);
+    g_proxy.items[3] = makeProxyTensor(in3, PROXY_FEATURES);
 
-    proxyLabels[0] = tensorInitFloat(lb0, lbDims, 2, NULL);
-    proxyLabels[1] = tensorInitFloat(lb1, lbDims, 2, NULL);
-    proxyLabels[2] = tensorInitFloat(lb2, lbDims, 2, NULL);
-    proxyLabels[3] = tensorInitFloat(lb3, lbDims, 2, NULL);
+    g_proxy.labels[0] = makeProxyTensor(lb0, PROXY_FEATURES);
+    g_proxy.labels[1] = makeProxyTensor(lb1, PROXY_FEATURES);
+    g_proxy.labels[2] = makeProxyTensor(lb2, PROXY_FEATURES);
+    g_proxy.labels[3] = makeProxyTensor(lb3, PROXY_FEATURES);
 
-    proxyItemsArr.array = proxyItems;
-    proxyItemsArr.size = PROXY_DATASET_SIZE;
-    proxyLabelsArr.array = proxyLabels;
-    proxyLabelsArr.size = PROXY_DATASET_SIZE;
+    g_proxy.itemsArr.array = g_proxy.items;
+    g_proxy.itemsArr.size = PROXY_DATASET_SIZE;
+    g_proxy.labelsArr.array = g_proxy.labels;
+    g_proxy.labelsArr.size = PROXY_DATASET_SIZE;
 
-    proxyDataset.items = &proxyItemsArr;
-    proxyDataset.labels = &proxyLabelsArr;
-    proxyInit = true;
+    g_proxy.dataset.items = &g_proxy.itemsArr;
+    g_proxy.dataset.labels = &g_proxy.labelsArr;
+}
+
+static void freeProxyDataset(void) {
+    /* Release each heap proxy tensor; the tensorArray_t and dataset_t
+     * containers themselves are stack/static (members of g_proxy) and
+     * need no free. */
+    for (size_t i = 0; i < PROXY_DATASET_SIZE; i++) {
+        freeTensor(g_proxy.items[i]);
+        freeTensor(g_proxy.labels[i]);
+    }
 }
 
 static sample_t *getProxySample(size_t id) {
     sample_t *s = reserveMemory(sizeof(sample_t));
-    s->item = proxyDataset.items->array[id];
-    s->label = proxyDataset.labels->array[id];
+    s->item = g_proxy.dataset.items->array[id];
+    s->label = g_proxy.dataset.labels->array[id];
     return s;
 }
 
-static size_t getProxyDatasetSize() {
+static size_t getProxyDatasetSize(void) {
     return PROXY_DATASET_SIZE;
 }
 
-static dataset_t npyProxyDataset;
-static bool npyProxyInit = false;
+/* NPY-backed dataset. Each test that uses it loads at start and frees with
+ * freeTensorArray (added in this batch) before exiting. */
+static dataset_t g_npyDataset;
 
-static void initNpyProxyDataset() {
-    if (npyProxyInit) return;
-    npyProxyDataset.items = npyLoad(PROXY_X_PATH);
-    npyProxyDataset.labels = npyLoad(PROXY_Y_PATH);
-    npyProxyInit = true;
+static void makeNpyDataset(void) {
+    g_npyDataset.items = npyLoad(PROXY_X_PATH);
+    g_npyDataset.labels = npyLoad(PROXY_Y_PATH);
+}
+
+static void freeNpyDataset(void) {
+    freeTensorArray(g_npyDataset.items);
+    freeTensorArray(g_npyDataset.labels);
 }
 
 static sample_t *getNpyProxySample(size_t id) {
-    return npyGetSample(&npyProxyDataset, id);
+    return npyGetSample(&g_npyDataset, id);
 }
 
-static size_t getNpyProxyDatasetSize() {
-    return npyProxyDataset.items->size;
+static size_t getNpyProxyDatasetSize(void) {
+    return g_npyDataset.items->size;
 }
 
 void setUp() {}
@@ -90,56 +121,89 @@ void setUp() {}
 void tearDown() {}
 
 void testGetSample() {
-    initProxyDataset();
+    makeProxyDataset();
 
-    dataLoader_t *dl = dataLoaderInit(getProxySample, getProxyDatasetSize, 1,
-                                      NULL, NULL, false, 0, true);
+    dataLoader_t *dl =
+        dataLoaderInit(getProxySample, getProxyDatasetSize, 1, NULL, NULL, false, 0, true);
 
     sample_t *s = dl->getSample(0);
 
-    TEST_ASSERT_EQUAL_FLOAT_ARRAY(proxyDataset.items->array[0]->data, s->item->data,
-                                  PROXY_FEATURES);
-    TEST_ASSERT_EQUAL_FLOAT_ARRAY(proxyDataset.labels->array[0]->data, s->label->data,
-                                  PROXY_FEATURES);
+    /* CAPTURE: copy data referenced by sample so we can assert after free. */
+    float capturedItem[PROXY_FEATURES];
+    float capturedLabel[PROXY_FEATURES];
+    for (size_t i = 0; i < PROXY_FEATURES; i++) {
+        capturedItem[i] = ((float *)s->item->data)[i];
+        capturedLabel[i] = ((float *)s->label->data)[i];
+    }
+    float expectedItem[PROXY_FEATURES];
+    float expectedLabel[PROXY_FEATURES];
+    for (size_t i = 0; i < PROXY_FEATURES; i++) {
+        expectedItem[i] = ((float *)g_proxy.dataset.items->array[0]->data)[i];
+        expectedLabel[i] = ((float *)g_proxy.dataset.labels->array[0]->data)[i];
+    }
 
+    /* FREE in reverse-init order. */
     freeSample(s);
     freeDataLoader(dl);
+    freeProxyDataset();
+
+    /* ASSERT on captured. */
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(expectedItem, capturedItem, PROXY_FEATURES);
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(expectedLabel, capturedLabel, PROXY_FEATURES);
 }
 
 void testGetBatch() {
-    initProxyDataset();
+    makeProxyDataset();
 
     size_t batchSize = 2;
     size_t numBatches = PROXY_DATASET_SIZE / batchSize;
-    dataLoader_t *dl = dataLoaderInit(getProxySample, getProxyDatasetSize, batchSize,
-                                      NULL, NULL, false, 0, true);
+    dataLoader_t *dl =
+        dataLoaderInit(getProxySample, getProxyDatasetSize, batchSize, NULL, NULL, false, 0, true);
+
+    /* CAPTURE: walk every batch, copy each sample's data side-by-side with
+     * the expected dataset values. Frees happen along the way (samples,
+     * batch struct) but assertions wait until everything is freed. */
+    float capturedItems[PROXY_DATASET_SIZE][PROXY_FEATURES];
+    float capturedLabels[PROXY_DATASET_SIZE][PROXY_FEATURES];
+    float expectedItems[PROXY_DATASET_SIZE][PROXY_FEATURES];
+    float expectedLabels[PROXY_DATASET_SIZE][PROXY_FEATURES];
 
     for (size_t b = 0; b < numBatches; b++) {
         batch_t *batch = dl->getBatch(dl, b);
 
         for (size_t i = 0; i < batchSize; i++) {
-            size_t sampleIndex = b * batchSize + i;
-            TEST_ASSERT_EQUAL_FLOAT_ARRAY(proxyDataset.items->array[sampleIndex]->data,
-                                          batch->samples[i]->item->data, PROXY_FEATURES);
-            TEST_ASSERT_EQUAL_FLOAT_ARRAY(proxyDataset.labels->array[sampleIndex]->data,
-                                          batch->samples[i]->label->data, PROXY_FEATURES);
+            size_t k = b * batchSize + i;
+            for (size_t f = 0; f < PROXY_FEATURES; f++) {
+                capturedItems[k][f] = ((float *)batch->samples[i]->item->data)[f];
+                capturedLabels[k][f] = ((float *)batch->samples[i]->label->data)[f];
+                expectedItems[k][f] = ((float *)g_proxy.dataset.items->array[k]->data)[f];
+                expectedLabels[k][f] = ((float *)g_proxy.dataset.labels->array[k]->data)[f];
+            }
             freeSample(batch->samples[i]);
         }
         freeBatch(batch);
     }
 
     freeDataLoader(dl);
+    freeProxyDataset();
+
+    /* ASSERT on captured. */
+    for (size_t k = 0; k < PROXY_DATASET_SIZE; k++) {
+        TEST_ASSERT_EQUAL_FLOAT_ARRAY(expectedItems[k], capturedItems[k], PROXY_FEATURES);
+        TEST_ASSERT_EQUAL_FLOAT_ARRAY(expectedLabels[k], capturedLabels[k], PROXY_FEATURES);
+    }
 }
 
 void testGetBatch_ShuffledMinibatchCoversAllSamples() {
-    initProxyDataset();
+    makeProxyDataset();
 
     size_t batchSize = 2;
     size_t numBatches = PROXY_DATASET_SIZE / batchSize;
-    dataLoader_t *dl = dataLoaderInit(getProxySample, getProxyDatasetSize, batchSize,
-                                      NULL, NULL, true, 42, true);
+    dataLoader_t *dl =
+        dataLoaderInit(getProxySample, getProxyDatasetSize, batchSize, NULL, NULL, true, 42, true);
 
-    // Collect first feature value from every sample across all batches
+    /* CAPTURE: collect first feature value from every sample across all
+     * batches; assertions wait until everything is freed. */
     float seen[PROXY_DATASET_SIZE];
     for (size_t b = 0; b < numBatches; b++) {
         batch_t *batch = dl->getBatch(dl, b);
@@ -150,8 +214,7 @@ void testGetBatch_ShuffledMinibatchCoversAllSamples() {
         freeBatch(batch);
     }
 
-    // Every original sample has a unique first feature: 1, 3, 5, 7
-    // Sort and verify all four are present (no duplicates, no zeros)
+    /* Sort the captured values so they can be compared against {1,3,5,7}. */
     for (size_t i = 0; i < PROXY_DATASET_SIZE; i++) {
         for (size_t j = i + 1; j < PROXY_DATASET_SIZE; j++) {
             if (seen[j] < seen[i]) {
@@ -162,55 +225,69 @@ void testGetBatch_ShuffledMinibatchCoversAllSamples() {
         }
     }
 
+    freeDataLoader(dl);
+    freeProxyDataset();
+
+    /* ASSERT on captured. */
     float expected[] = {1.f, 3.f, 5.f, 7.f};
     TEST_ASSERT_EQUAL_FLOAT_ARRAY(expected, seen, PROXY_DATASET_SIZE);
-
-    freeDataLoader(dl);
 }
 
 void testGetBatch_NpyBackedDataset() {
-    initProxyDataset();
-    initNpyProxyDataset();
+    makeProxyDataset();
+    makeNpyDataset();
 
-    TEST_ASSERT_EQUAL(PROXY_DATASET_SIZE, getNpyProxyDatasetSize());
+    size_t capturedNpySize = getNpyProxyDatasetSize();
 
     size_t batchSize = 2;
     size_t numBatches = PROXY_DATASET_SIZE / batchSize;
-    dataLoader_t *dl = dataLoaderInit(getNpyProxySample, getNpyProxyDatasetSize, batchSize,
-                                      NULL, NULL, false, 0, true);
+    dataLoader_t *dl = dataLoaderInit(getNpyProxySample, getNpyProxyDatasetSize, batchSize, NULL,
+                                      NULL, false, 0, true);
+
+    float capturedItems[PROXY_DATASET_SIZE][PROXY_FEATURES];
+    float capturedLabels[PROXY_DATASET_SIZE][PROXY_FEATURES];
+    float expectedItems[PROXY_DATASET_SIZE][PROXY_FEATURES];
+    float expectedLabels[PROXY_DATASET_SIZE][PROXY_FEATURES];
 
     for (size_t b = 0; b < numBatches; b++) {
         batch_t *batch = dl->getBatch(dl, b);
 
         for (size_t i = 0; i < batchSize; i++) {
-            size_t sampleIndex = b * batchSize + i;
-            TEST_ASSERT_EQUAL_FLOAT_ARRAY(proxyDataset.items->array[sampleIndex]->data,
-                                          batch->samples[i]->item->data, PROXY_FEATURES);
-            TEST_ASSERT_EQUAL_FLOAT_ARRAY(proxyDataset.labels->array[sampleIndex]->data,
-                                          batch->samples[i]->label->data, PROXY_FEATURES);
+            size_t k = b * batchSize + i;
+            for (size_t f = 0; f < PROXY_FEATURES; f++) {
+                capturedItems[k][f] = ((float *)batch->samples[i]->item->data)[f];
+                capturedLabels[k][f] = ((float *)batch->samples[i]->label->data)[f];
+                expectedItems[k][f] = ((float *)g_proxy.dataset.items->array[k]->data)[f];
+                expectedLabels[k][f] = ((float *)g_proxy.dataset.labels->array[k]->data)[f];
+            }
             freeSample(batch->samples[i]);
         }
         freeBatch(batch);
     }
 
     freeDataLoader(dl);
+    freeNpyDataset();
+    freeProxyDataset();
+
+    /* ASSERT on captured. */
+    TEST_ASSERT_EQUAL((size_t)PROXY_DATASET_SIZE, capturedNpySize);
+    for (size_t k = 0; k < PROXY_DATASET_SIZE; k++) {
+        TEST_ASSERT_EQUAL_FLOAT_ARRAY(expectedItems[k], capturedItems[k], PROXY_FEATURES);
+        TEST_ASSERT_EQUAL_FLOAT_ARRAY(expectedLabels[k], capturedLabels[k], PROXY_FEATURES);
+    }
 }
 
 void testShuffle() {
-    size_t numberOfIndices = 10;
+    /* Stack-only test: stays in the stack-only tier per CONVENTIONS Rule 1.
+     * No heap fixtures, no frees needed. Asserts directly. */
     size_t indices[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
     rngSetSeed(1);
     rngShuffleIndices(indices, 10);
 
-    /*for (size_t i = 0; i < numberOfIndices; i++) {
-        printf("%lu\n", indices[i]);
-    }*/
-
     size_t expected[] = {3, 1, 0, 2, 6, 7, 8, 5, 4, 9};
-    TEST_ASSERT_EQUAL_size_t_ARRAY(expected, indices, numberOfIndices);
+    TEST_ASSERT_EQUAL_size_t_ARRAY(expected, indices, 10);
 }
-
 
 int main() {
     UNITY_BEGIN();

--- a/test/unit/serial/CMakeLists.txt
+++ b/test/unit/serial/CMakeLists.txt
@@ -16,4 +16,12 @@ add_elastic_ai_unit_test(
         ReluApi
         Softmax
         SoftmaxApi
+
+        StorageApi
+)
+
+# Absolute scratch-file path so the test runs from any working directory
+# (host build dir vs. Docker /work, see Phase 2 LSan migration).
+target_compile_definitions(UnitTestDeserialize PRIVATE
+        SERIALIZE_TEST_FILE_PATH="${CMAKE_CURRENT_BINARY_DIR}/SerializeTestFile.bin"
 )

--- a/test/unit/serial/UnitTestDeserialize.c
+++ b/test/unit/serial/UnitTestDeserialize.c
@@ -1,78 +1,106 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include "TensorApi.h"
-#include "Tensor.h"
-#include "unity.h"
-#include "Serialize.h"
 #include "Deserialize.h"
-
-#include "QuantizationApi.h"
 #include "Linear.h"
 #include "LinearApi.h"
-#include "ReluApi.h"
-#include "SoftmaxApi.h"
+#include "QuantizationApi.h"
 #include "Relu.h"
+#include "ReluApi.h"
+#include "Serialize.h"
+#include "Softmax.h"
+#include "SoftmaxApi.h"
+#include "StorageApi.h"
+#include "Tensor.h"
+#include "TensorApi.h"
+#include "unity.h"
 
-#include <Softmax.h>
+/* SERIALIZE_TEST_FILE_PATH is injected by the CMake target_compile_definitions
+ * in test/unit/serial/CMakeLists.txt as an absolute path so the test does not
+ * depend on the working directory (which differs between host runs and Docker
+ * LSan runs). */
+#define FILE_PATH SERIALIZE_TEST_FILE_PATH
 
-#define FILE_PATH "../../../../../test/unit/serial/SerializeTestFile.bin"
+static tensor_t *makeFloatTensor2D(size_t d0, size_t d1, const float *src, size_t count) {
+    /* Heap-tier construction per CONVENTIONS Rule 1. */
+    size_t *dims = reserveMemory(2 * sizeof(size_t));
+    dims[0] = d0;
+    dims[1] = d1;
+    size_t *order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, order);
+    shape_t *shape = reserveMemory(sizeof(shape_t));
+    setShape(shape, dims, 2, order);
+
+    tensor_t *t = initTensor(shape, quantizationInitFloat(), NULL);
+    if (src != NULL) {
+        tensorFillFromFloatBuffer(t, src, count);
+    }
+    return t;
+}
 
 void testSerializeAndDeserializeTensor() {
     size_t numberOfValues = 6;
     float data[] = {9, 9, 9, 4.5f, 2.1112f, 999.123f};
-    size_t dims[] = {2, 3};
-    size_t numberOfDims = 2;
 
-    tensor_t *serialTensor = tensorInitFloat(data, dims, numberOfDims, NULL);
+    tensor_t *serialTensor = makeFloatTensor2D(2, 3, data, numberOfValues);
 
     FILE *f = fopen(FILE_PATH, "wb");
     serializeTensor(serialTensor, f);
     fclose(f);
 
-    float deserialData[6] = {0};
-    size_t deserialDims[2] = {0};
-    size_t deserialOrder[2] = {0};
-    shape_t deserialShape = {
-        .dimensions = deserialDims,
-        .numberOfDimensions = 0,
-        .orderOfDimensions = deserialOrder
-    };
-    quantization_t deserialQ;
-
-    tensor_t deserialTensor = {
-        .shape = &deserialShape,
-        .data = (uint8_t *)deserialData,
-        .sparsity = NULL,
-        .quantization = &deserialQ
-    };
+    /* Heap-allocated zero-init buffer destination via initTensor. */
+    tensor_t *deserialTensor = makeFloatTensor2D(2, 3, NULL, 0);
 
     f = fopen(FILE_PATH, "rb");
-    deserializeTensor(&deserialTensor, f);
+    deserializeTensor(deserialTensor, f);
     fclose(f);
 
-    TEST_ASSERT_EQUAL_FLOAT_ARRAY(data, deserialTensor.data, numberOfValues);
-    TEST_ASSERT_EQUAL(serialTensor->quantization->type, deserialTensor.quantization->type);
-    TEST_ASSERT_EQUAL(serialTensor->shape->numberOfDimensions,
-                      deserialTensor.shape->numberOfDimensions);
-    TEST_ASSERT_EQUAL_size_t_ARRAY(serialTensor->shape->dimensions,
-                                   deserialTensor.shape->dimensions, numberOfDims);
-    TEST_ASSERT_EQUAL_size_t_ARRAY(serialTensor->shape->orderOfDimensions,
-                                   deserialTensor.shape->orderOfDimensions, numberOfDims);
+    /* CAPTURE every assertion value before any free. */
+    float capturedDeserialData[6];
+    for (size_t i = 0; i < numberOfValues; i++) {
+        capturedDeserialData[i] = ((float *)deserialTensor->data)[i];
+    }
+    qtype_t capturedSerialQType = serialTensor->quantization->type;
+    qtype_t capturedDeserialQType = deserialTensor->quantization->type;
+    size_t capturedSerialNumDims = serialTensor->shape->numberOfDimensions;
+    size_t capturedDeserialNumDims = deserialTensor->shape->numberOfDimensions;
+
+    size_t capturedSerialDims[2];
+    size_t capturedDeserialDims[2];
+    size_t capturedSerialOrder[2];
+    size_t capturedDeserialOrder[2];
+    for (size_t i = 0; i < 2; i++) {
+        capturedSerialDims[i] = serialTensor->shape->dimensions[i];
+        capturedDeserialDims[i] = deserialTensor->shape->dimensions[i];
+        capturedSerialOrder[i] = serialTensor->shape->orderOfDimensions[i];
+        capturedDeserialOrder[i] = deserialTensor->shape->orderOfDimensions[i];
+    }
+
+    /* FREE in reverse-init order. */
+    freeTensor(deserialTensor);
+    freeTensor(serialTensor);
+
+    /* ASSERT on captured. */
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(data, capturedDeserialData, numberOfValues);
+    TEST_ASSERT_EQUAL(capturedSerialQType, capturedDeserialQType);
+    TEST_ASSERT_EQUAL(capturedSerialNumDims, capturedDeserialNumDims);
+    TEST_ASSERT_EQUAL_size_t_ARRAY(capturedSerialDims, capturedDeserialDims, 2);
+    TEST_ASSERT_EQUAL_size_t_ARRAY(capturedSerialOrder, capturedDeserialOrder, 2);
 }
 
 void testSerializeAndDeserializeModel() {
-    quantization_t *serialQ = quantizationInitFloat();
+    /* One shared layer-config quantization per side. Layer free-functions
+     * release only the wrapper, so layerQ stays alive across the layer
+     * frees and is freed once with freeQuantization at the end. */
+    quantization_t *serialLayerQ = quantizationInitFloat();
+    quantization_t *deserialLayerQ = quantizationInitFloat();
 
+    /* === Serial side: Linear (20 x 28*28) -> ReLU -> Linear (10 x 20) -> Softmax === */
     float serialWeight0Data[20 * 28 * 28];
     for (size_t i = 0; i < 28 * 28 * 20; i++) {
-        serialWeight0Data[i] = (float) i;
+        serialWeight0Data[i] = (float)i;
     }
-
-    size_t serialWeight0Dims[] = {20, 28 * 28};
-    size_t serialWeight0NumberOfDims = 2;
-    tensor_t *serialWeight0Param = tensorInitFloat(serialWeight0Data, serialWeight0Dims,
-                                                   serialWeight0NumberOfDims, NULL);
+    tensor_t *serialWeight0Param = makeFloatTensor2D(20, 28 * 28, serialWeight0Data, 20 * 28 * 28);
     tensor_t *serialWeight0Grad = gradInitFloat(serialWeight0Param, NULL);
     parameter_t *serialWeight0 = parameterInit(serialWeight0Param, serialWeight0Grad);
 
@@ -80,26 +108,19 @@ void testSerializeAndDeserializeModel() {
     for (size_t i = 0; i < 20; i++) {
         serialBias0Data[i] = (float)i;
     }
-    size_t serialBias0Dims[] = {1, 20};
-    size_t serialBias0NumberOfDims = 2;
-    tensor_t *serialBias0Param = tensorInitFloat(serialBias0Data, serialBias0Dims,
-                                                 serialBias0NumberOfDims, NULL);
+    tensor_t *serialBias0Param = makeFloatTensor2D(1, 20, serialBias0Data, 20);
     tensor_t *serialBias0Grad = gradInitFloat(serialBias0Param, NULL);
     parameter_t *serialBias0 = parameterInit(serialBias0Param, serialBias0Grad);
 
-    layer_t *serialLinear0 = linearLayerInit(serialWeight0, serialBias0, serialQ, serialQ, serialQ,
-                                             serialQ);
-
-    layer_t *serialRelu = reluLayerInit(serialQ, serialQ);
+    layer_t *serialLinear0 = linearLayerInit(serialWeight0, serialBias0, serialLayerQ, serialLayerQ,
+                                             serialLayerQ, serialLayerQ);
+    layer_t *serialRelu = reluLayerInit(serialLayerQ, serialLayerQ);
 
     float serialWeight1Data[10 * 20];
     for (size_t i = 0; i < 10 * 20; i++) {
         serialWeight1Data[i] = (float)i;
     }
-    size_t serialWeight1Dims[] = {10, 20};
-    size_t serialWeight1NumberOfDims = 2;
-    tensor_t *serialWeight1Param = tensorInitFloat(serialWeight1Data, serialWeight1Dims,
-                                                   serialWeight1NumberOfDims, NULL);
+    tensor_t *serialWeight1Param = makeFloatTensor2D(10, 20, serialWeight1Data, 10 * 20);
     tensor_t *serialWeight1Grad = gradInitFloat(serialWeight1Param, NULL);
     parameter_t *serialWeight1 = parameterInit(serialWeight1Param, serialWeight1Grad);
 
@@ -107,17 +128,13 @@ void testSerializeAndDeserializeModel() {
     for (size_t i = 0; i < 10; i++) {
         serialBias1Data[i] = (float)i;
     }
-    size_t serialBias1Dims[] = {1, 10};
-    size_t serialBias1NumberOfDims = 2;
-    tensor_t *serialBias1Param = tensorInitFloat(serialBias1Data, serialBias1Dims,
-                                                 serialBias1NumberOfDims, NULL);
+    tensor_t *serialBias1Param = makeFloatTensor2D(1, 10, serialBias1Data, 10);
     tensor_t *serialBias1Grad = gradInitFloat(serialBias1Param, NULL);
     parameter_t *serialBias1 = parameterInit(serialBias1Param, serialBias1Grad);
 
-    layer_t *serialLinear1 = linearLayerInit(serialWeight1, serialBias1, serialQ, serialQ, serialQ,
-                                             serialQ);
-
-    layer_t *serialSoftmax = softmaxLayerInit(serialQ, serialQ);
+    layer_t *serialLinear1 = linearLayerInit(serialWeight1, serialBias1, serialLayerQ, serialLayerQ,
+                                             serialLayerQ, serialLayerQ);
+    layer_t *serialSoftmax = softmaxLayerInit(serialLayerQ, serialLayerQ);
 
     layer_t *serialModel[] = {serialLinear0, serialRelu, serialLinear1, serialSoftmax};
     size_t sizeModel = 4;
@@ -126,50 +143,30 @@ void testSerializeAndDeserializeModel() {
     serializeModel(serialModel, sizeModel, f);
     fclose(f);
 
-    quantization_t deserialQ;
-
-    float deserialWeight0Data[20 * 28 * 28] = {0};
-    size_t deserialWeight0Dims[] = {20, 28 * 28};
-    size_t deserialWeight0NumberOfDims = 2;
-    tensor_t *deserialWeight0Param = tensorInitFloat(deserialWeight0Data, deserialWeight0Dims,
-                                                     deserialWeight0NumberOfDims, NULL);
+    /* === Deserial side: zero-init mirror with the same layer topology. === */
+    tensor_t *deserialWeight0Param = makeFloatTensor2D(20, 28 * 28, NULL, 0);
     tensor_t *deserialWeight0Grad = gradInitFloat(deserialWeight0Param, NULL);
     parameter_t *deserialWeight0 = parameterInit(deserialWeight0Param, deserialWeight0Grad);
 
-    float deserialBias0Data[20] = {0};
-    size_t deserialBias0Dims[] = {1, 20};
-    size_t deserialBias0NumberOfDims = 2;
-    tensor_t *deserialBias0Param = tensorInitFloat(deserialBias0Data, deserialBias0Dims,
-                                                   deserialBias0NumberOfDims, NULL);
+    tensor_t *deserialBias0Param = makeFloatTensor2D(1, 20, NULL, 0);
     tensor_t *deserialBias0Grad = gradInitFloat(deserialBias0Param, NULL);
     parameter_t *deserialBias0 = parameterInit(deserialBias0Param, deserialBias0Grad);
 
-    layer_t *deserialLinear0 = linearLayerInit(deserialWeight0, deserialBias0, &deserialQ,
-                                               &deserialQ,
-                                               &deserialQ, &deserialQ);
+    layer_t *deserialLinear0 = linearLayerInit(deserialWeight0, deserialBias0, deserialLayerQ,
+                                               deserialLayerQ, deserialLayerQ, deserialLayerQ);
+    layer_t *deserialRelu = reluLayerInit(deserialLayerQ, deserialLayerQ);
 
-    layer_t *deserialRelu = reluLayerInit(&deserialQ, &deserialQ);
-
-    float deserialWeight1Data[10 * 20] = {0};
-    size_t deserialWeight1Dims[] = {10, 20};
-    size_t deserialWeight1NumberOfDims = 2;
-    tensor_t *deserialWeight1Param = tensorInitFloat(deserialWeight1Data, deserialWeight1Dims,
-                                                     deserialWeight1NumberOfDims, NULL);
+    tensor_t *deserialWeight1Param = makeFloatTensor2D(10, 20, NULL, 0);
     tensor_t *deserialWeight1Grad = gradInitFloat(deserialWeight1Param, NULL);
     parameter_t *deserialWeight1 = parameterInit(deserialWeight1Param, deserialWeight1Grad);
 
-    float deserialBias1Data[10] = {0};
-    size_t deserialBias1Dims[] = {1, 10};
-    size_t deserialBias1NumberOfDims = 2;
-    tensor_t *deserialBias1Param = tensorInitFloat(deserialBias1Data, deserialBias1Dims,
-                                                   deserialBias1NumberOfDims, NULL);
+    tensor_t *deserialBias1Param = makeFloatTensor2D(1, 10, NULL, 0);
     tensor_t *deserialBias1Grad = gradInitFloat(deserialBias1Param, NULL);
     parameter_t *deserialBias1 = parameterInit(deserialBias1Param, deserialBias1Grad);
 
-    layer_t *deserialLinear1 = linearLayerInit(deserialWeight1, deserialBias1, &deserialQ,
-                                               &deserialQ, &deserialQ, &deserialQ);
-
-    layer_t *deserialSoftmax = softmaxLayerInit(&deserialQ, &deserialQ);
+    layer_t *deserialLinear1 = linearLayerInit(deserialWeight1, deserialBias1, deserialLayerQ,
+                                               deserialLayerQ, deserialLayerQ, deserialLayerQ);
+    layer_t *deserialSoftmax = softmaxLayerInit(deserialLayerQ, deserialLayerQ);
 
     layer_t *deserialModel[] = {deserialLinear0, deserialRelu, deserialLinear1, deserialSoftmax};
 
@@ -177,56 +174,127 @@ void testSerializeAndDeserializeModel() {
     deserializeModel(deserialModel, sizeModel, f);
     fclose(f);
 
-    size_t numberOfWeights0 = calcNumberOfElementsByTensor(
-        serialModel[0]->config->linear->weights->param);
-    float *serialLinear0Weights = (float *)serialModel[0]->config->linear->weights->param->data;
-    float *deserialLinear0Weights = (float *)deserialModel[0]->config->linear->weights->param->data;
-    TEST_ASSERT_EQUAL_FLOAT_ARRAY(serialLinear0Weights, deserialLinear0Weights, numberOfWeights0);
+    /* CAPTURE every assertion value before any free. */
+    size_t numberOfWeights0 =
+        calcNumberOfElementsByTensor(serialModel[0]->config->linear->weights->param);
+    size_t numberOfBiases0 =
+        calcNumberOfElementsByTensor(serialModel[0]->config->linear->bias->param);
+    size_t numberOfWeights1 =
+        calcNumberOfElementsByTensor(serialModel[2]->config->linear->weights->param);
+    size_t numberOfBiases1 =
+        calcNumberOfElementsByTensor(serialModel[2]->config->linear->bias->param);
 
-    size_t numberOfBiases0 = calcNumberOfElementsByTensor(
-        serialModel[0]->config->linear->bias->param);
-    float *serialLinear0Biases = (float *)serialModel[0]->config->linear->bias->param->data;
-    float *deserialLinear0Biases = (float *)deserialModel[0]->config->linear->bias->param->data;
-    TEST_ASSERT_EQUAL_FLOAT_ARRAY(serialLinear0Biases, deserialLinear0Biases, numberOfBiases0);
+    /* Capture weight/bias arrays into heap buffers (sizes vary per layer). */
+    float *capturedSerialW0 = reserveMemory(numberOfWeights0 * sizeof(float));
+    float *capturedDeserialW0 = reserveMemory(numberOfWeights0 * sizeof(float));
+    float *capturedSerialB0 = reserveMemory(numberOfBiases0 * sizeof(float));
+    float *capturedDeserialB0 = reserveMemory(numberOfBiases0 * sizeof(float));
+    float *capturedSerialW1 = reserveMemory(numberOfWeights1 * sizeof(float));
+    float *capturedDeserialW1 = reserveMemory(numberOfWeights1 * sizeof(float));
+    float *capturedSerialB1 = reserveMemory(numberOfBiases1 * sizeof(float));
+    float *capturedDeserialB1 = reserveMemory(numberOfBiases1 * sizeof(float));
 
-    TEST_ASSERT_EQUAL(serialModel[0]->config->linear->forwardQ->type,
-                      deserialModel[0]->config->linear->forwardQ->type);
-    TEST_ASSERT_EQUAL(serialModel[0]->config->linear->weightGradQ->type,
-                      deserialModel[0]->config->linear->weightGradQ->type);
-    TEST_ASSERT_EQUAL(serialModel[0]->config->linear->biasGradQ->type,
-                      deserialModel[0]->config->linear->biasGradQ->type);
-    TEST_ASSERT_EQUAL(serialModel[0]->config->linear->propLossQ->type,
-                      deserialModel[0]->config->linear->propLossQ->type);
+    for (size_t i = 0; i < numberOfWeights0; i++) {
+        capturedSerialW0[i] = ((float *)serialModel[0]->config->linear->weights->param->data)[i];
+        capturedDeserialW0[i] =
+            ((float *)deserialModel[0]->config->linear->weights->param->data)[i];
+    }
+    for (size_t i = 0; i < numberOfBiases0; i++) {
+        capturedSerialB0[i] = ((float *)serialModel[0]->config->linear->bias->param->data)[i];
+        capturedDeserialB0[i] = ((float *)deserialModel[0]->config->linear->bias->param->data)[i];
+    }
+    for (size_t i = 0; i < numberOfWeights1; i++) {
+        capturedSerialW1[i] = ((float *)serialModel[2]->config->linear->weights->param->data)[i];
+        capturedDeserialW1[i] =
+            ((float *)deserialModel[2]->config->linear->weights->param->data)[i];
+    }
+    for (size_t i = 0; i < numberOfBiases1; i++) {
+        capturedSerialB1[i] = ((float *)serialModel[2]->config->linear->bias->param->data)[i];
+        capturedDeserialB1[i] = ((float *)deserialModel[2]->config->linear->bias->param->data)[i];
+    }
 
-    TEST_ASSERT_EQUAL(serialModel[1]->config->relu->forwardQ->type,
-                      deserialModel[1]->config->relu->forwardQ->type);
-    TEST_ASSERT_EQUAL(serialModel[1]->config->relu->backwardQ->type,
-                      deserialModel[1]->config->relu->backwardQ->type);
+    qtype_t capturedSerialL0FwdQ = serialModel[0]->config->linear->forwardQ->type;
+    qtype_t capturedDeserialL0FwdQ = deserialModel[0]->config->linear->forwardQ->type;
+    qtype_t capturedSerialL0WGQ = serialModel[0]->config->linear->weightGradQ->type;
+    qtype_t capturedDeserialL0WGQ = deserialModel[0]->config->linear->weightGradQ->type;
+    qtype_t capturedSerialL0BGQ = serialModel[0]->config->linear->biasGradQ->type;
+    qtype_t capturedDeserialL0BGQ = deserialModel[0]->config->linear->biasGradQ->type;
+    qtype_t capturedSerialL0PLQ = serialModel[0]->config->linear->propLossQ->type;
+    qtype_t capturedDeserialL0PLQ = deserialModel[0]->config->linear->propLossQ->type;
 
-    size_t numberOfWeights1 = calcNumberOfElementsByTensor(
-    serialModel[2]->config->linear->weights->param);
-    float *serialLinear1Weights = (float *)serialModel[2]->config->linear->weights->param->data;
-    float *deserialLinear1Weights = (float *)deserialModel[2]->config->linear->weights->param->data;
-    TEST_ASSERT_EQUAL_FLOAT_ARRAY(serialLinear1Weights, deserialLinear1Weights, numberOfWeights1);
+    qtype_t capturedSerialReluFwdQ = serialModel[1]->config->relu->forwardQ->type;
+    qtype_t capturedDeserialReluFwdQ = deserialModel[1]->config->relu->forwardQ->type;
+    qtype_t capturedSerialReluBwdQ = serialModel[1]->config->relu->backwardQ->type;
+    qtype_t capturedDeserialReluBwdQ = deserialModel[1]->config->relu->backwardQ->type;
 
-    size_t numberOfBiases1 = calcNumberOfElementsByTensor(
-        serialModel[2]->config->linear->bias->param);
-    float *serialLinear1Biases = (float *)serialModel[2]->config->linear->bias->param->data;
-    float *deserialLinear1Biases = (float *)deserialModel[2]->config->linear->bias->param->data;
-    TEST_ASSERT_EQUAL_FLOAT_ARRAY(serialLinear1Biases, deserialLinear1Biases, numberOfBiases1);
+    qtype_t capturedSerialL1FwdQ = serialModel[2]->config->linear->forwardQ->type;
+    qtype_t capturedDeserialL1FwdQ = deserialModel[2]->config->linear->forwardQ->type;
+    qtype_t capturedSerialL1WGQ = serialModel[2]->config->linear->weightGradQ->type;
+    qtype_t capturedDeserialL1WGQ = deserialModel[2]->config->linear->weightGradQ->type;
+    qtype_t capturedSerialL1BGQ = serialModel[2]->config->linear->biasGradQ->type;
+    qtype_t capturedDeserialL1BGQ = deserialModel[2]->config->linear->biasGradQ->type;
+    qtype_t capturedSerialL1PLQ = serialModel[2]->config->linear->propLossQ->type;
+    qtype_t capturedDeserialL1PLQ = deserialModel[2]->config->linear->propLossQ->type;
 
-    TEST_ASSERT_EQUAL(serialModel[2]->config->linear->forwardQ->type,
-                      deserialModel[2]->config->linear->forwardQ->type);
-    TEST_ASSERT_EQUAL(serialModel[2]->config->linear->weightGradQ->type,
-                      deserialModel[2]->config->linear->weightGradQ->type);
-    TEST_ASSERT_EQUAL(serialModel[2]->config->linear->biasGradQ->type,
-                      deserialModel[2]->config->linear->biasGradQ->type);
-    TEST_ASSERT_EQUAL(serialModel[2]->config->linear->propLossQ->type,
-                      deserialModel[2]->config->linear->propLossQ->type);
+    qtype_t capturedSerialSoftFwdQ = serialModel[3]->config->softmax->forwardQ->type;
+    qtype_t capturedDeserialSoftFwdQ = deserialModel[3]->config->softmax->forwardQ->type;
+    qtype_t capturedSerialSoftBwdQ = serialModel[3]->config->softmax->backwardQ->type;
+    qtype_t capturedDeserialSoftBwdQ = deserialModel[3]->config->softmax->backwardQ->type;
 
+    /* FREE in reverse-init order. Layer free-functions release only the
+     * wrapper; parameters and the shared layerQ are caller-managed (per
+     * docs/CONVENTIONS.md "Test memory discipline"). */
+    freeSoftmaxLayer(deserialSoftmax);
+    freeLinearLayer(deserialLinear1);
+    freeParameter(deserialBias1);
+    freeParameter(deserialWeight1);
+    freeReluLayer(deserialRelu);
+    freeLinearLayer(deserialLinear0);
+    freeParameter(deserialBias0);
+    freeParameter(deserialWeight0);
+    freeQuantization(deserialLayerQ);
 
-    TEST_ASSERT_EQUAL(serialModel[3]->config->softmax->forwardQ->type, deserialModel[3]->config->softmax->forwardQ->type);
-    TEST_ASSERT_EQUAL(serialModel[3]->config->softmax->backwardQ->type, deserialModel[3]->config->softmax->backwardQ->type);
+    freeSoftmaxLayer(serialSoftmax);
+    freeLinearLayer(serialLinear1);
+    freeParameter(serialBias1);
+    freeParameter(serialWeight1);
+    freeReluLayer(serialRelu);
+    freeLinearLayer(serialLinear0);
+    freeParameter(serialBias0);
+    freeParameter(serialWeight0);
+    freeQuantization(serialLayerQ);
+
+    /* ASSERT on captured. */
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(capturedSerialW0, capturedDeserialW0, numberOfWeights0);
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(capturedSerialB0, capturedDeserialB0, numberOfBiases0);
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(capturedSerialW1, capturedDeserialW1, numberOfWeights1);
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(capturedSerialB1, capturedDeserialB1, numberOfBiases1);
+
+    TEST_ASSERT_EQUAL(capturedSerialL0FwdQ, capturedDeserialL0FwdQ);
+    TEST_ASSERT_EQUAL(capturedSerialL0WGQ, capturedDeserialL0WGQ);
+    TEST_ASSERT_EQUAL(capturedSerialL0BGQ, capturedDeserialL0BGQ);
+    TEST_ASSERT_EQUAL(capturedSerialL0PLQ, capturedDeserialL0PLQ);
+
+    TEST_ASSERT_EQUAL(capturedSerialReluFwdQ, capturedDeserialReluFwdQ);
+    TEST_ASSERT_EQUAL(capturedSerialReluBwdQ, capturedDeserialReluBwdQ);
+
+    TEST_ASSERT_EQUAL(capturedSerialL1FwdQ, capturedDeserialL1FwdQ);
+    TEST_ASSERT_EQUAL(capturedSerialL1WGQ, capturedDeserialL1WGQ);
+    TEST_ASSERT_EQUAL(capturedSerialL1BGQ, capturedDeserialL1BGQ);
+    TEST_ASSERT_EQUAL(capturedSerialL1PLQ, capturedDeserialL1PLQ);
+
+    TEST_ASSERT_EQUAL(capturedSerialSoftFwdQ, capturedDeserialSoftFwdQ);
+    TEST_ASSERT_EQUAL(capturedSerialSoftBwdQ, capturedDeserialSoftBwdQ);
+
+    /* Release the assertion-buffer scratch space last. */
+    freeReservedMemory(capturedSerialW0);
+    freeReservedMemory(capturedDeserialW0);
+    freeReservedMemory(capturedSerialB0);
+    freeReservedMemory(capturedDeserialB0);
+    freeReservedMemory(capturedSerialW1);
+    freeReservedMemory(capturedDeserialW1);
+    freeReservedMemory(capturedSerialB1);
+    freeReservedMemory(capturedDeserialB1);
 }
 
 void setUp() {}

--- a/test/unit/tensor/UnitTestTensorApi.c
+++ b/test/unit/tensor/UnitTestTensorApi.c
@@ -34,82 +34,102 @@ _Static_assert(_Generic((&tensorFillFromFloatBuffer),
 void setUp() {}
 void tearDown() {}
 
+/* Forward decl for the file-local factory (definition further down). */
+static tensor_t *makeFloatTensorForDistTest(size_t d0, size_t d1);
+
 void testTensorInitWithDistribution_Zeros_InitializesProductOfDimsValues() {
-    // dims = {2, 5} → product = 10, sum = 7
-    // Bug: += gives 7, *= gives 10
-    // Fill data with sentinel 42.0f, then ZEROS should overwrite exactly 10 values
-    float data[10];
+    /* dims = {2, 5} -> product = 10, sum = 7. Pre-fill with sentinel 42.0f,
+     * then ZEROS should overwrite exactly 10 values (loop bound = product,
+     * not sum). */
+    tensor_t *t = makeFloatTensorForDistTest(2, 5);
+    float *vals = (float *)t->data;
     for (size_t i = 0; i < 10; i++) {
-        data[i] = 42.0f;
+        vals[i] = 42.0f;
     }
-    size_t dims[] = {2, 5};
-    quantization_t q;
-    initFloat32Quantization(&q);
 
-    tensor_t *t = tensorInitWithDistribution(ZEROS, data, dims, 2, &q, NULL, 2, 5);
+    distribution_t d = {.type = ZEROS};
+    initDistribution(t, &d);
 
-    // All 10 values should be zero
-    float *values = (float *)t->data;
+    /* CAPTURE before free. */
+    float captured[10];
     for (size_t i = 0; i < 10; i++) {
-        TEST_ASSERT_FLOAT_WITHIN(1e-9f, 0.0f, values[i]);
+        captured[i] = vals[i];
+    }
+    freeTensor(t);
+
+    /* ASSERT on captured. */
+    for (size_t i = 0; i < 10; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(1e-9f, 0.0f, captured[i]);
     }
 }
 
 void testTensorInitWithDistribution_Ones_InitializesAllValues() {
-    // dims = {3, 4} → product = 12, sum = 7
-    // Fill data with 0.0f, then ONES should set exactly 12 values to 1.0f
-    float data[12];
-    memset(data, 0, sizeof(data));
-    size_t dims[] = {3, 4};
-    quantization_t q;
-    initFloat32Quantization(&q);
-
-    tensor_t *t = tensorInitWithDistribution(ONES, data, dims, 2, &q, NULL, 3, 4);
-
-    float *values = (float *)t->data;
+    /* dims = {3, 4} -> product = 12. Pre-fill with 0.0f, then ONES sets all
+     * 12 values to 1.0f. */
+    tensor_t *t = makeFloatTensorForDistTest(3, 4);
+    float *vals = (float *)t->data;
+    /* initTensor zero-initializes data; explicit pre-fill kept for clarity. */
     for (size_t i = 0; i < 12; i++) {
-        TEST_ASSERT_FLOAT_WITHIN(1e-9f, 1.0f, values[i]);
+        vals[i] = 0.0f;
+    }
+
+    distribution_t d = {.type = ONES};
+    initDistribution(t, &d);
+
+    /* CAPTURE. */
+    float captured[12];
+    for (size_t i = 0; i < 12; i++) {
+        captured[i] = vals[i];
+    }
+    freeTensor(t);
+
+    /* ASSERT. */
+    for (size_t i = 0; i < 12; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(1e-9f, 1.0f, captured[i]);
     }
 }
 
 void testTensorInitWithDistribution_Normal_InitializesAllValues() {
-    // dims = {4, 5} → product = 20, sum = 9
-    // If only 9 values are initialized, remaining 11 stay at sentinel
-    float data[20];
+    /* dims = {4, 5} -> product = 20, sum = 9. If the loop runs sum-many
+     * iterations only, the trailing 11 values stay at sentinel. */
+    tensor_t *t = makeFloatTensorForDistTest(4, 5);
+    float *vals = (float *)t->data;
     float sentinel = -999.0f;
     for (size_t i = 0; i < 20; i++) {
-        data[i] = sentinel;
+        vals[i] = sentinel;
     }
-    size_t dims[] = {4, 5};
-    quantization_t q;
-    initFloat32Quantization(&q);
 
-    tensor_t *t = tensorInitWithDistribution(NORMAL, data, dims, 2, &q, NULL, 4, 5);
+    distribution_t d = {.type = NORMAL, .params.normal = {0.0f, 0.01f}};
+    initDistribution(t, &d);
 
-    // With NORMAL distribution, values should NOT be the sentinel
-    float *values = (float *)t->data;
+    /* CAPTURE the derived sentinel count. */
     size_t sentinelCount = 0;
     for (size_t i = 0; i < 20; i++) {
-        if (values[i] == sentinel) {
+        if (vals[i] == sentinel) {
             sentinelCount++;
         }
     }
-    // All 20 values should have been overwritten — none should remain as sentinel
+    freeTensor(t);
+
+    /* ASSERT on captured. */
     TEST_ASSERT_EQUAL_UINT(0, sentinelCount);
 }
 
 void testTensorInitWithDistribution_ShapeIsCorrect() {
-    // Verify the resulting tensor has the correct shape dimensions
-    float data[6] = {0};
-    size_t dims[] = {2, 3};
-    quantization_t q;
-    initFloat32Quantization(&q);
+    /* Verify the resulting tensor has the correct shape dimensions after
+     * initDistribution runs. */
+    tensor_t *t = makeFloatTensorForDistTest(2, 3);
+    distribution_t d = {.type = ZEROS};
+    initDistribution(t, &d);
 
-    tensor_t *t = tensorInitWithDistribution(ZEROS, data, dims, 2, &q, NULL, 2, 3);
+    /* CAPTURE shape data before free. */
+    size_t capturedNumDims = t->shape->numberOfDimensions;
+    size_t capturedNumElements = calcNumberOfElementsByTensor(t);
+    freeTensor(t);
 
-    TEST_ASSERT_EQUAL_UINT(2, t->shape->numberOfDimensions);
-    size_t numElements = calcNumberOfElementsByTensor(t);
-    TEST_ASSERT_EQUAL_UINT(6, numElements);
+    /* ASSERT on captured. */
+    TEST_ASSERT_EQUAL_UINT(2, capturedNumDims);
+    TEST_ASSERT_EQUAL_UINT(6, capturedNumElements);
 }
 
 static tensor_t *makeFloatTensorForDistTest(size_t d0, size_t d1) {


### PR DESCRIPTION
**Stack position:** `develop ← #109 ← #110 ← #111 ← #112 ← #114 ← #115 ← #116 ← #117 ← #118 ← #THIS`

Stacked on #118. Per `codebase_stacked_pr_merge_trap.md`: do not merge before #118.

---

## Summary

Wave batch 6. Three test files migrated to the Phase 2 explicit-free + assert-last idiom.

## Test-side changes

- `test/unit/tensor/UnitTestTensorApi.c`: 4 `testTensorInitWithDistribution_*` tests rewritten with `initTensor + initDistribution` via the existing `makeFloatTensorForDistTest` factory. The `testInitDistribution_*` tests (already migrated in #111) and the H1/H2/H3 regression tests are unchanged.
- `test/unit/data_loader/UnitTestDataLoader.c`: 5 tests rewritten with post-#106 primitives for proxy tensors via a per-test `makeProxyDataset`/`freeProxyDataset` fixture; existing `freeSample`/`freeBatch`/`freeDataLoader` chain preserved; assertions captured-then-asserted last. NPY-backed test now calls the new `freeNpyDataset` to release the loader's `tensorArray_t` containers.
- `test/unit/serial/UnitTestDeserialize.c`: both serialize/deserialize tests rewritten with post-#106 primitives; per-parameter `freeParameter` cleanup; per-side shared `quantizationInitFloat()` `layerQ` released with `freeQuantization`; FILE handles closed.

## Standing-rule production-side bundle

- `src/userApi/data_loader/include/NPYLoaderApi.h` + `.c`: add `freeTensorArray`, the symmetric counterpart of `npyLoad`. Without it, every NPY-backed dataset leaked the entire `tensorArray_t` (struct + pointer-array + every loaded tensor).
- `src/userApi/data_loader/NPYLoaderApi.c`: `npyLoad` now releases the header buffer the moment it has been consumed by `getDTypeFromHeader`/`getNumberOfDimsFromHeader`/`getShapeFromHeader`. Pre-existing 119-byte/per-call leak that surfaced under valgrind once the test layer was fully closed.

## Test infra bundle

- `test/unit/serial/CMakeLists.txt`: injects `SERIALIZE_TEST_FILE_PATH` (absolute, `CMAKE_CURRENT_BINARY_DIR`-relative) so the test runs from any working directory; this lets `valgrind-in-Docker` run from `/work` without breaking the relative path the source previously used. Also adds `StorageApi` to `MORE_LIBS` for the new `reserveMemory`-driven fixtures.

## Verification

- macOS: all three binaries pass all tests, zero deprecation warnings. Full `ctest --preset unit_test_debug` green (32/32).
- LSan in `odt-lsan-recon:2026-04-22`: zero residual on all three files ("All heap blocks were freed -- no leaks are possible", ERROR SUMMARY 0).

Spec: `docs/superpowers/specs/2026-04-25-phase-2-teardown-idiom-design.md`
Plan: `docs/superpowers/plans/2026-04-27-phase-2-teardown-idiom.md`