### PR TITLE
fix(boyscout): close two latent bugs in optimizer + tensor-conversion paths

### DIFF
--- a/src/tensor/TensorConversion.c
+++ b/src/tensor/TensorConversion.c
@@ -1,14 +1,14 @@
 #define SOURCE_FILE "TENSOR_CONVERSION"
 
 #include <stdio.h>
-#include <string.h>
 #include <stdlib.h>
+#include <string.h>
 
-#include "TensorConversion.h"
-#include "Tensor.h"
 #include "DTypes.h"
-#include "math.h"
 #include "MinMax.h"
+#include "Tensor.h"
+#include "TensorConversion.h"
+#include "math.h"
 
 void zeroTensorData(tensor_t *tensor) {
     size_t numberOfElements = calcNumberOfElementsByTensor(tensor);
@@ -59,9 +59,9 @@ void convertInt32TensorToAsymTensor(tensor_t *inputTensor, tensor_t *outputTenso
     for (size_t elementIndex = 0; elementIndex < numberOfElements; elementIndex++) {
         int32_t inputElement = readBytesAsInt32(&inputTensor->data[elementIndex * sizeof(int32_t)]);
 
-        outputElements[elementIndex] = roundByMode(
-            clamp((float)inputElement / scale - (float)zeroPoint, 0.f, qMax - 1),
-            linearQConfig->roundingMode);
+        outputElements[elementIndex] =
+            roundByMode(clamp((float)inputElement / scale - (float)zeroPoint, 0.f, qMax - 1),
+                        linearQConfig->roundingMode);
     }
     linearQConfig->scale = scale;
     linearQConfig->zeroPoint = zeroPoint;
@@ -71,7 +71,6 @@ void convertInt32TensorToAsymTensor(tensor_t *inputTensor, tensor_t *outputTenso
     byteConversion(outputElement, 32, outputTensor->data, linearQConfig->qBits, numberOfElements);
     copyDimsAndSparsityToTensor(inputTensor, outputTensor);
 }
-
 
 void convertFloatTensorToInt32Tensor(tensor_t *inputTensor, tensor_t *outputTensor) {
     size_t numberOfElements = calcNumberOfElementsByTensor(inputTensor);
@@ -85,7 +84,6 @@ void convertFloatTensorToInt32Tensor(tensor_t *inputTensor, tensor_t *outputTens
     writeInt32ArrayToByteArray(numberOfElements, outputData, outputTensor->data);
     copyDimsAndSparsityToTensor(inputTensor, outputTensor);
 }
-
 
 void convertFloatTensorToSymInt32Tensor(tensor_t *inputTensor, tensor_t *outputTensor) {
     size_t numberOfElements = calcNumberOfElementsByTensor(inputTensor);
@@ -112,9 +110,8 @@ void convertFloatTensorToSymInt32Tensor(tensor_t *inputTensor, tensor_t *outputT
     float *inputFloat = (float *)inputTensor->data;
 
     for (size_t i = 0; i < numberOfElements; i++) {
-        outputInt32[i] = roundByMode(
-            clamp(inputFloat[i] / scale, qMin, qMax),
-            outputSymInt32QC->roundingMode);
+        outputInt32[i] =
+            roundByMode(clamp(inputFloat[i] / scale, qMin, qMax), outputSymInt32QC->roundingMode);
     }
 }
 
@@ -138,8 +135,8 @@ void convertFloatTensorToSymTensor(tensor_t *inputTensor, tensor_t *outputTensor
     uint8_t outputs[numberOfElements * bytesPerOutputElement];
 
     for (size_t i = 0; i < numberOfElements; i++) {
-        outputs[i] = roundByMode(clamp(inputs[i] / scale, 0.f, qMax - 1),
-                                 outputSymQConfig->roundingMode);
+        outputs[i] =
+            roundByMode(clamp(inputs[i] / scale, 0.f, qMax - 1), outputSymQConfig->roundingMode);
     }
 
     memcpy(outputTensor->data, outputs, numberOfElements * bytesPerOutputElement);
@@ -168,9 +165,9 @@ void convertFloatTensorToAsymTensor(tensor_t *inputTensor, tensor_t *outputTenso
     float *inputFloat = (float *)inputTensor->data;
 
     for (size_t i = 0; i < numberOfElements; i++) {
-        outputElements[i] = roundByMode(
-            clamp(inputFloat[i] / scale - (float)zeroPoint, 0.f, qMax - 1),
-            asymQConfig->roundingMode);
+        outputElements[i] =
+            roundByMode(clamp(inputFloat[i] / scale - (float)zeroPoint, 0.f, qMax - 1),
+                        asymQConfig->roundingMode);
     }
 
     asymQConfig->scale = scale;
@@ -237,15 +234,14 @@ void convertSymInt32TensorToAsymTensor(tensor_t *inputTensor, tensor_t *outputTe
 
     int32_t outputInt[numberOfValues];
     for (size_t i = 0; i < numberOfValues; i++) {
-        outputInt[i] = roundByMode(
-            clamp(inputAsFloat[i] / outputScale - (float)zeroPoint, 0.f, qMax),
-            outputAsymQConfig->roundingMode);
+        outputInt[i] =
+            roundByMode(clamp(inputAsFloat[i] / outputScale - (float)zeroPoint, 0.f, qMax),
+                        outputAsymQConfig->roundingMode);
     }
 
     byteConversion((uint8_t *)outputInt, 32, outputTensor->data, outputAsymQConfig->qBits,
                    numberOfValues);
 }
-
 
 void convertAsymTensorToInt32Tensor(tensor_t *inputTensor, tensor_t *outputTensor) {
     asymQConfig_t *asymQConfig = inputTensor->quantization->qConfig;
@@ -277,8 +273,8 @@ void convertAsymTensorToFloatTensor(tensor_t *inputTensor, tensor_t *outputTenso
     float *outputElements = (float *)outputTensor->data;
 
     for (size_t elementIndex = 0; elementIndex < numberOfElements; elementIndex++) {
-        outputElements[elementIndex] = ((float)inputInt[elementIndex] + (float)zeroPoint) *
-                                       asymQConfig->scale;
+        outputElements[elementIndex] =
+            ((float)inputInt[elementIndex] + (float)zeroPoint) * asymQConfig->scale;
     }
 
     copyDimsAndSparsityToTensor(inputTensor, outputTensor);
@@ -307,7 +303,6 @@ void convertAsymTensorToSymInt32Tensor(tensor_t *inputTensor, tensor_t *outputTe
     outputSymInt32QConfig->scale = inputAsymQConfig->scale;
 }
 
-
 char *quantTypeToString(qtype_t t) {
     switch (t) {
     case INT32:
@@ -334,49 +329,38 @@ void unsupportedConversionTypes(tensor_t *inputTensor, tensor_t *outputTensor) {
 }
 
 conversionFunction_t conversionMatrix[5][5] = {
-    [INT32] = {
-        [INT32] = NULL,
-        [FLOAT32] = convertInt32TensorToFloatTensor,
-        [SYM_INT32] = convertInt32TensorToSymInt32Tensor,
-        [SYM] = unsupportedConversionTypes,
-        [ASYM] = convertInt32TensorToAsymTensor
-    },
-    [FLOAT32] = {
-        [INT32] = convertFloatTensorToInt32Tensor,
-        [FLOAT32] = NULL,
-        [SYM_INT32] = convertFloatTensorToSymInt32Tensor,
-        [SYM] = unsupportedConversionTypes,
-        [ASYM] = convertFloatTensorToAsymTensor
-    },
-    [SYM_INT32] = {
-        [INT32] = extractInt32TensorFromSymInt32Tensor,
-        [FLOAT32] = convertSymInt32TensorToFloat32Tensor,
-        [SYM_INT32] = NULL,
-        [SYM] = unsupportedConversionTypes,
-        [ASYM] = convertSymInt32TensorToAsymTensor
-    },
-    [SYM] = {
-        [INT32] = unsupportedConversionTypes,
-        [FLOAT32] = unsupportedConversionTypes,
-        [SYM_INT32] = unsupportedConversionTypes,
-        [SYM] = NULL,
-        [ASYM] = unsupportedConversionTypes
-    },
-    [ASYM] = {
-        [INT32] = convertAsymTensorToInt32Tensor,
-        [FLOAT32] = convertAsymTensorToFloatTensor,
-        [SYM_INT32] = convertAsymTensorToSymInt32Tensor,
-        [SYM] = unsupportedConversionTypes,
-        [ASYM] = NULL
-    }
-};
+    [INT32] = {[INT32] = NULL,
+               [FLOAT32] = convertInt32TensorToFloatTensor,
+               [SYM_INT32] = convertInt32TensorToSymInt32Tensor,
+               [SYM] = unsupportedConversionTypes,
+               [ASYM] = convertInt32TensorToAsymTensor},
+    [FLOAT32] = {[INT32] = convertFloatTensorToInt32Tensor,
+                 [FLOAT32] = NULL,
+                 [SYM_INT32] = convertFloatTensorToSymInt32Tensor,
+                 [SYM] = unsupportedConversionTypes,
+                 [ASYM] = convertFloatTensorToAsymTensor},
+    [SYM_INT32] = {[INT32] = extractInt32TensorFromSymInt32Tensor,
+                   [FLOAT32] = convertSymInt32TensorToFloat32Tensor,
+                   [SYM_INT32] = NULL,
+                   [SYM] = unsupportedConversionTypes,
+                   [ASYM] = convertSymInt32TensorToAsymTensor},
+    [SYM] = {[INT32] = unsupportedConversionTypes,
+             [FLOAT32] = unsupportedConversionTypes,
+             [SYM_INT32] = unsupportedConversionTypes,
+             [SYM] = NULL,
+             [ASYM] = unsupportedConversionTypes},
+    [ASYM] = {[INT32] = convertAsymTensorToInt32Tensor,
+              [FLOAT32] = convertAsymTensorToFloatTensor,
+              [SYM_INT32] = convertAsymTensorToSymInt32Tensor,
+              [SYM] = unsupportedConversionTypes,
+              [ASYM] = NULL}};
 
 static void convertTensorsWithSameType(tensor_t *inputTensor, tensor_t *outputTensor,
                                        qtype_t qType) {
     size_t numberOfElements = calcNumberOfElementsByTensor(inputTensor);
     size_t bytesPerElement = calcBytesPerElement(inputTensor->quantization);
 
-    memcpy(outputTensor->data, inputTensor->data, numberOfElements * bytesPerElement);
+    memmove(outputTensor->data, inputTensor->data, numberOfElements * bytesPerElement);
 
     switch (qType) {
     case SYM_INT32:
@@ -394,7 +378,6 @@ static void convertTensorsWithSameType(tensor_t *inputTensor, tensor_t *outputTe
         break;
     }
 }
-
 
 void convertTensor(tensor_t *inputTensor, tensor_t *outputTensor) {
     qtype_t inputDType = inputTensor->quantization->type;

--- a/src/userApi/optimizer/SgdApi.c
+++ b/src/userApi/optimizer/SgdApi.c
@@ -51,12 +51,12 @@ optimizer_t *sgdMCreateOptim(float learningRate, float momentumFactor, float wei
 
             states_t *weightStates = reserveMemory(sizeof(states_t));
             weightStates->statesPerParameter = statesPerParam;
-            weightStates->stateBuffers = reserveMemory(sizeof(tensor_t));
+            weightStates->stateBuffers = reserveMemory(sizeof(tensor_t *));
             weightStates->stateBuffers[0] = weightStateBuffer;
 
             states_t *biasStates = reserveMemory(sizeof(states_t));
             biasStates->statesPerParameter = statesPerParam;
-            biasStates->stateBuffers = reserveMemory(sizeof(tensor_t));
+            biasStates->stateBuffers = reserveMemory(sizeof(tensor_t *));
             biasStates->stateBuffers[0] = biasStateBuffer;
 
             states[i] = weightStates;


### PR DESCRIPTION
**Stack position:** \`develop ← #109 ← ... ← #121 ← #THIS\`

Stacked on #121. Per \`codebase_stacked_pr_merge_trap.md\`: do not merge before #121.

---

## Summary

Two 1-line Boy Scout fixes for pre-existing bugs that surfaced during the Phase 2 LSan teardown idiom wave (#109–#121) but were left out of scope of the migration PRs.

## Bug 1 — SgdApi.c::sgdMCreateOptim over-allocates state-buffer arrays

\`weightStates->stateBuffers\` and \`biasStates->stateBuffers\` have type \`tensor_t **\`; the allocations on lines 54 and 59 used \`sizeof(tensor_t)\` instead of \`sizeof(tensor_t *)\`. Functionally harmless (only \`stateBuffers[0]\` is ever written), but each call wasted ~112 bytes per state. After #110 closed the sister leak (the array container itself was never freed), this became the dominant over-allocation in the SGD path.

Originally noted in #110's PR body as \"latent over-allocation; out of scope\".

## Bug 2 — TensorConversion.c::convertTensorsWithSameType undefined-behavior memcpy

When \`inputTensor\` and \`outputTensor\` alias (or share data pointers due to in-place identity conversion), the unconditional \`memcpy(outputTensor->data, inputTensor->data, ...)\` is undefined behavior per C11 §7.24.2.1. Modern libcs happen to do the right thing for the identity case via byte-loop fallback, but \`__builtin_memcpy\` under -O2 may assume non-overlap.

Valgrind flagged 200+ \"Source and destination overlap in memcpy\" errors across UnitTestLinear / UnitTestMultiLayerTraining / UnitTestFlattenIntegration / UnitTestMnistSmoke / UnitTestTrainingLoopApi reports. Fix: replace \`memcpy\` with \`memmove\`, which permits overlap by contract.

## Verification

- \`cmake --build --preset unit_test_debug && ctest --preset unit_test_debug\`: 32/32 green.
- Spot-check via \`odt-lsan-recon:2026-04-22\` Docker on UnitTestLinear: \"All heap blocks were freed\"; the 200+ memcpy-self-overlap errors are gone.
- 15 remaining valgrind errors in UnitTestLinear are a separate pre-existing ASYM byte-count bug (\`byteConversion\` out-of-bounds reads/writes 1 byte past a 2-byte allocation in mixed-quantization paths) — out of scope; tracked by issue #108 territory.