### PR TITLE
fix(#92): PRINT_ERROR fires by default — DEBUG_MODE_ERROR unconditional in Common__hdrs

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -5,9 +5,9 @@ target_include_directories(Common__hdrs INTERFACE
 add_library(Common INTERFACE)
 target_link_libraries(Common INTERFACE Common__hdrs)
 
-if(DEBUG_MODE_ERROR)
-    target_compile_definitions(Common__hdrs INTERFACE DEBUG_MODE_ERROR=true)
-endif()
+# DEBUG_MODE_ERROR is the default — every ODT consumer gets PRINT_ERROR output
+# unless explicitly silenced (no opt-out preset today; revisit when MCU presets land).
+target_compile_definitions(Common__hdrs INTERFACE DEBUG_MODE_ERROR=true)
 
 if(DEBUG_MODE_INFO)
     target_compile_definitions(Common__hdrs INTERFACE DEBUG_MODE_INFO=true)

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -1,6 +1,7 @@
 include(unit_test.cmake)
 
 add_subdirectory(arithmetic)
+add_subdirectory(common)
 add_subdirectory(csv)
 add_subdirectory(data_loader)
 add_subdirectory(layer)

--- a/test/unit/common/CMakeLists.txt
+++ b/test/unit/common/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_elastic_ai_unit_test(
+        LIB_UNDER_TEST
+        Common
+)

--- a/test/unit/common/UnitTestCommon.c
+++ b/test/unit/common/UnitTestCommon.c
@@ -1,0 +1,21 @@
+#define SOURCE_FILE "UnitTestCommon"
+
+#include "Common.h"
+#include "unity.h"
+
+_Static_assert(
+    DLEVEL >= 1,
+    "DEBUG_MODE_ERROR must be defined by default — PRINT_ERROR would be silently compiled out");
+
+void setUp(void) {}
+void tearDown(void) {}
+
+void testDLevelDefaultIsErrorOrHigher(void) {
+    TEST_ASSERT_GREATER_OR_EQUAL_INT(1, DLEVEL);
+}
+
+int main(void) {
+    UNITY_BEGIN();
+    RUN_TEST(testDLevelDefaultIsErrorOrHigher);
+    return UNITY_END();
+}


### PR DESCRIPTION
## Summary

`PRINT_ERROR` was silently compiled out for any ODT consumer who didn't pass `-DDEBUG_MODE_ERROR=ON` at CMake configure time — including the default `unit_test` preset that CI uses, and any external integrator using ODT as a library. Every internal "Dimensions don't match", "Unknown QType!", "Could not open file" was a no-op.

This PR makes `DEBUG_MODE_ERROR=true` unconditional on the `Common__hdrs` interface target, so every consumer of `Common.h` (every ODT lib, every test, every downstream app) compiles with `DLEVEL >= 1` and `PRINT_ERROR` fires by default. `INFO` and `DEBUG` stay opt-in via their respective presets.

## Stack

This PR is **stacked on #125** (the #96 RNG fix). PR base is `96-rng-seed-zero-fix`, not `develop`. Merge order matters — merge #125 first, then this PR.

## Change

- `src/common/CMakeLists.txt` — drop the `if(DEBUG_MODE_ERROR) ... endif()` guard around the `target_compile_definitions(Common__hdrs INTERFACE DEBUG_MODE_ERROR=true)` line. Add a comment explaining why (default-loud, MCU revisit later).
- `test/unit/common/UnitTestCommon.c` — new file; compile-time `_Static_assert(DLEVEL >= 1, ...)` plus Unity smoke `testDLevelDefaultIsErrorOrHigher`. The static-assert is the actual contract enforcer — if anyone re-introduces the guard, the build breaks at compile time.
- `test/unit/common/CMakeLists.txt` — new; standard `add_elastic_ai_unit_test(LIB_UNDER_TEST Common)`.
- `test/unit/CMakeLists.txt` — add `add_subdirectory(common)` (alphabetical).

## Why CMake-only and not Common.h

Audit Option A (recommended). Smallest surface to fix the actual root cause: the interface-target wiring, not the macro cascade. Option B (invert defaults inside `Common.h` with `DEBUG_MODE_QUIET` opt-out) was rejected as larger surface for no concrete benefit yet — no MCU presets exist today that would need an opt-out.

## Side effect: `unit_test_error` preset becomes vestigial

It still works (it sets a flag that's now always on, which is benign), but it no longer materially differs from `unit_test`. Removing/renaming it is cosmetic and out of scope.

## Test plan

- [x] `_Static_assert` in new test fails on un-fixed `CMakeLists.txt` (compile-time RED verified)
- [x] Static-assert passes after the unconditional define (GREEN verified)
- [x] Mutation check: revert guard → build fails → restore → green again
- [x] Full `ctest --preset unit_test` — all 33 cases pass (32 prior + new UnitTestCommon)
- [x] `uv run pytest` — 3/3 Python smoke tests pass

## Closes

Closes #92.

🤖 Generated with [Claude Code](https://claude.com/claude-code)