### PR TITLE
test(#82): wave batch 7b — migrate UnitTestTrainingLoopApi (final wave PR)

### DIFF
--- a/test/unit/userAPI/UnitTestTrainingLoopApi.c
+++ b/test/unit/userAPI/UnitTestTrainingLoopApi.c
@@ -13,6 +13,7 @@
 #include "ReluApi.h"
 #include "SgdApi.h"
 #include "StorageApi.h"
+#include "Tensor.h"
 #include "TensorApi.h"
 #include "TensorConversion.h"
 #include "TrainingBatchDefault.h"
@@ -20,33 +21,29 @@
 #include "TrainingLoopApi.h"
 #include "unity.h"
 
-void testCalculateGradsSequential_MatchesPyTorch() {
-    float weightData[] = {1.f, 1.f, 1.f, 1.f, 1.f, 1.f};
-    size_t weightDims[] = {2, 3};
-    tensor_t *weightsParam = tensorInitFloat(weightData, weightDims, 2, NULL);
+/* Build a fresh 2-D float tensor from a literal float buffer. Encapsulates the
+ * post-#106 chain so each test stays readable. */
+static tensor_t *buildFloatTensor2D(size_t d0, size_t d1, const float *src, size_t count) {
+    size_t *dims = reserveMemory(2 * sizeof(size_t));
+    dims[0] = d0;
+    dims[1] = d1;
+    size_t *order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, order);
+    shape_t *shape = reserveMemory(sizeof(shape_t));
+    setShape(shape, dims, 2, order);
+    tensor_t *t = initTensor(shape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(t, src, count);
+    return t;
+}
 
-    float weightGradData[] = {0.f, 0.f, 0.f, 0.f, 0.f, 0.f};
-    tensor_t *weightsGrad = tensorInitFloat(weightGradData, weightDims, 2, NULL);
+void testCalculateGradsSequential_MatchesPyTorch() {
+    tensor_t *weightsParam = buildFloatTensor2D(2, 3, (float[]){1.f, 1.f, 1.f, 1.f, 1.f, 1.f}, 6);
+    tensor_t *weightsGrad = gradInitFloat(weightsParam, NULL);
     parameter_t *weights = parameterInit(weightsParam, weightsGrad);
 
-    float biasData[] = {-1.f, 3.f};
-    size_t biasDims[] = {1, 2};
-    tensor_t *biasParam = tensorInitFloat(biasData, biasDims, 2, NULL);
-    float biasGradData[] = {0.f, 0.f};
-    tensor_t *biasGrad = tensorInitFloat(biasGradData, biasDims, 2, NULL);
+    tensor_t *biasParam = buildFloatTensor2D(1, 2, (float[]){-1.f, 3.f}, 2);
+    tensor_t *biasGrad = gradInitFloat(biasParam, NULL);
     parameter_t *bias = parameterInit(biasParam, biasGrad);
-
-    float input0Data[] = {-4.f, 1.f, 9.f};
-    size_t input0Dims[] = {1, 3};
-    tensor_t *input0 = tensorInitFloat(input0Data, input0Dims, 2, NULL);
-
-    float input1Data[] = {5.f, -1.f, 2.f};
-    size_t input1Dims[] = {1, 3};
-    tensor_t *input1 = tensorInitFloat(input1Data, input1Dims, 2, NULL);
-
-    float input2Data[] = {-7.f, -5.f, 6.f};
-    size_t input2Dims[] = {1, 3};
-    tensor_t *input2 = tensorInitFloat(input2Data, input2Dims, 2, NULL);
 
     quantization_t testQ;
     initFloat32Quantization(&testQ);
@@ -55,20 +52,20 @@ void testCalculateGradsSequential_MatchesPyTorch() {
     layer_t *model[] = {linear};
     size_t sizeModel = 1;
 
-    float label0Data[] = {59.f, -23.f};
-    size_t label0Dims[] = {1, 2};
-    tensor_t *label0 = tensorInitFloat(label0Data, label0Dims, 2, NULL);
+    tensor_t *input0 = buildFloatTensor2D(1, 3, (float[]){-4.f, 1.f, 9.f}, 3);
+    tensor_t *input1 = buildFloatTensor2D(1, 3, (float[]){5.f, -1.f, 2.f}, 3);
+    tensor_t *input2 = buildFloatTensor2D(1, 3, (float[]){-7.f, -5.f, 6.f}, 3);
 
-    float label1Data[] = {43.f, 249.f};
-    size_t label1Dims[] = {1, 2};
-    tensor_t *label1 = tensorInitFloat(label1Data, label1Dims, 2, NULL);
-
-    float label2Data[] = {23.f, 457.f};
-    size_t label2Dims[] = {1, 2};
-    tensor_t *label2 = tensorInitFloat(label2Data, label2Dims, 2, NULL);
+    tensor_t *label0 = buildFloatTensor2D(1, 2, (float[]){59.f, -23.f}, 2);
+    tensor_t *label1 = buildFloatTensor2D(1, 2, (float[]){43.f, 249.f}, 2);
+    tensor_t *label2 = buildFloatTensor2D(1, 2, (float[]){23.f, 457.f}, 2);
 
     optimizer_t *sgd = sgdMCreateOptim(0.01f, 0.f, 0.f, model, sizeModel, FLOAT32);
     optimizerFunctions_t sgdFns = optimizerFunctions[SGD_M];
+    /* Pre-existing test hack: only step weights, leaving bias unchanged across
+     * iterations. We restore sizeStates to 2 before the free below so
+     * freeOptimSgdM cascades to BOTH registered parameters and their state
+     * buffers (otherwise parameter[1]/states[1] would leak). */
     sgd->sizeStates = 1;
 
     for (size_t i = 0; i < 23; i++) {
@@ -84,31 +81,45 @@ void testCalculateGradsSequential_MatchesPyTorch() {
         freeTrainingStats(ts2);
     }
 
+    /* CAPTURE assertion values into stack locals BEFORE any free. */
     float expectedWeights[] = {5.f, -1.f, 9.f, 22.f, -100.f, 18.f};
     linearConfig_t *linearConfig = linear->config->linear;
-    float *actualWeights = (float *)linearConfig->weights->param->data;
+    float capturedActualWeights[6];
+    {
+        float *actualWeights = (float *)linearConfig->weights->param->data;
+        for (size_t i = 0; i < 6; i++) {
+            capturedActualWeights[i] = actualWeights[i];
+        }
+    }
 
+    /* FREE in reverse-init order. Restore sizeStates so freeOptimSgdM cascades
+     * to both weights and bias parameters + their state buffers. */
+    sgd->sizeStates = 2;
+    freeOptimSgdM(sgd);
+    freeTensor(label2);
+    freeTensor(label1);
+    freeTensor(label0);
+    freeTensor(input2);
+    freeTensor(input1);
+    freeTensor(input0);
+    freeLinearLayer(linear);
+
+    /* ASSERT on captured. */
     const float errorPercent = 0.03f;
     for (size_t i = 0; i < 6; i++) {
-        float currentThreshold = actualWeights[i] * errorPercent;
-        TEST_ASSERT_FLOAT_WITHIN(currentThreshold, expectedWeights[i], actualWeights[i]);
+        float currentThreshold = capturedActualWeights[i] * errorPercent;
+        TEST_ASSERT_FLOAT_WITHIN(currentThreshold, expectedWeights[i], capturedActualWeights[i]);
     }
 }
 
 void testEvaluationBatch_ReturnsAverageLoss() {
-    // Set up a simple linear model: weights=[1,1,1,1,1,1] shape=[2,3], bias=[-1,3]
-    float weightData[] = {1.f, 1.f, 1.f, 1.f, 1.f, 1.f};
-    size_t weightDims[] = {2, 3};
-    tensor_t *wParam = tensorInitFloat(weightData, weightDims, 2, NULL);
-    float wGradData[] = {0.f, 0.f, 0.f, 0.f, 0.f, 0.f};
-    tensor_t *wGrad = tensorInitFloat(wGradData, weightDims, 2, NULL);
+    /* Set up a simple linear model: weights=[1,1,1,1,1,1] shape=[2,3], bias=[-1,3] */
+    tensor_t *wParam = buildFloatTensor2D(2, 3, (float[]){1.f, 1.f, 1.f, 1.f, 1.f, 1.f}, 6);
+    tensor_t *wGrad = gradInitFloat(wParam, NULL);
     parameter_t *w = parameterInit(wParam, wGrad);
 
-    float biasData[] = {-1.f, 3.f};
-    size_t biasDims[] = {1, 2};
-    tensor_t *bParam = tensorInitFloat(biasData, biasDims, 2, NULL);
-    float bGradData[] = {0.f, 0.f};
-    tensor_t *bGrad = tensorInitFloat(bGradData, biasDims, 2, NULL);
+    tensor_t *bParam = buildFloatTensor2D(1, 2, (float[]){-1.f, 3.f}, 2);
+    tensor_t *bGrad = gradInitFloat(bParam, NULL);
     parameter_t *b = parameterInit(bParam, bGrad);
 
     quantization_t testQ;
@@ -116,28 +127,21 @@ void testEvaluationBatch_ReturnsAverageLoss() {
     layer_t *linear = linearLayerInit(w, b, &testQ, &testQ, &testQ, &testQ);
     layer_t *model[] = {linear};
 
-    // Create 2 samples manually
-    float input0Data[] = {0.f, 1.f, 2.f};
-    size_t inputDims[] = {1, 3};
-    tensor_t *input0 = tensorInitFloat(input0Data, inputDims, 2, NULL);
-    float label0Data[] = {10.f, 20.f};
-    size_t labelDims[] = {1, 2};
-    tensor_t *label0 = tensorInitFloat(label0Data, labelDims, 2, NULL);
+    /* Create 2 samples manually */
+    tensor_t *input0 = buildFloatTensor2D(1, 3, (float[]){0.f, 1.f, 2.f}, 3);
+    tensor_t *label0 = buildFloatTensor2D(1, 2, (float[]){10.f, 20.f}, 2);
+    tensor_t *input1 = buildFloatTensor2D(1, 3, (float[]){1.f, 0.f, 0.f}, 3);
+    tensor_t *label1 = buildFloatTensor2D(1, 2, (float[]){5.f, 5.f}, 2);
 
-    float input1Data[] = {1.f, 0.f, 0.f};
-    tensor_t *input1 = tensorInitFloat(input1Data, inputDims, 2, NULL);
-    float label1Data[] = {5.f, 5.f};
-    tensor_t *label1 = tensorInitFloat(label1Data, labelDims, 2, NULL);
-
-    // Compute expected losses via inferenceWithLoss directly
+    /* Compute expected losses via inferenceWithLoss directly */
     inferenceStats_t *stats0 = inferenceWithLoss(model, 1, input0, label0, MSE);
     inferenceStats_t *stats1 = inferenceWithLoss(model, 1, input1, label1, MSE);
     float expectedAvgLoss = (stats0->loss + stats1->loss) / 2.0f;
     freeInferenceStats(stats0);
     freeInferenceStats(stats1);
 
-    // Build a batch. Samples must be heap-allocated: evaluationBatch frees
-    // each via freeSample (the batch-consumer convention set by #119).
+    /* Build a batch. Samples must be heap-allocated: evaluationBatch frees
+     * each via freeSample (the batch-consumer convention set by #119). */
     sample_t *s0 = reserveMemory(sizeof(sample_t));
     s0->item = input0;
     s0->label = label0;
@@ -149,53 +153,79 @@ void testEvaluationBatch_ReturnsAverageLoss() {
 
     float actualAvgLoss = evaluationBatch(model, 1, MSE, &batch, inferenceWithLoss);
 
-    TEST_ASSERT_FLOAT_WITHIN(1e-5f, expectedAvgLoss, actualAvgLoss);
+    /* CAPTURE. */
+    float capturedExpected = expectedAvgLoss;
+    float capturedActual = actualAvgLoss;
+
+    /* FREE in reverse-init order. evaluationBatch consumed s0/s1 (freed via
+     * freeSample inside the production loop). The tensors they referenced
+     * (input0/label0/input1/label1) are still ours to free. */
+    freeTensor(label1);
+    freeTensor(input1);
+    freeTensor(label0);
+    freeTensor(input0);
+    freeLinearLayer(linear);
+    freeParameter(b);
+    freeParameter(w);
+
+    /* ASSERT on captured. */
+    TEST_ASSERT_FLOAT_WITHIN(1e-5f, capturedExpected, capturedActual);
 }
 
-// Test dataset for epoch-level tests: 4 samples, batchSize=2 → 2 batches
+/* Test dataset for epoch-level tests: 4 samples, batchSize=2 → 2 batches.
+ * File-scope so the dataLoader callback can reach it. Each test that calls
+ * initEpochDataset() must call freeEpochDataset() at end so the per-test
+ * teardown idiom holds (no shared lazy-init/never-free state).
+ *
+ * Mirrors the dataset pattern in UnitTestMnistSmoke.c (#120). */
 static tensor_t *epochItems[4];
 static tensor_t *epochLabels[4];
 static dataset_t epochDataset;
+static tensorArray_t epochItemsArr;
+static tensorArray_t epochLabelsArr;
 static bool epochDatasetInit = false;
+
+static const float epochItemDataLiteral[4][2] = {
+    {5.f, 1.f},
+    {1.f, 5.f},
+    {3.f, 1.f},
+    {1.f, 3.f},
+};
+static const float epochLabelDataLiteral[4][2] = {
+    {1.f, 0.f},
+    {0.f, 1.f},
+    {1.f, 0.f},
+    {0.f, 1.f},
+};
 
 static void initEpochDataset() {
     if (epochDatasetInit) {
         return;
     }
+    for (size_t i = 0; i < 4; i++) {
+        epochItems[i] = buildFloatTensor2D(1, 2, epochItemDataLiteral[i], 2);
+        epochLabels[i] = buildFloatTensor2D(1, 2, epochLabelDataLiteral[i], 2);
+    }
 
-    // 4 samples: input [1,2], label [1,0] or [0,1]
-    static float in0[] = {5.f, 1.f};
-    static float in1[] = {1.f, 5.f};
-    static float in2[] = {3.f, 1.f};
-    static float in3[] = {1.f, 3.f};
-    static float lb0[] = {1.f, 0.f};
-    static float lb1[] = {0.f, 1.f};
-    static float lb2[] = {1.f, 0.f};
-    static float lb3[] = {0.f, 1.f};
+    epochItemsArr.array = epochItems;
+    epochItemsArr.size = 4;
+    epochLabelsArr.array = epochLabels;
+    epochLabelsArr.size = 4;
 
-    static size_t inDims[] = {1, 2};
-    static size_t lbDims[] = {1, 2};
-
-    epochItems[0] = tensorInitFloat(in0, inDims, 2, NULL);
-    epochItems[1] = tensorInitFloat(in1, inDims, 2, NULL);
-    epochItems[2] = tensorInitFloat(in2, inDims, 2, NULL);
-    epochItems[3] = tensorInitFloat(in3, inDims, 2, NULL);
-
-    epochLabels[0] = tensorInitFloat(lb0, lbDims, 2, NULL);
-    epochLabels[1] = tensorInitFloat(lb1, lbDims, 2, NULL);
-    epochLabels[2] = tensorInitFloat(lb2, lbDims, 2, NULL);
-    epochLabels[3] = tensorInitFloat(lb3, lbDims, 2, NULL);
-
-    static tensorArray_t itemsArr;
-    itemsArr.array = epochItems;
-    itemsArr.size = 4;
-    static tensorArray_t labelsArr;
-    labelsArr.array = epochLabels;
-    labelsArr.size = 4;
-
-    epochDataset.items = &itemsArr;
-    epochDataset.labels = &labelsArr;
+    epochDataset.items = &epochItemsArr;
+    epochDataset.labels = &epochLabelsArr;
     epochDatasetInit = true;
+}
+
+static void freeEpochDataset() {
+    if (!epochDatasetInit) {
+        return;
+    }
+    for (size_t i = 0; i < 4; i++) {
+        freeTensor(epochItems[i]);
+        freeTensor(epochLabels[i]);
+    }
+    epochDatasetInit = false;
 }
 
 static sample_t *getEpochSample(size_t id) {
@@ -212,19 +242,13 @@ static size_t getEpochDatasetSize() {
 void testEvaluationEpoch_ReturnsAverageLossAcrossBatches() {
     initEpochDataset();
 
-    // Identity model
-    float wData[] = {1.f, 0.f, 0.f, 1.f};
-    size_t wDims[] = {2, 2};
-    tensor_t *wParam = tensorInitFloat(wData, wDims, 2, NULL);
-    float wgData[] = {0.f, 0.f, 0.f, 0.f};
-    tensor_t *wGrad = tensorInitFloat(wgData, wDims, 2, NULL);
+    /* Identity model */
+    tensor_t *wParam = buildFloatTensor2D(2, 2, (float[]){1.f, 0.f, 0.f, 1.f}, 4);
+    tensor_t *wGrad = gradInitFloat(wParam, NULL);
     parameter_t *w = parameterInit(wParam, wGrad);
 
-    float bData[] = {0.f, 0.f};
-    size_t bDims[] = {1, 2};
-    tensor_t *bParam = tensorInitFloat(bData, bDims, 2, NULL);
-    float bgData[] = {0.f, 0.f};
-    tensor_t *bGrad = tensorInitFloat(bgData, bDims, 2, NULL);
+    tensor_t *bParam = buildFloatTensor2D(1, 2, (float[]){0.f, 0.f}, 2);
+    tensor_t *bGrad = gradInitFloat(bParam, NULL);
     parameter_t *b = parameterInit(bParam, bGrad);
 
     quantization_t testQ;
@@ -237,31 +261,35 @@ void testEvaluationEpoch_ReturnsAverageLossAcrossBatches() {
 
     float totalAvg = evaluationEpoch(model, 1, MSE, dl, inferenceWithLoss);
 
-    // Identity model output = input, so loss = MSE(input, label)
-    // s0: MSE([5,1],[1,0]) = ((5-1)^2+(1-0)^2)/2 = 8.5
-    // s1: MSE([1,5],[0,1]) = ((1-0)^2+(5-1)^2)/2 = 8.5
-    // s2: MSE([3,1],[1,0]) = ((3-1)^2+(1-0)^2)/2 = 2.5
-    // s3: MSE([1,3],[0,1]) = ((1-0)^2+(3-1)^2)/2 = 2.5
-    // 4 batches of 1, avg of per-batch avg = (8.5+8.5+2.5+2.5)/4 = 5.5
-    TEST_ASSERT_FLOAT_WITHIN(0.01f, 5.5f, totalAvg);
+    /* CAPTURE. */
+    float capturedTotalAvg = totalAvg;
+
+    /* FREE. */
+    freeDataLoader(dl);
+    freeLinearLayer(linear);
+    freeParameter(b);
+    freeParameter(w);
+    freeEpochDataset();
+
+    /* Identity model output = input, so loss = MSE(input, label)
+     * s0: MSE([5,1],[1,0]) = ((5-1)^2+(1-0)^2)/2 = 8.5
+     * s1: MSE([1,5],[0,1]) = ((1-0)^2+(5-1)^2)/2 = 8.5
+     * s2: MSE([3,1],[1,0]) = ((3-1)^2+(1-0)^2)/2 = 2.5
+     * s3: MSE([1,3],[0,1]) = ((1-0)^2+(3-1)^2)/2 = 2.5
+     * 4 batches of 1, avg of per-batch avg = (8.5+8.5+2.5+2.5)/4 = 5.5 */
+    TEST_ASSERT_FLOAT_WITHIN(0.01f, 5.5f, capturedTotalAvg);
 }
 
 void testEvaluationEpoch_MinibatchMatchesMicrobatchAverage() {
     initEpochDataset();
 
-    // Identity model — output = input, so loss = MSE(input, label)
-    float wData[] = {1.f, 0.f, 0.f, 1.f};
-    size_t wDims[] = {2, 2};
-    tensor_t *wParam = tensorInitFloat(wData, wDims, 2, NULL);
-    float wgData[] = {0.f, 0.f, 0.f, 0.f};
-    tensor_t *wGrad = tensorInitFloat(wgData, wDims, 2, NULL);
+    /* Identity model — output = input, so loss = MSE(input, label) */
+    tensor_t *wParam = buildFloatTensor2D(2, 2, (float[]){1.f, 0.f, 0.f, 1.f}, 4);
+    tensor_t *wGrad = gradInitFloat(wParam, NULL);
     parameter_t *w = parameterInit(wParam, wGrad);
 
-    float bData[] = {0.f, 0.f};
-    size_t bDims[] = {1, 2};
-    tensor_t *bParam = tensorInitFloat(bData, bDims, 2, NULL);
-    float bgData[] = {0.f, 0.f};
-    tensor_t *bGrad = tensorInitFloat(bgData, bDims, 2, NULL);
+    tensor_t *bParam = buildFloatTensor2D(1, 2, (float[]){0.f, 0.f}, 2);
+    tensor_t *bGrad = gradInitFloat(bParam, NULL);
     parameter_t *b = parameterInit(bParam, bGrad);
 
     quantization_t testQ;
@@ -269,32 +297,37 @@ void testEvaluationEpoch_MinibatchMatchesMicrobatchAverage() {
     layer_t *linear = linearLayerInit(w, b, &testQ, &testQ, &testQ, &testQ);
     layer_t *model[] = {linear};
 
-    // batchSize=2 → 2 minibatches of 2 samples each
-    // Per-sample losses: 8.5, 8.5, 2.5, 2.5
-    // Batch 0 avg = (8.5+8.5)/2 = 8.5; Batch 1 avg = (2.5+2.5)/2 = 2.5
-    // Epoch avg = (8.5+2.5)/2 = 5.5 — identical to microbatch result
+    /* batchSize=2 → 2 minibatches of 2 samples each
+     * Per-sample losses: 8.5, 8.5, 2.5, 2.5
+     * Batch 0 avg = (8.5+8.5)/2 = 8.5; Batch 1 avg = (2.5+2.5)/2 = 2.5
+     * Epoch avg = (8.5+2.5)/2 = 5.5 — identical to microbatch result */
     dataLoader_t *dl =
         dataLoaderInit(getEpochSample, getEpochDatasetSize, 2, NULL, NULL, false, 0, true);
 
     float totalAvg = evaluationEpoch(model, 1, MSE, dl, inferenceWithLoss);
 
-    TEST_ASSERT_FLOAT_WITHIN(0.01f, 5.5f, totalAvg);
+    /* CAPTURE. */
+    float capturedTotalAvg = totalAvg;
+
+    /* FREE. */
+    freeDataLoader(dl);
+    freeLinearLayer(linear);
+    freeParameter(b);
+    freeParameter(w);
+    freeEpochDataset();
+
+    /* ASSERT. */
+    TEST_ASSERT_FLOAT_WITHIN(0.01f, 5.5f, capturedTotalAvg);
 }
 
 void testTrainingBatchDefault_ReturnsAverageLossAndAccumulatesGrads() {
-    // Single linear layer, 2 samples → avg loss should match manually computed value
-    float wData[] = {1.f, 1.f, 1.f, 1.f, 1.f, 1.f};
-    size_t wDims[] = {2, 3};
-    tensor_t *wParam = tensorInitFloat(wData, wDims, 2, NULL);
-    float wgData[] = {0.f, 0.f, 0.f, 0.f, 0.f, 0.f};
-    tensor_t *wGrad = tensorInitFloat(wgData, wDims, 2, NULL);
+    /* Single linear layer, 2 samples → avg loss should match manually computed value */
+    tensor_t *wParam = buildFloatTensor2D(2, 3, (float[]){1.f, 1.f, 1.f, 1.f, 1.f, 1.f}, 6);
+    tensor_t *wGrad = gradInitFloat(wParam, NULL);
     parameter_t *w = parameterInit(wParam, wGrad);
 
-    float bData[] = {-1.f, 3.f};
-    size_t bDims[] = {1, 2};
-    tensor_t *bParam = tensorInitFloat(bData, bDims, 2, NULL);
-    float bgData[] = {0.f, 0.f};
-    tensor_t *bGrad = tensorInitFloat(bgData, bDims, 2, NULL);
+    tensor_t *bParam = buildFloatTensor2D(1, 2, (float[]){-1.f, 3.f}, 2);
+    tensor_t *bGrad = gradInitFloat(bParam, NULL);
     parameter_t *b = parameterInit(bParam, bGrad);
 
     quantization_t testQ;
@@ -302,27 +335,20 @@ void testTrainingBatchDefault_ReturnsAverageLossAndAccumulatesGrads() {
     layer_t *linear = linearLayerInit(w, b, &testQ, &testQ, &testQ, &testQ);
     layer_t *model[] = {linear};
 
-    // Compute expected: run calculateGradsSequential manually per sample
-    float in0Data[] = {-4.f, 1.f, 9.f};
-    size_t inDims[] = {1, 3};
-    tensor_t *in0 = tensorInitFloat(in0Data, inDims, 2, NULL);
-    float lb0Data[] = {59.f, -23.f};
-    size_t lbDims[] = {1, 2};
-    tensor_t *lb0 = tensorInitFloat(lb0Data, lbDims, 2, NULL);
+    /* Compute expected: run calculateGradsSequential manually per sample */
+    tensor_t *in0 = buildFloatTensor2D(1, 3, (float[]){-4.f, 1.f, 9.f}, 3);
+    tensor_t *lb0 = buildFloatTensor2D(1, 2, (float[]){59.f, -23.f}, 2);
+    tensor_t *in1 = buildFloatTensor2D(1, 3, (float[]){5.f, -1.f, 2.f}, 3);
+    tensor_t *lb1 = buildFloatTensor2D(1, 2, (float[]){43.f, 249.f}, 2);
 
-    float in1Data[] = {5.f, -1.f, 2.f};
-    tensor_t *in1 = tensorInitFloat(in1Data, inDims, 2, NULL);
-    float lb1Data[] = {43.f, 249.f};
-    tensor_t *lb1 = tensorInitFloat(lb1Data, lbDims, 2, NULL);
-
-    // Get expected losses from individual calculateGrads calls
+    /* Get expected losses from individual calculateGrads calls */
     trainingStats_t *ts0 = calculateGradsSequential(model, 1, MSE, in0, lb0);
     trainingStats_t *ts1 = calculateGradsSequential(model, 1, MSE, in1, lb1);
     float expectedAvg = (ts0->loss + ts1->loss) / 2.0f;
     freeTrainingStats(ts0);
     freeTrainingStats(ts1);
 
-    // Reset grads to zero before testing trainingBatchDefault
+    /* Reset grads to zero before testing trainingBatchDefault */
     float *gArr = (float *)wGrad->data;
     for (size_t i = 0; i < 6; i++) {
         gArr[i] = 0.f;
@@ -331,8 +357,8 @@ void testTrainingBatchDefault_ReturnsAverageLossAndAccumulatesGrads() {
     bgArr[0] = 0.f;
     bgArr[1] = 0.f;
 
-    // Build batch. Samples must be heap-allocated: trainingBatchDefault frees
-    // each via freeSample (the batch-consumer convention set by #119).
+    /* Build batch. Samples must be heap-allocated: trainingBatchDefault frees
+     * each via freeSample (the batch-consumer convention set by #119). */
     sample_t *s0 = reserveMemory(sizeof(sample_t));
     s0->item = in0;
     s0->label = lb0;
@@ -344,24 +370,33 @@ void testTrainingBatchDefault_ReturnsAverageLossAndAccumulatesGrads() {
 
     float actualAvg = trainingBatchDefault(model, 1, MSE, &batch, calculateGradsSequential);
 
-    TEST_ASSERT_FLOAT_WITHIN(1e-5f, expectedAvg, actualAvg);
+    /* CAPTURE. */
+    float capturedExpected = expectedAvg;
+    float capturedActual = actualAvg;
+
+    /* FREE. */
+    freeTensor(lb1);
+    freeTensor(in1);
+    freeTensor(lb0);
+    freeTensor(in0);
+    freeLinearLayer(linear);
+    freeParameter(b);
+    freeParameter(w);
+
+    /* ASSERT. */
+    TEST_ASSERT_FLOAT_WITHIN(1e-5f, capturedExpected, capturedActual);
 }
 
 void testTrainingEpochDefault_DoesOptimizerStepPerBatch() {
-    // After one epoch with known data, weights should change
-    // Epoch dataset has 2 input features, 2 output classes
-    float wData[] = {1.f, 0.f, 0.f, 1.f};
-    size_t wDims[] = {2, 2};
-    tensor_t *wParam = tensorInitFloat(wData, wDims, 2, NULL);
-    float wgData[] = {0.f, 0.f, 0.f, 0.f};
-    tensor_t *wGrad = tensorInitFloat(wgData, wDims, 2, NULL);
+    /* After one epoch with known data, weights should change.
+     * Epoch dataset has 2 input features, 2 output classes. */
+    static const float wInitData[4] = {1.f, 0.f, 0.f, 1.f};
+    tensor_t *wParam = buildFloatTensor2D(2, 2, wInitData, 4);
+    tensor_t *wGrad = gradInitFloat(wParam, NULL);
     parameter_t *w = parameterInit(wParam, wGrad);
 
-    float bData[] = {0.f, 0.f};
-    size_t bDims[] = {1, 2};
-    tensor_t *bParam = tensorInitFloat(bData, bDims, 2, NULL);
-    float bgData[] = {0.f, 0.f};
-    tensor_t *bGrad = tensorInitFloat(bgData, bDims, 2, NULL);
+    tensor_t *bParam = buildFloatTensor2D(1, 2, (float[]){0.f, 0.f}, 2);
+    tensor_t *bGrad = gradInitFloat(bParam, NULL);
     parameter_t *b = parameterInit(bParam, bGrad);
 
     quantization_t testQ;
@@ -370,15 +405,15 @@ void testTrainingEpochDefault_DoesOptimizerStepPerBatch() {
     layer_t *model[] = {linear};
     size_t sizeModel = 1;
 
-    // Save initial weights
+    /* Save initial weights */
     float initWeights[4];
     for (size_t i = 0; i < 4; i++) {
-        initWeights[i] = wData[i];
+        initWeights[i] = wInitData[i];
     }
 
     optimizer_t *sgd = sgdMCreateOptim(0.01f, 0.f, 0.f, model, sizeModel, FLOAT32);
 
-    // Use epoch dataset (batchSize=1 → 4 batches)
+    /* Use epoch dataset (batchSize=1 → 4 batches) */
     initEpochDataset();
     dataLoader_t *dl =
         dataLoaderInit(getEpochSample, getEpochDatasetSize, 1, NULL, NULL, false, 0, true);
@@ -386,37 +421,44 @@ void testTrainingEpochDefault_DoesOptimizerStepPerBatch() {
     float epochLoss =
         trainingEpochDefault(model, sizeModel, MSE, dl, sgd, calculateGradsSequential);
 
-    // Weights should have changed
-    float *curWeights = (float *)wParam->data;
-    bool changed = false;
-    for (size_t i = 0; i < 4; i++) {
-        if (curWeights[i] != initWeights[i]) {
-            changed = true;
-            break;
+    /* CAPTURE assertion values BEFORE any free. */
+    bool capturedChanged = false;
+    {
+        float *curWeights = (float *)wParam->data;
+        for (size_t i = 0; i < 4; i++) {
+            if (curWeights[i] != initWeights[i]) {
+                capturedChanged = true;
+                break;
+            }
         }
     }
-    TEST_ASSERT_TRUE(changed);
-    TEST_ASSERT_TRUE(epochLoss > 0.0f);
+    float capturedEpochLoss = epochLoss;
+
+    /* FREE. freeOptimSgdM cascades to w and b parameters; do NOT also free
+     * those (would double-free). */
+    freeOptimSgdM(sgd);
+    freeDataLoader(dl);
+    freeLinearLayer(linear);
+    freeEpochDataset();
+
+    /* ASSERT. */
+    TEST_ASSERT_TRUE(capturedChanged);
+    TEST_ASSERT_TRUE(capturedEpochLoss > 0.0f);
 }
 
 void testTrainingEpochDefault_MinibatchStepsOncePerMinibatch() {
-    // Same model + dataset as microbatch training test, but batchSize=2
-    // means the optimizer steps twice (once per minibatch) instead of
-    // four times, with gradients accumulated across two samples per step.
-    // Weight trajectory differs from microbatch; only property tested
-    // here is that training runs end-to-end and updates the model.
-    float wData[] = {1.f, 0.f, 0.f, 1.f};
-    size_t wDims[] = {2, 2};
-    tensor_t *wParam = tensorInitFloat(wData, wDims, 2, NULL);
-    float wgData[] = {0.f, 0.f, 0.f, 0.f};
-    tensor_t *wGrad = tensorInitFloat(wgData, wDims, 2, NULL);
+    /* Same model + dataset as microbatch training test, but batchSize=2
+     * means the optimizer steps twice (once per minibatch) instead of
+     * four times, with gradients accumulated across two samples per step.
+     * Weight trajectory differs from microbatch; only property tested
+     * here is that training runs end-to-end and updates the model. */
+    static const float wInitData[4] = {1.f, 0.f, 0.f, 1.f};
+    tensor_t *wParam = buildFloatTensor2D(2, 2, wInitData, 4);
+    tensor_t *wGrad = gradInitFloat(wParam, NULL);
     parameter_t *w = parameterInit(wParam, wGrad);
 
-    float bData[] = {0.f, 0.f};
-    size_t bDims[] = {1, 2};
-    tensor_t *bParam = tensorInitFloat(bData, bDims, 2, NULL);
-    float bgData[] = {0.f, 0.f};
-    tensor_t *bGrad = tensorInitFloat(bgData, bDims, 2, NULL);
+    tensor_t *bParam = buildFloatTensor2D(1, 2, (float[]){0.f, 0.f}, 2);
+    tensor_t *bGrad = gradInitFloat(bParam, NULL);
     parameter_t *b = parameterInit(bParam, bGrad);
 
     quantization_t testQ;
@@ -427,7 +469,7 @@ void testTrainingEpochDefault_MinibatchStepsOncePerMinibatch() {
 
     float initWeights[4];
     for (size_t i = 0; i < 4; i++) {
-        initWeights[i] = wData[i];
+        initWeights[i] = wInitData[i];
     }
 
     optimizer_t *sgd = sgdMCreateOptim(0.01f, 0.f, 0.f, model, sizeModel, FLOAT32);
@@ -439,31 +481,37 @@ void testTrainingEpochDefault_MinibatchStepsOncePerMinibatch() {
     float epochLoss =
         trainingEpochDefault(model, sizeModel, MSE, dl, sgd, calculateGradsSequential);
 
-    float *curWeights = (float *)wParam->data;
-    bool changed = false;
-    for (size_t i = 0; i < 4; i++) {
-        if (curWeights[i] != initWeights[i]) {
-            changed = true;
-            break;
+    /* CAPTURE. */
+    bool capturedChanged = false;
+    {
+        float *curWeights = (float *)wParam->data;
+        for (size_t i = 0; i < 4; i++) {
+            if (curWeights[i] != initWeights[i]) {
+                capturedChanged = true;
+                break;
+            }
         }
     }
-    TEST_ASSERT_TRUE(changed);
-    TEST_ASSERT_TRUE(epochLoss > 0.0f);
+    float capturedEpochLoss = epochLoss;
+
+    /* FREE. */
+    freeOptimSgdM(sgd);
+    freeDataLoader(dl);
+    freeLinearLayer(linear);
+    freeEpochDataset();
+
+    /* ASSERT. */
+    TEST_ASSERT_TRUE(capturedChanged);
+    TEST_ASSERT_TRUE(capturedEpochLoss > 0.0f);
 }
 
 void testTrainingRun_ReturnsResult() {
-    float wData[] = {1.f, 0.f, 0.f, 1.f};
-    size_t wDims[] = {2, 2};
-    tensor_t *wParam = tensorInitFloat(wData, wDims, 2, NULL);
-    float wgData[] = {0.f, 0.f, 0.f, 0.f};
-    tensor_t *wGrad = tensorInitFloat(wgData, wDims, 2, NULL);
+    tensor_t *wParam = buildFloatTensor2D(2, 2, (float[]){1.f, 0.f, 0.f, 1.f}, 4);
+    tensor_t *wGrad = gradInitFloat(wParam, NULL);
     parameter_t *w = parameterInit(wParam, wGrad);
 
-    float bData[] = {0.f, 0.f};
-    size_t bDims[] = {1, 2};
-    tensor_t *bParam = tensorInitFloat(bData, bDims, 2, NULL);
-    float bgData[] = {0.f, 0.f};
-    tensor_t *bGrad = tensorInitFloat(bgData, bDims, 2, NULL);
+    tensor_t *bParam = buildFloatTensor2D(1, 2, (float[]){0.f, 0.f}, 2);
+    tensor_t *bGrad = gradInitFloat(bParam, NULL);
     parameter_t *b = parameterInit(bParam, bGrad);
 
     quantization_t testQ;
@@ -482,10 +530,23 @@ void testTrainingRun_ReturnsResult() {
     trainingRunResult_t result = trainingRun(model, 1, MSE, trainDl, evalDl, sgd, 2,
                                              calculateGradsSequential, inferenceWithLoss, NULL);
 
-    TEST_ASSERT_TRUE(result.finalTrainLoss > 0.0f);
-    TEST_ASSERT_TRUE(result.finalEvalStats.loss > 0.0f);
-    TEST_ASSERT_TRUE(result.finalEvalStats.accuracy >= 0.0f);
-    TEST_ASSERT_TRUE(result.finalEvalStats.accuracy <= 1.0f);
+    /* CAPTURE. */
+    float capturedFinalTrainLoss = result.finalTrainLoss;
+    float capturedEvalLoss = result.finalEvalStats.loss;
+    float capturedAccuracy = result.finalEvalStats.accuracy;
+
+    /* FREE. */
+    freeOptimSgdM(sgd);
+    freeDataLoader(evalDl);
+    freeDataLoader(trainDl);
+    freeLinearLayer(linear);
+    freeEpochDataset();
+
+    /* ASSERT. */
+    TEST_ASSERT_TRUE(capturedFinalTrainLoss > 0.0f);
+    TEST_ASSERT_TRUE(capturedEvalLoss > 0.0f);
+    TEST_ASSERT_TRUE(capturedAccuracy >= 0.0f);
+    TEST_ASSERT_TRUE(capturedAccuracy <= 1.0f);
 }
 
 static size_t cbCallCount;
@@ -506,18 +567,12 @@ void testTrainingRun_CallsCallbackEachEpochWithStats() {
     cbLastTrainLoss = 0.0f;
     cbLastStats = (epochStats_t){0};
 
-    float wData[] = {1.f, 0.f, 0.f, 1.f};
-    size_t wDims[] = {2, 2};
-    tensor_t *wParam = tensorInitFloat(wData, wDims, 2, NULL);
-    float wgData[] = {0.f, 0.f, 0.f, 0.f};
-    tensor_t *wGrad = tensorInitFloat(wgData, wDims, 2, NULL);
+    tensor_t *wParam = buildFloatTensor2D(2, 2, (float[]){1.f, 0.f, 0.f, 1.f}, 4);
+    tensor_t *wGrad = gradInitFloat(wParam, NULL);
     parameter_t *w = parameterInit(wParam, wGrad);
 
-    float bData[] = {0.f, 0.f};
-    size_t bDims[] = {1, 2};
-    tensor_t *bParam = tensorInitFloat(bData, bDims, 2, NULL);
-    float bgData[] = {0.f, 0.f};
-    tensor_t *bGrad = tensorInitFloat(bgData, bDims, 2, NULL);
+    tensor_t *bParam = buildFloatTensor2D(1, 2, (float[]){0.f, 0.f}, 2);
+    tensor_t *bGrad = gradInitFloat(bParam, NULL);
     parameter_t *b = parameterInit(bParam, bGrad);
 
     quantization_t testQ;
@@ -538,33 +593,44 @@ void testTrainingRun_CallsCallbackEachEpochWithStats() {
         trainingRun(model, 1, MSE, trainDl, evalDl, sgd, numberOfEpochs, calculateGradsSequential,
                     inferenceWithLoss, captureCallback);
 
-    // Callback was invoked once per epoch, in order
-    TEST_ASSERT_EQUAL_UINT(numberOfEpochs, cbCallCount);
-    TEST_ASSERT_EQUAL_UINT(numberOfEpochs - 1, cbLastEpoch); // 0-indexed
+    /* CAPTURE. */
+    size_t capturedCbCallCount = cbCallCount;
+    size_t capturedCbLastEpoch = cbLastEpoch;
+    float capturedCbLastTrainLoss = cbLastTrainLoss;
+    float capturedCbLastStatsLoss = cbLastStats.loss;
+    float capturedCbLastStatsAccuracy = cbLastStats.accuracy;
+    float capturedFinalTrainLoss = result.finalTrainLoss;
+    float capturedFinalEvalLoss = result.finalEvalStats.loss;
+    float capturedFinalEvalAccuracy = result.finalEvalStats.accuracy;
 
-    // Stats passed to callback are real (not zero-initialized) and match the final result
-    TEST_ASSERT_TRUE(cbLastTrainLoss > 0.0f);
-    TEST_ASSERT_TRUE(cbLastStats.loss > 0.0f);
-    TEST_ASSERT_EQUAL_FLOAT(result.finalTrainLoss, cbLastTrainLoss);
-    TEST_ASSERT_EQUAL_FLOAT(result.finalEvalStats.loss, cbLastStats.loss);
-    TEST_ASSERT_EQUAL_FLOAT(result.finalEvalStats.accuracy, cbLastStats.accuracy);
+    /* FREE. */
+    freeOptimSgdM(sgd);
+    freeDataLoader(evalDl);
+    freeDataLoader(trainDl);
+    freeLinearLayer(linear);
+    freeEpochDataset();
+
+    /* ASSERT. Callback was invoked once per epoch, in order. */
+    TEST_ASSERT_EQUAL_UINT(numberOfEpochs, capturedCbCallCount);
+    TEST_ASSERT_EQUAL_UINT(numberOfEpochs - 1, capturedCbLastEpoch); /* 0-indexed */
+
+    /* Stats passed to callback are real (not zero-initialized) and match the final result. */
+    TEST_ASSERT_TRUE(capturedCbLastTrainLoss > 0.0f);
+    TEST_ASSERT_TRUE(capturedCbLastStatsLoss > 0.0f);
+    TEST_ASSERT_EQUAL_FLOAT(capturedFinalTrainLoss, capturedCbLastTrainLoss);
+    TEST_ASSERT_EQUAL_FLOAT(capturedFinalEvalLoss, capturedCbLastStatsLoss);
+    TEST_ASSERT_EQUAL_FLOAT(capturedFinalEvalAccuracy, capturedCbLastStatsAccuracy);
 }
 
 void testEvaluationEpochWithMetrics_AllCorrect() {
     initEpochDataset();
 
-    float wData[] = {1.f, 0.f, 0.f, 1.f};
-    size_t wDims[] = {2, 2};
-    tensor_t *wParam = tensorInitFloat(wData, wDims, 2, NULL);
-    float wgData[] = {0.f, 0.f, 0.f, 0.f};
-    tensor_t *wGrad = tensorInitFloat(wgData, wDims, 2, NULL);
+    tensor_t *wParam = buildFloatTensor2D(2, 2, (float[]){1.f, 0.f, 0.f, 1.f}, 4);
+    tensor_t *wGrad = gradInitFloat(wParam, NULL);
     parameter_t *w = parameterInit(wParam, wGrad);
 
-    float bData[] = {0.f, 0.f};
-    size_t bDims[] = {1, 2};
-    tensor_t *bParam = tensorInitFloat(bData, bDims, 2, NULL);
-    float bgData[] = {0.f, 0.f};
-    tensor_t *bGrad = tensorInitFloat(bgData, bDims, 2, NULL);
+    tensor_t *bParam = buildFloatTensor2D(1, 2, (float[]){0.f, 0.f}, 2);
+    tensor_t *bGrad = gradInitFloat(bParam, NULL);
     parameter_t *b = parameterInit(bParam, bGrad);
 
     quantization_t testQ;
@@ -575,60 +641,80 @@ void testEvaluationEpochWithMetrics_AllCorrect() {
     dataLoader_t *dl =
         dataLoaderInit(getEpochSample, getEpochDatasetSize, 1, NULL, NULL, false, 0, true);
 
-    // Identity model: all 4 samples predict correctly (same as testEvaluationEpochAccuracy)
+    /* Identity model: all 4 samples predict correctly (same as testEvaluationEpochAccuracy) */
     epochStats_t stats = evaluationEpochWithMetrics(model, 1, MSE, dl, inferenceWithLoss);
 
-    TEST_ASSERT_FLOAT_WITHIN(0.01f, 5.5f, stats.loss); // same as testEvaluationEpoch
-    TEST_ASSERT_FLOAT_WITHIN(0.001f, 1.0f, stats.accuracy);
-    TEST_ASSERT_FLOAT_WITHIN(0.001f, 1.0f, stats.precision);
-    TEST_ASSERT_FLOAT_WITHIN(0.001f, 1.0f, stats.recall);
-    TEST_ASSERT_FLOAT_WITHIN(0.001f, 1.0f, stats.f1);
+    /* CAPTURE. */
+    float capturedLoss = stats.loss;
+    float capturedAccuracy = stats.accuracy;
+    float capturedPrecision = stats.precision;
+    float capturedRecall = stats.recall;
+    float capturedF1 = stats.f1;
+
+    /* FREE. */
+    freeDataLoader(dl);
+    freeLinearLayer(linear);
+    freeParameter(b);
+    freeParameter(w);
+    freeEpochDataset();
+
+    /* ASSERT. */
+    TEST_ASSERT_FLOAT_WITHIN(0.01f, 5.5f, capturedLoss); /* same as testEvaluationEpoch */
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 1.0f, capturedAccuracy);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 1.0f, capturedPrecision);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 1.0f, capturedRecall);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 1.0f, capturedF1);
 }
 
-// Partially-correct dataset: 4 samples, 3 correct, 1 wrong
+/* Partially-correct dataset: 4 samples, 3 correct, 1 wrong */
 static tensor_t *partialItems[4];
 static tensor_t *partialLabels[4];
 static dataset_t partialDataset;
+static tensorArray_t partialItemsArr;
+static tensorArray_t partialLabelsArr;
 static bool partialDatasetInit = false;
+
+static const float partialItemDataLiteral[4][2] = {
+    {5.f, 1.f}, /* pred=0 */
+    {3.f, 1.f}, /* pred=0 */
+    {4.f, 1.f}, /* pred=0 (wrong!) */
+    {1.f, 3.f}, /* pred=1 */
+};
+static const float partialLabelDataLiteral[4][2] = {
+    {1.f, 0.f}, /* true=0 */
+    {1.f, 0.f}, /* true=0 */
+    {0.f, 1.f}, /* true=1 */
+    {0.f, 1.f}, /* true=1 */
+};
 
 static void initPartialDataset() {
     if (partialDatasetInit) {
         return;
     }
+    for (size_t i = 0; i < 4; i++) {
+        partialItems[i] = buildFloatTensor2D(1, 2, partialItemDataLiteral[i], 2);
+        partialLabels[i] = buildFloatTensor2D(1, 2, partialLabelDataLiteral[i], 2);
+    }
 
-    static float in0[] = {5.f, 1.f}; // pred=0
-    static float in1[] = {3.f, 1.f}; // pred=0
-    static float in2[] = {4.f, 1.f}; // pred=0 (wrong!)
-    static float in3[] = {1.f, 3.f}; // pred=1
+    partialItemsArr.array = partialItems;
+    partialItemsArr.size = 4;
+    partialLabelsArr.array = partialLabels;
+    partialLabelsArr.size = 4;
 
-    static float lb0[] = {1.f, 0.f}; // true=0
-    static float lb1[] = {1.f, 0.f}; // true=0
-    static float lb2[] = {0.f, 1.f}; // true=1
-    static float lb3[] = {0.f, 1.f}; // true=1
-
-    static size_t inDims[] = {1, 2};
-    static size_t lbDims[] = {1, 2};
-
-    partialItems[0] = tensorInitFloat(in0, inDims, 2, NULL);
-    partialItems[1] = tensorInitFloat(in1, inDims, 2, NULL);
-    partialItems[2] = tensorInitFloat(in2, inDims, 2, NULL);
-    partialItems[3] = tensorInitFloat(in3, inDims, 2, NULL);
-
-    partialLabels[0] = tensorInitFloat(lb0, lbDims, 2, NULL);
-    partialLabels[1] = tensorInitFloat(lb1, lbDims, 2, NULL);
-    partialLabels[2] = tensorInitFloat(lb2, lbDims, 2, NULL);
-    partialLabels[3] = tensorInitFloat(lb3, lbDims, 2, NULL);
-
-    static tensorArray_t itemsArr;
-    itemsArr.array = partialItems;
-    itemsArr.size = 4;
-    static tensorArray_t labelsArr;
-    labelsArr.array = partialLabels;
-    labelsArr.size = 4;
-
-    partialDataset.items = &itemsArr;
-    partialDataset.labels = &labelsArr;
+    partialDataset.items = &partialItemsArr;
+    partialDataset.labels = &partialLabelsArr;
     partialDatasetInit = true;
+}
+
+static void freePartialDataset() {
+    if (!partialDatasetInit) {
+        return;
+    }
+    for (size_t i = 0; i < 4; i++) {
+        freeTensor(partialItems[i]);
+        freeTensor(partialLabels[i]);
+    }
+    partialDatasetInit = false;
 }
 
 static sample_t *getPartialSample(size_t id) {
@@ -645,18 +731,12 @@ static size_t getPartialDatasetSize() {
 void testEvaluationEpochWithMetrics_PartiallyCorrect() {
     initPartialDataset();
 
-    float wData[] = {1.f, 0.f, 0.f, 1.f};
-    size_t wDims[] = {2, 2};
-    tensor_t *wParam = tensorInitFloat(wData, wDims, 2, NULL);
-    float wgData[] = {0.f, 0.f, 0.f, 0.f};
-    tensor_t *wGrad = tensorInitFloat(wgData, wDims, 2, NULL);
+    tensor_t *wParam = buildFloatTensor2D(2, 2, (float[]){1.f, 0.f, 0.f, 1.f}, 4);
+    tensor_t *wGrad = gradInitFloat(wParam, NULL);
     parameter_t *w = parameterInit(wParam, wGrad);
 
-    float bData[] = {0.f, 0.f};
-    size_t bDims[] = {1, 2};
-    tensor_t *bParam = tensorInitFloat(bData, bDims, 2, NULL);
-    float bgData[] = {0.f, 0.f};
-    tensor_t *bGrad = tensorInitFloat(bgData, bDims, 2, NULL);
+    tensor_t *bParam = buildFloatTensor2D(1, 2, (float[]){0.f, 0.f}, 2);
+    tensor_t *bGrad = gradInitFloat(bParam, NULL);
     parameter_t *b = parameterInit(bParam, bGrad);
 
     quantization_t testQ;
@@ -669,58 +749,79 @@ void testEvaluationEpochWithMetrics_PartiallyCorrect() {
 
     epochStats_t stats = evaluationEpochWithMetrics(model, 1, MSE, dl, inferenceWithLoss);
 
-    // tp=[2,1], predCount=[3,1], actualCount=[2,2]
-    // accuracy = 3/4 = 0.75
-    TEST_ASSERT_FLOAT_WITHIN(0.001f, 0.75f, stats.accuracy);
-    // precision = mean(2/3, 1/1) = 5/6
-    TEST_ASSERT_FLOAT_WITHIN(0.001f, 5.0f / 6.0f, stats.precision);
-    // recall = mean(2/2, 1/2) = 0.75
-    TEST_ASSERT_FLOAT_WITHIN(0.001f, 0.75f, stats.recall);
-    // F1 = mean(2*(2/3)*1/(2/3+1), 2*1*0.5/(1+0.5)) = mean(4/5, 2/3) = 11/15
-    TEST_ASSERT_FLOAT_WITHIN(0.001f, 11.0f / 15.0f, stats.f1);
+    /* CAPTURE. */
+    float capturedAccuracy = stats.accuracy;
+    float capturedPrecision = stats.precision;
+    float capturedRecall = stats.recall;
+    float capturedF1 = stats.f1;
+
+    /* FREE. */
+    freeDataLoader(dl);
+    freeLinearLayer(linear);
+    freeParameter(b);
+    freeParameter(w);
+    freePartialDataset();
+
+    /* ASSERT.
+     * tp=[2,1], predCount=[3,1], actualCount=[2,2]
+     * accuracy = 3/4 = 0.75 */
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 0.75f, capturedAccuracy);
+    /* precision = mean(2/3, 1/1) = 5/6 */
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 5.0f / 6.0f, capturedPrecision);
+    /* recall = mean(2/2, 1/2) = 0.75 */
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 0.75f, capturedRecall);
+    /* F1 = mean(2*(2/3)*1/(2/3+1), 2*1*0.5/(1+0.5)) = mean(4/5, 2/3) = 11/15 */
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 11.0f / 15.0f, capturedF1);
 }
 
-// Zero-prediction dataset: model never predicts class 1.
-// 3 samples: 2 correct for class 0, 1 wrong (true class 1, predicted 0).
+/* Zero-prediction dataset: model never predicts class 1.
+ * 3 samples: 2 correct for class 0, 1 wrong (true class 1, predicted 0). */
 static tensor_t *zeroPredItems[3];
 static tensor_t *zeroPredLabels[3];
 static dataset_t zeroPredDataset;
+static tensorArray_t zeroPredItemsArr;
+static tensorArray_t zeroPredLabelsArr;
 static bool zeroPredDatasetInit = false;
+
+static const float zeroPredItemDataLiteral[3][2] = {
+    {5.f, 1.f}, /* pred=0 */
+    {3.f, 1.f}, /* pred=0 */
+    {4.f, 1.f}, /* pred=0 (wrong, true=1) */
+};
+static const float zeroPredLabelDataLiteral[3][2] = {
+    {1.f, 0.f}, /* true=0 */
+    {1.f, 0.f}, /* true=0 */
+    {0.f, 1.f}, /* true=1 */
+};
 
 static void initZeroPredDataset() {
     if (zeroPredDatasetInit) {
         return;
     }
+    for (size_t i = 0; i < 3; i++) {
+        zeroPredItems[i] = buildFloatTensor2D(1, 2, zeroPredItemDataLiteral[i], 2);
+        zeroPredLabels[i] = buildFloatTensor2D(1, 2, zeroPredLabelDataLiteral[i], 2);
+    }
 
-    static float in0[] = {5.f, 1.f}; // pred=0
-    static float in1[] = {3.f, 1.f}; // pred=0
-    static float in2[] = {4.f, 1.f}; // pred=0 (wrong, true=1)
+    zeroPredItemsArr.array = zeroPredItems;
+    zeroPredItemsArr.size = 3;
+    zeroPredLabelsArr.array = zeroPredLabels;
+    zeroPredLabelsArr.size = 3;
 
-    static float lb0[] = {1.f, 0.f}; // true=0
-    static float lb1[] = {1.f, 0.f}; // true=0
-    static float lb2[] = {0.f, 1.f}; // true=1
-
-    static size_t inDims[] = {1, 2};
-    static size_t lbDims[] = {1, 2};
-
-    zeroPredItems[0] = tensorInitFloat(in0, inDims, 2, NULL);
-    zeroPredItems[1] = tensorInitFloat(in1, inDims, 2, NULL);
-    zeroPredItems[2] = tensorInitFloat(in2, inDims, 2, NULL);
-
-    zeroPredLabels[0] = tensorInitFloat(lb0, lbDims, 2, NULL);
-    zeroPredLabels[1] = tensorInitFloat(lb1, lbDims, 2, NULL);
-    zeroPredLabels[2] = tensorInitFloat(lb2, lbDims, 2, NULL);
-
-    static tensorArray_t itemsArr;
-    itemsArr.array = zeroPredItems;
-    itemsArr.size = 3;
-    static tensorArray_t labelsArr;
-    labelsArr.array = zeroPredLabels;
-    labelsArr.size = 3;
-
-    zeroPredDataset.items = &itemsArr;
-    zeroPredDataset.labels = &labelsArr;
+    zeroPredDataset.items = &zeroPredItemsArr;
+    zeroPredDataset.labels = &zeroPredLabelsArr;
     zeroPredDatasetInit = true;
+}
+
+static void freeZeroPredDataset() {
+    if (!zeroPredDatasetInit) {
+        return;
+    }
+    for (size_t i = 0; i < 3; i++) {
+        freeTensor(zeroPredItems[i]);
+        freeTensor(zeroPredLabels[i]);
+    }
+    zeroPredDatasetInit = false;
 }
 
 static sample_t *getZeroPredSample(size_t id) {
@@ -737,18 +838,12 @@ static size_t getZeroPredDatasetSize() {
 void testEvaluationEpochWithMetrics_HandlesZeroPredictionClass() {
     initZeroPredDataset();
 
-    float wData[] = {1.f, 0.f, 0.f, 1.f};
-    size_t wDims[] = {2, 2};
-    tensor_t *wParam = tensorInitFloat(wData, wDims, 2, NULL);
-    float wgData[] = {0.f, 0.f, 0.f, 0.f};
-    tensor_t *wGrad = tensorInitFloat(wgData, wDims, 2, NULL);
+    tensor_t *wParam = buildFloatTensor2D(2, 2, (float[]){1.f, 0.f, 0.f, 1.f}, 4);
+    tensor_t *wGrad = gradInitFloat(wParam, NULL);
     parameter_t *w = parameterInit(wParam, wGrad);
 
-    float bData[] = {0.f, 0.f};
-    size_t bDims[] = {1, 2};
-    tensor_t *bParam = tensorInitFloat(bData, bDims, 2, NULL);
-    float bgData[] = {0.f, 0.f};
-    tensor_t *bGrad = tensorInitFloat(bgData, bDims, 2, NULL);
+    tensor_t *bParam = buildFloatTensor2D(1, 2, (float[]){0.f, 0.f}, 2);
+    tensor_t *bGrad = gradInitFloat(bParam, NULL);
     parameter_t *b = parameterInit(bParam, bGrad);
 
     quantization_t testQ;
@@ -761,40 +856,48 @@ void testEvaluationEpochWithMetrics_HandlesZeroPredictionClass() {
 
     epochStats_t stats = evaluationEpochWithMetrics(model, 1, MSE, dl, inferenceWithLoss);
 
-    // tp=[2,0], predCount=[3,0], actualCount=[2,1]
-    // Class 1 has no predictions -> precision guard skips it
-    // Class 1 has zero tp -> recall=0 for class 1
-    // Class 1 prec+rec=0 -> F1 guard skips it
-    // accuracy = 2/3
-    TEST_ASSERT_FLOAT_WITHIN(0.001f, 2.0f / 3.0f, stats.accuracy);
-    // precision = (2/3 + 0) / 2 = 1/3
-    TEST_ASSERT_FLOAT_WITHIN(0.001f, 1.0f / 3.0f, stats.precision);
-    // recall = (2/2 + 0/1) / 2 = 0.5
-    TEST_ASSERT_FLOAT_WITHIN(0.001f, 0.5f, stats.recall);
-    // F1 class 0: 2*(2/3)*1 / ((2/3)+1) = 4/5; class 1: 0. Mean = 2/5
-    TEST_ASSERT_FLOAT_WITHIN(0.001f, 2.0f / 5.0f, stats.f1);
+    /* CAPTURE. */
+    float capturedAccuracy = stats.accuracy;
+    float capturedPrecision = stats.precision;
+    float capturedRecall = stats.recall;
+    float capturedF1 = stats.f1;
 
-    // No NaN or Inf from division by zero
-    TEST_ASSERT_TRUE(stats.precision == stats.precision); // NaN check
-    TEST_ASSERT_TRUE(stats.recall == stats.recall);
-    TEST_ASSERT_TRUE(stats.f1 == stats.f1);
+    /* FREE. */
+    freeDataLoader(dl);
+    freeLinearLayer(linear);
+    freeParameter(b);
+    freeParameter(w);
+    freeZeroPredDataset();
+
+    /* ASSERT.
+     * tp=[2,0], predCount=[3,0], actualCount=[2,1]
+     * Class 1 has no predictions -> precision guard skips it
+     * Class 1 has zero tp -> recall=0 for class 1
+     * Class 1 prec+rec=0 -> F1 guard skips it
+     * accuracy = 2/3 */
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 2.0f / 3.0f, capturedAccuracy);
+    /* precision = (2/3 + 0) / 2 = 1/3 */
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 1.0f / 3.0f, capturedPrecision);
+    /* recall = (2/2 + 0/1) / 2 = 0.5 */
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 0.5f, capturedRecall);
+    /* F1 class 0: 2*(2/3)*1 / ((2/3)+1) = 4/5; class 1: 0. Mean = 2/5 */
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 2.0f / 5.0f, capturedF1);
+
+    /* No NaN or Inf from division by zero */
+    TEST_ASSERT_TRUE(capturedPrecision == capturedPrecision); /* NaN check */
+    TEST_ASSERT_TRUE(capturedRecall == capturedRecall);
+    TEST_ASSERT_TRUE(capturedF1 == capturedF1);
 }
 
 void testEvaluationEpochWithReport_ReturnsConfusionMatrix() {
     initPartialDataset();
 
-    float wData[] = {1.f, 0.f, 0.f, 1.f};
-    size_t wDims[] = {2, 2};
-    tensor_t *wParam = tensorInitFloat(wData, wDims, 2, NULL);
-    float wgData[] = {0.f, 0.f, 0.f, 0.f};
-    tensor_t *wGrad = tensorInitFloat(wgData, wDims, 2, NULL);
+    tensor_t *wParam = buildFloatTensor2D(2, 2, (float[]){1.f, 0.f, 0.f, 1.f}, 4);
+    tensor_t *wGrad = gradInitFloat(wParam, NULL);
     parameter_t *w = parameterInit(wParam, wGrad);
 
-    float bData[] = {0.f, 0.f};
-    size_t bDims[] = {1, 2};
-    tensor_t *bParam = tensorInitFloat(bData, bDims, 2, NULL);
-    float bgData[] = {0.f, 0.f};
-    tensor_t *bGrad = tensorInitFloat(bgData, bDims, 2, NULL);
+    tensor_t *bParam = buildFloatTensor2D(1, 2, (float[]){0.f, 0.f}, 2);
+    tensor_t *bGrad = gradInitFloat(bParam, NULL);
     parameter_t *b = parameterInit(bParam, bGrad);
 
     quantization_t testQ;
@@ -805,20 +908,36 @@ void testEvaluationEpochWithReport_ReturnsConfusionMatrix() {
     dataLoader_t *dl =
         dataLoaderInit(getPartialSample, getPartialDatasetSize, 1, NULL, NULL, false, 0, true);
 
-    // Pre-fill with non-zero to verify WithReport zeroes the caller's buffer before accumulating
+    /* Pre-fill with non-zero to verify WithReport zeroes the caller's buffer before accumulating */
     size_t cm[2 * 2] = {99, 99, 99, 99};
     classificationReport_t report =
         evaluationEpochWithReport(model, 1, MSE, dl, inferenceWithLoss, cm, 2);
 
-    // Expected CM[predicted][actual]: [[2,1],[0,1]]
-    // cm[0*2+0]=2, cm[0*2+1]=1, cm[1*2+0]=0, cm[1*2+1]=1
-    TEST_ASSERT_EQUAL_UINT(2, report.confusionMatrix[0]); // pred=0, actual=0
-    TEST_ASSERT_EQUAL_UINT(1, report.confusionMatrix[1]); // pred=0, actual=1
-    TEST_ASSERT_EQUAL_UINT(0, report.confusionMatrix[2]); // pred=1, actual=0
-    TEST_ASSERT_EQUAL_UINT(1, report.confusionMatrix[3]); // pred=1, actual=1
+    /* CAPTURE. */
+    size_t capturedCM[4];
+    for (size_t i = 0; i < 4; i++) {
+        capturedCM[i] = report.confusionMatrix[i];
+    }
+    size_t capturedNumClasses = report.numClasses;
+    float capturedAccuracy = report.stats.accuracy;
 
-    TEST_ASSERT_EQUAL_UINT(2, report.numClasses);
-    TEST_ASSERT_FLOAT_WITHIN(0.001f, 0.75f, report.stats.accuracy);
+    /* FREE. */
+    freeDataLoader(dl);
+    freeLinearLayer(linear);
+    freeParameter(b);
+    freeParameter(w);
+    freePartialDataset();
+
+    /* ASSERT.
+     * Expected CM[predicted][actual]: [[2,1],[0,1]]
+     * cm[0*2+0]=2, cm[0*2+1]=1, cm[1*2+0]=0, cm[1*2+1]=1 */
+    TEST_ASSERT_EQUAL_UINT(2, capturedCM[0]); /* pred=0, actual=0 */
+    TEST_ASSERT_EQUAL_UINT(1, capturedCM[1]); /* pred=0, actual=1 */
+    TEST_ASSERT_EQUAL_UINT(0, capturedCM[2]); /* pred=1, actual=0 */
+    TEST_ASSERT_EQUAL_UINT(1, capturedCM[3]); /* pred=1, actual=1 */
+
+    TEST_ASSERT_EQUAL_UINT(2, capturedNumClasses);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 0.75f, capturedAccuracy);
 }
 
 void setUp() {}


### PR DESCRIPTION
**Stack position:** `develop ← #109 ← ... ← #120 ← #THIS`

Final framework-wave PR. Stacked on #120. Per `codebase_stacked_pr_merge_trap.md`: do not merge before #120.

---

## Summary

Wave batch 7b — the last per-file migration in the Phase 2 framework wave. Migrates the largest leaky test file (843 lines, 13 tests) to the explicit-free + assert-last idiom.

Together with #109–#120, the entire 14-file leaky test set in the Phase 1 LSan recon report (`docs/superpowers/reports/2026-04-22-lsan-recon.md`) is now idiom-compliant.

## Test-side changes

`test/unit/userAPI/UnitTestTrainingLoopApi.c`:
- 13 test bodies migrated to post-#106 primitives.
- Two tests partially modified by #120 (`testEvaluationBatch_*`, `testTrainingBatchDefault_*`) get the remaining migration applied on top.
- Shared file-scope `epochDataset` gets a `freeEpochDataset()` helper called from each user. Same pattern applied to `partialDataset` and `zeroPredDataset`. Mirrors the dataset pattern in `UnitTestMnistSmoke.c` (#120).
- `testCalculateGradsSequential_MatchesPyTorch` restores `sgd->sizeStates=2` before `freeOptimSgdM` so the bias parameter and its state container are also freed (the test deliberately sets `sizeStates=1` to skip stepping bias during training).
- Cleanup order: `freeOptimSgdM` → `freeDataLoader` → `free*Layer` → `freeTensor` for any not-registered-with-optimizer tensors → `free*Dataset` (where applicable).

## Verification

- macOS: 13/13 tests pass; full `ctest --preset unit_test_debug` is green (32/32).
- LSan in `odt-lsan-recon:2026-04-22`: zero residual ("All heap blocks were freed -- no leaks are possible").

Spec: `docs/superpowers/specs/2026-04-25-phase-2-teardown-idiom-design.md`
Plan: `docs/superpowers/plans/2026-04-27-phase-2-teardown-idiom.md`