### PR TITLE
test(#82): wave batch 7a — migrate UnitTestMnistSmoke + close trainingRun sample leaks

### DIFF
--- a/src/userApi/training_loop/TrainingLoopApi.c
+++ b/src/userApi/training_loop/TrainingLoopApi.c
@@ -2,15 +2,14 @@
 
 #include <stddef.h>
 
-#include "TrainingLoopApi.h"
-#include "TrainingEpochDefault.h"
-#include "InferenceApi.h"
-#include "TensorApi.h"
-#include "StorageApi.h"
 #include "Common.h"
 #include "DataLoaderApi.h"
+#include "InferenceApi.h"
 #include "Optimizer.h"
-
+#include "StorageApi.h"
+#include "TensorApi.h"
+#include "TrainingEpochDefault.h"
+#include "TrainingLoopApi.h"
 
 void freeTrainingStats(trainingStats_t *trainingStats) {
     freeTensor(trainingStats->output);
@@ -22,11 +21,11 @@ float evaluationBatch(layer_t **model, size_t modelSize, lossType_t lossType, ba
     float totalLoss = 0.0f;
 
     for (size_t i = 0; i < batch->size; i++) {
-        inferenceStats_t *stats =
-            inferenceFn(model, modelSize, batch->samples[i]->item, batch->samples[i]->label,
-                        lossType);
+        inferenceStats_t *stats = inferenceFn(model, modelSize, batch->samples[i]->item,
+                                              batch->samples[i]->label, lossType);
         totalLoss += stats->loss;
         freeInferenceStats(stats);
+        freeSample(batch->samples[i]);
     }
 
     return totalLoss / (float)batch->size;
@@ -61,15 +60,14 @@ float evaluationEpoch(layer_t **model, size_t modelSize, lossType_t lossType,
 }
 
 static float evaluateBatchInternal(layer_t **model, size_t modelSize, lossType_t lossType,
-                                    batch_t *batch, inferenceWithLossFn_t inferenceFn,
-                                    size_t *tp, size_t *predCount, size_t *actualCount,
-                                    size_t *confusionMatrix, size_t numClasses) {
+                                   batch_t *batch, inferenceWithLossFn_t inferenceFn, size_t *tp,
+                                   size_t *predCount, size_t *actualCount, size_t *confusionMatrix,
+                                   size_t numClasses) {
     float totalLoss = 0.0f;
 
     for (size_t i = 0; i < batch->size; i++) {
-        inferenceStats_t *stats =
-            inferenceFn(model, modelSize, batch->samples[i]->item, batch->samples[i]->label,
-                        lossType);
+        inferenceStats_t *stats = inferenceFn(model, modelSize, batch->samples[i]->item,
+                                              batch->samples[i]->label, lossType);
         totalLoss += stats->loss;
 
         float *outputData = (float *)stats->output->data;
@@ -77,7 +75,9 @@ static float evaluateBatchInternal(layer_t **model, size_t modelSize, lossType_t
         size_t predicted = argmax(outputData, numClasses);
         size_t target = argmax(labelData, numClasses);
 
-        if (predicted == target) tp[predicted]++;
+        if (predicted == target) {
+            tp[predicted]++;
+        }
         predCount[predicted]++;
         actualCount[target]++;
 
@@ -86,6 +86,7 @@ static float evaluateBatchInternal(layer_t **model, size_t modelSize, lossType_t
         }
 
         freeInferenceStats(stats);
+        freeSample(batch->samples[i]);
     }
 
     return totalLoss / (float)batch->size;
@@ -120,7 +121,7 @@ static float computeMacroRecall(const size_t *tp, const size_t *actualCount, siz
 }
 
 static float computeMacroF1(const size_t *tp, const size_t *predCount, const size_t *actualCount,
-                             size_t numClasses) {
+                            size_t numClasses) {
     float sum = 0.0f;
     for (size_t c = 0; c < numClasses; c++) {
         float prec = (predCount[c] > 0) ? (float)tp[c] / (float)predCount[c] : 0.0f;
@@ -133,9 +134,9 @@ static float computeMacroF1(const size_t *tp, const size_t *predCount, const siz
 }
 
 static epochStats_t evaluateEpochInternal(layer_t **model, size_t modelSize, lossType_t lossType,
-                                           dataLoader_t *dataLoader,
-                                           inferenceWithLossFn_t inferenceFn,
-                                           size_t *confusionMatrix, size_t numClasses) {
+                                          dataLoader_t *dataLoader,
+                                          inferenceWithLossFn_t inferenceFn,
+                                          size_t *confusionMatrix, size_t numClasses) {
     size_t datasetSize = dataLoader->getDatasetSize();
     size_t numberOfBatches = datasetSize / dataLoader->batchSize;
 
@@ -154,9 +155,8 @@ static epochStats_t evaluateEpochInternal(layer_t **model, size_t modelSize, los
 
     for (size_t i = 0; i < numberOfBatches; i++) {
         batch_t *batch = dataLoader->getBatch(dataLoader, i);
-        totalLoss += evaluateBatchInternal(model, modelSize, lossType, batch, inferenceFn,
-                                            tp, predCount, actualCount, confusionMatrix,
-                                            numClasses);
+        totalLoss += evaluateBatchInternal(model, modelSize, lossType, batch, inferenceFn, tp,
+                                           predCount, actualCount, confusionMatrix, numClasses);
         totalSamples += batch->size;
         freeBatch(batch);
     }
@@ -181,17 +181,19 @@ epochStats_t evaluationEpochWithMetrics(layer_t **model, size_t modelSize, lossT
     // Peek at first sample to derive numClasses from label shape
     batch_t *firstBatch = dataLoader->getBatch(dataLoader, 0);
     size_t numClasses = calcNumberOfElementsByTensor(firstBatch->samples[0]->label);
+    for (size_t i = 0; i < firstBatch->size; i++) {
+        freeSample(firstBatch->samples[i]);
+    }
     freeBatch(firstBatch);
 
-    return evaluateEpochInternal(model, modelSize, lossType, dataLoader, inferenceFn,
-                                  NULL, numClasses);
+    return evaluateEpochInternal(model, modelSize, lossType, dataLoader, inferenceFn, NULL,
+                                 numClasses);
 }
 
 classificationReport_t evaluationEpochWithReport(layer_t **model, size_t modelSize,
-                                                  lossType_t lossType,
-                                                  dataLoader_t *dataLoader,
-                                                  inferenceWithLossFn_t inferenceFn,
-                                                  size_t *cmBuffer, size_t numClasses) {
+                                                 lossType_t lossType, dataLoader_t *dataLoader,
+                                                 inferenceWithLossFn_t inferenceFn,
+                                                 size_t *cmBuffer, size_t numClasses) {
     // Zero the caller's CM buffer
     for (size_t i = 0; i < numClasses * numClasses; i++) {
         cmBuffer[i] = 0;
@@ -199,7 +201,7 @@ classificationReport_t evaluationEpochWithReport(layer_t **model, size_t modelSi
 
     classificationReport_t report;
     report.stats = evaluateEpochInternal(model, modelSize, lossType, dataLoader, inferenceFn,
-                                          cmBuffer, numClasses);
+                                         cmBuffer, numClasses);
     report.confusionMatrix = cmBuffer;
     report.numClasses = numClasses;
     return report;
@@ -209,21 +211,22 @@ trainingRunResult_t trainingRun(layer_t **model, size_t modelSize, lossType_t lo
                                 dataLoader_t *trainDataLoader, dataLoader_t *evalDataLoader,
                                 optimizer_t *optimizer, size_t numberOfEpochs,
                                 calculateGradsFn_t calculateGradsFn,
-                                inferenceWithLossFn_t inferenceFn,
-                                epochCallbackFn_t callback) {
+                                inferenceWithLossFn_t inferenceFn, epochCallbackFn_t callback) {
     trainingRunResult_t result = {0};
 
     // Derive numClasses from eval dataset labels
     batch_t *firstBatch = evalDataLoader->getBatch(evalDataLoader, 0);
     size_t numClasses = calcNumberOfElementsByTensor(firstBatch->samples[0]->label);
+    for (size_t i = 0; i < firstBatch->size; i++) {
+        freeSample(firstBatch->samples[i]);
+    }
     freeBatch(firstBatch);
 
     for (size_t epoch = 0; epoch < numberOfEpochs; epoch++) {
         float trainLoss = trainingEpochDefault(model, modelSize, lossType, trainDataLoader,
                                                optimizer, calculateGradsFn);
-        epochStats_t evalStats = evaluateEpochInternal(model, modelSize, lossType,
-                                                        evalDataLoader, inferenceFn,
-                                                        NULL, numClasses);
+        epochStats_t evalStats = evaluateEpochInternal(model, modelSize, lossType, evalDataLoader,
+                                                       inferenceFn, NULL, numClasses);
 
         if (callback != NULL) {
             callback(epoch, trainLoss, evalStats);

--- a/src/userApi/training_loop/training_batch/CMakeLists.txt
+++ b/src/userApi/training_loop/training_batch/CMakeLists.txt
@@ -9,5 +9,6 @@ target_link_libraries(TrainingBatchDefault PRIVATE
         LossFunction
         InferenceApi
         DataLoader
+        DataLoaderApi
         Common
 )

--- a/src/userApi/training_loop/training_batch/TrainingBatchDefault.c
+++ b/src/userApi/training_loop/training_batch/TrainingBatchDefault.c
@@ -2,17 +2,18 @@
 
 #include "TrainingBatchDefault.h"
 #include "Common.h"
+#include "DataLoaderApi.h"
 
-float trainingBatchDefault(layer_t **model, size_t modelSize, lossType_t lossType,
-                           batch_t *batch, calculateGradsFn_t calculateGradsFn) {
+float trainingBatchDefault(layer_t **model, size_t modelSize, lossType_t lossType, batch_t *batch,
+                           calculateGradsFn_t calculateGradsFn) {
     float totalLoss = 0.0f;
 
     for (size_t i = 0; i < batch->size; i++) {
-        trainingStats_t *stats =
-            calculateGradsFn(model, modelSize, lossType,
-                             batch->samples[i]->item, batch->samples[i]->label);
+        trainingStats_t *stats = calculateGradsFn(
+            model, modelSize, lossType, batch->samples[i]->item, batch->samples[i]->label);
         totalLoss += stats->loss;
         freeTrainingStats(stats);
+        freeSample(batch->samples[i]);
     }
 
     return totalLoss / (float)batch->size;

--- a/test/unit/userAPI/UnitTestMnistSmoke.c
+++ b/test/unit/userAPI/UnitTestMnistSmoke.c
@@ -4,25 +4,23 @@
 
 #include "unity.h"
 
-#include "Tensor.h"
-#include "TensorApi.h"
-#include "LinearApi.h"
-#include "ReluApi.h"
-#include "SoftmaxApi.h"
-#include "SgdApi.h"
-#include "QuantizationApi.h"
-#include "LossFunction.h"
-#include "InferenceApi.h"
+#include "CalculateGradsSequential.h"
 #include "DataLoaderApi.h"
 #include "Dataset.h"
+#include "InferenceApi.h"
+#include "LinearApi.h"
+#include "LossFunction.h"
+#include "QuantizationApi.h"
+#include "ReluApi.h"
+#include "SgdApi.h"
+#include "SoftmaxApi.h"
 #include "StorageApi.h"
+#include "Tensor.h"
+#include "TensorApi.h"
 #include "TrainingLoopApi.h"
-#include "CalculateGradsSequential.h"
-
 
 void setUp() {}
 void tearDown() {}
-
 
 #define INPUT_DIM 4
 #define HIDDEN_DIM 8
@@ -30,34 +28,51 @@ void tearDown() {}
 #define DATASET_SIZE 6
 #define MODEL_SIZE 4
 
-
-// Tiny trivially-learnable dataset: each input is a noisy one-hot prototype of its class.
+/* Tiny trivially-learnable dataset: each input is a noisy one-hot prototype of
+ * its class. The arrays are file-scope because the getSample callback (fired
+ * during trainingRun) must reach them; freeDataset releases them at end. */
 static tensor_t *items[DATASET_SIZE];
 static tensor_t *labels[DATASET_SIZE];
 
-static void initDataset() {
-    static float itemData[DATASET_SIZE][INPUT_DIM] = {
-        {1.0f, 0.0f, 0.0f, 0.0f},
-        {0.0f, 1.0f, 0.0f, 0.0f},
-        {0.0f, 0.0f, 1.0f, 0.0f},
-        {0.9f, 0.1f, 0.0f, 0.0f},
-        {0.1f, 0.9f, 0.0f, 0.0f},
-        {0.0f, 0.1f, 0.9f, 0.0f},
-    };
-    static float labelData[DATASET_SIZE][NUM_CLASSES] = {
-        {1.0f, 0.0f, 0.0f},
-        {0.0f, 1.0f, 0.0f},
-        {0.0f, 0.0f, 1.0f},
-        {1.0f, 0.0f, 0.0f},
-        {0.0f, 1.0f, 0.0f},
-        {0.0f, 0.0f, 1.0f},
-    };
-    static size_t itemDims[] = {1, INPUT_DIM};
-    static size_t labelDims[] = {1, NUM_CLASSES};
+static const float itemDataLiteral[DATASET_SIZE][INPUT_DIM] = {
+    {1.0f, 0.0f, 0.0f, 0.0f}, {0.0f, 1.0f, 0.0f, 0.0f}, {0.0f, 0.0f, 1.0f, 0.0f},
+    {0.9f, 0.1f, 0.0f, 0.0f}, {0.1f, 0.9f, 0.0f, 0.0f}, {0.0f, 0.1f, 0.9f, 0.0f},
+};
+static const float labelDataLiteral[DATASET_SIZE][NUM_CLASSES] = {
+    {1.0f, 0.0f, 0.0f}, {0.0f, 1.0f, 0.0f}, {0.0f, 0.0f, 1.0f},
+    {1.0f, 0.0f, 0.0f}, {0.0f, 1.0f, 0.0f}, {0.0f, 0.0f, 1.0f},
+};
 
+static void initDataset() {
     for (size_t i = 0; i < DATASET_SIZE; i++) {
-        items[i] = tensorInitFloat(itemData[i], itemDims, 2, NULL);
-        labels[i] = tensorInitFloat(labelData[i], labelDims, 2, NULL);
+        /* Item tensor (1, INPUT_DIM). */
+        size_t *itemDims = reserveMemory(2 * sizeof(size_t));
+        itemDims[0] = 1;
+        itemDims[1] = INPUT_DIM;
+        size_t *itemOrder = reserveMemory(2 * sizeof(size_t));
+        setOrderOfDimsForNewTensor(2, itemOrder);
+        shape_t *itemShape = reserveMemory(sizeof(shape_t));
+        setShape(itemShape, itemDims, 2, itemOrder);
+        items[i] = initTensor(itemShape, quantizationInitFloat(), NULL);
+        tensorFillFromFloatBuffer(items[i], itemDataLiteral[i], INPUT_DIM);
+
+        /* Label tensor (1, NUM_CLASSES). */
+        size_t *labelDims = reserveMemory(2 * sizeof(size_t));
+        labelDims[0] = 1;
+        labelDims[1] = NUM_CLASSES;
+        size_t *labelOrder = reserveMemory(2 * sizeof(size_t));
+        setOrderOfDimsForNewTensor(2, labelOrder);
+        shape_t *labelShape = reserveMemory(sizeof(shape_t));
+        setShape(labelShape, labelDims, 2, labelOrder);
+        labels[i] = initTensor(labelShape, quantizationInitFloat(), NULL);
+        tensorFillFromFloatBuffer(labels[i], labelDataLiteral[i], NUM_CLASSES);
+    }
+}
+
+static void freeDataset() {
+    for (size_t i = 0; i < DATASET_SIZE; i++) {
+        freeTensor(items[i]);
+        freeTensor(labels[i]);
     }
 }
 
@@ -72,48 +87,81 @@ static size_t getDatasetSize() {
     return DATASET_SIZE;
 }
 
-
-// Mirrors the buildModel pattern from experiments/MnistExperiment.c: model is
-// constructed inside a helper that returns to its caller before trainingRun()
-// runs. This exercises the stack-lifetime contract of setShape()/tensorInit*.
-static void buildModel(layer_t **model) {
+/* Builds a 4-layer Linear -> ReLU -> Linear -> Softmax model. The shared
+ * layer-level quantization q is exposed via q_out so the test can free it
+ * after the model layers are freed. Each parameter tensor takes its own
+ * fresh quantization (initTensor takes ownership), distinct from q. */
+static void buildModel(layer_t **model, quantization_t **q_out) {
     quantization_t *q = quantizationInitFloat();
+    *q_out = q;
 
-    static float w0Data[HIDDEN_DIM * INPUT_DIM] = {0};
-    static size_t w0Dims[] = {HIDDEN_DIM, INPUT_DIM};
-    tensor_t *w0Param = tensorInitWithDistribution(XAVIER_UNIFORM, w0Data, w0Dims, 2, q, NULL,
-                                                    INPUT_DIM, HIDDEN_DIM);
+    distribution_t xavier0 = {
+        .type = XAVIER_UNIFORM,
+        .params.xavier = {.gain = 1.0f, .fanIn = INPUT_DIM, .fanOut = HIDDEN_DIM}};
+    distribution_t zeros = {.type = ZEROS};
+
+    /* w0 (HIDDEN_DIM x INPUT_DIM, XAVIER_UNIFORM). */
+    size_t *w0Dims = reserveMemory(2 * sizeof(size_t));
+    w0Dims[0] = HIDDEN_DIM;
+    w0Dims[1] = INPUT_DIM;
+    size_t *w0Order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, w0Order);
+    shape_t *w0Shape = reserveMemory(sizeof(shape_t));
+    setShape(w0Shape, w0Dims, 2, w0Order);
+    tensor_t *w0Param = initTensor(w0Shape, quantizationInitFloat(), NULL);
+    initDistribution(w0Param, &xavier0);
     tensor_t *w0Grad = gradInitFloat(w0Param, NULL);
     parameter_t *w0 = parameterInit(w0Param, w0Grad);
 
-    static float b0Data[HIDDEN_DIM] = {0};
-    static size_t b0Dims[] = {1, HIDDEN_DIM};
-    tensor_t *b0Param = tensorInitWithDistribution(ZEROS, b0Data, b0Dims, 2, q, NULL, 1,
-                                                    HIDDEN_DIM);
+    /* b0 (1 x HIDDEN_DIM, ZEROS). */
+    size_t *b0Dims = reserveMemory(2 * sizeof(size_t));
+    b0Dims[0] = 1;
+    b0Dims[1] = HIDDEN_DIM;
+    size_t *b0Order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, b0Order);
+    shape_t *b0Shape = reserveMemory(sizeof(shape_t));
+    setShape(b0Shape, b0Dims, 2, b0Order);
+    tensor_t *b0Param = initTensor(b0Shape, quantizationInitFloat(), NULL);
+    initDistribution(b0Param, &zeros);
     tensor_t *b0Grad = gradInitFloat(b0Param, NULL);
     parameter_t *b0 = parameterInit(b0Param, b0Grad);
 
     model[0] = linearLayerInit(w0, b0, q, q, q, q);
     model[1] = reluLayerInit(q, q);
 
-    static float w1Data[NUM_CLASSES * HIDDEN_DIM] = {0};
-    static size_t w1Dims[] = {NUM_CLASSES, HIDDEN_DIM};
-    tensor_t *w1Param = tensorInitWithDistribution(XAVIER_UNIFORM, w1Data, w1Dims, 2, q, NULL,
-                                                    HIDDEN_DIM, NUM_CLASSES);
+    distribution_t xavier1 = {
+        .type = XAVIER_UNIFORM,
+        .params.xavier = {.gain = 1.0f, .fanIn = HIDDEN_DIM, .fanOut = NUM_CLASSES}};
+
+    /* w1 (NUM_CLASSES x HIDDEN_DIM, XAVIER_UNIFORM). */
+    size_t *w1Dims = reserveMemory(2 * sizeof(size_t));
+    w1Dims[0] = NUM_CLASSES;
+    w1Dims[1] = HIDDEN_DIM;
+    size_t *w1Order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, w1Order);
+    shape_t *w1Shape = reserveMemory(sizeof(shape_t));
+    setShape(w1Shape, w1Dims, 2, w1Order);
+    tensor_t *w1Param = initTensor(w1Shape, quantizationInitFloat(), NULL);
+    initDistribution(w1Param, &xavier1);
     tensor_t *w1Grad = gradInitFloat(w1Param, NULL);
     parameter_t *w1 = parameterInit(w1Param, w1Grad);
 
-    static float b1Data[NUM_CLASSES] = {0};
-    static size_t b1Dims[] = {1, NUM_CLASSES};
-    tensor_t *b1Param = tensorInitWithDistribution(ZEROS, b1Data, b1Dims, 2, q, NULL, 1,
-                                                    NUM_CLASSES);
+    /* b1 (1 x NUM_CLASSES, ZEROS). */
+    size_t *b1Dims = reserveMemory(2 * sizeof(size_t));
+    b1Dims[0] = 1;
+    b1Dims[1] = NUM_CLASSES;
+    size_t *b1Order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, b1Order);
+    shape_t *b1Shape = reserveMemory(sizeof(shape_t));
+    setShape(b1Shape, b1Dims, 2, b1Order);
+    tensor_t *b1Param = initTensor(b1Shape, quantizationInitFloat(), NULL);
+    initDistribution(b1Param, &zeros);
     tensor_t *b1Grad = gradInitFloat(b1Param, NULL);
     parameter_t *b1 = parameterInit(b1Param, b1Grad);
 
     model[2] = linearLayerInit(w1, b1, q, q, q, q);
     model[3] = softmaxLayerInit(q, q);
 }
-
 
 static size_t cbInvocations;
 static float firstTrainLoss;
@@ -129,7 +177,6 @@ static void captureEpoch(size_t epoch, float trainLoss, epochStats_t evalStats) 
     cbInvocations++;
 }
 
-
 /* End-to-end smoke test: runs the same pipeline as MnistExperiment at miniature
  * scale. Catches regressions in the Linear->ReLU->Linear->Softmax + CrossEntropy
  * path, trainingRun()'s epoch/batch orchestration, and the epochCallback
@@ -138,30 +185,49 @@ static void captureEpoch(size_t epoch, float trainLoss, epochStats_t evalStats) 
 void testMnistSmoke_FullTrainingPipelineReducesLoss() {
     initDataset();
 
-    dataLoader_t *trainDl = dataLoaderInit(getSample, getDatasetSize, 2,
-                                            NULL, NULL, false, 0, true);
-    dataLoader_t *evalDl = dataLoaderInit(getSample, getDatasetSize, 1,
-                                           NULL, NULL, false, 0, true);
+    dataLoader_t *trainDl =
+        dataLoaderInit(getSample, getDatasetSize, 2, NULL, NULL, false, 0, true);
+    dataLoader_t *evalDl = dataLoaderInit(getSample, getDatasetSize, 1, NULL, NULL, false, 0, true);
 
     layer_t *model[MODEL_SIZE];
-    buildModel(model);
+    quantization_t *q = NULL;
+    buildModel(model, &q);
 
     optimizer_t *sgd = sgdMCreateOptim(0.1f, 0.0f, 0.0f, model, MODEL_SIZE, FLOAT32);
 
     cbInvocations = 0;
     size_t numberOfEpochs = 20;
-    trainingRunResult_t result = trainingRun(model, MODEL_SIZE, CROSS_ENTROPY,
-                                              trainDl, evalDl, sgd, numberOfEpochs,
-                                              calculateGradsSequential, inferenceWithLoss,
-                                              captureEpoch);
+    trainingRunResult_t result =
+        trainingRun(model, MODEL_SIZE, CROSS_ENTROPY, trainDl, evalDl, sgd, numberOfEpochs,
+                    calculateGradsSequential, inferenceWithLoss, captureEpoch);
 
-    TEST_ASSERT_EQUAL_UINT(numberOfEpochs, cbInvocations);
-    TEST_ASSERT_TRUE(result.finalTrainLoss > 0.0f);
-    TEST_ASSERT_TRUE(result.finalEvalStats.accuracy >= 0.0f);
-    TEST_ASSERT_TRUE(result.finalEvalStats.accuracy <= 1.0f);
-    TEST_ASSERT_TRUE(lastTrainLoss < firstTrainLoss);
+    /* CAPTURE all assertion values into stack locals BEFORE any free. */
+    size_t capturedCbInvocations = cbInvocations;
+    float capturedFinalTrainLoss = result.finalTrainLoss;
+    float capturedAccuracy = result.finalEvalStats.accuracy;
+    float capturedFirstTrainLoss = firstTrainLoss;
+    float capturedLastTrainLoss = lastTrainLoss;
+
+    /* FREE in reverse-init order.
+     * NOTE: freeOptimSgdM cascades to all model parameters via freeParameter.
+     * Do NOT also call freeParameter on w0/b0/w1/b1 — would be a double-free. */
+    freeOptimSgdM(sgd);
+    freeSoftmaxLayer(model[3]);
+    freeLinearLayer(model[2]);
+    freeReluLayer(model[1]);
+    freeLinearLayer(model[0]);
+    freeDataLoader(evalDl);
+    freeDataLoader(trainDl);
+    freeQuantization(q);
+    freeDataset();
+
+    /* ASSERT on captured. */
+    TEST_ASSERT_EQUAL_UINT(numberOfEpochs, capturedCbInvocations);
+    TEST_ASSERT_TRUE(capturedFinalTrainLoss > 0.0f);
+    TEST_ASSERT_TRUE(capturedAccuracy >= 0.0f);
+    TEST_ASSERT_TRUE(capturedAccuracy <= 1.0f);
+    TEST_ASSERT_TRUE(capturedLastTrainLoss < capturedFirstTrainLoss);
 }
-
 
 int main() {
     UNITY_BEGIN();

--- a/test/unit/userAPI/UnitTestTrainingLoopApi.c
+++ b/test/unit/userAPI/UnitTestTrainingLoopApi.c
@@ -2,23 +2,23 @@
 
 #include <stddef.h>
 
-#include "LossFunction.h"
-#include "TensorApi.h"
-#include "LinearApi.h"
-#include "SgdApi.h"
-#include "unity.h"
-#include "TrainingLoopApi.h"
 #include "CalculateGradsSequential.h"
+#include "DataLoaderApi.h"
+#include "Dataset.h"
+#include "InferenceApi.h"
+#include "Linear.h"
+#include "LinearApi.h"
+#include "LossFunction.h"
+#include "QuantizationApi.h"
+#include "ReluApi.h"
+#include "SgdApi.h"
+#include "StorageApi.h"
+#include "TensorApi.h"
+#include "TensorConversion.h"
 #include "TrainingBatchDefault.h"
 #include "TrainingEpochDefault.h"
-#include "TensorConversion.h"
-#include "QuantizationApi.h"
-#include "Linear.h"
-#include "ReluApi.h"
-#include "InferenceApi.h"
-#include "DataLoaderApi.h"
-#include "StorageApi.h"
-#include "Dataset.h"
+#include "TrainingLoopApi.h"
+#include "unity.h"
 
 void testCalculateGradsSequential_MatchesPyTorch() {
     float weightData[] = {1.f, 1.f, 1.f, 1.f, 1.f, 1.f};
@@ -136,10 +136,15 @@ void testEvaluationBatch_ReturnsAverageLoss() {
     freeInferenceStats(stats0);
     freeInferenceStats(stats1);
 
-    // Build a batch
-    sample_t s0 = {.item = input0, .label = label0};
-    sample_t s1 = {.item = input1, .label = label1};
-    sample_t *samples[] = {&s0, &s1};
+    // Build a batch. Samples must be heap-allocated: evaluationBatch frees
+    // each via freeSample (the batch-consumer convention set by #119).
+    sample_t *s0 = reserveMemory(sizeof(sample_t));
+    s0->item = input0;
+    s0->label = label0;
+    sample_t *s1 = reserveMemory(sizeof(sample_t));
+    s1->item = input1;
+    s1->label = label1;
+    sample_t *samples[] = {s0, s1};
     batch_t batch = {.samples = samples, .size = 2};
 
     float actualAvgLoss = evaluationBatch(model, 1, MSE, &batch, inferenceWithLoss);
@@ -154,13 +159,19 @@ static dataset_t epochDataset;
 static bool epochDatasetInit = false;
 
 static void initEpochDataset() {
-    if (epochDatasetInit) return;
+    if (epochDatasetInit) {
+        return;
+    }
 
     // 4 samples: input [1,2], label [1,0] or [0,1]
-    static float in0[] = {5.f, 1.f}; static float in1[] = {1.f, 5.f};
-    static float in2[] = {3.f, 1.f}; static float in3[] = {1.f, 3.f};
-    static float lb0[] = {1.f, 0.f}; static float lb1[] = {0.f, 1.f};
-    static float lb2[] = {1.f, 0.f}; static float lb3[] = {0.f, 1.f};
+    static float in0[] = {5.f, 1.f};
+    static float in1[] = {1.f, 5.f};
+    static float in2[] = {3.f, 1.f};
+    static float in3[] = {1.f, 3.f};
+    static float lb0[] = {1.f, 0.f};
+    static float lb1[] = {0.f, 1.f};
+    static float lb2[] = {1.f, 0.f};
+    static float lb3[] = {0.f, 1.f};
 
     static size_t inDims[] = {1, 2};
     static size_t lbDims[] = {1, 2};
@@ -221,8 +232,8 @@ void testEvaluationEpoch_ReturnsAverageLossAcrossBatches() {
     layer_t *linear = linearLayerInit(w, b, &testQ, &testQ, &testQ, &testQ);
     layer_t *model[] = {linear};
 
-    dataLoader_t *dl = dataLoaderInit(getEpochSample, getEpochDatasetSize, 1,
-                                       NULL, NULL, false, 0, true);
+    dataLoader_t *dl =
+        dataLoaderInit(getEpochSample, getEpochDatasetSize, 1, NULL, NULL, false, 0, true);
 
     float totalAvg = evaluationEpoch(model, 1, MSE, dl, inferenceWithLoss);
 
@@ -262,8 +273,8 @@ void testEvaluationEpoch_MinibatchMatchesMicrobatchAverage() {
     // Per-sample losses: 8.5, 8.5, 2.5, 2.5
     // Batch 0 avg = (8.5+8.5)/2 = 8.5; Batch 1 avg = (2.5+2.5)/2 = 2.5
     // Epoch avg = (8.5+2.5)/2 = 5.5 — identical to microbatch result
-    dataLoader_t *dl = dataLoaderInit(getEpochSample, getEpochDatasetSize, 2,
-                                       NULL, NULL, false, 0, true);
+    dataLoader_t *dl =
+        dataLoaderInit(getEpochSample, getEpochDatasetSize, 2, NULL, NULL, false, 0, true);
 
     float totalAvg = evaluationEpoch(model, 1, MSE, dl, inferenceWithLoss);
 
@@ -313,14 +324,22 @@ void testTrainingBatchDefault_ReturnsAverageLossAndAccumulatesGrads() {
 
     // Reset grads to zero before testing trainingBatchDefault
     float *gArr = (float *)wGrad->data;
-    for (size_t i = 0; i < 6; i++) gArr[i] = 0.f;
+    for (size_t i = 0; i < 6; i++) {
+        gArr[i] = 0.f;
+    }
     float *bgArr = (float *)bGrad->data;
-    bgArr[0] = 0.f; bgArr[1] = 0.f;
+    bgArr[0] = 0.f;
+    bgArr[1] = 0.f;
 
-    // Build batch
-    sample_t s0 = {.item = in0, .label = lb0};
-    sample_t s1 = {.item = in1, .label = lb1};
-    sample_t *samples[] = {&s0, &s1};
+    // Build batch. Samples must be heap-allocated: trainingBatchDefault frees
+    // each via freeSample (the batch-consumer convention set by #119).
+    sample_t *s0 = reserveMemory(sizeof(sample_t));
+    s0->item = in0;
+    s0->label = lb0;
+    sample_t *s1 = reserveMemory(sizeof(sample_t));
+    s1->item = in1;
+    s1->label = lb1;
+    sample_t *samples[] = {s0, s1};
     batch_t batch = {.samples = samples, .size = 2};
 
     float actualAvg = trainingBatchDefault(model, 1, MSE, &batch, calculateGradsSequential);
@@ -353,17 +372,19 @@ void testTrainingEpochDefault_DoesOptimizerStepPerBatch() {
 
     // Save initial weights
     float initWeights[4];
-    for (size_t i = 0; i < 4; i++) initWeights[i] = wData[i];
+    for (size_t i = 0; i < 4; i++) {
+        initWeights[i] = wData[i];
+    }
 
     optimizer_t *sgd = sgdMCreateOptim(0.01f, 0.f, 0.f, model, sizeModel, FLOAT32);
 
     // Use epoch dataset (batchSize=1 → 4 batches)
     initEpochDataset();
-    dataLoader_t *dl = dataLoaderInit(getEpochSample, getEpochDatasetSize, 1,
-                                       NULL, NULL, false, 0, true);
+    dataLoader_t *dl =
+        dataLoaderInit(getEpochSample, getEpochDatasetSize, 1, NULL, NULL, false, 0, true);
 
-    float epochLoss = trainingEpochDefault(model, sizeModel, MSE, dl, sgd,
-                                            calculateGradsSequential);
+    float epochLoss =
+        trainingEpochDefault(model, sizeModel, MSE, dl, sgd, calculateGradsSequential);
 
     // Weights should have changed
     float *curWeights = (float *)wParam->data;
@@ -405,16 +426,18 @@ void testTrainingEpochDefault_MinibatchStepsOncePerMinibatch() {
     size_t sizeModel = 1;
 
     float initWeights[4];
-    for (size_t i = 0; i < 4; i++) initWeights[i] = wData[i];
+    for (size_t i = 0; i < 4; i++) {
+        initWeights[i] = wData[i];
+    }
 
     optimizer_t *sgd = sgdMCreateOptim(0.01f, 0.f, 0.f, model, sizeModel, FLOAT32);
 
     initEpochDataset();
-    dataLoader_t *dl = dataLoaderInit(getEpochSample, getEpochDatasetSize, 2,
-                                       NULL, NULL, false, 0, true);
+    dataLoader_t *dl =
+        dataLoaderInit(getEpochSample, getEpochDatasetSize, 2, NULL, NULL, false, 0, true);
 
-    float epochLoss = trainingEpochDefault(model, sizeModel, MSE, dl, sgd,
-                                            calculateGradsSequential);
+    float epochLoss =
+        trainingEpochDefault(model, sizeModel, MSE, dl, sgd, calculateGradsSequential);
 
     float *curWeights = (float *)wParam->data;
     bool changed = false;
@@ -451,10 +474,10 @@ void testTrainingRun_ReturnsResult() {
     optimizer_t *sgd = sgdMCreateOptim(0.01f, 0.f, 0.f, model, 1, FLOAT32);
 
     initEpochDataset();
-    dataLoader_t *trainDl = dataLoaderInit(getEpochSample, getEpochDatasetSize, 1,
-                                            NULL, NULL, false, 0, true);
-    dataLoader_t *evalDl = dataLoaderInit(getEpochSample, getEpochDatasetSize, 1,
-                                           NULL, NULL, false, 0, true);
+    dataLoader_t *trainDl =
+        dataLoaderInit(getEpochSample, getEpochDatasetSize, 1, NULL, NULL, false, 0, true);
+    dataLoader_t *evalDl =
+        dataLoaderInit(getEpochSample, getEpochDatasetSize, 1, NULL, NULL, false, 0, true);
 
     trainingRunResult_t result = trainingRun(model, 1, MSE, trainDl, evalDl, sgd, 2,
                                              calculateGradsSequential, inferenceWithLoss, NULL);
@@ -505,15 +528,15 @@ void testTrainingRun_CallsCallbackEachEpochWithStats() {
     optimizer_t *sgd = sgdMCreateOptim(0.01f, 0.f, 0.f, model, 1, FLOAT32);
 
     initEpochDataset();
-    dataLoader_t *trainDl = dataLoaderInit(getEpochSample, getEpochDatasetSize, 1,
-                                            NULL, NULL, false, 0, true);
-    dataLoader_t *evalDl = dataLoaderInit(getEpochSample, getEpochDatasetSize, 1,
-                                           NULL, NULL, false, 0, true);
+    dataLoader_t *trainDl =
+        dataLoaderInit(getEpochSample, getEpochDatasetSize, 1, NULL, NULL, false, 0, true);
+    dataLoader_t *evalDl =
+        dataLoaderInit(getEpochSample, getEpochDatasetSize, 1, NULL, NULL, false, 0, true);
 
     size_t numberOfEpochs = 3;
-    trainingRunResult_t result = trainingRun(model, 1, MSE, trainDl, evalDl, sgd, numberOfEpochs,
-                                              calculateGradsSequential, inferenceWithLoss,
-                                              captureCallback);
+    trainingRunResult_t result =
+        trainingRun(model, 1, MSE, trainDl, evalDl, sgd, numberOfEpochs, calculateGradsSequential,
+                    inferenceWithLoss, captureCallback);
 
     // Callback was invoked once per epoch, in order
     TEST_ASSERT_EQUAL_UINT(numberOfEpochs, cbCallCount);
@@ -549,13 +572,13 @@ void testEvaluationEpochWithMetrics_AllCorrect() {
     layer_t *linear = linearLayerInit(w, b, &testQ, &testQ, &testQ, &testQ);
     layer_t *model[] = {linear};
 
-    dataLoader_t *dl = dataLoaderInit(getEpochSample, getEpochDatasetSize, 1,
-                                       NULL, NULL, false, 0, true);
+    dataLoader_t *dl =
+        dataLoaderInit(getEpochSample, getEpochDatasetSize, 1, NULL, NULL, false, 0, true);
 
     // Identity model: all 4 samples predict correctly (same as testEvaluationEpochAccuracy)
     epochStats_t stats = evaluationEpochWithMetrics(model, 1, MSE, dl, inferenceWithLoss);
 
-    TEST_ASSERT_FLOAT_WITHIN(0.01f, 5.5f, stats.loss);  // same as testEvaluationEpoch
+    TEST_ASSERT_FLOAT_WITHIN(0.01f, 5.5f, stats.loss); // same as testEvaluationEpoch
     TEST_ASSERT_FLOAT_WITHIN(0.001f, 1.0f, stats.accuracy);
     TEST_ASSERT_FLOAT_WITHIN(0.001f, 1.0f, stats.precision);
     TEST_ASSERT_FLOAT_WITHIN(0.001f, 1.0f, stats.recall);
@@ -569,7 +592,9 @@ static dataset_t partialDataset;
 static bool partialDatasetInit = false;
 
 static void initPartialDataset() {
-    if (partialDatasetInit) return;
+    if (partialDatasetInit) {
+        return;
+    }
 
     static float in0[] = {5.f, 1.f}; // pred=0
     static float in1[] = {3.f, 1.f}; // pred=0
@@ -639,8 +664,8 @@ void testEvaluationEpochWithMetrics_PartiallyCorrect() {
     layer_t *linear = linearLayerInit(w, b, &testQ, &testQ, &testQ, &testQ);
     layer_t *model[] = {linear};
 
-    dataLoader_t *dl = dataLoaderInit(getPartialSample, getPartialDatasetSize, 1,
-                                       NULL, NULL, false, 0, true);
+    dataLoader_t *dl =
+        dataLoaderInit(getPartialSample, getPartialDatasetSize, 1, NULL, NULL, false, 0, true);
 
     epochStats_t stats = evaluationEpochWithMetrics(model, 1, MSE, dl, inferenceWithLoss);
 
@@ -663,7 +688,9 @@ static dataset_t zeroPredDataset;
 static bool zeroPredDatasetInit = false;
 
 static void initZeroPredDataset() {
-    if (zeroPredDatasetInit) return;
+    if (zeroPredDatasetInit) {
+        return;
+    }
 
     static float in0[] = {5.f, 1.f}; // pred=0
     static float in1[] = {3.f, 1.f}; // pred=0
@@ -729,8 +756,8 @@ void testEvaluationEpochWithMetrics_HandlesZeroPredictionClass() {
     layer_t *linear = linearLayerInit(w, b, &testQ, &testQ, &testQ, &testQ);
     layer_t *model[] = {linear};
 
-    dataLoader_t *dl = dataLoaderInit(getZeroPredSample, getZeroPredDatasetSize, 1,
-                                       NULL, NULL, false, 0, true);
+    dataLoader_t *dl =
+        dataLoaderInit(getZeroPredSample, getZeroPredDatasetSize, 1, NULL, NULL, false, 0, true);
 
     epochStats_t stats = evaluationEpochWithMetrics(model, 1, MSE, dl, inferenceWithLoss);
 
@@ -775,13 +802,13 @@ void testEvaluationEpochWithReport_ReturnsConfusionMatrix() {
     layer_t *linear = linearLayerInit(w, b, &testQ, &testQ, &testQ, &testQ);
     layer_t *model[] = {linear};
 
-    dataLoader_t *dl = dataLoaderInit(getPartialSample, getPartialDatasetSize, 1,
-                                       NULL, NULL, false, 0, true);
+    dataLoader_t *dl =
+        dataLoaderInit(getPartialSample, getPartialDatasetSize, 1, NULL, NULL, false, 0, true);
 
     // Pre-fill with non-zero to verify WithReport zeroes the caller's buffer before accumulating
     size_t cm[2 * 2] = {99, 99, 99, 99};
-    classificationReport_t report = evaluationEpochWithReport(model, 1, MSE, dl,
-                                                               inferenceWithLoss, cm, 2);
+    classificationReport_t report =
+        evaluationEpochWithReport(model, 1, MSE, dl, inferenceWithLoss, cm, 2);
 
     // Expected CM[predicted][actual]: [[2,1],[0,1]]
     // cm[0*2+0]=2, cm[0*2+1]=1, cm[1*2+0]=0, cm[1*2+1]=1


### PR DESCRIPTION
**Stack position:** \`develop ← #109 ← ... ← #119 ← #THIS\`

Stacked on #119. Per \`codebase_stacked_pr_merge_trap.md\`: do not merge before #119.

---

## Summary

Wave batch 7a. Migrates the MNIST smoke test (full training-pipeline integration test, 20 epochs) **and** closes a production-side leak in the training-loop batch-iteration paths that the migration spike surfaced.

## Test-side changes

\`test/unit/userAPI/UnitTestMnistSmoke.c\`:
- \`initDataset\` rewritten with post-#106 primitives; new \`freeDataset\` helper.
- \`buildModel\` exposes its shared \`quantization_t *\` to the caller for cleanup.
- Static data arrays inside \`buildModel\` removed — \`initTensor + initDistribution\` own the data.
- Cleanup order: \`freeOptimSgdM\` → \`free*Layer\` → \`freeDataLoader\` → \`freeQuantization\` → \`freeDataset\`.

## Production-side fix

5 call sites in 2 files: each iterates \`batch->samples[i]\` for processing but never \`freeSample\`s the entries before \`freeBatch(batch)\`. Same \"destructor frees container but not children\" pattern as the inference \`outputNext\` leak (#109) and the \`freeOptimSgdM\` container leaks (#110). The convention is set by \`test/unit/data_loader/UnitTestDataLoader.c\` (already merged via #119): the batch consumer frees its samples before freeing the batch.

Sites:
- \`src/userApi/training_loop/TrainingLoopApi.c::evaluationBatch\`
- \`src/userApi/training_loop/TrainingLoopApi.c::evaluateBatchInternal\`
- \`src/userApi/training_loop/TrainingLoopApi.c::trainingRun\` — \"peek first batch\" site
- \`src/userApi/training_loop/TrainingLoopApi.c::evaluationEpochWithMetrics\` — \"peek first batch\" site
- \`src/userApi/training_loop/training_batch/TrainingBatchDefault.c::trainingBatchDefault\`

Each fix is a single \`freeSample(batch->samples[i])\` call inserted inside the existing iteration (or a short cleanup loop before \`freeBatch\` for the peek sites).

Infra: \`TrainingBatchDefault\` now uses \`freeSample\` from \`DataLoaderApi.h\`, so \`DataLoaderApi\` is added to its CMakeLists \`target_link_libraries\`.

## Test-side adjustment in UnitTestTrainingLoopApi.c

Two existing tests (\`testEvaluationBatch_ReturnsAverageLoss\`, \`testTrainingBatchDefault_ReturnsAverageLossAndAccumulatesGrads\`) constructed batches by hand with stack-allocated \`sample_t\` structs and passed them to \`evaluationBatch\` / \`trainingBatchDefault\` directly. With the new contract that consumers call \`freeSample()\`, passing stack pointers crashes via \`free()\` on stack addresses. Both tests now \`reserveMemory\` the samples to match the contract that real \`getBatch\` produces (samples are heap-allocated in \`DataLoaderApi.c::getBatch\`).

## Verification

- macOS: \`UnitTestMnistSmoke\` passes 1/1; \`UnitTestTrainingLoopApi\` passes 13/13; full \`ctest --preset unit_test_debug\` is green (32/32).
- LSan in \`odt-lsan-recon:2026-04-22\`: \"All heap blocks were freed -- no leaks are possible\" (was 3,856 bytes / 241 blocks pre-fix).

Spec: \`docs/superpowers/specs/2026-04-25-phase-2-teardown-idiom-design.md\`
Plan: \`docs/superpowers/plans/2026-04-27-phase-2-teardown-idiom.md\`