### PR TITLE
chore: integrate develop branch — Flatten + ASan + initTensor + LSan Phase 2 + boyscout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,30 @@ on:
     branches: [main]
 
 jobs:
+  alloc-locality:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Reject malloc/calloc/realloc/free outside src/userApi/
+        run: |
+          set +e
+          matches=$(git grep -nE '\b(malloc|calloc|realloc|free)\s*\(' \
+            -- 'src/' 'test/' \
+            ':!src/userApi/' \
+            ':!*.md' \
+            | grep -vE '^[^:]+:[0-9]+:[[:space:]]*(//|\*)')
+          set -e
+          if [ -n "$matches" ]; then
+            echo "Allocation-locality violation: malloc/calloc/realloc/free are only allowed in src/userApi/."
+            echo "All other code must route through reserveMemory/freeReservedMemory in src/userApi/StorageApi.{c,h}."
+            echo
+            echo "Offending lines:"
+            echo "$matches"
+            exit 1
+          fi
+
   c-build-and-test:
     runs-on: ubuntu-latest
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -45,6 +45,15 @@
       "cacheVariables": {
         "DEBUG_MODE_DEBUG": "ON"
       }
+    },
+    {
+      "name": "unit_test_asan",
+      "displayName": "Unit-Test-ASan",
+      "inherits": "host",
+      "cacheVariables": {
+        "CMAKE_C_FLAGS": "-fsanitize=address,undefined -fno-sanitize=function -fno-omit-frame-pointer -fno-sanitize-recover=all -g -O1",
+        "CMAKE_EXE_LINKER_FLAGS": "-fsanitize=address,undefined"
+      }
     }
   ],
   "buildPresets": [
@@ -76,6 +85,12 @@
       "name": "unit_test_debug",
       "inherits": "host",
       "configurePreset": "unit_test_debug",
+      "targets": "all_unit_tests"
+    },
+    {
+      "name": "unit_test_asan",
+      "inherits": "host",
+      "configurePreset": "unit_test_asan",
       "targets": "all_unit_tests"
     }
   ],
@@ -134,6 +149,24 @@
         "include": {
           "label": "unit"
         }
+      }
+    },
+    {
+      "name": "unit_test_asan",
+      "displayName": "Unit Tests (ASan + UBSan)",
+      "configurePreset": "unit_test_asan",
+      "output": {
+        "outputJUnitFile": "unit-test-asan.junit",
+        "outputOnFailure": true
+      },
+      "filter": {
+        "include": {
+          "label": "unit"
+        }
+      },
+      "environment": {
+        "ASAN_OPTIONS": "detect_leaks=0:abort_on_error=1:halt_on_error=1:strict_string_checks=1:check_initialization_order=1",
+        "UBSAN_OPTIONS": "print_stacktrace=1:halt_on_error=1"
       }
     }
   ]

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -9,7 +9,7 @@ the dataset. This:
 
 - keeps dataset code independent of downstream model topology
 - allows one dataset to feed models with different input ranks
-- matches the PyTorch / Keras / elastic-ai.creator IR convention, so ir2c
-  can compile each shape transform to a corresponding C layer
+- matches the PyTorch / Keras / elastic-ai.creator IR convention, so a future
+  ir2c can compile each shape transform to a corresponding C layer
 
 For flatten-to-2D, use `flattenLayerInit()` from `FlattenApi.h`.

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -26,3 +26,101 @@ Why:
 Enforcement:
 - A CI job (`alloc-locality` in `.github/workflows/ci.yml`) runs `git grep` against `src/` and `test/` (excluding `src/userApi/`) and fails the build on any match. Comments are excluded from the match.
 - Exceptions: none today. If a use-case arises that genuinely needs a direct alloc primitive outside `src/userApi/`, escalate via a PR comment so the rule itself can be revisited.
+
+## Test memory discipline
+
+Unit tests in `test/unit/**` follow a tiered idiom for memory cleanup. The
+tier boundary is mechanical: tests that contain no `*Init*` calls (i.e.,
+purely stack-allocated `tensor_t`/`shape_t`/`quantization_t` designated
+initializers) stay in the **stack-only tier** and need no cleanup. Any test
+that calls `*Init*` (= heap allocation through `reserveMemory`) is in the
+**heap tier** and follows three rules.
+
+### Rule 1 — Build via the post-#106 primitives
+
+Heap tensors are built by:
+
+```c
+size_t *dims  = reserveMemory(N * sizeof(size_t));
+/* ... populate dims[i] ... */
+size_t *order = reserveMemory(N * sizeof(size_t));
+setOrderOfDimsForNewTensor(N, order);
+shape_t *s    = reserveMemory(sizeof(shape_t));
+setShape(s, dims, N, order);
+tensor_t *t   = initTensor(s, quantizationInitFloat(), NULL);
+tensorFillFromFloatBuffer(t, src, count);   /* or initDistribution(t, &d); */
+```
+
+The deprecated `tensorInitFloat` / `tensorInitSymInt32` / `tensorInit*`
+family must not be used in new tests. Their attributes emit
+`-Wdeprecated-declarations` to surface accidental adoption.
+
+A file-local factory like `makeFloatTensorForDistTest` in
+`test/unit/tensor/UnitTestTensorApi.c` is fine when 3+ tests in the same
+file repeat the construction. A *cross-file* helper is deferred until 3+
+test files repeat the same construction.
+
+### Rule 2 — Free in reverse-init order
+
+`freeTensor` cascades to data + shape (with its dims and order blocks) +
+quantization + sparsity + the tensor struct itself. Do not call
+`freeShape` or `freeQuantization` on a shape/quantization that was already
+consumed by `initTensor` — that is a double-free. The cascade table:
+
+| Allocation                                | Cleanup call         | Cascades to                         |
+|-------------------------------------------|----------------------|-------------------------------------|
+| `initTensor(s, q, sp)`                    | `freeTensor(t)`      | data, shape (+dims, +order), q, sp  |
+| `parameterInit(p, g)`                     | `freeParameter(par)` | param tensor + grad (if non-NULL)   |
+| `linearLayerInit(...)`                    | `freeLinearLayer(l)` | layer config wrapper only           |
+| `reluLayerInit(...)`                      | `freeReluLayer(l)`   | layer config wrapper only           |
+| `softmaxLayerInit(...)`                   | `freeSoftmaxLayer(l)`| layer config wrapper only           |
+| `sgdMCreateOptim(...)`                    | `freeOptimSgdM(o)`   | all registered parameters + states  |
+| `inference(...)` (returns `tensor_t *`)   | `freeTensor(out)`    | as above                            |
+| `inferenceWithLoss(...)`                  | `freeInferenceStats` | stats struct + output tensor        |
+| `calculateGradsSequential(...)`           | `freeTrainingStats`  | stats struct                        |
+
+Layer free-functions release only the config wrapper, not the parameters
+they reference. When an optimizer is in play, `freeOptimSgdM` takes
+ownership of the parameter cleanup — do not also call `freeParameter` on
+the same pointers.
+
+### Rule 3 — Assert-last (capture, free, assert)
+
+ODT's Unity build defines `UNITY_INCLUDE_SETJMP`, so a failing
+`TEST_ASSERT_*` longjmps out of the test function and any code after it
+does not run. To keep LSan output meaningful — failing tests should still
+report zero leaks attributable to the test fixture — every heap-tier test
+follows this three-block shape:
+
+```c
+void testFoo(void) {
+    /* 1. Build heap fixtures (Rule 1). */
+    quantization_t *q = quantizationInitFloat();
+    /* ... etc ... */
+
+    /* 2. Exercise the system, capture every assertion value into a
+     *    stack local. Do not assert here. */
+    float capturedLoss = inferenceWithLoss(model, ...)->loss;
+    /* (capture more if needed) */
+
+    /* 3. Free in reverse-init order (Rule 2). */
+    freeTensor(t);
+    /* ... etc ... */
+
+    /* 4. Assert on the captured locals. */
+    TEST_ASSERT_FLOAT_WITHIN(1e-4f, EXPECTED_LOSS, capturedLoss);
+}
+```
+
+Reference exemplars in the tree: `test/unit/userAPI/UnitTestInferenceApi.c`,
+`test/unit/userAPI/UnitTestMultiLayerTraining.c`,
+`test/unit/tensor/UnitTestTensorApi.c::testInitDistribution_*`.
+
+### Verification
+
+A test file is considered idiom-compliant when, run under valgrind in the
+`odt-lsan-recon:2026-04-22` Docker image with
+`--leak-check=full --show-leak-kinds=all`, all four LEAK SUMMARY
+categories report 0 bytes in 0 blocks (or valgrind emits "All heap blocks
+were freed -- no leaks are possible"). The reproducible recipe and
+container Dockerfile live in `docs/superpowers/tools/lsan-recon/`.

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -13,3 +13,16 @@ the dataset. This:
   ir2c can compile each shape transform to a corresponding C layer
 
 For flatten-to-2D, use `flattenLayerInit()` from `FlattenApi.h`.
+
+## Allocation Locality
+
+Only `src/userApi/` may call `malloc`, `calloc`, `realloc`, or `free` directly. All other code (sub-layers under `src/`, tests under `test/`) must route allocations through `reserveMemory` and `freeReservedMemory` in `src/userApi/StorageApi.{c,h}`.
+
+Why:
+- MCU stack overflows are silent killers; routing through StorageApi keeps stack usage predictable and small.
+- Reviewers know exactly where to look for memory issues: `src/userApi/`.
+- A future handle-based allocator can subsume the entire allocation surface in one API change instead of touching every call site.
+
+Enforcement:
+- A CI job (`alloc-locality` in `.github/workflows/ci.yml`) runs `git grep` against `src/` and `test/` (excluding `src/userApi/`) and fails the build on any match. Comments are excluded from the match.
+- Exceptions: none today. If a use-case arises that genuinely needs a direct alloc primitive outside `src/userApi/`, escalate via a PR comment so the rule itself can be revisited.

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -1,0 +1,15 @@
+# Project Conventions
+
+## Data Shape Convention
+
+Datasets deliver samples in their natural geometric shape (e.g. `[C, H, W]`
+for images, `[C, L]` for time series). Any `reshape`, `flatten`, or `view`
+operation is the **first layer of the model**, not a preprocessing step in
+the dataset. This:
+
+- keeps dataset code independent of downstream model topology
+- allows one dataset to feed models with different input ranks
+- matches the PyTorch / Keras / elastic-ai.creator IR convention, so ir2c
+  can compile each shape transform to a corresponding C layer
+
+For flatten-to-2D, use `flattenLayerInit()` from `FlattenApi.h`.

--- a/experiments/CMakeLists.txt
+++ b/experiments/CMakeLists.txt
@@ -13,6 +13,9 @@ target_link_libraries(MnistExperiment PRIVATE
         ReluApi
         Relu
 
+        FlattenApi
+        Flatten
+
         QuantizationApi
         Quantization
 

--- a/experiments/MnistExperiment.c
+++ b/experiments/MnistExperiment.c
@@ -25,31 +25,30 @@
 #define LOG "MnistExperimentLog.csv"
 #endif
 
-
-#include <stdlib.h>
-#include <time.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
+#include <time.h>
 
+#include "CSVHelper.h"
+#include "CalculateGradsSequential.h"
+#include "Common.h"
 #include "DataLoader.h"
 #include "DataLoaderApi.h"
-#include "NPYLoaderApi.h"
+#include "FlattenApi.h"
+#include "InferenceApi.h"
 #include "Layer.h"
+#include "LinearApi.h"
+#include "NPYLoaderApi.h"
 #include "Quantization.h"
 #include "QuantizationApi.h"
-#include "LinearApi.h"
 #include "ReluApi.h"
-#include "TensorApi.h"
-#include "Tensor.h"
 #include "SgdApi.h"
-#include "StorageApi.h"
 #include "SoftmaxApi.h"
-#include "InferenceApi.h"
-#include "CSVHelper.h"
-#include "Common.h"
+#include "StorageApi.h"
+#include "Tensor.h"
+#include "TensorApi.h"
 #include "TrainingLoopApi.h"
-#include "CalculateGradsSequential.h"
-
 
 static dataset_t trainDataset;
 static dataset_t testDataset;
@@ -57,195 +56,129 @@ static dataset_t testDataset;
 static size_t batchSize = 32;
 
 static void initDataSets() {
-    tensorArray_t *trainItems = npyLoad(MNIST_TRAIN_X);
-    tensorArray_t *trainLabels = npyLoad(MNIST_TRAIN_Y);
-    trainDataset.items = trainItems;
-    trainDataset.labels = trainLabels;
+  tensorArray_t *trainItems = npyLoad(MNIST_TRAIN_X);
+  tensorArray_t *trainLabels = npyLoad(MNIST_TRAIN_Y);
+  trainDataset.items = trainItems;
+  trainDataset.labels = trainLabels;
 
-    tensorArray_t *testItems = npyLoad(MNIST_TEST_X);
-    tensorArray_t *testLabels = npyLoad(MNIST_TEST_Y);
-    testDataset.items = testItems;
-    testDataset.labels = testLabels;
+  tensorArray_t *testItems = npyLoad(MNIST_TEST_X);
+  tensorArray_t *testLabels = npyLoad(MNIST_TEST_Y);
+  testDataset.items = testItems;
+  testDataset.labels = testLabels;
 }
 
 static sample_t *getTrainSample(size_t id) {
-    sample_t *sample = npyGetSample(&trainDataset, id);
-    return sample;
+  sample_t *sample = npyGetSample(&trainDataset, id);
+  return sample;
 }
 
 static sample_t *getTestSample(size_t id) {
-    sample_t *sample = npyGetSample(&testDataset, id);
-    return sample;
+  sample_t *sample = npyGetSample(&testDataset, id);
+  return sample;
 }
 
-static size_t getTrainDatasetSize() {
-    return trainDataset.items->size;
-}
+static size_t getTrainDatasetSize() { return trainDataset.items->size; }
 
-static size_t getTestDatasetSize() {
-    return testDataset.items->size;
-}
-
-// raw tensor dims look like this: [1, 28, 28]
-// we want dims to look like this: [1, 28*28] (linear layer only accepts 2D tensors)
-static void flattenItemDims() {
-
-    size_t trainNumberOfTensors = getTrainDatasetSize();
-    size_t testNumberOfTensors = getTestDatasetSize();
-
-    size_t numberOfDims = 2;
-
-    shape_t *shape;
-
-    for (size_t i = 0; i < trainNumberOfTensors; i++) {
-        shape = trainDataset.items->array[i]->shape;
-        size_t *newDims = *reserveMemory(numberOfDims * sizeof(size_t));
-        size_t newDimsData[] = {shape->dimensions[0],
-                                shape->dimensions[2] * shape->dimensions[2]};
-        size_t *newOrder = *reserveMemory(numberOfDims * sizeof(size_t));
-
-        for (size_t j = 0; j < numberOfDims; j++) {
-            newDims[j] = newDimsData[j];
-            newOrder[j] = j;
-        }
-
-        freeReservedMemory(shape->dimensions);
-        freeReservedMemory(shape->orderOfDimensions);
-
-        shape->numberOfDimensions = numberOfDims;
-        shape->dimensions = newDims;
-        shape->orderOfDimensions = newOrder;
-    }
-
-    for (size_t i = 0; i < testNumberOfTensors; i++) {
-        shape = testDataset.items->array[i]->shape;
-        size_t *newDims = *reserveMemory(numberOfDims * sizeof(size_t));
-        size_t newDimsData[] = {shape->dimensions[0],
-                                shape->dimensions[2] * shape->dimensions[2]};
-        size_t *newOrder = *reserveMemory(numberOfDims * sizeof(size_t));
-        for (size_t j = 0; j < numberOfDims; j++) {
-            newDims[j] = newDimsData[j];
-            newOrder[j] = j;
-        }
-
-        freeReservedMemory(shape->dimensions);
-        freeReservedMemory(shape->orderOfDimensions);
-
-        shape->numberOfDimensions = numberOfDims;
-        shape->dimensions = newDims;
-        shape->orderOfDimensions = newOrder;
-
-    }
-}
+static size_t getTestDatasetSize() { return testDataset.items->size; }
 
 static void epochCallback(size_t epoch, float trainLoss, epochStats_t evalStats) {
-    char row[256] = {0};
-    sprintf(row, "%lu, %f, %f, %f, %f, %f, %f\n",
-            epoch, trainLoss, evalStats.loss, evalStats.accuracy,
-            evalStats.precision, evalStats.recall, evalStats.f1);
-    PRINT_DEBUG("%s\n", row);
+  char row[256] = {0};
+  sprintf(row, "%lu, %f, %f, %f, %f, %f, %f\n", epoch, trainLoss, evalStats.loss,
+          evalStats.accuracy, evalStats.precision, evalStats.recall, evalStats.f1);
+  PRINT_DEBUG("%s\n", row);
 
-    char *rows[] = {row};
-    size_t entriesInRow[] = {7};
-    csvData_t csvData;
-    setCSVData(&csvData, rows, 1, entriesInRow);
-    csvWriteRowsByBufferSize(LOG, &csvData, "a");
+  char *rows[] = {row};
+  size_t entriesInRow[] = {7};
+  csvData_t csvData;
+  setCSVData(&csvData, rows, 1, entriesInRow);
+  csvWriteRowsByBufferSize(LOG, &csvData, "a");
 }
 
 static void writeCsvHeader(char *filePath) {
-    char *header = "epoch, train_loss, eval_loss, eval_accuracy, eval_precision, eval_recall, eval_f1\n";
-    char *row[] = {header};
-    size_t entriesInRow[] = {7};
-    csvData_t csvData;
-    setCSVData(&csvData, row, 1, entriesInRow);
-    csvWriteRowsByBufferSize(filePath, &csvData, "w");
+  char *header =
+      "epoch, train_loss, eval_loss, eval_accuracy, eval_precision, eval_recall, eval_f1\n";
+  char *row[] = {header};
+  size_t entriesInRow[] = {7};
+  csvData_t csvData;
+  setCSVData(&csvData, row, 1, entriesInRow);
+  csvWriteRowsByBufferSize(filePath, &csvData, "w");
 }
 
-#define MODEL_SIZE 4
+#define MODEL_SIZE 5
 
 static void buildModel(layer_t **model) {
-    quantization_t *q = quantizationInitFloat();
+  quantization_t *q = quantizationInitFloat();
 
-    // Linear 784→20
-    static float weight0Data[20 * 28 * 28] = {0};
-    static size_t weight0Dims[] = {20, 28 * 28};
-    tensor_t *weight0Param = tensorInitWithDistribution(XAVIER_UNIFORM, weight0Data, weight0Dims, 2, q, NULL, 28*28, 20);
-    tensor_t *weight0Grad = gradInitFloat(weight0Param, NULL);
-    parameter_t *weight0 = parameterInit(weight0Param, weight0Grad);
+  // Flatten [1, 28, 28] -> [1, 784]
+  model[0] = flattenLayerInit();
 
-    static float bias0Data[20] = {0};
-    static size_t bias0Dims[] = {1, 20};
-    tensor_t *bias0Param = tensorInitWithDistribution(ZEROS, bias0Data, bias0Dims, 2, q, NULL, 1, 20);
-    tensor_t *bias0Grad = gradInitFloat(bias0Param, NULL);
-    parameter_t *bias0 = parameterInit(bias0Param, bias0Grad);
+  // Linear 784→20
+  static float weight0Data[20 * 28 * 28] = {0};
+  static size_t weight0Dims[] = {20, 28 * 28};
+  tensor_t *weight0Param =
+      tensorInitWithDistribution(XAVIER_UNIFORM, weight0Data, weight0Dims, 2, q, NULL, 28 * 28, 20);
+  tensor_t *weight0Grad = gradInitFloat(weight0Param, NULL);
+  parameter_t *weight0 = parameterInit(weight0Param, weight0Grad);
 
-    model[0] = linearLayerInit(weight0, bias0, q, q, q, q);
+  static float bias0Data[20] = {0};
+  static size_t bias0Dims[] = {1, 20};
+  tensor_t *bias0Param = tensorInitWithDistribution(ZEROS, bias0Data, bias0Dims, 2, q, NULL, 1, 20);
+  tensor_t *bias0Grad = gradInitFloat(bias0Param, NULL);
+  parameter_t *bias0 = parameterInit(bias0Param, bias0Grad);
 
-    // ReLU
-    model[1] = reluLayerInit(q, q);
+  model[1] = linearLayerInit(weight0, bias0, q, q, q, q);
 
-    // Linear 20→10
-    static float weight1Data[10 * 20] = {0};
-    static size_t weight1Dims[] = {10, 20};
-    tensor_t *weight1Param = tensorInitWithDistribution(XAVIER_UNIFORM, weight1Data, weight1Dims, 2, q, NULL, 20, 10);
-    tensor_t *weight1Grad = gradInitFloat(weight1Param, NULL);
-    parameter_t *weight1 = parameterInit(weight1Param, weight1Grad);
+  // ReLU
+  model[2] = reluLayerInit(q, q);
 
-    static float bias1Data[10] = {0};
-    static size_t bias1Dims[] = {1, 10};
-    tensor_t *bias1Param = tensorInitWithDistribution(ZEROS, bias1Data, bias1Dims, 2, q, NULL, 1, 10);
-    tensor_t *bias1Grad = gradInitFloat(bias1Param, NULL);
-    parameter_t *bias1 = parameterInit(bias1Param, bias1Grad);
+  // Linear 20→10
+  static float weight1Data[10 * 20] = {0};
+  static size_t weight1Dims[] = {10, 20};
+  tensor_t *weight1Param =
+      tensorInitWithDistribution(XAVIER_UNIFORM, weight1Data, weight1Dims, 2, q, NULL, 20, 10);
+  tensor_t *weight1Grad = gradInitFloat(weight1Param, NULL);
+  parameter_t *weight1 = parameterInit(weight1Param, weight1Grad);
 
-    model[2] = linearLayerInit(weight1, bias1, q, q, q, q);
+  static float bias1Data[10] = {0};
+  static size_t bias1Dims[] = {1, 10};
+  tensor_t *bias1Param = tensorInitWithDistribution(ZEROS, bias1Data, bias1Dims, 2, q, NULL, 1, 10);
+  tensor_t *bias1Grad = gradInitFloat(bias1Param, NULL);
+  parameter_t *bias1 = parameterInit(bias1Param, bias1Grad);
 
-    // Softmax
-    model[3] = softmaxLayerInit(q, q);
+  model[3] = linearLayerInit(weight1, bias1, q, q, q, q);
+
+  // Softmax
+  model[4] = softmaxLayerInit(q, q);
 }
 
-
 int main(void) {
-    writeCsvHeader(LOG);
+  writeCsvHeader(LOG);
 
-    size_t numberOfEpochs = 10;
-    initDataSets();
-    flattenItemDims();
+  size_t numberOfEpochs = 10;
+  initDataSets();
 
-    dataLoader_t *trainDataloader = dataLoaderInit(getTrainSample,
-                                                   getTrainDatasetSize,
-                                                   batchSize,
-                                                   NULL,
-                                                   NULL,
-                                                   false,
-                                                   0,
-                                                   true);
+  dataLoader_t *trainDataloader =
+      dataLoaderInit(getTrainSample, getTrainDatasetSize, batchSize, NULL, NULL, false, 0, true);
 
-    dataLoader_t *testDataloader = dataLoaderInit(getTestSample,
-                                                  getTestDatasetSize,
-                                                  1,
-                                                  NULL,
-                                                  NULL,
-                                                  false,
-                                                  0,
-                                                  true);
+  dataLoader_t *testDataloader =
+      dataLoaderInit(getTestSample, getTestDatasetSize, 1, NULL, NULL, false, 0, true);
 
-    layer_t *model[MODEL_SIZE];
-    buildModel(model);
+  layer_t *model[MODEL_SIZE];
+  buildModel(model);
 
-    optimizer_t *sgd = sgdMCreateOptim(0.001f, 0.f, 0.f, model, MODEL_SIZE, FLOAT32);
+  optimizer_t *sgd = sgdMCreateOptim(0.001f, 0.f, 0.f, model, MODEL_SIZE, FLOAT32);
 
-    clock_t start = clock();
+  clock_t start = clock();
 
-    trainingRunResult_t result = trainingRun(model, MODEL_SIZE, CROSS_ENTROPY,
-                                             trainDataloader, testDataloader, sgd,
-                                             numberOfEpochs, calculateGradsSequential,
-                                             inferenceWithLoss, epochCallback);
+  trainingRunResult_t result =
+      trainingRun(model, MODEL_SIZE, CROSS_ENTROPY, trainDataloader, testDataloader, sgd,
+                  numberOfEpochs, calculateGradsSequential, inferenceWithLoss, epochCallback);
 
-    clock_t end = clock();
+  clock_t end = clock();
 
-    double duration_sec = (double)(end - start) / CLOCKS_PER_SEC;
-    PRINT_INFO("Training finished in %f seconds\n", duration_sec);
-    PRINT_INFO("Final train loss: %f, eval loss: %f\n", result.finalTrainLoss,
-                result.finalEvalStats.loss);
-    PRINT_INFO("Final accuracy: %.2f%%\n", result.finalEvalStats.accuracy * 100.0f);
+  double duration_sec = (double)(end - start) / CLOCKS_PER_SEC;
+  PRINT_INFO("Training finished in %f seconds\n", duration_sec);
+  PRINT_INFO("Final train loss: %f, eval loss: %f\n", result.finalTrainLoss,
+             result.finalEvalStats.loss);
+  PRINT_INFO("Final accuracy: %.2f%%\n", result.finalEvalStats.accuracy * 100.0f);
 }

--- a/experiments/MnistExperiment.c
+++ b/experiments/MnistExperiment.c
@@ -56,129 +56,135 @@ static dataset_t testDataset;
 static size_t batchSize = 32;
 
 static void initDataSets() {
-  tensorArray_t *trainItems = npyLoad(MNIST_TRAIN_X);
-  tensorArray_t *trainLabels = npyLoad(MNIST_TRAIN_Y);
-  trainDataset.items = trainItems;
-  trainDataset.labels = trainLabels;
+    tensorArray_t *trainItems = npyLoad(MNIST_TRAIN_X);
+    tensorArray_t *trainLabels = npyLoad(MNIST_TRAIN_Y);
+    trainDataset.items = trainItems;
+    trainDataset.labels = trainLabels;
 
-  tensorArray_t *testItems = npyLoad(MNIST_TEST_X);
-  tensorArray_t *testLabels = npyLoad(MNIST_TEST_Y);
-  testDataset.items = testItems;
-  testDataset.labels = testLabels;
+    tensorArray_t *testItems = npyLoad(MNIST_TEST_X);
+    tensorArray_t *testLabels = npyLoad(MNIST_TEST_Y);
+    testDataset.items = testItems;
+    testDataset.labels = testLabels;
 }
 
 static sample_t *getTrainSample(size_t id) {
-  sample_t *sample = npyGetSample(&trainDataset, id);
-  return sample;
+    sample_t *sample = npyGetSample(&trainDataset, id);
+    return sample;
 }
 
 static sample_t *getTestSample(size_t id) {
-  sample_t *sample = npyGetSample(&testDataset, id);
-  return sample;
+    sample_t *sample = npyGetSample(&testDataset, id);
+    return sample;
 }
 
-static size_t getTrainDatasetSize() { return trainDataset.items->size; }
+static size_t getTrainDatasetSize() {
+    return trainDataset.items->size;
+}
 
-static size_t getTestDatasetSize() { return testDataset.items->size; }
+static size_t getTestDatasetSize() {
+    return testDataset.items->size;
+}
 
 static void epochCallback(size_t epoch, float trainLoss, epochStats_t evalStats) {
-  char row[256] = {0};
-  sprintf(row, "%lu, %f, %f, %f, %f, %f, %f\n", epoch, trainLoss, evalStats.loss,
-          evalStats.accuracy, evalStats.precision, evalStats.recall, evalStats.f1);
-  PRINT_DEBUG("%s\n", row);
+    char row[256] = {0};
+    sprintf(row, "%lu, %f, %f, %f, %f, %f, %f\n", epoch, trainLoss, evalStats.loss,
+            evalStats.accuracy, evalStats.precision, evalStats.recall, evalStats.f1);
+    PRINT_DEBUG("%s\n", row);
 
-  char *rows[] = {row};
-  size_t entriesInRow[] = {7};
-  csvData_t csvData;
-  setCSVData(&csvData, rows, 1, entriesInRow);
-  csvWriteRowsByBufferSize(LOG, &csvData, "a");
+    char *rows[] = {row};
+    size_t entriesInRow[] = {7};
+    csvData_t csvData;
+    setCSVData(&csvData, rows, 1, entriesInRow);
+    csvWriteRowsByBufferSize(LOG, &csvData, "a");
 }
 
 static void writeCsvHeader(char *filePath) {
-  char *header =
-      "epoch, train_loss, eval_loss, eval_accuracy, eval_precision, eval_recall, eval_f1\n";
-  char *row[] = {header};
-  size_t entriesInRow[] = {7};
-  csvData_t csvData;
-  setCSVData(&csvData, row, 1, entriesInRow);
-  csvWriteRowsByBufferSize(filePath, &csvData, "w");
+    char *header =
+        "epoch, train_loss, eval_loss, eval_accuracy, eval_precision, eval_recall, eval_f1\n";
+    char *row[] = {header};
+    size_t entriesInRow[] = {7};
+    csvData_t csvData;
+    setCSVData(&csvData, row, 1, entriesInRow);
+    csvWriteRowsByBufferSize(filePath, &csvData, "w");
 }
 
 #define MODEL_SIZE 5
 
 static void buildModel(layer_t **model) {
-  quantization_t *q = quantizationInitFloat();
+    quantization_t *q = quantizationInitFloat();
 
-  // Flatten [1, 28, 28] -> [1, 784]
-  model[0] = flattenLayerInit();
+    // Flatten [1, 28, 28] -> [1, 784]
+    model[0] = flattenLayerInit();
 
-  // Linear 784→20
-  static float weight0Data[20 * 28 * 28] = {0};
-  static size_t weight0Dims[] = {20, 28 * 28};
-  tensor_t *weight0Param =
-      tensorInitWithDistribution(XAVIER_UNIFORM, weight0Data, weight0Dims, 2, q, NULL, 28 * 28, 20);
-  tensor_t *weight0Grad = gradInitFloat(weight0Param, NULL);
-  parameter_t *weight0 = parameterInit(weight0Param, weight0Grad);
+    // Linear 784→20
+    static float weight0Data[20 * 28 * 28] = {0};
+    static size_t weight0Dims[] = {20, 28 * 28};
+    tensor_t *weight0Param = tensorInitWithDistribution(XAVIER_UNIFORM, weight0Data, weight0Dims, 2,
+                                                        q, NULL, 28 * 28, 20);
+    tensor_t *weight0Grad = gradInitFloat(weight0Param, NULL);
+    parameter_t *weight0 = parameterInit(weight0Param, weight0Grad);
 
-  static float bias0Data[20] = {0};
-  static size_t bias0Dims[] = {1, 20};
-  tensor_t *bias0Param = tensorInitWithDistribution(ZEROS, bias0Data, bias0Dims, 2, q, NULL, 1, 20);
-  tensor_t *bias0Grad = gradInitFloat(bias0Param, NULL);
-  parameter_t *bias0 = parameterInit(bias0Param, bias0Grad);
+    static float bias0Data[20] = {0};
+    static size_t bias0Dims[] = {1, 20};
+    tensor_t *bias0Param =
+        tensorInitWithDistribution(ZEROS, bias0Data, bias0Dims, 2, q, NULL, 1, 20);
+    tensor_t *bias0Grad = gradInitFloat(bias0Param, NULL);
+    parameter_t *bias0 = parameterInit(bias0Param, bias0Grad);
 
-  model[1] = linearLayerInit(weight0, bias0, q, q, q, q);
+    model[1] = linearLayerInit(weight0, bias0, q, q, q, q);
 
-  // ReLU
-  model[2] = reluLayerInit(q, q);
+    // ReLU
+    model[2] = reluLayerInit(q, q);
 
-  // Linear 20→10
-  static float weight1Data[10 * 20] = {0};
-  static size_t weight1Dims[] = {10, 20};
-  tensor_t *weight1Param =
-      tensorInitWithDistribution(XAVIER_UNIFORM, weight1Data, weight1Dims, 2, q, NULL, 20, 10);
-  tensor_t *weight1Grad = gradInitFloat(weight1Param, NULL);
-  parameter_t *weight1 = parameterInit(weight1Param, weight1Grad);
+    // Linear 20→10
+    static float weight1Data[10 * 20] = {0};
+    static size_t weight1Dims[] = {10, 20};
+    tensor_t *weight1Param =
+        tensorInitWithDistribution(XAVIER_UNIFORM, weight1Data, weight1Dims, 2, q, NULL, 20, 10);
+    tensor_t *weight1Grad = gradInitFloat(weight1Param, NULL);
+    parameter_t *weight1 = parameterInit(weight1Param, weight1Grad);
 
-  static float bias1Data[10] = {0};
-  static size_t bias1Dims[] = {1, 10};
-  tensor_t *bias1Param = tensorInitWithDistribution(ZEROS, bias1Data, bias1Dims, 2, q, NULL, 1, 10);
-  tensor_t *bias1Grad = gradInitFloat(bias1Param, NULL);
-  parameter_t *bias1 = parameterInit(bias1Param, bias1Grad);
+    static float bias1Data[10] = {0};
+    static size_t bias1Dims[] = {1, 10};
+    tensor_t *bias1Param =
+        tensorInitWithDistribution(ZEROS, bias1Data, bias1Dims, 2, q, NULL, 1, 10);
+    tensor_t *bias1Grad = gradInitFloat(bias1Param, NULL);
+    parameter_t *bias1 = parameterInit(bias1Param, bias1Grad);
 
-  model[3] = linearLayerInit(weight1, bias1, q, q, q, q);
+    model[3] = linearLayerInit(weight1, bias1, q, q, q, q);
 
-  // Softmax
-  model[4] = softmaxLayerInit(q, q);
+    // Softmax
+    model[4] = softmaxLayerInit(q, q);
 }
 
 int main(void) {
-  writeCsvHeader(LOG);
+    writeCsvHeader(LOG);
 
-  size_t numberOfEpochs = 10;
-  initDataSets();
+    size_t numberOfEpochs = 10;
+    initDataSets();
 
-  dataLoader_t *trainDataloader =
-      dataLoaderInit(getTrainSample, getTrainDatasetSize, batchSize, NULL, NULL, false, 0, true);
+    dataLoader_t *trainDataloader =
+        dataLoaderInit(getTrainSample, getTrainDatasetSize, batchSize, NULL, NULL, false, 0, true);
 
-  dataLoader_t *testDataloader =
-      dataLoaderInit(getTestSample, getTestDatasetSize, 1, NULL, NULL, false, 0, true);
+    dataLoader_t *testDataloader =
+        dataLoaderInit(getTestSample, getTestDatasetSize, 1, NULL, NULL, false, 0, true);
 
-  layer_t *model[MODEL_SIZE];
-  buildModel(model);
+    layer_t *model[MODEL_SIZE];
+    buildModel(model);
 
-  optimizer_t *sgd = sgdMCreateOptim(0.001f, 0.f, 0.f, model, MODEL_SIZE, FLOAT32);
+    optimizer_t *sgd = sgdMCreateOptim(0.001f, 0.f, 0.f, model, MODEL_SIZE, FLOAT32);
 
-  clock_t start = clock();
+    clock_t start = clock();
 
-  trainingRunResult_t result =
-      trainingRun(model, MODEL_SIZE, CROSS_ENTROPY, trainDataloader, testDataloader, sgd,
-                  numberOfEpochs, calculateGradsSequential, inferenceWithLoss, epochCallback);
+    trainingRunResult_t result =
+        trainingRun(model, MODEL_SIZE, CROSS_ENTROPY, trainDataloader, testDataloader, sgd,
+                    numberOfEpochs, calculateGradsSequential, inferenceWithLoss, epochCallback);
 
-  clock_t end = clock();
+    clock_t end = clock();
 
-  double duration_sec = (double)(end - start) / CLOCKS_PER_SEC;
-  PRINT_INFO("Training finished in %f seconds\n", duration_sec);
-  PRINT_INFO("Final train loss: %f, eval loss: %f\n", result.finalTrainLoss,
-             result.finalEvalStats.loss);
-  PRINT_INFO("Final accuracy: %.2f%%\n", result.finalEvalStats.accuracy * 100.0f);
+    double duration_sec = (double)(end - start) / CLOCKS_PER_SEC;
+    PRINT_INFO("Training finished in %f seconds\n", duration_sec);
+    PRINT_INFO("Final train loss: %f, eval loss: %f\n", result.finalTrainLoss,
+               result.finalEvalStats.loss);
+    PRINT_INFO("Final accuracy: %.2f%%\n", result.finalEvalStats.accuracy * 100.0f);
 }

--- a/src/arithmetic/include/Distributions.h
+++ b/src/arithmetic/include/Distributions.h
@@ -3,8 +3,7 @@
 
 #include <stddef.h>
 
-typedef enum
-{
+typedef enum {
     ZEROS,
     ONES,
     UNIFORM,
@@ -14,6 +13,33 @@ typedef enum
     KAIMING_UNIFORM,
     KAIMING_NORMAL
 } distributionType_t;
+
+/*! Carries both the kind of distribution and the kind-specific parameters
+ * needed to draw values. Used by initDistribution() (TensorApi.h) and by
+ * future layer factories that take an initialization recipe.
+ *
+ * Discriminant: `type`. Read the union member matching that discriminant.
+ * ZEROS and ONES need no params; their union slot is unused.
+ */
+typedef struct {
+    distributionType_t type;
+    union {
+        struct {
+            float min, max;
+        } uniform;
+        struct {
+            float mean, stddev;
+        } normal;
+        struct {
+            float gain;
+            size_t fanIn, fanOut;
+        } xavier;
+        struct {
+            float gain;
+            size_t fanMode;
+        } kaiming;
+    } params;
+} distribution_t;
 
 /*! Gets random value from normal distribution.\n
  * Uses the Box-Muller transform.
@@ -61,7 +87,6 @@ float kaimingUniform(float gain, size_t fanMode);
  * @returns Float value
  */
 float xavierNormal(float gain, size_t fanIn, size_t fanOut);
-
 
 /*! Gets random value from Xavier distribution using the uniform distribution.
  *

--- a/src/layer/CMakeLists.txt
+++ b/src/layer/CMakeLists.txt
@@ -23,6 +23,7 @@ target_link_libraries(Layer PRIVATE
         Linear
         Relu
         Softmax
+        Flatten
 )
 
 add_library(Linear Linear.c)
@@ -66,6 +67,16 @@ target_link_libraries(Softmax PRIVATE
         Common
 )
 
+add_library(Flatten Flatten.c)
+target_include_directories(Flatten PUBLIC include)
+target_link_libraries(Flatten PRIVATE
+        DTypes
+        Tensor
+        Arithmetic
+        Layer
+        Common
+)
+
 add_library(CommonLayerLibs INTERFACE)
 target_link_libraries(CommonLayerLibs INTERFACE
         Layer
@@ -73,6 +84,7 @@ target_link_libraries(CommonLayerLibs INTERFACE
         Relu
         Conv1d
         Softmax
+        Flatten
         Rounding
         Tensor
         Sgd

--- a/src/layer/Flatten.c
+++ b/src/layer/Flatten.c
@@ -28,6 +28,12 @@ void flattenBackward(layer_t *flattenLayer, tensor_t *forwardInput, tensor_t *lo
   size_t numberOfElements = calcNumberOfElementsByTensor(loss);
   size_t numberOfBytes = calcNumberOfBytesForData(loss->quantization, numberOfElements);
   memcpy(propLoss->data, loss->data, numberOfBytes);
+
+  if (loss->quantization->type == SYM_INT32) {
+    symInt32QConfig_t *lossQC = loss->quantization->qConfig;
+    symInt32QConfig_t *propLossQC = propLoss->quantization->qConfig;
+    propLossQC->scale = lossQC->scale;
+  }
 }
 
 void flattenCalcOutputShape(layer_t *flattenLayer, shape_t *inputShape, shape_t *outputShape) {

--- a/src/layer/Flatten.c
+++ b/src/layer/Flatten.c
@@ -1,16 +1,17 @@
 #define SOURCE_FILE "FLATTEN"
 
 #include <stdlib.h>
+#include <string.h>
 
 #include "Common.h"
 #include "Flatten.h"
 
 void flattenForward(layer_t *flattenLayer, tensor_t *input, tensor_t *output) {
   (void)flattenLayer;
-  (void)input;
-  (void)output;
-  PRINT_ERROR("flattenForward not implemented yet");
-  exit(1);
+
+  size_t numberOfElements = calcNumberOfElementsByTensor(input);
+  size_t numberOfBytes = calcNumberOfBytesForData(input->quantization, numberOfElements);
+  memcpy(output->data, input->data, numberOfBytes);
 }
 
 void flattenBackward(layer_t *flattenLayer, tensor_t *forwardInput, tensor_t *loss,

--- a/src/layer/Flatten.c
+++ b/src/layer/Flatten.c
@@ -24,10 +24,10 @@ void flattenBackward(layer_t *flattenLayer, tensor_t *forwardInput, tensor_t *lo
                      tensor_t *propLoss) {
   (void)flattenLayer;
   (void)forwardInput;
-  (void)loss;
-  (void)propLoss;
-  PRINT_ERROR("flattenBackward not implemented yet");
-  exit(1);
+
+  size_t numberOfElements = calcNumberOfElementsByTensor(loss);
+  size_t numberOfBytes = calcNumberOfBytesForData(loss->quantization, numberOfElements);
+  memcpy(propLoss->data, loss->data, numberOfBytes);
 }
 
 void flattenCalcOutputShape(layer_t *flattenLayer, shape_t *inputShape, shape_t *outputShape) {

--- a/src/layer/Flatten.c
+++ b/src/layer/Flatten.c
@@ -25,8 +25,15 @@ void flattenBackward(layer_t *flattenLayer, tensor_t *forwardInput, tensor_t *lo
 
 void flattenCalcOutputShape(layer_t *flattenLayer, shape_t *inputShape, shape_t *outputShape) {
   (void)flattenLayer;
-  (void)inputShape;
-  (void)outputShape;
-  PRINT_ERROR("flattenCalcOutputShape not implemented yet");
-  exit(1);
+
+  size_t batch = inputShape->dimensions[0];
+  size_t features = 1;
+  for (size_t i = 1; i < inputShape->numberOfDimensions; i++) {
+    features *= inputShape->dimensions[i];
+  }
+
+  outputShape->dimensions[0] = batch;
+  outputShape->dimensions[1] = features;
+  outputShape->numberOfDimensions = 2;
+  setOrderOfDimsForNewTensor(outputShape->numberOfDimensions, outputShape->orderOfDimensions);
 }

--- a/src/layer/Flatten.c
+++ b/src/layer/Flatten.c
@@ -45,6 +45,8 @@ void flattenCalcOutputShape(layer_t *flattenLayer, shape_t *inputShape, shape_t 
         features *= inputShape->dimensions[i];
     }
 
+    // Precondition: caller allocates outputShape->dimensions and
+    // ->orderOfDimensions with >= 2 slots, regardless of input rank.
     outputShape->dimensions[0] = batch;
     outputShape->dimensions[1] = features;
     outputShape->numberOfDimensions = 2;

--- a/src/layer/Flatten.c
+++ b/src/layer/Flatten.c
@@ -7,46 +7,46 @@
 #include "Flatten.h"
 
 void flattenForward(layer_t *flattenLayer, tensor_t *input, tensor_t *output) {
-  (void)flattenLayer;
+    (void)flattenLayer;
 
-  size_t numberOfElements = calcNumberOfElementsByTensor(input);
-  size_t numberOfBytes = calcNumberOfBytesForData(input->quantization, numberOfElements);
-  memcpy(output->data, input->data, numberOfBytes);
+    size_t numberOfElements = calcNumberOfElementsByTensor(input);
+    size_t numberOfBytes = calcNumberOfBytesForData(input->quantization, numberOfElements);
+    memcpy(output->data, input->data, numberOfBytes);
 
-  if (input->quantization->type == SYM_INT32) {
-    symInt32QConfig_t *inputQC = input->quantization->qConfig;
-    symInt32QConfig_t *outputQC = output->quantization->qConfig;
-    outputQC->scale = inputQC->scale;
-  }
+    if (input->quantization->type == SYM_INT32) {
+        symInt32QConfig_t *inputQC = input->quantization->qConfig;
+        symInt32QConfig_t *outputQC = output->quantization->qConfig;
+        outputQC->scale = inputQC->scale;
+    }
 }
 
 void flattenBackward(layer_t *flattenLayer, tensor_t *forwardInput, tensor_t *loss,
                      tensor_t *propLoss) {
-  (void)flattenLayer;
-  (void)forwardInput;
+    (void)flattenLayer;
+    (void)forwardInput;
 
-  size_t numberOfElements = calcNumberOfElementsByTensor(loss);
-  size_t numberOfBytes = calcNumberOfBytesForData(loss->quantization, numberOfElements);
-  memcpy(propLoss->data, loss->data, numberOfBytes);
+    size_t numberOfElements = calcNumberOfElementsByTensor(loss);
+    size_t numberOfBytes = calcNumberOfBytesForData(loss->quantization, numberOfElements);
+    memcpy(propLoss->data, loss->data, numberOfBytes);
 
-  if (loss->quantization->type == SYM_INT32) {
-    symInt32QConfig_t *lossQC = loss->quantization->qConfig;
-    symInt32QConfig_t *propLossQC = propLoss->quantization->qConfig;
-    propLossQC->scale = lossQC->scale;
-  }
+    if (loss->quantization->type == SYM_INT32) {
+        symInt32QConfig_t *lossQC = loss->quantization->qConfig;
+        symInt32QConfig_t *propLossQC = propLoss->quantization->qConfig;
+        propLossQC->scale = lossQC->scale;
+    }
 }
 
 void flattenCalcOutputShape(layer_t *flattenLayer, shape_t *inputShape, shape_t *outputShape) {
-  (void)flattenLayer;
+    (void)flattenLayer;
 
-  size_t batch = inputShape->dimensions[0];
-  size_t features = 1;
-  for (size_t i = 1; i < inputShape->numberOfDimensions; i++) {
-    features *= inputShape->dimensions[i];
-  }
+    size_t batch = inputShape->dimensions[0];
+    size_t features = 1;
+    for (size_t i = 1; i < inputShape->numberOfDimensions; i++) {
+        features *= inputShape->dimensions[i];
+    }
 
-  outputShape->dimensions[0] = batch;
-  outputShape->dimensions[1] = features;
-  outputShape->numberOfDimensions = 2;
-  setOrderOfDimsForNewTensor(outputShape->numberOfDimensions, outputShape->orderOfDimensions);
+    outputShape->dimensions[0] = batch;
+    outputShape->dimensions[1] = features;
+    outputShape->numberOfDimensions = 2;
+    setOrderOfDimsForNewTensor(outputShape->numberOfDimensions, outputShape->orderOfDimensions);
 }

--- a/src/layer/Flatten.c
+++ b/src/layer/Flatten.c
@@ -1,0 +1,32 @@
+#define SOURCE_FILE "FLATTEN"
+
+#include <stdlib.h>
+
+#include "Common.h"
+#include "Flatten.h"
+
+void flattenForward(layer_t *flattenLayer, tensor_t *input, tensor_t *output) {
+  (void)flattenLayer;
+  (void)input;
+  (void)output;
+  PRINT_ERROR("flattenForward not implemented yet");
+  exit(1);
+}
+
+void flattenBackward(layer_t *flattenLayer, tensor_t *forwardInput, tensor_t *loss,
+                     tensor_t *propLoss) {
+  (void)flattenLayer;
+  (void)forwardInput;
+  (void)loss;
+  (void)propLoss;
+  PRINT_ERROR("flattenBackward not implemented yet");
+  exit(1);
+}
+
+void flattenCalcOutputShape(layer_t *flattenLayer, shape_t *inputShape, shape_t *outputShape) {
+  (void)flattenLayer;
+  (void)inputShape;
+  (void)outputShape;
+  PRINT_ERROR("flattenCalcOutputShape not implemented yet");
+  exit(1);
+}

--- a/src/layer/Flatten.c
+++ b/src/layer/Flatten.c
@@ -12,6 +12,12 @@ void flattenForward(layer_t *flattenLayer, tensor_t *input, tensor_t *output) {
   size_t numberOfElements = calcNumberOfElementsByTensor(input);
   size_t numberOfBytes = calcNumberOfBytesForData(input->quantization, numberOfElements);
   memcpy(output->data, input->data, numberOfBytes);
+
+  if (input->quantization->type == SYM_INT32) {
+    symInt32QConfig_t *inputQC = input->quantization->qConfig;
+    symInt32QConfig_t *outputQC = output->quantization->qConfig;
+    outputQC->scale = inputQC->scale;
+  }
 }
 
 void flattenBackward(layer_t *flattenLayer, tensor_t *forwardInput, tensor_t *loss,

--- a/src/layer/Layer.c
+++ b/src/layer/Layer.c
@@ -14,6 +14,6 @@ layerFunctions_t layerFunctions[] = {
     [FLATTEN] = {flattenForward, flattenBackward, flattenCalcOutputShape}};
 
 void initLayer(layer_t *layer, layerType_t type, layerConfig_t *config) {
-  layer->type = type;
-  layer->config = config;
+    layer->type = type;
+    layer->config = config;
 }

--- a/src/layer/Layer.c
+++ b/src/layer/Layer.c
@@ -1,19 +1,19 @@
 #define SOURCE_FILE "LAYER"
 
+#include "Layer.h"
+#include "Flatten.h"
 #include "Linear.h"
 #include "Relu.h"
 #include "Softmax.h"
-#include "Layer.h"
-
 
 layerFunctions_t layerFunctions[] = {
     [LINEAR] = {linearForward, linearBackward, linearCalcOutputShape},
     [RELU] = {reluForward, reluBackward, reluCalcOutputShape},
     [CONV1D] = {NULL, NULL, NULL},
-    [SOFTMAX] = {softmaxForward, softmaxBackward, softmaxCalcOutputShape}
-};
+    [SOFTMAX] = {softmaxForward, softmaxBackward, softmaxCalcOutputShape},
+    [FLATTEN] = {flattenForward, flattenBackward, flattenCalcOutputShape}};
 
-void initLayer(layer_t *layer, layerType_t type, layerConfig_t* config) {
-    layer->type = type;
-    layer->config = config;
+void initLayer(layer_t *layer, layerType_t type, layerConfig_t *config) {
+  layer->type = type;
+  layer->config = config;
 }

--- a/src/layer/include/Flatten.h
+++ b/src/layer/include/Flatten.h
@@ -1,0 +1,12 @@
+#ifndef ODT_FLATTEN_H
+#define ODT_FLATTEN_H
+
+#include "Layer.h"
+#include "Tensor.h"
+
+void flattenForward(layer_t *flattenLayer, tensor_t *input, tensor_t *output);
+void flattenBackward(layer_t *flattenLayer, tensor_t *forwardInput, tensor_t *loss,
+                     tensor_t *propLoss);
+void flattenCalcOutputShape(layer_t *flattenLayer, shape_t *inputShape, shape_t *outputShape);
+
+#endif

--- a/src/layer/include/Layer.h
+++ b/src/layer/include/Layer.h
@@ -7,49 +7,42 @@ typedef struct linearConfig linearConfig_t;
 typedef struct reluConfig reluConfig_t;
 typedef struct softmaxConfig softmaxConfig_t;
 
-typedef enum layerType
-{
+typedef enum layerType {
     LINEAR,
     RELU,
     CONV1D,
     SOFTMAX,
+    FLATTEN,
     SEQUENTIAL,
     QUANTIZATION
 } layerType_t;
 
-typedef enum layerQType
-{
-    FLOAT_LAYER,
-    ASYM_LAYER
-} layerQType_t;
+typedef enum layerQType { FLOAT_LAYER, ASYM_LAYER } layerQType_t;
 
-typedef union layerConfig
-{
-    linearConfig_t* linear;
-    reluConfig_t* relu;
-    softmaxConfig_t* softmax;
+typedef union layerConfig {
+    linearConfig_t *linear;
+    reluConfig_t *relu;
+    softmaxConfig_t *softmax;
 } layerConfig_t;
 
-typedef struct layer
-{
+typedef struct layer {
     layerType_t type;
-    layerConfig_t* config;
+    layerConfig_t *config;
 } layer_t;
 
-typedef void (*forwardFn_t)(layer_t* layer, tensor_t* inputTensor, tensor_t* outputTensor);
-typedef void (*backwardFn_t)(layer_t* layer, tensor_t* forwardInput, tensor_t* loss, tensor_t* propLoss);
-typedef void (*calcOutputShapeFn_t)(layer_t* layer, shape_t* inputShape, shape_t* outputShape);
+typedef void (*forwardFn_t)(layer_t *layer, tensor_t *inputTensor, tensor_t *outputTensor);
+typedef void (*backwardFn_t)(layer_t *layer, tensor_t *forwardInput, tensor_t *loss,
+                             tensor_t *propLoss);
+typedef void (*calcOutputShapeFn_t)(layer_t *layer, shape_t *inputShape, shape_t *outputShape);
 
-typedef struct layerFunctions
-{
+typedef struct layerFunctions {
     forwardFn_t forward;
     backwardFn_t backward;
     calcOutputShapeFn_t calcOutputShape;
 } layerFunctions_t;
 
-
 extern layerFunctions_t layerFunctions[];
 
-void initLayer(layer_t* layer, layerType_t layerType, layerConfig_t* config);
+void initLayer(layer_t *layer, layerType_t layerType, layerConfig_t *config);
 
 #endif

--- a/src/serial/Deserialize.c
+++ b/src/serial/Deserialize.c
@@ -12,106 +12,106 @@
 #include "Tensor.h"
 
 void deserializeTensor(tensor_t *tensor, FILE *f) {
-  deserializeShape(tensor->shape, f);
-  deserializeQuantization(tensor->quantization, f);
+    deserializeShape(tensor->shape, f);
+    deserializeQuantization(tensor->quantization, f);
 
-  size_t numberOfValues = calcNumberOfElementsByShape(tensor->shape);
-  size_t bytesPerValue = calcBytesPerElement(tensor->quantization);
+    size_t numberOfValues = calcNumberOfElementsByShape(tensor->shape);
+    size_t bytesPerValue = calcBytesPerElement(tensor->quantization);
 
-  deserializeData(tensor->data, numberOfValues, bytesPerValue, f);
-  deserializeSparsity();
+    deserializeData(tensor->data, numberOfValues, bytesPerValue, f);
+    deserializeSparsity();
 }
 
 void deserializeParameter(parameter_t *parameter, FILE *f) {
-  deserializeTensor(parameter->param, f);
-  deserializeTensor(parameter->grad, f);
+    deserializeTensor(parameter->param, f);
+    deserializeTensor(parameter->grad, f);
 }
 
 void deserializeModel(layer_t **model, size_t sizeModel, FILE *f) {
-  for (size_t i = 0; i < sizeModel; i++) {
-    deserializeLayer(model[i], f);
-  }
+    for (size_t i = 0; i < sizeModel; i++) {
+        deserializeLayer(model[i], f);
+    }
 }
 
 // Helper Functions
 
 static void deserialize(void *values, size_t numberOfElements, size_t sizeOfElement, FILE *f) {
-  fread(values, numberOfElements, sizeOfElement, f);
+    fread(values, numberOfElements, sizeOfElement, f);
 }
 
 static void deserializeShape(shape_t *shape, FILE *f) {
-  deserialize(&shape->numberOfDimensions, 1, sizeof(size_t), f);
-  deserialize(shape->dimensions, shape->numberOfDimensions, sizeof(size_t), f);
-  deserialize(shape->orderOfDimensions, shape->numberOfDimensions, sizeof(size_t), f);
+    deserialize(&shape->numberOfDimensions, 1, sizeof(size_t), f);
+    deserialize(shape->dimensions, shape->numberOfDimensions, sizeof(size_t), f);
+    deserialize(shape->orderOfDimensions, shape->numberOfDimensions, sizeof(size_t), f);
 }
 
 static void deserializeQuantization(quantization_t *q, FILE *f) {
-  deserialize(&q->type, 1, sizeof(qtype_t), f);
-  deserializeQConfig(q, f);
+    deserialize(&q->type, 1, sizeof(qtype_t), f);
+    deserializeQConfig(q, f);
 }
 
 static void deserializeData(uint8_t *data, size_t numberOfValues, size_t bytesPerValue, FILE *f) {
-  deserialize(data, numberOfValues, bytesPerValue, f);
+    deserialize(data, numberOfValues, bytesPerValue, f);
 }
 
 static void deserializeQConfig(quantization_t *q, FILE *f) {
-  switch (q->type) {
-  case INT32:
-  case FLOAT32:
-    break;
-  case SYM_INT32:
-    symInt32QConfig_t *symIntQC = q->qConfig;
-    deserialize(&symIntQC->scale, 1, sizeof(float), f);
-    deserialize(&symIntQC->roundingMode, 1, sizeof(roundingMode_t), f);
-    deserialize(&symIntQC->qMaxBits, 1, sizeof(uint8_t), f);
-    break;
-  case SYM:
-    symQConfig_t *symQC = q->qConfig;
-    deserialize(&symQC->scale, 1, sizeof(float), f);
-    deserialize(&symQC->qBits, 1, sizeof(uint8_t), f);
-    break;
-  case ASYM:
-    asymQConfig_t *asymQC = q->qConfig;
-    deserialize(&asymQC->scale, 1, sizeof(float), f);
-    deserialize(&asymQC->qBits, 1, sizeof(uint8_t), f);
-    deserialize(&asymQC->roundingMode, 1, sizeof(roundingMode_t), f);
-    deserialize(&asymQC->zeroPoint, 1, sizeof(int16_t), f);
-    break;
-  default:
-    PRINT_ERROR("Unknown qType!");
-    exit(1);
-  }
+    switch (q->type) {
+    case INT32:
+    case FLOAT32:
+        break;
+    case SYM_INT32:
+        symInt32QConfig_t *symIntQC = q->qConfig;
+        deserialize(&symIntQC->scale, 1, sizeof(float), f);
+        deserialize(&symIntQC->roundingMode, 1, sizeof(roundingMode_t), f);
+        deserialize(&symIntQC->qMaxBits, 1, sizeof(uint8_t), f);
+        break;
+    case SYM:
+        symQConfig_t *symQC = q->qConfig;
+        deserialize(&symQC->scale, 1, sizeof(float), f);
+        deserialize(&symQC->qBits, 1, sizeof(uint8_t), f);
+        break;
+    case ASYM:
+        asymQConfig_t *asymQC = q->qConfig;
+        deserialize(&asymQC->scale, 1, sizeof(float), f);
+        deserialize(&asymQC->qBits, 1, sizeof(uint8_t), f);
+        deserialize(&asymQC->roundingMode, 1, sizeof(roundingMode_t), f);
+        deserialize(&asymQC->zeroPoint, 1, sizeof(int16_t), f);
+        break;
+    default:
+        PRINT_ERROR("Unknown qType!");
+        exit(1);
+    }
 }
 
 // TODO
 static void deserializeSparsity() {}
 
 static void deserializeLayer(layer_t *layer, FILE *f) {
-  switch (layer->type) {
-  case LINEAR:
-    linearConfig_t *linearConfig = layer->config->linear;
-    deserializeParameter(linearConfig->weights, f);
-    deserializeParameter(linearConfig->bias, f);
-    deserializeQuantization(linearConfig->forwardQ, f);
-    deserializeQuantization(linearConfig->weightGradQ, f);
-    deserializeQuantization(linearConfig->biasGradQ, f);
-    deserializeQuantization(linearConfig->propLossQ, f);
-    break;
-  case RELU:
-    reluConfig_t *reluConfig = layer->config->relu;
-    deserializeQuantization(reluConfig->forwardQ, f);
-    deserializeQuantization(reluConfig->backwardQ, f);
-    break;
-  case SOFTMAX:
-    softmaxConfig_t *softmaxConfig = layer->config->softmax;
-    deserializeQuantization(softmaxConfig->forwardQ, f);
-    deserializeQuantization(softmaxConfig->backwardQ, f);
-    break;
-  case FLATTEN:
-    // Flatten carries no state (no parameters, no quantization).
-    break;
-  default:
-    PRINT_ERROR("Unsupported qtype!\n");
-    exit(1);
-  }
+    switch (layer->type) {
+    case LINEAR:
+        linearConfig_t *linearConfig = layer->config->linear;
+        deserializeParameter(linearConfig->weights, f);
+        deserializeParameter(linearConfig->bias, f);
+        deserializeQuantization(linearConfig->forwardQ, f);
+        deserializeQuantization(linearConfig->weightGradQ, f);
+        deserializeQuantization(linearConfig->biasGradQ, f);
+        deserializeQuantization(linearConfig->propLossQ, f);
+        break;
+    case RELU:
+        reluConfig_t *reluConfig = layer->config->relu;
+        deserializeQuantization(reluConfig->forwardQ, f);
+        deserializeQuantization(reluConfig->backwardQ, f);
+        break;
+    case SOFTMAX:
+        softmaxConfig_t *softmaxConfig = layer->config->softmax;
+        deserializeQuantization(softmaxConfig->forwardQ, f);
+        deserializeQuantization(softmaxConfig->backwardQ, f);
+        break;
+    case FLATTEN:
+        // Flatten carries no state (no parameters, no quantization).
+        break;
+    default:
+        PRINT_ERROR("Unsupported qtype!\n");
+        exit(1);
+    }
 }

--- a/src/serial/Deserialize.c
+++ b/src/serial/Deserialize.c
@@ -2,115 +2,116 @@
 
 #include <stdlib.h>
 
-#include "DeserializeInternal.h"
-#include "Deserialize.h"
 #include "Common.h"
-#include "Tensor.h"
-#include "Rounding.h"
+#include "Deserialize.h"
+#include "DeserializeInternal.h"
 #include "Linear.h"
 #include "Relu.h"
+#include "Rounding.h"
 #include "Softmax.h"
-
+#include "Tensor.h"
 
 void deserializeTensor(tensor_t *tensor, FILE *f) {
-    deserializeShape(tensor->shape, f);
-    deserializeQuantization(tensor->quantization, f);
+  deserializeShape(tensor->shape, f);
+  deserializeQuantization(tensor->quantization, f);
 
-    size_t numberOfValues = calcNumberOfElementsByShape(tensor->shape);
-    size_t bytesPerValue = calcBytesPerElement(tensor->quantization);
+  size_t numberOfValues = calcNumberOfElementsByShape(tensor->shape);
+  size_t bytesPerValue = calcBytesPerElement(tensor->quantization);
 
-    deserializeData(tensor->data, numberOfValues, bytesPerValue, f);
-    deserializeSparsity();
+  deserializeData(tensor->data, numberOfValues, bytesPerValue, f);
+  deserializeSparsity();
 }
 
 void deserializeParameter(parameter_t *parameter, FILE *f) {
-    deserializeTensor(parameter->param, f);
-    deserializeTensor(parameter->grad, f);
+  deserializeTensor(parameter->param, f);
+  deserializeTensor(parameter->grad, f);
 }
 
 void deserializeModel(layer_t **model, size_t sizeModel, FILE *f) {
-    for (size_t i = 0; i < sizeModel; i++) {
-        deserializeLayer(model[i], f);
-    }
+  for (size_t i = 0; i < sizeModel; i++) {
+    deserializeLayer(model[i], f);
+  }
 }
 
 // Helper Functions
 
 static void deserialize(void *values, size_t numberOfElements, size_t sizeOfElement, FILE *f) {
-    fread(values, numberOfElements, sizeOfElement, f);
+  fread(values, numberOfElements, sizeOfElement, f);
 }
 
 static void deserializeShape(shape_t *shape, FILE *f) {
-    deserialize(&shape->numberOfDimensions, 1, sizeof(size_t), f);
-    deserialize(shape->dimensions, shape->numberOfDimensions, sizeof(size_t), f);
-    deserialize(shape->orderOfDimensions, shape->numberOfDimensions, sizeof(size_t), f);
+  deserialize(&shape->numberOfDimensions, 1, sizeof(size_t), f);
+  deserialize(shape->dimensions, shape->numberOfDimensions, sizeof(size_t), f);
+  deserialize(shape->orderOfDimensions, shape->numberOfDimensions, sizeof(size_t), f);
 }
 
 static void deserializeQuantization(quantization_t *q, FILE *f) {
-    deserialize(&q->type, 1, sizeof(qtype_t), f);
-    deserializeQConfig(q, f);
+  deserialize(&q->type, 1, sizeof(qtype_t), f);
+  deserializeQConfig(q, f);
 }
 
 static void deserializeData(uint8_t *data, size_t numberOfValues, size_t bytesPerValue, FILE *f) {
-    deserialize(data, numberOfValues, bytesPerValue, f);
+  deserialize(data, numberOfValues, bytesPerValue, f);
 }
 
 static void deserializeQConfig(quantization_t *q, FILE *f) {
-    switch (q->type) {
-    case INT32:
-    case FLOAT32:
-        break;
-    case SYM_INT32:
-        symInt32QConfig_t *symIntQC = q->qConfig;
-        deserialize(&symIntQC->scale, 1, sizeof(float), f);
-        deserialize(&symIntQC->roundingMode, 1, sizeof(roundingMode_t), f);
-        deserialize(&symIntQC->qMaxBits, 1, sizeof(uint8_t), f);
-        break;
-    case SYM:
-        symQConfig_t *symQC = q->qConfig;
-        deserialize(&symQC->scale, 1, sizeof(float), f);
-        deserialize(&symQC->qBits, 1, sizeof(uint8_t), f);
-        break;
-    case ASYM:
-        asymQConfig_t *asymQC = q->qConfig;
-        deserialize(&asymQC->scale, 1, sizeof(float), f);
-        deserialize(&asymQC->qBits, 1, sizeof(uint8_t), f);
-        deserialize(&asymQC->roundingMode, 1, sizeof(roundingMode_t), f);
-        deserialize(&asymQC->zeroPoint, 1, sizeof(int16_t), f);
-        break;
-    default:
-        PRINT_ERROR("Unknown qType!");
-        exit(1);
-    }
+  switch (q->type) {
+  case INT32:
+  case FLOAT32:
+    break;
+  case SYM_INT32:
+    symInt32QConfig_t *symIntQC = q->qConfig;
+    deserialize(&symIntQC->scale, 1, sizeof(float), f);
+    deserialize(&symIntQC->roundingMode, 1, sizeof(roundingMode_t), f);
+    deserialize(&symIntQC->qMaxBits, 1, sizeof(uint8_t), f);
+    break;
+  case SYM:
+    symQConfig_t *symQC = q->qConfig;
+    deserialize(&symQC->scale, 1, sizeof(float), f);
+    deserialize(&symQC->qBits, 1, sizeof(uint8_t), f);
+    break;
+  case ASYM:
+    asymQConfig_t *asymQC = q->qConfig;
+    deserialize(&asymQC->scale, 1, sizeof(float), f);
+    deserialize(&asymQC->qBits, 1, sizeof(uint8_t), f);
+    deserialize(&asymQC->roundingMode, 1, sizeof(roundingMode_t), f);
+    deserialize(&asymQC->zeroPoint, 1, sizeof(int16_t), f);
+    break;
+  default:
+    PRINT_ERROR("Unknown qType!");
+    exit(1);
+  }
 }
 
 // TODO
 static void deserializeSparsity() {}
 
-
 static void deserializeLayer(layer_t *layer, FILE *f) {
-    switch (layer->type) {
-    case LINEAR:
-        linearConfig_t *linearConfig = layer->config->linear;
-        deserializeParameter(linearConfig->weights, f);
-        deserializeParameter(linearConfig->bias, f);
-        deserializeQuantization(linearConfig->forwardQ, f);
-        deserializeQuantization(linearConfig->weightGradQ, f);
-        deserializeQuantization(linearConfig->biasGradQ, f);
-        deserializeQuantization(linearConfig->propLossQ, f);
-        break;
-    case RELU:
-        reluConfig_t *reluConfig = layer->config->relu;
-        deserializeQuantization(reluConfig->forwardQ, f);
-        deserializeQuantization(reluConfig->backwardQ, f);
-        break;
-    case SOFTMAX:
-        softmaxConfig_t *softmaxConfig = layer->config->softmax;
-        deserializeQuantization(softmaxConfig->forwardQ, f);
-        deserializeQuantization(softmaxConfig->backwardQ, f);
-        break;
-    default:
-        PRINT_ERROR("Unsupported qtype!\n");
-        exit(1);
-    }
+  switch (layer->type) {
+  case LINEAR:
+    linearConfig_t *linearConfig = layer->config->linear;
+    deserializeParameter(linearConfig->weights, f);
+    deserializeParameter(linearConfig->bias, f);
+    deserializeQuantization(linearConfig->forwardQ, f);
+    deserializeQuantization(linearConfig->weightGradQ, f);
+    deserializeQuantization(linearConfig->biasGradQ, f);
+    deserializeQuantization(linearConfig->propLossQ, f);
+    break;
+  case RELU:
+    reluConfig_t *reluConfig = layer->config->relu;
+    deserializeQuantization(reluConfig->forwardQ, f);
+    deserializeQuantization(reluConfig->backwardQ, f);
+    break;
+  case SOFTMAX:
+    softmaxConfig_t *softmaxConfig = layer->config->softmax;
+    deserializeQuantization(softmaxConfig->forwardQ, f);
+    deserializeQuantization(softmaxConfig->backwardQ, f);
+    break;
+  case FLATTEN:
+    // Flatten carries no state (no parameters, no quantization).
+    break;
+  default:
+    PRINT_ERROR("Unsupported qtype!\n");
+    exit(1);
+  }
 }

--- a/src/serial/Serialize.c
+++ b/src/serial/Serialize.c
@@ -2,114 +2,116 @@
 
 #include <stdlib.h>
 
-#include "SerializeInternal.h"
-#include "Serialize.h"
 #include "Common.h"
-#include "Tensor.h"
-#include "Rounding.h"
 #include "Layer.h"
 #include "Linear.h"
 #include "Relu.h"
+#include "Rounding.h"
+#include "Serialize.h"
+#include "SerializeInternal.h"
 #include "Softmax.h"
+#include "Tensor.h"
 
 void serializeTensor(tensor_t *tensor, FILE *f) {
-    size_t numberOfValues = calcNumberOfElementsByTensor(tensor);
-    size_t bytesPerValue = calcBytesPerElement(tensor->quantization);
+  size_t numberOfValues = calcNumberOfElementsByTensor(tensor);
+  size_t bytesPerValue = calcBytesPerElement(tensor->quantization);
 
-    serializeShape(tensor->shape, f);
-    serializeQuantization(tensor->quantization, f);
-    serializeData(tensor->data, numberOfValues, bytesPerValue, f);
-    serializeSparsity();
+  serializeShape(tensor->shape, f);
+  serializeQuantization(tensor->quantization, f);
+  serializeData(tensor->data, numberOfValues, bytesPerValue, f);
+  serializeSparsity();
 }
 
 void serializeParameter(parameter_t *parameter, FILE *f) {
-    serializeTensor(parameter->param, f);
-    serializeTensor(parameter->grad, f);
+  serializeTensor(parameter->param, f);
+  serializeTensor(parameter->grad, f);
 }
 
 void serializeModel(layer_t **model, size_t sizeModel, FILE *f) {
-    for (size_t i = 0; i < sizeModel; i++) {
-        serializeLayer(model[i], f);
-    }
+  for (size_t i = 0; i < sizeModel; i++) {
+    serializeLayer(model[i], f);
+  }
 }
 
 // Helper Functions
 
 static void serialize(void *values, size_t numberOfElements, size_t sizeOfElement, FILE *f) {
-    fwrite(values, numberOfElements, sizeOfElement, f);
+  fwrite(values, numberOfElements, sizeOfElement, f);
 }
 
 static void serializeShape(shape_t *shape, FILE *f) {
-    serialize(&shape->numberOfDimensions, 1, sizeof(size_t), f);
-    serialize(shape->dimensions, shape->numberOfDimensions, sizeof(size_t), f);
-    serialize(shape->orderOfDimensions, shape->numberOfDimensions, sizeof(size_t), f);
+  serialize(&shape->numberOfDimensions, 1, sizeof(size_t), f);
+  serialize(shape->dimensions, shape->numberOfDimensions, sizeof(size_t), f);
+  serialize(shape->orderOfDimensions, shape->numberOfDimensions, sizeof(size_t), f);
 }
 
 static void serializeQuantization(quantization_t *q, FILE *f) {
-    serialize(&q->type, 1, sizeof(qtype_t), f);
-    serializeQConfig(q, f);
+  serialize(&q->type, 1, sizeof(qtype_t), f);
+  serializeQConfig(q, f);
 }
 
 static void serializeData(uint8_t *data, size_t numberOfValues, size_t bytesPerValue, FILE *f) {
-    serialize(data, numberOfValues, bytesPerValue, f);
+  serialize(data, numberOfValues, bytesPerValue, f);
 }
 
 static void serializeQConfig(quantization_t *q, FILE *f) {
-    switch (q->type) {
-    case INT32:
-    case FLOAT32:
-        break;
-    case SYM_INT32:
-        symInt32QConfig_t *symIntQC = q->qConfig;
-        serialize(&symIntQC->scale, 1, sizeof(float), f);
-        serialize(&symIntQC->roundingMode, 1, sizeof(roundingMode_t), f);
-        serialize(&symIntQC->qMaxBits, 1, sizeof(uint8_t), f);
-        break;
-    case SYM:
-        symQConfig_t *symQC = q->qConfig;
-        serialize(&symQC->scale, 1, sizeof(float), f);
-        serialize(&symQC->qBits, 1, sizeof(uint8_t), f);
-        break;
-    case ASYM:
-        asymQConfig_t *asymQC = q->qConfig;
-        serialize(&asymQC->scale, 1, sizeof(float), f);
-        serialize(&asymQC->qBits, 1, sizeof(uint8_t), f);
-        serialize(&asymQC->roundingMode, 1, sizeof(roundingMode_t), f);
-        serialize(&asymQC->zeroPoint, 1, sizeof(int16_t), f);
-        break;
-    default:
-        PRINT_ERROR("Unknown qType!");
-        exit(1);
-    }
+  switch (q->type) {
+  case INT32:
+  case FLOAT32:
+    break;
+  case SYM_INT32:
+    symInt32QConfig_t *symIntQC = q->qConfig;
+    serialize(&symIntQC->scale, 1, sizeof(float), f);
+    serialize(&symIntQC->roundingMode, 1, sizeof(roundingMode_t), f);
+    serialize(&symIntQC->qMaxBits, 1, sizeof(uint8_t), f);
+    break;
+  case SYM:
+    symQConfig_t *symQC = q->qConfig;
+    serialize(&symQC->scale, 1, sizeof(float), f);
+    serialize(&symQC->qBits, 1, sizeof(uint8_t), f);
+    break;
+  case ASYM:
+    asymQConfig_t *asymQC = q->qConfig;
+    serialize(&asymQC->scale, 1, sizeof(float), f);
+    serialize(&asymQC->qBits, 1, sizeof(uint8_t), f);
+    serialize(&asymQC->roundingMode, 1, sizeof(roundingMode_t), f);
+    serialize(&asymQC->zeroPoint, 1, sizeof(int16_t), f);
+    break;
+  default:
+    PRINT_ERROR("Unknown qType!");
+    exit(1);
+  }
 }
 
 // TODO
 static void serializeSparsity() {}
 
-
 static void serializeLayer(layer_t *layer, FILE *f) {
-    switch (layer->type) {
-    case LINEAR:
-        linearConfig_t *linearConfig = layer->config->linear;
-        serializeParameter(linearConfig->weights, f);
-        serializeParameter(linearConfig->bias, f);
-        serializeQuantization(linearConfig->forwardQ, f);
-        serializeQuantization(linearConfig->weightGradQ, f);
-        serializeQuantization(linearConfig->biasGradQ, f);
-        serializeQuantization(linearConfig->propLossQ, f);
-        break;
-    case RELU:
-        reluConfig_t *reluConfig = layer->config->relu;
-        serializeQuantization(reluConfig->forwardQ, f);
-        serializeQuantization(reluConfig->backwardQ, f);
-        break;
-    case SOFTMAX:
-        softmaxConfig_t *softmaxConfig = layer->config->softmax;
-        serializeQuantization(softmaxConfig->forwardQ, f);
-        serializeQuantization(softmaxConfig->backwardQ, f);
-        break;
-    default:
-        PRINT_ERROR("Unsupported qtype!\n");
-        exit(1);
-    }
+  switch (layer->type) {
+  case LINEAR:
+    linearConfig_t *linearConfig = layer->config->linear;
+    serializeParameter(linearConfig->weights, f);
+    serializeParameter(linearConfig->bias, f);
+    serializeQuantization(linearConfig->forwardQ, f);
+    serializeQuantization(linearConfig->weightGradQ, f);
+    serializeQuantization(linearConfig->biasGradQ, f);
+    serializeQuantization(linearConfig->propLossQ, f);
+    break;
+  case RELU:
+    reluConfig_t *reluConfig = layer->config->relu;
+    serializeQuantization(reluConfig->forwardQ, f);
+    serializeQuantization(reluConfig->backwardQ, f);
+    break;
+  case SOFTMAX:
+    softmaxConfig_t *softmaxConfig = layer->config->softmax;
+    serializeQuantization(softmaxConfig->forwardQ, f);
+    serializeQuantization(softmaxConfig->backwardQ, f);
+    break;
+  case FLATTEN:
+    // Flatten carries no state (no parameters, no quantization).
+    break;
+  default:
+    PRINT_ERROR("Unsupported qtype!\n");
+    exit(1);
+  }
 }

--- a/src/serial/Serialize.c
+++ b/src/serial/Serialize.c
@@ -13,105 +13,105 @@
 #include "Tensor.h"
 
 void serializeTensor(tensor_t *tensor, FILE *f) {
-  size_t numberOfValues = calcNumberOfElementsByTensor(tensor);
-  size_t bytesPerValue = calcBytesPerElement(tensor->quantization);
+    size_t numberOfValues = calcNumberOfElementsByTensor(tensor);
+    size_t bytesPerValue = calcBytesPerElement(tensor->quantization);
 
-  serializeShape(tensor->shape, f);
-  serializeQuantization(tensor->quantization, f);
-  serializeData(tensor->data, numberOfValues, bytesPerValue, f);
-  serializeSparsity();
+    serializeShape(tensor->shape, f);
+    serializeQuantization(tensor->quantization, f);
+    serializeData(tensor->data, numberOfValues, bytesPerValue, f);
+    serializeSparsity();
 }
 
 void serializeParameter(parameter_t *parameter, FILE *f) {
-  serializeTensor(parameter->param, f);
-  serializeTensor(parameter->grad, f);
+    serializeTensor(parameter->param, f);
+    serializeTensor(parameter->grad, f);
 }
 
 void serializeModel(layer_t **model, size_t sizeModel, FILE *f) {
-  for (size_t i = 0; i < sizeModel; i++) {
-    serializeLayer(model[i], f);
-  }
+    for (size_t i = 0; i < sizeModel; i++) {
+        serializeLayer(model[i], f);
+    }
 }
 
 // Helper Functions
 
 static void serialize(void *values, size_t numberOfElements, size_t sizeOfElement, FILE *f) {
-  fwrite(values, numberOfElements, sizeOfElement, f);
+    fwrite(values, numberOfElements, sizeOfElement, f);
 }
 
 static void serializeShape(shape_t *shape, FILE *f) {
-  serialize(&shape->numberOfDimensions, 1, sizeof(size_t), f);
-  serialize(shape->dimensions, shape->numberOfDimensions, sizeof(size_t), f);
-  serialize(shape->orderOfDimensions, shape->numberOfDimensions, sizeof(size_t), f);
+    serialize(&shape->numberOfDimensions, 1, sizeof(size_t), f);
+    serialize(shape->dimensions, shape->numberOfDimensions, sizeof(size_t), f);
+    serialize(shape->orderOfDimensions, shape->numberOfDimensions, sizeof(size_t), f);
 }
 
 static void serializeQuantization(quantization_t *q, FILE *f) {
-  serialize(&q->type, 1, sizeof(qtype_t), f);
-  serializeQConfig(q, f);
+    serialize(&q->type, 1, sizeof(qtype_t), f);
+    serializeQConfig(q, f);
 }
 
 static void serializeData(uint8_t *data, size_t numberOfValues, size_t bytesPerValue, FILE *f) {
-  serialize(data, numberOfValues, bytesPerValue, f);
+    serialize(data, numberOfValues, bytesPerValue, f);
 }
 
 static void serializeQConfig(quantization_t *q, FILE *f) {
-  switch (q->type) {
-  case INT32:
-  case FLOAT32:
-    break;
-  case SYM_INT32:
-    symInt32QConfig_t *symIntQC = q->qConfig;
-    serialize(&symIntQC->scale, 1, sizeof(float), f);
-    serialize(&symIntQC->roundingMode, 1, sizeof(roundingMode_t), f);
-    serialize(&symIntQC->qMaxBits, 1, sizeof(uint8_t), f);
-    break;
-  case SYM:
-    symQConfig_t *symQC = q->qConfig;
-    serialize(&symQC->scale, 1, sizeof(float), f);
-    serialize(&symQC->qBits, 1, sizeof(uint8_t), f);
-    break;
-  case ASYM:
-    asymQConfig_t *asymQC = q->qConfig;
-    serialize(&asymQC->scale, 1, sizeof(float), f);
-    serialize(&asymQC->qBits, 1, sizeof(uint8_t), f);
-    serialize(&asymQC->roundingMode, 1, sizeof(roundingMode_t), f);
-    serialize(&asymQC->zeroPoint, 1, sizeof(int16_t), f);
-    break;
-  default:
-    PRINT_ERROR("Unknown qType!");
-    exit(1);
-  }
+    switch (q->type) {
+    case INT32:
+    case FLOAT32:
+        break;
+    case SYM_INT32:
+        symInt32QConfig_t *symIntQC = q->qConfig;
+        serialize(&symIntQC->scale, 1, sizeof(float), f);
+        serialize(&symIntQC->roundingMode, 1, sizeof(roundingMode_t), f);
+        serialize(&symIntQC->qMaxBits, 1, sizeof(uint8_t), f);
+        break;
+    case SYM:
+        symQConfig_t *symQC = q->qConfig;
+        serialize(&symQC->scale, 1, sizeof(float), f);
+        serialize(&symQC->qBits, 1, sizeof(uint8_t), f);
+        break;
+    case ASYM:
+        asymQConfig_t *asymQC = q->qConfig;
+        serialize(&asymQC->scale, 1, sizeof(float), f);
+        serialize(&asymQC->qBits, 1, sizeof(uint8_t), f);
+        serialize(&asymQC->roundingMode, 1, sizeof(roundingMode_t), f);
+        serialize(&asymQC->zeroPoint, 1, sizeof(int16_t), f);
+        break;
+    default:
+        PRINT_ERROR("Unknown qType!");
+        exit(1);
+    }
 }
 
 // TODO
 static void serializeSparsity() {}
 
 static void serializeLayer(layer_t *layer, FILE *f) {
-  switch (layer->type) {
-  case LINEAR:
-    linearConfig_t *linearConfig = layer->config->linear;
-    serializeParameter(linearConfig->weights, f);
-    serializeParameter(linearConfig->bias, f);
-    serializeQuantization(linearConfig->forwardQ, f);
-    serializeQuantization(linearConfig->weightGradQ, f);
-    serializeQuantization(linearConfig->biasGradQ, f);
-    serializeQuantization(linearConfig->propLossQ, f);
-    break;
-  case RELU:
-    reluConfig_t *reluConfig = layer->config->relu;
-    serializeQuantization(reluConfig->forwardQ, f);
-    serializeQuantization(reluConfig->backwardQ, f);
-    break;
-  case SOFTMAX:
-    softmaxConfig_t *softmaxConfig = layer->config->softmax;
-    serializeQuantization(softmaxConfig->forwardQ, f);
-    serializeQuantization(softmaxConfig->backwardQ, f);
-    break;
-  case FLATTEN:
-    // Flatten carries no state (no parameters, no quantization).
-    break;
-  default:
-    PRINT_ERROR("Unsupported qtype!\n");
-    exit(1);
-  }
+    switch (layer->type) {
+    case LINEAR:
+        linearConfig_t *linearConfig = layer->config->linear;
+        serializeParameter(linearConfig->weights, f);
+        serializeParameter(linearConfig->bias, f);
+        serializeQuantization(linearConfig->forwardQ, f);
+        serializeQuantization(linearConfig->weightGradQ, f);
+        serializeQuantization(linearConfig->biasGradQ, f);
+        serializeQuantization(linearConfig->propLossQ, f);
+        break;
+    case RELU:
+        reluConfig_t *reluConfig = layer->config->relu;
+        serializeQuantization(reluConfig->forwardQ, f);
+        serializeQuantization(reluConfig->backwardQ, f);
+        break;
+    case SOFTMAX:
+        softmaxConfig_t *softmaxConfig = layer->config->softmax;
+        serializeQuantization(softmaxConfig->forwardQ, f);
+        serializeQuantization(softmaxConfig->backwardQ, f);
+        break;
+    case FLATTEN:
+        // Flatten carries no state (no parameters, no quantization).
+        break;
+    default:
+        PRINT_ERROR("Unsupported qtype!\n");
+        exit(1);
+    }
 }

--- a/src/tensor/Tensor.c
+++ b/src/tensor/Tensor.c
@@ -1,15 +1,15 @@
 #define SOURCE_FILE "TENSOR"
 
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
 #include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
-#include "Tensor.h"
-#include "Quantization.h"
-#include "MinMax.h"
-#include "DTypes.h"
 #include "Common.h"
+#include "DTypes.h"
+#include "MinMax.h"
+#include "Quantization.h"
+#include "Tensor.h"
 
 size_t calcNumberOfElementsByShape(shape_t *shape) {
     size_t numElem = 1;
@@ -79,6 +79,8 @@ size_t calcNumberOfBytesForData(quantization_t *q, size_t numberOfElements) {
     switch (q->type) {
     case FLOAT32:
         return numberOfElements * sizeof(float);
+    case INT32:
+        return numberOfElements * sizeof(int32_t);
     case SYM_INT32:
         return numberOfElements * sizeof(int32_t);
     case ASYM:
@@ -116,8 +118,8 @@ uint32_t getBitmask(uint32_t startbit, uint32_t endbit) {
         }
         value *= 2;
     }
-    //printf("bitmask ");
-    //print_binary_uint8(counter);
+    // printf("bitmask ");
+    // print_binary_uint8(counter);
     return counter;
 }
 
@@ -133,12 +135,12 @@ uint8_t writeByte(uint8_t existingData, uint8_t data, uint8_t startbit, uint8_t 
     uint8_t endbitInternal = endbit - (startbit / 8) * 8;
     uint8_t bitmask = getBitmask(startbitInternal, endbitInternal);
     data <<= startbitInternal;
-    //print_binary_uint8(data);
+    // print_binary_uint8(data);
     uint8_t intermediate = data & bitmask;
-    //print_binary_uint8(bitmask);
-    //print_binary_uint8(intermediate);
+    // print_binary_uint8(bitmask);
+    // print_binary_uint8(intermediate);
     existingData = intermediate | existingData;
-    //print_binary_uint8(existingData);
+    // print_binary_uint8(existingData);
     return existingData;
 }
 
@@ -149,7 +151,6 @@ int max(int a, int b) {
 int min(int a, int b) {
     return (a < b) ? a : b;
 }
-
 
 void byteConversion(uint8_t *dataIn, size_t dataInBits, uint8_t *dataOut, size_t dataOutBits,
                     size_t numValues) {
@@ -167,8 +168,8 @@ void byteConversion(uint8_t *dataIn, size_t dataInBits, uint8_t *dataOut, size_t
         printf("Value %i\n", i);*/
         while ((dataInStartbit < dataInEndbit) | (dataOutStartbit < dataOutEndbit)) {
             uint8_t data = readByte(dataIn[dataInIndex], dataInStartbit, dataInEndbit);
-            dataOut[dataOutIndex] = writeByte(dataOut[dataOutIndex], data, dataOutStartbit,
-                                              dataOutEndbit);
+            dataOut[dataOutIndex] =
+                writeByte(dataOut[dataOutIndex], data, dataOutStartbit, dataOutEndbit);
 
             /*
             printf("dataInStartbit %d\n", dataInStartbit);
@@ -213,17 +214,14 @@ void byteConversion(uint8_t *dataIn, size_t dataInBits, uint8_t *dataOut, size_t
             if (dataOutStartbit / 8 > (dataOutStartbit - deltaOut) / 8) {
                 dataOutIndex += 1;
             }
-            //printf("\n");
-
+            // printf("\n");
         }
         dataInStartbit = dataInEndbit % 8;
         dataInEndbit = dataInStartbit + dataInBits;
         dataOutStartbit = dataOutEndbit % 8;
         dataOutEndbit = dataOutStartbit + dataOutBits;
-
     }
 }
-
 
 tensor_t *getParamFromParameter(parameter_t *parameter) {
     return parameter->param;
@@ -242,7 +240,6 @@ void transposeTensor(tensor_t *tensor, size_t dim0Index, size_t dim1Index) {
     tensor->shape->orderOfDimensions[dim1Index] = temp;
 }
 
-
 void setTensorValuesForConversion(uint8_t *data, quantization_t *q, tensor_t *originalTensor,
                                   tensor_t *outputTensor) {
     outputTensor->data = data;
@@ -251,8 +248,8 @@ void setTensorValuesForConversion(uint8_t *data, quantization_t *q, tensor_t *or
     outputTensor->sparsity = originalTensor->sparsity;
 }
 
-void setTensorValues(tensor_t *tensor, uint8_t *data, shape_t *shape,
-                     quantization_t *quantization, sparsity_t *sparsity) {
+void setTensorValues(tensor_t *tensor, uint8_t *data, shape_t *shape, quantization_t *quantization,
+                     sparsity_t *sparsity) {
     tensor->data = data;
     tensor->shape = shape;
     tensor->quantization = quantization;

--- a/src/tensor/TensorConversion.c
+++ b/src/tensor/TensorConversion.c
@@ -1,14 +1,14 @@
 #define SOURCE_FILE "TENSOR_CONVERSION"
 
 #include <stdio.h>
-#include <string.h>
 #include <stdlib.h>
+#include <string.h>
 
-#include "TensorConversion.h"
-#include "Tensor.h"
 #include "DTypes.h"
-#include "math.h"
 #include "MinMax.h"
+#include "Tensor.h"
+#include "TensorConversion.h"
+#include "math.h"
 
 void zeroTensorData(tensor_t *tensor) {
     size_t numberOfElements = calcNumberOfElementsByTensor(tensor);
@@ -59,9 +59,9 @@ void convertInt32TensorToAsymTensor(tensor_t *inputTensor, tensor_t *outputTenso
     for (size_t elementIndex = 0; elementIndex < numberOfElements; elementIndex++) {
         int32_t inputElement = readBytesAsInt32(&inputTensor->data[elementIndex * sizeof(int32_t)]);
 
-        outputElements[elementIndex] = roundByMode(
-            clamp((float)inputElement / scale - (float)zeroPoint, 0.f, qMax - 1),
-            linearQConfig->roundingMode);
+        outputElements[elementIndex] =
+            roundByMode(clamp((float)inputElement / scale - (float)zeroPoint, 0.f, qMax - 1),
+                        linearQConfig->roundingMode);
     }
     linearQConfig->scale = scale;
     linearQConfig->zeroPoint = zeroPoint;
@@ -71,7 +71,6 @@ void convertInt32TensorToAsymTensor(tensor_t *inputTensor, tensor_t *outputTenso
     byteConversion(outputElement, 32, outputTensor->data, linearQConfig->qBits, numberOfElements);
     copyDimsAndSparsityToTensor(inputTensor, outputTensor);
 }
-
 
 void convertFloatTensorToInt32Tensor(tensor_t *inputTensor, tensor_t *outputTensor) {
     size_t numberOfElements = calcNumberOfElementsByTensor(inputTensor);
@@ -85,7 +84,6 @@ void convertFloatTensorToInt32Tensor(tensor_t *inputTensor, tensor_t *outputTens
     writeInt32ArrayToByteArray(numberOfElements, outputData, outputTensor->data);
     copyDimsAndSparsityToTensor(inputTensor, outputTensor);
 }
-
 
 void convertFloatTensorToSymInt32Tensor(tensor_t *inputTensor, tensor_t *outputTensor) {
     size_t numberOfElements = calcNumberOfElementsByTensor(inputTensor);
@@ -112,9 +110,8 @@ void convertFloatTensorToSymInt32Tensor(tensor_t *inputTensor, tensor_t *outputT
     float *inputFloat = (float *)inputTensor->data;
 
     for (size_t i = 0; i < numberOfElements; i++) {
-        outputInt32[i] = roundByMode(
-            clamp(inputFloat[i] / scale, qMin, qMax),
-            outputSymInt32QC->roundingMode);
+        outputInt32[i] =
+            roundByMode(clamp(inputFloat[i] / scale, qMin, qMax), outputSymInt32QC->roundingMode);
     }
 }
 
@@ -138,8 +135,8 @@ void convertFloatTensorToSymTensor(tensor_t *inputTensor, tensor_t *outputTensor
     uint8_t outputs[numberOfElements * bytesPerOutputElement];
 
     for (size_t i = 0; i < numberOfElements; i++) {
-        outputs[i] = roundByMode(clamp(inputs[i] / scale, 0.f, qMax - 1),
-                                 outputSymQConfig->roundingMode);
+        outputs[i] =
+            roundByMode(clamp(inputs[i] / scale, 0.f, qMax - 1), outputSymQConfig->roundingMode);
     }
 
     memcpy(outputTensor->data, outputs, numberOfElements * bytesPerOutputElement);
@@ -168,9 +165,9 @@ void convertFloatTensorToAsymTensor(tensor_t *inputTensor, tensor_t *outputTenso
     float *inputFloat = (float *)inputTensor->data;
 
     for (size_t i = 0; i < numberOfElements; i++) {
-        outputElements[i] = roundByMode(
-            clamp(inputFloat[i] / scale - (float)zeroPoint, 0.f, qMax - 1),
-            asymQConfig->roundingMode);
+        outputElements[i] =
+            roundByMode(clamp(inputFloat[i] / scale - (float)zeroPoint, 0.f, qMax - 1),
+                        asymQConfig->roundingMode);
     }
 
     asymQConfig->scale = scale;
@@ -237,15 +234,14 @@ void convertSymInt32TensorToAsymTensor(tensor_t *inputTensor, tensor_t *outputTe
 
     int32_t outputInt[numberOfValues];
     for (size_t i = 0; i < numberOfValues; i++) {
-        outputInt[i] = roundByMode(
-            clamp(inputAsFloat[i] / outputScale - (float)zeroPoint, 0.f, qMax),
-            outputAsymQConfig->roundingMode);
+        outputInt[i] =
+            roundByMode(clamp(inputAsFloat[i] / outputScale - (float)zeroPoint, 0.f, qMax),
+                        outputAsymQConfig->roundingMode);
     }
 
     byteConversion((uint8_t *)outputInt, 32, outputTensor->data, outputAsymQConfig->qBits,
                    numberOfValues);
 }
-
 
 void convertAsymTensorToInt32Tensor(tensor_t *inputTensor, tensor_t *outputTensor) {
     asymQConfig_t *asymQConfig = inputTensor->quantization->qConfig;
@@ -277,8 +273,8 @@ void convertAsymTensorToFloatTensor(tensor_t *inputTensor, tensor_t *outputTenso
     float *outputElements = (float *)outputTensor->data;
 
     for (size_t elementIndex = 0; elementIndex < numberOfElements; elementIndex++) {
-        outputElements[elementIndex] = ((float)inputInt[elementIndex] + (float)zeroPoint) *
-                                       asymQConfig->scale;
+        outputElements[elementIndex] =
+            ((float)inputInt[elementIndex] + (float)zeroPoint) * asymQConfig->scale;
     }
 
     copyDimsAndSparsityToTensor(inputTensor, outputTensor);
@@ -307,7 +303,6 @@ void convertAsymTensorToSymInt32Tensor(tensor_t *inputTensor, tensor_t *outputTe
     outputSymInt32QConfig->scale = inputAsymQConfig->scale;
 }
 
-
 char *quantTypeToString(qtype_t t) {
     switch (t) {
     case INT32:
@@ -334,49 +329,38 @@ void unsupportedConversionTypes(tensor_t *inputTensor, tensor_t *outputTensor) {
 }
 
 conversionFunction_t conversionMatrix[5][5] = {
-    [INT32] = {
-        [INT32] = NULL,
-        [FLOAT32] = convertInt32TensorToFloatTensor,
-        [SYM_INT32] = convertInt32TensorToSymInt32Tensor,
-        [SYM] = unsupportedConversionTypes,
-        [ASYM] = convertInt32TensorToAsymTensor
-    },
-    [FLOAT32] = {
-        [INT32] = convertFloatTensorToInt32Tensor,
-        [FLOAT32] = NULL,
-        [SYM_INT32] = convertFloatTensorToSymInt32Tensor,
-        [SYM] = unsupportedConversionTypes,
-        [ASYM] = convertFloatTensorToAsymTensor
-    },
-    [SYM_INT32] = {
-        [INT32] = extractInt32TensorFromSymInt32Tensor,
-        [FLOAT32] = convertSymInt32TensorToFloat32Tensor,
-        [SYM_INT32] = NULL,
-        [SYM] = unsupportedConversionTypes,
-        [ASYM] = convertSymInt32TensorToAsymTensor
-    },
-    [SYM] = {
-        [INT32] = unsupportedConversionTypes,
-        [FLOAT32] = unsupportedConversionTypes,
-        [SYM_INT32] = unsupportedConversionTypes,
-        [SYM] = NULL,
-        [ASYM] = unsupportedConversionTypes
-    },
-    [ASYM] = {
-        [INT32] = convertAsymTensorToInt32Tensor,
-        [FLOAT32] = convertAsymTensorToFloatTensor,
-        [SYM_INT32] = convertAsymTensorToSymInt32Tensor,
-        [SYM] = unsupportedConversionTypes,
-        [ASYM] = NULL
-    }
-};
+    [INT32] = {[INT32] = NULL,
+               [FLOAT32] = convertInt32TensorToFloatTensor,
+               [SYM_INT32] = convertInt32TensorToSymInt32Tensor,
+               [SYM] = unsupportedConversionTypes,
+               [ASYM] = convertInt32TensorToAsymTensor},
+    [FLOAT32] = {[INT32] = convertFloatTensorToInt32Tensor,
+                 [FLOAT32] = NULL,
+                 [SYM_INT32] = convertFloatTensorToSymInt32Tensor,
+                 [SYM] = unsupportedConversionTypes,
+                 [ASYM] = convertFloatTensorToAsymTensor},
+    [SYM_INT32] = {[INT32] = extractInt32TensorFromSymInt32Tensor,
+                   [FLOAT32] = convertSymInt32TensorToFloat32Tensor,
+                   [SYM_INT32] = NULL,
+                   [SYM] = unsupportedConversionTypes,
+                   [ASYM] = convertSymInt32TensorToAsymTensor},
+    [SYM] = {[INT32] = unsupportedConversionTypes,
+             [FLOAT32] = unsupportedConversionTypes,
+             [SYM_INT32] = unsupportedConversionTypes,
+             [SYM] = NULL,
+             [ASYM] = unsupportedConversionTypes},
+    [ASYM] = {[INT32] = convertAsymTensorToInt32Tensor,
+              [FLOAT32] = convertAsymTensorToFloatTensor,
+              [SYM_INT32] = convertAsymTensorToSymInt32Tensor,
+              [SYM] = unsupportedConversionTypes,
+              [ASYM] = NULL}};
 
 static void convertTensorsWithSameType(tensor_t *inputTensor, tensor_t *outputTensor,
                                        qtype_t qType) {
     size_t numberOfElements = calcNumberOfElementsByTensor(inputTensor);
     size_t bytesPerElement = calcBytesPerElement(inputTensor->quantization);
 
-    memcpy(outputTensor->data, inputTensor->data, numberOfElements * bytesPerElement);
+    memmove(outputTensor->data, inputTensor->data, numberOfElements * bytesPerElement);
 
     switch (qType) {
     case SYM_INT32:
@@ -394,7 +378,6 @@ static void convertTensorsWithSameType(tensor_t *inputTensor, tensor_t *outputTe
         break;
     }
 }
-
 
 void convertTensor(tensor_t *inputTensor, tensor_t *outputTensor) {
     qtype_t inputDType = inputTensor->quantization->type;

--- a/src/userApi/InferenceApi.c
+++ b/src/userApi/InferenceApi.c
@@ -140,6 +140,7 @@ tensor_t *inference(layer_t **model, size_t numberOfLayers, tensor_t *input) {
 
     tensor_t *output = getTensorLike(&outputNext);
     convertTensor(&outputNext, output);
+    deInitBuffer(&outputNext);
     return output;
 }
 
@@ -192,5 +193,6 @@ inferenceStats_t *inferenceWithLoss(layer_t **model, size_t numberOfLayers, tens
     float loss = lossFns.forward(&outputNext, label);
     inferenceStats->loss = loss;
 
+    deInitBuffer(&outputNext);
     return inferenceStats;
 }

--- a/src/userApi/InferenceApi.c
+++ b/src/userApi/InferenceApi.c
@@ -39,9 +39,9 @@ static void initBufferOutput(tensor_t *buffer, layer_t *currentLayer, shape_t *i
 
     size_t sizeDims = inputShape->numberOfDimensions;
 
-    shape_t *outShape = *reserveMemory(sizeof(shape_t));
-    size_t *outDims = *reserveMemory(sizeDims * sizeof(size_t));
-    size_t *outOrder = *reserveMemory(sizeDims * sizeof(size_t));
+    shape_t *outShape = reserveMemory(sizeof(shape_t));
+    size_t *outDims = reserveMemory(sizeDims * sizeof(size_t));
+    size_t *outOrder = reserveMemory(sizeDims * sizeof(size_t));
 
     outShape->dimensions = outDims;
     outShape->numberOfDimensions = sizeDims;
@@ -53,16 +53,16 @@ static void initBufferOutput(tensor_t *buffer, layer_t *currentLayer, shape_t *i
     size_t numValues =
         calcNumberOfElementsByShape(outShape);
     size_t sizeData = calcNumberOfBytesForData(currentQ, numValues);
-    uint8_t *data = *reserveMemory(sizeData);
+    uint8_t *data = reserveMemory(sizeData);
 
-    quantization_t *q = *reserveMemory(sizeof(quantization_t));
+    quantization_t *q = reserveMemory(sizeof(quantization_t));
     switch (currentQ->type) {
     case FLOAT32:
         initFloat32Quantization(q);
         break;
     case SYM_INT32:
         symInt32QConfig_t *currentQC = currentQ->qConfig;
-        symInt32QConfig_t *symInt32QC = *reserveMemory(sizeof(symInt32QConfig_t));
+        symInt32QConfig_t *symInt32QC = reserveMemory(sizeof(symInt32QConfig_t));
 
         initSymInt32QConfig(currentQC->roundingMode, symInt32QC);
         initSymInt32Quantization(symInt32QC, q);
@@ -81,9 +81,9 @@ static void initBufferInput(tensor_t *input, tensor_t *buffer) {
 
     size_t sizeDims = input->shape->numberOfDimensions;
 
-    shape_t *outShape = *reserveMemory(sizeof(shape_t));
-    size_t *outDims = *reserveMemory(sizeDims * sizeof(size_t));
-    size_t *outOrder = *reserveMemory(sizeDims * sizeof(size_t));
+    shape_t *outShape = reserveMemory(sizeof(shape_t));
+    size_t *outDims = reserveMemory(sizeDims * sizeof(size_t));
+    size_t *outOrder = reserveMemory(sizeDims * sizeof(size_t));
 
     outShape->dimensions = outDims;
     outShape->numberOfDimensions = sizeDims;
@@ -91,9 +91,9 @@ static void initBufferInput(tensor_t *input, tensor_t *buffer) {
 
     size_t numValues = calcNumberOfElementsByTensor(input);
     size_t sizeData = calcNumberOfBytesForData(currentQ, numValues);
-    uint8_t *data = *reserveMemory(sizeData);
+    uint8_t *data = reserveMemory(sizeData);
 
-    quantization_t *q = *reserveMemory(sizeof(quantization_t));
+    quantization_t *q = reserveMemory(sizeof(quantization_t));
     switch (currentQ->type) {
     case FLOAT32:
         q->type = FLOAT32;
@@ -102,7 +102,7 @@ static void initBufferInput(tensor_t *input, tensor_t *buffer) {
     case SYM_INT32:
         q->type = SYM_INT32;
         symInt32QConfig_t *currentQC = currentQ->qConfig;
-        symInt32QConfig_t *symInt32QC = *reserveMemory(sizeof(symInt32QConfig_t));
+        symInt32QConfig_t *symInt32QC = reserveMemory(sizeof(symInt32QConfig_t));
         symInt32QC->roundingMode = currentQC->roundingMode;
         q->qConfig = symInt32QC;
         break;
@@ -146,7 +146,7 @@ tensor_t *inference(layer_t **model, size_t numberOfLayers, tensor_t *input) {
 }
 
 tensor_t **inferenceBatched(layer_t **model, size_t numberOfLayers, batch_t *batch) {
-    tensor_t **tensorArr = *reserveMemory(batch->size * sizeof(tensor_t));
+    tensor_t **tensorArr = reserveMemory(batch->size * sizeof(tensor_t));
 
     for (size_t i = 0; i < batch->size; i++) {
         tensorArr[i] = inference(model, numberOfLayers, batch->samples[i]->item);
@@ -156,13 +156,13 @@ tensor_t **inferenceBatched(layer_t **model, size_t numberOfLayers, batch_t *bat
 }
 
 inferenceStats_t *reserveInferenceStats(tensor_t *label) {
-    inferenceStats_t *inferenceStats = *reserveMemory(sizeof(inferenceStats_t));
+    inferenceStats_t *inferenceStats = reserveMemory(sizeof(inferenceStats_t));
 
     size_t sizeOutput = calcNumberOfElementsByTensor(label);
 
-    float *outputData = *reserveMemory(sizeOutput * sizeof(float));
+    float *outputData = reserveMemory(sizeOutput * sizeof(float));
     size_t outputNumberOfDims = label->shape->numberOfDimensions;
-    size_t *outputDims = *reserveMemory(outputNumberOfDims * sizeof(size_t));
+    size_t *outputDims = reserveMemory(outputNumberOfDims * sizeof(size_t));
     quantization_t *outputQ = getQLike(label->quantization);
     tensor_t *output = tensorInit(outputData, outputDims, outputNumberOfDims, outputQ, NULL);
 

--- a/src/userApi/InferenceApi.c
+++ b/src/userApi/InferenceApi.c
@@ -1,20 +1,19 @@
 #define SOURCE_FILE "INFERENCE_Api"
 
-#include <stdio.h>
 #include <stdbool.h>
+#include <stdio.h>
 #include <stdlib.h>
 
-#include "Tensor.h"
-#include "Layer.h"
+#include "Common.h"
 #include "InferenceApi.h"
-#include "TensorApi.h"
-#include "StorageApi.h"
+#include "Layer.h"
 #include "Linear.h"
 #include "Relu.h"
-#include "TensorConversion.h"
-#include "Common.h"
 #include "Softmax.h"
-
+#include "StorageApi.h"
+#include "Tensor.h"
+#include "TensorApi.h"
+#include "TensorConversion.h"
 
 // Initializes buffer to match output
 static void initBufferOutput(tensor_t *buffer, layer_t *currentLayer, shape_t *inputShape,
@@ -50,8 +49,7 @@ static void initBufferOutput(tensor_t *buffer, layer_t *currentLayer, shape_t *i
     calcOutputShapeFn_t calcOutputShape = layerFunctions[currentLayerType].calcOutputShape;
     calcOutputShape(currentLayer, inputShape, outShape);
 
-    size_t numValues =
-        calcNumberOfElementsByShape(outShape);
+    size_t numValues = calcNumberOfElementsByShape(outShape);
     size_t sizeData = calcNumberOfBytesForData(currentQ, numValues);
     uint8_t *data = reserveMemory(sizeData);
 
@@ -158,15 +156,9 @@ tensor_t **inferenceBatched(layer_t **model, size_t numberOfLayers, batch_t *bat
 inferenceStats_t *reserveInferenceStats(tensor_t *label) {
     inferenceStats_t *inferenceStats = reserveMemory(sizeof(inferenceStats_t));
 
-    size_t sizeOutput = calcNumberOfElementsByTensor(label);
-
-    float *outputData = reserveMemory(sizeOutput * sizeof(float));
-    size_t outputNumberOfDims = label->shape->numberOfDimensions;
-    size_t *outputDims = reserveMemory(outputNumberOfDims * sizeof(size_t));
+    shape_t *outputShape = getShapeLike(label->shape);
     quantization_t *outputQ = getQLike(label->quantization);
-    tensor_t *output = tensorInit(outputData, outputDims, outputNumberOfDims, outputQ, NULL);
-
-    inferenceStats->output = output;
+    inferenceStats->output = initTensor(outputShape, outputQ, NULL);
 
     return inferenceStats;
 }

--- a/src/userApi/StorageApi.c
+++ b/src/userApi/StorageApi.c
@@ -4,15 +4,10 @@
 
 #include "StorageApi.h"
 
-
-void **reserveMemory(size_t numberOfBytes) {
-    void *ptr = calloc(1, numberOfBytes);
-    void **handle = malloc(sizeof(void *));
-    *handle = ptr;
-    return handle;
+void *reserveMemory(size_t numberOfBytes) {
+    return calloc(1, numberOfBytes);
 }
 
 void freeReservedMemory(void *ptr) {
     free(ptr);
 }
-

--- a/src/userApi/data_loader/DataLoaderApi.c
+++ b/src/userApi/data_loader/DataLoaderApi.c
@@ -23,10 +23,10 @@ dataLoader_t *dataLoaderInit(getSampleFn_t getSample,
         exit(1);
     }
 
-    dataLoader_t *dataLoader = *reserveMemory(sizeof(dataLoader_t));
+    dataLoader_t *dataLoader = reserveMemory(sizeof(dataLoader_t));
 
     size_t numberOfIndices = getDatasetSize();
-    size_t *indices = *reserveMemory(numberOfIndices * sizeof(size_t));
+    size_t *indices = reserveMemory(numberOfIndices * sizeof(size_t));
 
     initDataLoader(dataLoader, getSample, getDatasetSize, getBatch, batchSize, transform,
                    targetTransform, shuffle,
@@ -57,11 +57,11 @@ static sample_t *getSampleByIndex(dataLoader_t *dataLoader, size_t index) {
 }
 
 static batch_t *getBatch(dataLoader_t *dataLoader, size_t index) {
-    batch_t *batch = *reserveMemory(sizeof(batch_t));
+    batch_t *batch = reserveMemory(sizeof(batch_t));
 
     size_t batchSize = dataLoader->batchSize;
     batch->size = batchSize;
-    batch->samples = *reserveMemory(batchSize * sizeof(sample_t *));
+    batch->samples = reserveMemory(batchSize * sizeof(sample_t *));
 
     size_t sampleIndex = index * batchSize;
 

--- a/src/userApi/data_loader/NPYLoaderApi.c
+++ b/src/userApi/data_loader/NPYLoaderApi.c
@@ -20,7 +20,7 @@ tensorArray_t *npyLoad(char *path) {
     checkMagic(f);
 
     uint32_t headerSize = readHeaderSize(f);
-    char *header = *reserveMemory(headerSize);
+    char *header = *reserveMemory(headerSize + 1);
     readHeader(header, headerSize, f);
 
     dtype_t dtype = getDTypeFromHeader(header);

--- a/src/userApi/data_loader/NPYLoaderApi.c
+++ b/src/userApi/data_loader/NPYLoaderApi.c
@@ -19,7 +19,7 @@ tensorArray_t *npyLoad(char *path) {
     checkMagic(f);
 
     uint32_t headerSize = readHeaderSize(f);
-    char *header = *reserveMemory(headerSize + 1);
+    char *header = reserveMemory(headerSize + 1);
     readHeader(header, headerSize, f);
 
     dtype_t dtype = getDTypeFromHeader(header);
@@ -45,14 +45,14 @@ tensorArray_t *npyLoad(char *path) {
     size_t bytesPerValue = calcBytesPerElement(q);
     size_t numberOfValuesInRow = calcNumberOfElementsByShape(&rowShape);
 
-    tensorArray_t *tensorArr = *reserveMemory(sizeof(tensorArray_t));
-    tensor_t **arr = *reserveMemory(numberOfTensors * sizeof(tensor_t *));
+    tensorArray_t *tensorArr = reserveMemory(sizeof(tensorArray_t));
+    tensor_t **arr = reserveMemory(numberOfTensors * sizeof(tensor_t *));
     tensorArr->array = arr;
     tensorArr->size = numberOfTensors;
 
     for (size_t i = 0; i < numberOfTensors; i++) {
-        float *data = *reserveMemory(numberOfValuesInRow * bytesPerValue);
-        size_t *dims = *reserveMemory(numberOfDims * sizeof(size_t));
+        float *data = reserveMemory(numberOfValuesInRow * bytesPerValue);
+        size_t *dims = reserveMemory(numberOfDims * sizeof(size_t));
         memcpy(dims, rowDims, rowNumberOfDims * sizeof(size_t));
 
         size_t n = fread(data, bytesPerValue, numberOfValuesInRow, f);
@@ -69,7 +69,7 @@ tensorArray_t *npyLoad(char *path) {
 }
 
 sample_t *npyGetSample(dataset_t *dataset, size_t index) {
-    sample_t *sample = *reserveMemory(sizeof(sample_t));
+    sample_t *sample = reserveMemory(sizeof(sample_t));
     sample->item = dataset->items->array[index];
     sample->label = dataset->labels->array[index];
 

--- a/src/userApi/data_loader/NPYLoaderApi.c
+++ b/src/userApi/data_loader/NPYLoaderApi.c
@@ -73,6 +73,9 @@ tensorArray_t *npyLoad(char *path) {
         }
     }
 
+    /* `q` was deep-copied per tensor via getQLike; free the original. */
+    freeQuantization(q);
+
     fclose(f);
 
     return tensorArr;

--- a/src/userApi/data_loader/NPYLoaderApi.c
+++ b/src/userApi/data_loader/NPYLoaderApi.c
@@ -53,7 +53,7 @@ tensorArray_t *npyLoad(char *path) {
     for (size_t i = 0; i < numberOfTensors; i++) {
         float *data = *reserveMemory(numberOfValuesInRow * bytesPerValue);
         size_t *dims = *reserveMemory(numberOfDims * sizeof(size_t));
-        memcpy(dims, rowDims, numberOfDims * sizeof(size_t));
+        memcpy(dims, rowDims, rowNumberOfDims * sizeof(size_t));
 
         size_t n = fread(data, bytesPerValue, numberOfValuesInRow, f);
         tensorArr->array[i] = tensorInit(data, dims, rowShape.numberOfDimensions, q, NULL);

--- a/src/userApi/data_loader/NPYLoaderApi.c
+++ b/src/userApi/data_loader/NPYLoaderApi.c
@@ -3,16 +3,15 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include "TensorApi.h"
-#include "Tensor.h"
 #include "Common.h"
-#include "StorageApi.h"
 #include "Dataset.h"
-#include "NPYLoaderApiInternal.h"
 #include "NPYLoader.h"
-#include "QuantizationApi.h"
+#include "NPYLoaderApiInternal.h"
 #include "Quantization.h"
-
+#include "QuantizationApi.h"
+#include "StorageApi.h"
+#include "Tensor.h"
+#include "TensorApi.h"
 
 tensorArray_t *npyLoad(char *path) {
     FILE *f = openNPYFile(path);
@@ -57,11 +56,7 @@ tensorArray_t *npyLoad(char *path) {
         memcpy(dims, rowDims, numberOfDims * sizeof(size_t));
 
         size_t n = fread(data, bytesPerValue, numberOfValuesInRow, f);
-        tensorArr->array[i] = tensorInit(data,
-                                         dims,
-                                         rowShape.numberOfDimensions,
-                                         q,
-                                         NULL);
+        tensorArr->array[i] = tensorInit(data, dims, rowShape.numberOfDimensions, q, NULL);
         if (n != numberOfValuesInRow) {
             PRINT_ERROR("fread did not read the correct number of bytes!");
             exit(1);
@@ -80,7 +75,6 @@ sample_t *npyGetSample(dataset_t *dataset, size_t index) {
 
     return sample;
 }
-
 
 static void getRowShape(shape_t *totalShape, shape_t *rowShape) {
     for (size_t i = 0; i < rowShape->numberOfDimensions; i++) {

--- a/src/userApi/data_loader/NPYLoaderApi.c
+++ b/src/userApi/data_loader/NPYLoaderApi.c
@@ -31,6 +31,9 @@ tensorArray_t *npyLoad(char *path) {
     size_t orderOfDims[numberOfDims];
     getShapeFromHeader(&totalShape, totalDims, orderOfDims, header, numberOfDims);
 
+    /* Header is fully consumed; release before the per-tensor loop runs. */
+    freeReservedMemory(header);
+
     size_t numberOfTensors = totalShape.dimensions[0];
 
     shape_t rowShape;
@@ -87,6 +90,18 @@ sample_t *npyGetSample(dataset_t *dataset, size_t index) {
     sample->label = dataset->labels->array[index];
 
     return sample;
+}
+
+void freeTensorArray(tensorArray_t *tensorArr) {
+    /* Walk every entry and freeTensor it; freeTensor cascades to data,
+     * shape (+ dims, + order), quantization, sparsity, and the tensor
+     * struct. Then release the array buffer and the tensorArray_t struct
+     * itself, both reservedMemory-allocated by npyLoad. */
+    for (size_t i = 0; i < tensorArr->size; i++) {
+        freeTensor(tensorArr->array[i]);
+    }
+    freeReservedMemory(tensorArr->array);
+    freeReservedMemory(tensorArr);
 }
 
 static void getRowShape(shape_t *totalShape, shape_t *rowShape) {

--- a/src/userApi/data_loader/NPYLoaderApi.c
+++ b/src/userApi/data_loader/NPYLoaderApi.c
@@ -51,12 +51,22 @@ tensorArray_t *npyLoad(char *path) {
     tensorArr->size = numberOfTensors;
 
     for (size_t i = 0; i < numberOfTensors; i++) {
-        float *data = reserveMemory(numberOfValuesInRow * bytesPerValue);
-        size_t *dims = reserveMemory(numberOfDims * sizeof(size_t));
+        size_t *dims = reserveMemory(rowNumberOfDims * sizeof(size_t));
         memcpy(dims, rowDims, rowNumberOfDims * sizeof(size_t));
+        size_t *order = reserveMemory(rowNumberOfDims * sizeof(size_t));
+        setOrderOfDimsForNewTensor(rowNumberOfDims, order);
+        shape_t *shape = reserveMemory(sizeof(shape_t));
+        setShape(shape, dims, rowNumberOfDims, order);
 
-        size_t n = fread(data, bytesPerValue, numberOfValuesInRow, f);
-        tensorArr->array[i] = tensorInit(data, dims, rowShape.numberOfDimensions, q, NULL);
+        /* Fresh quantization clone per tensor: every array entry now owns its
+         * own quantization, so freeTensor on any one doesn't double-free a
+         * shared `q`. */
+        quantization_t *rowQ = getQLike(q);
+
+        tensor_t *t = initTensor(shape, rowQ, NULL);
+        tensorArr->array[i] = t;
+
+        size_t n = fread(t->data, bytesPerValue, numberOfValuesInRow, f);
         if (n != numberOfValuesInRow) {
             PRINT_ERROR("fread did not read the correct number of bytes!");
             exit(1);

--- a/src/userApi/data_loader/include/NPYLoaderApi.h
+++ b/src/userApi/data_loader/include/NPYLoaderApi.h
@@ -1,6 +1,8 @@
 #ifndef NPYLOADERAPI_H
 #define NPYLOADERAPI_H
 
+#include "Dataset.h"
+
 /*!
  * Loads a .npy file as a tensor array.
  *
@@ -20,4 +22,14 @@ tensorArray_t *npyLoad(char *path);
  */
 sample_t *npyGetSample(dataset_t *dataset, size_t index);
 
-#endif //NPYLOADERAPI_H
+/*!
+ * Frees a tensorArray_t allocated by npyLoad: walks the inner array,
+ * freeTensor()s every entry, then releases the array buffer and the
+ * tensorArray_t struct itself. Stack- or static-allocated tensorArray_t
+ * values must not be passed here.
+ *
+ * \param tensorArr: Pointer returned by npyLoad
+ */
+void freeTensorArray(tensorArray_t *tensorArr);
+
+#endif // NPYLOADERAPI_H

--- a/src/userApi/include/StorageApi.h
+++ b/src/userApi/include/StorageApi.h
@@ -3,11 +3,9 @@
 
 #include <stddef.h>
 
+void *reserveMemory(size_t numberOfBytes);
 
-void **reserveMemory(size_t numberOfBytes);
-
+/* NULL-safe (mirrors free(NULL)). */
 void freeReservedMemory(void *ptr);
 
-
-
-#endif //STORAGEAPI_H
+#endif // STORAGEAPI_H

--- a/src/userApi/layer/CMakeLists.txt
+++ b/src/userApi/layer/CMakeLists.txt
@@ -30,3 +30,13 @@ target_link_libraries(SoftmaxApi PRIVATE
         Common
         StorageApi
 )
+
+add_library(FlattenApi FlattenApi.c)
+target_include_directories(FlattenApi PUBLIC include)
+target_link_libraries(FlattenApi PRIVATE
+        Tensor
+        Rounding
+        Layer
+        Common
+        StorageApi
+)

--- a/src/userApi/layer/FlattenApi.c
+++ b/src/userApi/layer/FlattenApi.c
@@ -6,6 +6,7 @@
 layer_t *flattenLayerInit(void) {
     layer_t *flattenLayer = *reserveMemory(sizeof(layer_t));
     flattenLayer->type = FLATTEN;
+    // Load-bearing: initLayerOutputs' FLATTEN case never reads config.
     flattenLayer->config = NULL;
     return flattenLayer;
 }

--- a/src/userApi/layer/FlattenApi.c
+++ b/src/userApi/layer/FlattenApi.c
@@ -1,0 +1,13 @@
+#define SOURCE_FILE "FLATTEN_API"
+
+#include "FlattenApi.h"
+#include "StorageApi.h"
+
+layer_t *flattenLayerInit(void) {
+  layer_t *flattenLayer = *reserveMemory(sizeof(layer_t));
+  flattenLayer->type = FLATTEN;
+  flattenLayer->config = NULL;
+  return flattenLayer;
+}
+
+void freeFlattenLayer(layer_t *flattenLayer) { freeReservedMemory(flattenLayer); }

--- a/src/userApi/layer/FlattenApi.c
+++ b/src/userApi/layer/FlattenApi.c
@@ -4,10 +4,12 @@
 #include "StorageApi.h"
 
 layer_t *flattenLayerInit(void) {
-  layer_t *flattenLayer = *reserveMemory(sizeof(layer_t));
-  flattenLayer->type = FLATTEN;
-  flattenLayer->config = NULL;
-  return flattenLayer;
+    layer_t *flattenLayer = *reserveMemory(sizeof(layer_t));
+    flattenLayer->type = FLATTEN;
+    flattenLayer->config = NULL;
+    return flattenLayer;
 }
 
-void freeFlattenLayer(layer_t *flattenLayer) { freeReservedMemory(flattenLayer); }
+void freeFlattenLayer(layer_t *flattenLayer) {
+    freeReservedMemory(flattenLayer);
+}

--- a/src/userApi/layer/FlattenApi.c
+++ b/src/userApi/layer/FlattenApi.c
@@ -4,7 +4,7 @@
 #include "StorageApi.h"
 
 layer_t *flattenLayerInit(void) {
-    layer_t *flattenLayer = *reserveMemory(sizeof(layer_t));
+    layer_t *flattenLayer = reserveMemory(sizeof(layer_t));
     flattenLayer->type = FLATTEN;
     // Load-bearing: initLayerOutputs' FLATTEN case never reads config.
     flattenLayer->config = NULL;

--- a/src/userApi/layer/LinearApi.c
+++ b/src/userApi/layer/LinearApi.c
@@ -3,13 +3,15 @@
 #include <stdlib.h>
 
 #include "Layer.h"
-#include "Tensor.h"
-#include "StorageApi.h"
-#include "TensorApi.h"
-#include "LinearApi.h"
 #include "Linear.h"
+#include "LinearApi.h"
+#include "StorageApi.h"
+#include "Tensor.h"
+#include "TensorApi.h"
 
-layer_t *linearLayerInit(parameter_t *weights, parameter_t *bias, quantization_t *forwardQ, quantization_t *weightGradsQ, quantization_t *biasGradsQ, quantization_t *propLossQ) {
+layer_t *linearLayerInit(parameter_t *weights, parameter_t *bias, quantization_t *forwardQ,
+                         quantization_t *weightGradsQ, quantization_t *biasGradsQ,
+                         quantization_t *propLossQ) {
     layer_t *linearLayer = reserveMemory(sizeof(layer_t));
 
     linearLayer->type = LINEAR;
@@ -49,7 +51,7 @@ layer_t *linearLayerInitNonTrainable(tensor_t *weights, tensor_t *bias, quantiza
 }
 
 void freeLinearLayer(layer_t *linearLayer) {
-    linearConfig_t *linearConfig = linearLayer->config->linear;
-    freeReservedMemory(linearConfig);
+    freeReservedMemory(linearLayer->config->linear);
+    freeReservedMemory(linearLayer->config);
     freeReservedMemory(linearLayer);
 }

--- a/src/userApi/layer/LinearApi.c
+++ b/src/userApi/layer/LinearApi.c
@@ -10,12 +10,12 @@
 #include "Linear.h"
 
 layer_t *linearLayerInit(parameter_t *weights, parameter_t *bias, quantization_t *forwardQ, quantization_t *weightGradsQ, quantization_t *biasGradsQ, quantization_t *propLossQ) {
-    layer_t *linearLayer = *reserveMemory(sizeof(layer_t));
+    layer_t *linearLayer = reserveMemory(sizeof(layer_t));
 
     linearLayer->type = LINEAR;
 
-    layerConfig_t *layerConfig = *reserveMemory(sizeof(layerConfig_t));
-    linearConfig_t *linearConfig = *reserveMemory(sizeof(linearConfig_t));
+    layerConfig_t *layerConfig = reserveMemory(sizeof(layerConfig_t));
+    linearConfig_t *linearConfig = reserveMemory(sizeof(linearConfig_t));
     layerConfig->linear = linearConfig;
 
     linearConfig->weights = weights;
@@ -31,12 +31,12 @@ layer_t *linearLayerInit(parameter_t *weights, parameter_t *bias, quantization_t
 }
 
 layer_t *linearLayerInitNonTrainable(tensor_t *weights, tensor_t *bias, quantization_t *forwardQ) {
-    layer_t *linearLayer = *reserveMemory(sizeof(layer_t));
+    layer_t *linearLayer = reserveMemory(sizeof(layer_t));
 
     linearLayer->type = LINEAR;
 
-    layerConfig_t *layerConfig = *reserveMemory(sizeof(layerConfig_t));
-    linearConfig_t *linearConfig = *reserveMemory(sizeof(linearConfig_t));
+    layerConfig_t *layerConfig = reserveMemory(sizeof(layerConfig_t));
+    linearConfig_t *linearConfig = reserveMemory(sizeof(linearConfig_t));
     layerConfig->linear = linearConfig;
 
     linearConfig->weights = parameterInit(weights, NULL);

--- a/src/userApi/layer/ReluApi.c
+++ b/src/userApi/layer/ReluApi.c
@@ -6,13 +6,13 @@
 
 
 layer_t *reluLayerInit(quantization_t *forwardQ, quantization_t *backwardQ) {
-    layer_t *reluLayer = *reserveMemory(sizeof(layer_t));
+    layer_t *reluLayer = reserveMemory(sizeof(layer_t));
 
     reluLayer->type = RELU;
 
-    layerConfig_t *reluConfig = *reserveMemory(sizeof(layerConfig_t));
+    layerConfig_t *reluConfig = reserveMemory(sizeof(layerConfig_t));
 
-    reluConfig_t *reluCfg = *reserveMemory(sizeof(reluConfig_t));
+    reluConfig_t *reluCfg = reserveMemory(sizeof(reluConfig_t));
     reluConfig->relu = reluCfg;
     reluCfg->forwardQ = forwardQ;
     reluCfg->backwardQ = backwardQ;

--- a/src/userApi/layer/ReluApi.c
+++ b/src/userApi/layer/ReluApi.c
@@ -1,9 +1,8 @@
 #define SOURCE_FILE "RELU_API"
 
-#include "StorageApi.h"
 #include "ReluApi.h"
 #include "Relu.h"
-
+#include "StorageApi.h"
 
 layer_t *reluLayerInit(quantization_t *forwardQ, quantization_t *backwardQ) {
     layer_t *reluLayer = reserveMemory(sizeof(layer_t));
@@ -23,6 +22,7 @@ layer_t *reluLayerInit(quantization_t *forwardQ, quantization_t *backwardQ) {
 }
 
 void freeReluLayer(layer_t *reluLayer) {
+    freeReservedMemory(reluLayer->config->relu);
     freeReservedMemory(reluLayer->config);
     freeReservedMemory(reluLayer);
 }

--- a/src/userApi/layer/SoftmaxApi.c
+++ b/src/userApi/layer/SoftmaxApi.c
@@ -1,8 +1,8 @@
 #define SOURCE_FILE "SOFTMAX_API"
 
-#include "StorageApi.h"
-#include "Softmax.h"
 #include "SoftmaxApi.h"
+#include "Softmax.h"
+#include "StorageApi.h"
 
 layer_t *softmaxLayerInit(quantization_t *forwardQ, quantization_t *backwardQ) {
     layer_t *softmaxLayer = reserveMemory(sizeof(layer_t));
@@ -17,5 +17,11 @@ layer_t *softmaxLayerInit(quantization_t *forwardQ, quantization_t *backwardQ) {
     softmaxConfig->backwardQ = backwardQ;
     softmaxLayer->config = layerConfig;
 
-    return  softmaxLayer;
+    return softmaxLayer;
+}
+
+void freeSoftmaxLayer(layer_t *softmaxLayer) {
+    freeReservedMemory(softmaxLayer->config->softmax);
+    freeReservedMemory(softmaxLayer->config);
+    freeReservedMemory(softmaxLayer);
 }

--- a/src/userApi/layer/SoftmaxApi.c
+++ b/src/userApi/layer/SoftmaxApi.c
@@ -5,12 +5,12 @@
 #include "SoftmaxApi.h"
 
 layer_t *softmaxLayerInit(quantization_t *forwardQ, quantization_t *backwardQ) {
-    layer_t *softmaxLayer = *reserveMemory(sizeof(layer_t));
+    layer_t *softmaxLayer = reserveMemory(sizeof(layer_t));
 
     softmaxLayer->type = SOFTMAX;
 
-    layerConfig_t *layerConfig = *reserveMemory(sizeof(layerConfig_t));
-    softmaxConfig_t *softmaxConfig = *reserveMemory(sizeof(softmaxConfig_t));
+    layerConfig_t *layerConfig = reserveMemory(sizeof(layerConfig_t));
+    softmaxConfig_t *softmaxConfig = reserveMemory(sizeof(softmaxConfig_t));
     layerConfig->softmax = softmaxConfig;
 
     softmaxConfig->forwardQ = forwardQ;

--- a/src/userApi/layer/include/FlattenApi.h
+++ b/src/userApi/layer/include/FlattenApi.h
@@ -1,0 +1,9 @@
+#ifndef ODT_FLATTEN_API_H
+#define ODT_FLATTEN_API_H
+
+#include "Layer.h"
+
+layer_t *flattenLayerInit(void);
+void freeFlattenLayer(layer_t *flattenLayer);
+
+#endif

--- a/src/userApi/layer/include/SoftmaxApi.h
+++ b/src/userApi/layer/include/SoftmaxApi.h
@@ -1,9 +1,11 @@
 #ifndef SOFTMAXAPI_H
 #define SOFTMAXAPI_H
 
-#include "Tensor.h"
 #include "Layer.h"
+#include "Tensor.h"
 
 layer_t *softmaxLayerInit(quantization_t *forwardQ, quantization_t *backwardQ);
 
-#endif //SOFTMAXAPI_H
+void freeSoftmaxLayer(layer_t *softmaxLayer);
+
+#endif // SOFTMAXAPI_H

--- a/src/userApi/optimizer/SgdApi.c
+++ b/src/userApi/optimizer/SgdApi.c
@@ -15,21 +15,21 @@
 // IMPORTANT: Currently, the quantization for states are the same as the corresponding parameter
 optimizer_t *sgdMCreateOptim(float learningRate, float momentumFactor, float weightDecay,
                              layer_t **model, size_t sizeModel, qtype_t qType) {
-    optimizer_t *optim = *reserveMemory(sizeof(optimizer_t));
+    optimizer_t *optim = reserveMemory(sizeof(optimizer_t));
     optim->type = SGD_M;
     optim->qtype = qType;
 
-    optimImpl_t *sgdImpl = *reserveMemory(sizeof(optimImpl_t));
-    sgd_t *sgd = *reserveMemory(sizeof(sgd_t));
+    optimImpl_t *sgdImpl = reserveMemory(sizeof(optimImpl_t));
+    sgd_t *sgd = reserveMemory(sizeof(sgd_t));
     sgdInit(sgd, learningRate, momentumFactor, weightDecay);
     sgdImpl->sgd = sgd;
     optim->impl = sgdImpl;
 
     size_t sizeStates = calcTotalNumberOfStates(model, sizeModel);
     optim->sizeStates = sizeStates;
-    states_t **states = *reserveMemory(sizeStates * sizeof(states_t *));
+    states_t **states = reserveMemory(sizeStates * sizeof(states_t *));
     optim->states = states;
-    parameter_t **parameter = *reserveMemory(sizeStates * sizeof(parameter_t *));
+    parameter_t **parameter = reserveMemory(sizeStates * sizeof(parameter_t *));
     optim->parameter = parameter;
     size_t statesPerParam = 1;
 
@@ -50,14 +50,14 @@ optimizer_t *sgdMCreateOptim(float learningRate, float momentumFactor, float wei
             optim->parameter[i + 1] = bias;
             tensor_t *biasStateBuffer = getTensorLike(bias->param);
 
-            states_t *weightStates = *reserveMemory(sizeof(states_t));
+            states_t *weightStates = reserveMemory(sizeof(states_t));
             weightStates->statesPerParameter = statesPerParam;
-            weightStates->stateBuffers = *reserveMemory(sizeof(tensor_t));
+            weightStates->stateBuffers = reserveMemory(sizeof(tensor_t));
             weightStates->stateBuffers[0] = weightStateBuffer;
 
-            states_t *biasStates = *reserveMemory(sizeof(states_t));
+            states_t *biasStates = reserveMemory(sizeof(states_t));
             biasStates->statesPerParameter = statesPerParam;
-            biasStates->stateBuffers = *reserveMemory(sizeof(tensor_t));
+            biasStates->stateBuffers = reserveMemory(sizeof(tensor_t));
             biasStates->stateBuffers[0] = biasStateBuffer;
 
             states[i] = weightStates;

--- a/src/userApi/optimizer/SgdApi.c
+++ b/src/userApi/optimizer/SgdApi.c
@@ -3,14 +3,13 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include "Tensor.h"
-#include "Layer.h"
-#include "SgdApi.h"
-#include "TensorApi.h"
-#include "Linear.h"
 #include "Common.h"
+#include "Layer.h"
+#include "Linear.h"
+#include "SgdApi.h"
 #include "StorageApi.h"
-
+#include "Tensor.h"
+#include "TensorApi.h"
 
 // IMPORTANT: Currently, the quantization for states are the same as the corresponding parameter
 optimizer_t *sgdMCreateOptim(float learningRate, float momentumFactor, float weightDecay,
@@ -79,6 +78,7 @@ void freeState(states_t *state) {
     for (size_t i = 0; i < state->statesPerParameter; i++) {
         freeTensor(state->stateBuffers[i]);
     }
+    freeReservedMemory(state->stateBuffers);
     freeReservedMemory(state);
 }
 
@@ -87,7 +87,10 @@ void freeOptimSgdM(optimizer_t *sgdM) {
         freeParameter(sgdM->parameter[i]);
         freeState(sgdM->states[i]);
     }
+    freeReservedMemory(sgdM->parameter);
+    freeReservedMemory(sgdM->states);
     sgd_t *sgdImpl = sgdM->impl->sgd;
     freeReservedMemory(sgdImpl);
+    freeReservedMemory(sgdM->impl);
     freeReservedMemory(sgdM);
 }

--- a/src/userApi/optimizer/SgdApi.c
+++ b/src/userApi/optimizer/SgdApi.c
@@ -51,12 +51,12 @@ optimizer_t *sgdMCreateOptim(float learningRate, float momentumFactor, float wei
 
             states_t *weightStates = reserveMemory(sizeof(states_t));
             weightStates->statesPerParameter = statesPerParam;
-            weightStates->stateBuffers = reserveMemory(sizeof(tensor_t));
+            weightStates->stateBuffers = reserveMemory(sizeof(tensor_t *));
             weightStates->stateBuffers[0] = weightStateBuffer;
 
             states_t *biasStates = reserveMemory(sizeof(states_t));
             biasStates->statesPerParameter = statesPerParam;
-            biasStates->stateBuffers = reserveMemory(sizeof(tensor_t));
+            biasStates->stateBuffers = reserveMemory(sizeof(tensor_t *));
             biasStates->stateBuffers[0] = biasStateBuffer;
 
             states[i] = weightStates;

--- a/src/userApi/tensor/CMakeLists.txt
+++ b/src/userApi/tensor/CMakeLists.txt
@@ -16,4 +16,5 @@ target_link_libraries(TensorApi PRIVATE
         Common
         TensorConversion
         Distributions
+        QuantizationApi
 )

--- a/src/userApi/tensor/QuantizationApi.c
+++ b/src/userApi/tensor/QuantizationApi.c
@@ -6,28 +6,28 @@
 
 
 quantization_t *quantizationInitFloat() {
-    quantization_t *q = *reserveMemory(sizeof(quantization_t));
+    quantization_t *q = reserveMemory(sizeof(quantization_t));
     initFloat32Quantization(q);
     return q;
 }
 
 quantization_t *quantizationInitInt32() {
-    quantization_t *q = *reserveMemory(sizeof(quantization_t));
+    quantization_t *q = reserveMemory(sizeof(quantization_t));
     initInt32Quantization(q);
     return q;
 }
 
 quantization_t *quantizationInitSymInt32(roundingMode_t roundingMode) {
-    quantization_t *q = *reserveMemory(sizeof(quantization_t));
-    symInt32QConfig_t *qC = *reserveMemory(sizeof(symInt32QConfig_t));
+    quantization_t *q = reserveMemory(sizeof(quantization_t));
+    symInt32QConfig_t *qC = reserveMemory(sizeof(symInt32QConfig_t));
     initSymInt32QConfig(roundingMode, qC);
     initSymInt32Quantization(qC, q);
     return q;
 }
 
 quantization_t *quantizationInitAsym(uint8_t qBits, roundingMode_t roundingMode) {
-    quantization_t *q = *reserveMemory(sizeof(quantization_t));
-    asymQConfig_t *qC = *reserveMemory(sizeof(asymQConfig_t));
+    quantization_t *q = reserveMemory(sizeof(quantization_t));
+    asymQConfig_t *qC = reserveMemory(sizeof(asymQConfig_t));
     initAsymQConfig(qBits, roundingMode, qC);
     initAsymQuantization(qC, q);
     return q;

--- a/src/userApi/tensor/TensorApi.c
+++ b/src/userApi/tensor/TensorApi.c
@@ -19,14 +19,14 @@
 // tensor inits
 
 tensor_t *tensorInitInt32(int32_t *data, size_t *dims, size_t numberOfDims, sparsity_t *sparsity) {
-    quantization_t *q = *reserveMemory(sizeof(quantization_t));
+    quantization_t *q = reserveMemory(sizeof(quantization_t));
     initInt32Quantization(q);
 
     return initTensorWithQInt32(data, dims, numberOfDims, q, sparsity);
 }
 
 tensor_t *tensorInitFloat(float *data, size_t *dims, size_t numberOfDims, sparsity_t *sparsity) {
-    quantization_t *q = *reserveMemory(sizeof(quantization_t));
+    quantization_t *q = reserveMemory(sizeof(quantization_t));
     initFloat32Quantization(q);
 
     return initTensorWithQFloat(data, dims, numberOfDims, q, sparsity);
@@ -34,8 +34,8 @@ tensor_t *tensorInitFloat(float *data, size_t *dims, size_t numberOfDims, sparsi
 
 tensor_t *tensorInitSymInt32(float *data, size_t *dims, size_t numberOfDims,
                              roundingMode_t roundingMode, sparsity_t *sparsity) {
-    quantization_t *symInt32Q = *reserveMemory(sizeof(quantization_t));
-    symInt32QConfig_t *symInt32QC = *reserveMemory(sizeof(symInt32QConfig_t));
+    quantization_t *symInt32Q = reserveMemory(sizeof(quantization_t));
+    symInt32QConfig_t *symInt32QC = reserveMemory(sizeof(symInt32QConfig_t));
     initSymInt32QConfig(roundingMode, symInt32QC);
     initSymInt32Quantization(symInt32QC, symInt32Q);
 
@@ -44,10 +44,10 @@ tensor_t *tensorInitSymInt32(float *data, size_t *dims, size_t numberOfDims,
 
 tensor_t *tensorInitAsym(float *data, size_t *dims, size_t numberOfDims, uint8_t qBits,
                          roundingMode_t roundingMode, sparsity_t *sparsity) {
-    asymQConfig_t *asymQC = *reserveMemory(sizeof(asymQConfig_t));
+    asymQConfig_t *asymQC = reserveMemory(sizeof(asymQConfig_t));
     asymQC->qBits = qBits;
     asymQC->roundingMode = roundingMode;
-    quantization_t *asymQ = *reserveMemory(sizeof(quantization_t));
+    quantization_t *asymQ = reserveMemory(sizeof(quantization_t));
     asymQ->type = ASYM;
     asymQ->qConfig = asymQC;
 
@@ -64,7 +64,7 @@ tensor_t *tensorInit(float *data, size_t *dims, size_t numberOfDims, quantizatio
         for (size_t i = 0; i < numberOfDims; i++) {
             size += dims[i];
         }
-        int32_t *dataInt = *reserveMemory(size * sizeof(int32_t));
+        int32_t *dataInt = reserveMemory(size * sizeof(int32_t));
         for (size_t i = 0; i < size; i++) {
             dataInt[i] = (int32_t)data[i];
         }
@@ -140,16 +140,16 @@ tensor_t *tensorInitWithDistribution(distributionType_t distributionType, float 
 // grad inits
 
 tensor_t *gradInitInt32(tensor_t *param, sparsity_t *sparsity) {
-    tensor_t *grad = *reserveMemory(sizeof(tensor_t));
+    tensor_t *grad = reserveMemory(sizeof(tensor_t));
 
     grad->shape = param->shape;
-    quantization_t *gradQ = *reserveMemory(sizeof(quantization_t));
+    quantization_t *gradQ = reserveMemory(sizeof(quantization_t));
     initInt32Quantization(gradQ);
     grad->quantization = gradQ;
 
     size_t numberOfValues = calcNumberOfElementsByTensor(param);
     size_t bytesPerElement = sizeof(int32_t);
-    uint8_t *data = *reserveMemory(numberOfValues * bytesPerElement);
+    uint8_t *data = reserveMemory(numberOfValues * bytesPerElement);
     grad->data = data;
 
     grad->sparsity = sparsity;
@@ -158,16 +158,16 @@ tensor_t *gradInitInt32(tensor_t *param, sparsity_t *sparsity) {
 }
 
 tensor_t *gradInitFloat(tensor_t *param, sparsity_t *sparsity) {
-    tensor_t *grad = *reserveMemory(sizeof(tensor_t));
+    tensor_t *grad = reserveMemory(sizeof(tensor_t));
 
     grad->shape = param->shape;
-    quantization_t *gradQ = *reserveMemory(sizeof(quantization_t));
+    quantization_t *gradQ = reserveMemory(sizeof(quantization_t));
     initFloat32Quantization(gradQ);
     grad->quantization = gradQ;
 
     size_t numberOfValues = calcNumberOfElementsByTensor(param);
     size_t bytesPerElement = sizeof(float);
-    uint8_t *data = *reserveMemory(numberOfValues * bytesPerElement);
+    uint8_t *data = reserveMemory(numberOfValues * bytesPerElement);
     grad->data = data;
 
     grad->sparsity = sparsity;
@@ -176,18 +176,18 @@ tensor_t *gradInitFloat(tensor_t *param, sparsity_t *sparsity) {
 }
 
 tensor_t *gradInitSymInt32(tensor_t *param, roundingMode_t roundingMode, sparsity_t *sparsity) {
-    tensor_t *grad = *reserveMemory(sizeof(tensor_t));
+    tensor_t *grad = reserveMemory(sizeof(tensor_t));
 
     grad->shape = param->shape;
-    symInt32QConfig_t *gradQC = *reserveMemory(sizeof(symInt32QConfig_t));
+    symInt32QConfig_t *gradQC = reserveMemory(sizeof(symInt32QConfig_t));
     initSymInt32QConfig(roundingMode, gradQC);
-    quantization_t *gradQ = *reserveMemory(sizeof(quantization_t));
+    quantization_t *gradQ = reserveMemory(sizeof(quantization_t));
     initSymInt32Quantization(gradQC, gradQ);
     grad->quantization = gradQ;
 
     size_t numberOfValues = calcNumberOfElementsByTensor(param);
     size_t bytesPerElement = sizeof(float);
-    uint8_t *data = *reserveMemory(numberOfValues * bytesPerElement);
+    uint8_t *data = reserveMemory(numberOfValues * bytesPerElement);
     grad->data = data;
 
     grad->sparsity = sparsity;
@@ -197,18 +197,18 @@ tensor_t *gradInitSymInt32(tensor_t *param, roundingMode_t roundingMode, sparsit
 
 tensor_t *gradInitAsym(tensor_t *param, uint8_t qBits, roundingMode_t roundingMode,
                        sparsity_t *sparsity) {
-    tensor_t *grad = *reserveMemory(sizeof(tensor_t));
+    tensor_t *grad = reserveMemory(sizeof(tensor_t));
 
     grad->shape = param->shape;
-    asymQConfig_t *gradQC = *reserveMemory(sizeof(asymQConfig_t));
+    asymQConfig_t *gradQC = reserveMemory(sizeof(asymQConfig_t));
     initAsymQConfig(qBits, roundingMode, gradQC);
-    quantization_t *gradQ = *reserveMemory(sizeof(quantization_t));
+    quantization_t *gradQ = reserveMemory(sizeof(quantization_t));
     initAsymQuantization(gradQC, gradQ);
     grad->quantization = gradQ;
 
     size_t numberOfValues = calcNumberOfElementsByTensor(param);
     size_t bytesPerElement = sizeof(float);
-    uint8_t *data = *reserveMemory(numberOfValues * bytesPerElement);
+    uint8_t *data = reserveMemory(numberOfValues * bytesPerElement);
     grad->data = data;
 
     grad->sparsity = sparsity;
@@ -219,14 +219,14 @@ tensor_t *gradInitAsym(tensor_t *param, uint8_t qBits, roundingMode_t roundingMo
 // getLike
 
 shape_t *getShapeLike(shape_t *shape) {
-    shape_t *likeShape = *reserveMemory(sizeof(shape_t));
+    shape_t *likeShape = reserveMemory(sizeof(shape_t));
 
     size_t numberOfDims = shape->numberOfDimensions;
 
-    size_t *likeDims = *reserveMemory(numberOfDims * sizeof(size_t));
+    size_t *likeDims = reserveMemory(numberOfDims * sizeof(size_t));
     memcpy(likeDims, shape->dimensions, numberOfDims * sizeof(size_t));
 
-    size_t *likeOrder = *reserveMemory(numberOfDims * sizeof(size_t));
+    size_t *likeOrder = reserveMemory(numberOfDims * sizeof(size_t));
     setOrderOfDimsForNewTensor(numberOfDims, likeOrder);
 
     setShape(likeShape, likeDims, numberOfDims, likeOrder);
@@ -235,7 +235,7 @@ shape_t *getShapeLike(shape_t *shape) {
 }
 
 quantization_t *getQLike(quantization_t *quantization) {
-    quantization_t *likeQ = *reserveMemory(sizeof(quantization_t));
+    quantization_t *likeQ = reserveMemory(sizeof(quantization_t));
     switch (quantization->type) {
     case FLOAT32:
         initFloat32Quantization(likeQ);
@@ -244,14 +244,14 @@ quantization_t *getQLike(quantization_t *quantization) {
         initInt32Quantization(likeQ);
         break;
     case SYM_INT32:
-        symInt32QConfig_t *likeSymInt32QC = *reserveMemory(sizeof(symInt32QConfig_t));
+        symInt32QConfig_t *likeSymInt32QC = reserveMemory(sizeof(symInt32QConfig_t));
         symInt32QConfig_t *symInt32QC = quantization->qConfig;
 
         initSymInt32QConfig(symInt32QC->roundingMode, likeSymInt32QC);
         initSymInt32Quantization(likeSymInt32QC, likeQ);
         break;
     case ASYM:
-        asymQConfig_t *likeAsymQC = *reserveMemory(sizeof(asymQConfig_t));
+        asymQConfig_t *likeAsymQC = reserveMemory(sizeof(asymQConfig_t));
         asymQConfig_t *asymQC = quantization->qConfig;
 
         initAsymQConfig(asymQC->qBits, asymQC->roundingMode, likeAsymQC);
@@ -267,16 +267,16 @@ quantization_t *getQLike(quantization_t *quantization) {
 uint8_t *getDataLike(quantization_t *quantization, size_t numberOfValues) {
     switch (quantization->type) {
     case FLOAT32:
-        return *reserveMemory(numberOfValues * sizeof(float));
+        return reserveMemory(numberOfValues * sizeof(float));
     case INT32:
-        return *reserveMemory(numberOfValues * sizeof(int32_t));
+        return reserveMemory(numberOfValues * sizeof(int32_t));
     case SYM_INT32:
-        return *reserveMemory(numberOfValues * sizeof(int32_t));
+        return reserveMemory(numberOfValues * sizeof(int32_t));
     case ASYM:
         asymQConfig_t *asymQC = quantization->qConfig;
         size_t totalBits = numberOfValues * asymQC->qBits;
         size_t totalBytes = ceilf(totalBits / 8);
-        return *reserveMemory(totalBytes);
+        return reserveMemory(totalBytes);
     default:
         PRINT_ERROR("Unknown QType");
         exit(1);
@@ -285,13 +285,13 @@ uint8_t *getDataLike(quantization_t *quantization, size_t numberOfValues) {
 
 sparsity_t *getSparsityLike(sparsity_t *sparsity) {
     if (sparsity != NULL) {
-        return *reserveMemory(sizeof(sparsity_t));
+        return reserveMemory(sizeof(sparsity_t));
     }
     return NULL;
 }
 
 tensor_t *getTensorLike(tensor_t *tensor) {
-    tensor_t *likeTensor = *reserveMemory(sizeof(tensor_t));
+    tensor_t *likeTensor = reserveMemory(sizeof(tensor_t));
     size_t numberOfValues = calcNumberOfElementsByShape(tensor->shape);
     likeTensor->data = getDataLike(tensor->quantization, numberOfValues);
     likeTensor->quantization = getQLike(tensor->quantization);
@@ -304,7 +304,7 @@ tensor_t *getTensorLike(tensor_t *tensor) {
 // Free Functions
 
 parameter_t *parameterInit(tensor_t *param, tensor_t *grad) {
-    parameter_t *parameter = *reserveMemory(sizeof(parameter_t));
+    parameter_t *parameter = reserveMemory(sizeof(parameter_t));
     parameter->param = param;
     parameter->grad = grad;
 
@@ -349,8 +349,8 @@ static tensor_t *initTensorWithQInt32(int32_t *data, size_t *dims, size_t number
                                       quantization_t *quantization, sparsity_t *sparsity) {
     tensor_t *tensor = malloc(sizeof(tensor_t));
     tensor->data = (uint8_t *)data;
-    shape_t *shape = *reserveMemory(sizeof(shape_t));
-    size_t *order = *reserveMemory(numberOfDims * sizeof(size_t));
+    shape_t *shape = reserveMemory(sizeof(shape_t));
+    size_t *order = reserveMemory(numberOfDims * sizeof(size_t));
     setOrderOfDimsForNewTensor(numberOfDims, order);
     setShape(shape, dims, numberOfDims, order);
     tensor->shape = shape;
@@ -362,12 +362,12 @@ static tensor_t *initTensorWithQInt32(int32_t *data, size_t *dims, size_t number
 
 static tensor_t *initTensorWithQFloat(float *data, size_t *dims, size_t numberOfDims,
                                       quantization_t *quantization, sparsity_t *sparsity) {
-    tensor_t *tensor = *reserveMemory(sizeof(tensor_t));
+    tensor_t *tensor = reserveMemory(sizeof(tensor_t));
 
     tensor->data = (uint8_t *)data;
 
-    shape_t *shape = *reserveMemory(sizeof(shape_t));
-    size_t *order = *reserveMemory(numberOfDims * sizeof(size_t));
+    shape_t *shape = reserveMemory(sizeof(shape_t));
+    size_t *order = reserveMemory(numberOfDims * sizeof(size_t));
     setOrderOfDimsForNewTensor(numberOfDims, order);
     setShape(shape, dims, numberOfDims, order);
     tensor->shape = shape;
@@ -380,8 +380,8 @@ static tensor_t *initTensorWithQFloat(float *data, size_t *dims, size_t numberOf
 static tensor_t *initTensorWithQSymInt32(float *data, size_t *dims, size_t numberOfDims,
                                          quantization_t *quantization, sparsity_t *sparsity) {
 
-    shape_t *shape = *reserveMemory(sizeof(shape_t));
-    size_t *order = *reserveMemory(numberOfDims * sizeof(size_t));
+    shape_t *shape = reserveMemory(sizeof(shape_t));
+    size_t *order = reserveMemory(numberOfDims * sizeof(size_t));
     setOrderOfDimsForNewTensor(numberOfDims, order);
     setShape(shape, dims, numberOfDims, order);
 
@@ -394,10 +394,10 @@ static tensor_t *initTensorWithQSymInt32(float *data, size_t *dims, size_t numbe
     floatTensor.quantization = &floatQ;
     floatTensor.sparsity = sparsity;
 
-    tensor_t *symInt32Tensor = *reserveMemory(sizeof(tensor_t));
+    tensor_t *symInt32Tensor = reserveMemory(sizeof(tensor_t));
 
     size_t numberOfValues = calcNumberOfElementsByTensor(&floatTensor);
-    int32_t *symInt32Data = *reserveMemory(numberOfValues * sizeof(int32_t));
+    int32_t *symInt32Data = reserveMemory(numberOfValues * sizeof(int32_t));
 
     symInt32Tensor->data = (uint8_t *)symInt32Data;
     symInt32Tensor->shape = shape;
@@ -411,8 +411,8 @@ static tensor_t *initTensorWithQSymInt32(float *data, size_t *dims, size_t numbe
 static tensor_t *initTensorWithQAsym(float *data, size_t *dims, size_t numberOfDims,
                                      quantization_t *quantization, sparsity_t *sparsity) {
 
-    shape_t *shape = *reserveMemory(sizeof(shape_t));
-    size_t *order = *reserveMemory(numberOfDims * sizeof(size_t));
+    shape_t *shape = reserveMemory(sizeof(shape_t));
+    size_t *order = reserveMemory(numberOfDims * sizeof(size_t));
     setOrderOfDimsForNewTensor(numberOfDims, order);
     setShape(shape, dims, numberOfDims, order);
 
@@ -425,13 +425,13 @@ static tensor_t *initTensorWithQAsym(float *data, size_t *dims, size_t numberOfD
     floatTensor.quantization = &floatQ;
     floatTensor.sparsity = sparsity;
 
-    tensor_t *asymTensor = *reserveMemory(sizeof(tensor_t));
+    tensor_t *asymTensor = reserveMemory(sizeof(tensor_t));
 
     asymQConfig_t *asymQC = quantization->qConfig;
     size_t bitsPerElement = asymQC->qBits;
     size_t numberOfValues = calcNumberOfElementsByShape(shape);
     size_t sizeData = ceilf((float)(numberOfValues * bitsPerElement / 8));
-    uint8_t *asymData = *reserveMemory(sizeData);
+    uint8_t *asymData = reserveMemory(sizeData);
 
     asymTensor->data = asymData;
     asymTensor->shape = shape;

--- a/src/userApi/tensor/TensorApi.c
+++ b/src/userApi/tensor/TensorApi.c
@@ -240,80 +240,21 @@ tensor_t *tensorInitWithDistribution(distributionType_t distributionType, float 
 // grad inits
 
 tensor_t *gradInitInt32(tensor_t *param, sparsity_t *sparsity) {
-    tensor_t *grad = reserveMemory(sizeof(tensor_t));
-
-    grad->shape = param->shape;
-    quantization_t *gradQ = reserveMemory(sizeof(quantization_t));
-    initInt32Quantization(gradQ);
-    grad->quantization = gradQ;
-
-    size_t numberOfValues = calcNumberOfElementsByTensor(param);
-    size_t bytesPerElement = sizeof(int32_t);
-    uint8_t *data = reserveMemory(numberOfValues * bytesPerElement);
-    grad->data = data;
-
-    grad->sparsity = sparsity;
-
-    return grad;
+    return initTensor(getShapeLike(param->shape), quantizationInitInt32(), sparsity);
 }
 
 tensor_t *gradInitFloat(tensor_t *param, sparsity_t *sparsity) {
-    tensor_t *grad = reserveMemory(sizeof(tensor_t));
-
-    grad->shape = param->shape;
-    quantization_t *gradQ = reserveMemory(sizeof(quantization_t));
-    initFloat32Quantization(gradQ);
-    grad->quantization = gradQ;
-
-    size_t numberOfValues = calcNumberOfElementsByTensor(param);
-    size_t bytesPerElement = sizeof(float);
-    uint8_t *data = reserveMemory(numberOfValues * bytesPerElement);
-    grad->data = data;
-
-    grad->sparsity = sparsity;
-
-    return grad;
+    return initTensor(getShapeLike(param->shape), quantizationInitFloat(), sparsity);
 }
 
 tensor_t *gradInitSymInt32(tensor_t *param, roundingMode_t roundingMode, sparsity_t *sparsity) {
-    tensor_t *grad = reserveMemory(sizeof(tensor_t));
-
-    grad->shape = param->shape;
-    symInt32QConfig_t *gradQC = reserveMemory(sizeof(symInt32QConfig_t));
-    initSymInt32QConfig(roundingMode, gradQC);
-    quantization_t *gradQ = reserveMemory(sizeof(quantization_t));
-    initSymInt32Quantization(gradQC, gradQ);
-    grad->quantization = gradQ;
-
-    size_t numberOfValues = calcNumberOfElementsByTensor(param);
-    size_t bytesPerElement = sizeof(float);
-    uint8_t *data = reserveMemory(numberOfValues * bytesPerElement);
-    grad->data = data;
-
-    grad->sparsity = sparsity;
-
-    return grad;
+    return initTensor(getShapeLike(param->shape), quantizationInitSymInt32(roundingMode), sparsity);
 }
 
 tensor_t *gradInitAsym(tensor_t *param, uint8_t qBits, roundingMode_t roundingMode,
                        sparsity_t *sparsity) {
-    tensor_t *grad = reserveMemory(sizeof(tensor_t));
-
-    grad->shape = param->shape;
-    asymQConfig_t *gradQC = reserveMemory(sizeof(asymQConfig_t));
-    initAsymQConfig(qBits, roundingMode, gradQC);
-    quantization_t *gradQ = reserveMemory(sizeof(quantization_t));
-    initAsymQuantization(gradQC, gradQ);
-    grad->quantization = gradQ;
-
-    size_t numberOfValues = calcNumberOfElementsByTensor(param);
-    size_t bytesPerElement = sizeof(float);
-    uint8_t *data = reserveMemory(numberOfValues * bytesPerElement);
-    grad->data = data;
-
-    grad->sparsity = sparsity;
-
-    return grad;
+    return initTensor(getShapeLike(param->shape), quantizationInitAsym(qBits, roundingMode),
+                      sparsity);
 }
 
 // getLike

--- a/src/userApi/tensor/TensorApi.c
+++ b/src/userApi/tensor/TensorApi.c
@@ -91,6 +91,67 @@ tensor_t *initTensor(shape_t *shape, quantization_t *quantization, sparsity_t *s
     return tensor;
 }
 
+void initDistribution(tensor_t *tensor, const distribution_t *distribution) {
+    if (tensor->quantization->type != FLOAT32) {
+        PRINT_ERROR("initDistribution only supports FLOAT32 in this iteration");
+        exit(1);
+    }
+    float *vals = (float *)tensor->data;
+    size_t n = calcNumberOfElementsByTensor(tensor);
+
+    switch (distribution->type) {
+    case ZEROS:
+        memset(vals, 0, n * sizeof(float));
+        break;
+    case ONES:
+        for (size_t i = 0; i < n; ++i) {
+            vals[i] = 1.0f;
+        }
+        break;
+    case UNIFORM:
+        for (size_t i = 0; i < n; ++i) {
+            vals[i] =
+                randomUniform(distribution->params.uniform.min, distribution->params.uniform.max);
+        }
+        break;
+    case NORMAL:
+        for (size_t i = 0; i < n; ++i) {
+            vals[i] =
+                randomNormal(distribution->params.normal.mean, distribution->params.normal.stddev);
+        }
+        break;
+    case XAVIER_UNIFORM:
+        for (size_t i = 0; i < n; ++i) {
+            vals[i] =
+                xavierUniform(distribution->params.xavier.gain, distribution->params.xavier.fanIn,
+                              distribution->params.xavier.fanOut);
+        }
+        break;
+    case XAVIER_NORMAL:
+        for (size_t i = 0; i < n; ++i) {
+            vals[i] =
+                xavierNormal(distribution->params.xavier.gain, distribution->params.xavier.fanIn,
+                             distribution->params.xavier.fanOut);
+        }
+        break;
+    case KAIMING_UNIFORM:
+        for (size_t i = 0; i < n; ++i) {
+            vals[i] = kaimingUniform(distribution->params.kaiming.gain,
+                                     distribution->params.kaiming.fanMode);
+        }
+        break;
+    case KAIMING_NORMAL:
+        for (size_t i = 0; i < n; ++i) {
+            vals[i] = kaimingNormal(distribution->params.kaiming.gain,
+                                    distribution->params.kaiming.fanMode);
+        }
+        break;
+    default:
+        PRINT_ERROR("Unknown distribution type!");
+        exit(1);
+    }
+}
+
 tensor_t *tensorInitWithDistribution(distributionType_t distributionType, float *data, size_t *dims,
                                      size_t numberOfDims, quantization_t *quantization,
                                      sparsity_t *sparsity, size_t inputFeatures,

--- a/src/userApi/tensor/TensorApi.c
+++ b/src/userApi/tensor/TensorApi.c
@@ -384,7 +384,9 @@ void freeTensor(tensor_t *tensor) {
 
 void freeParameter(parameter_t *parameter) {
     freeTensor(parameter->param);
-    freeTensor(parameter->grad);
+    if (parameter->grad != NULL) {
+        freeTensor(parameter->grad);
+    }
     freeReservedMemory(parameter);
 }
 

--- a/src/userApi/tensor/TensorApi.c
+++ b/src/userApi/tensor/TensorApi.c
@@ -91,6 +91,33 @@ tensor_t *initTensor(shape_t *shape, quantization_t *quantization, sparsity_t *s
     return tensor;
 }
 
+void tensorFillFromFloatBuffer(tensor_t *tensor, const float *source, size_t count) {
+    size_t expected = calcNumberOfElementsByTensor(tensor);
+    if (count != expected) {
+        PRINT_ERROR("tensorFillFromFloatBuffer count mismatch (expected vs given)");
+        exit(1);
+    }
+
+    if (tensor->quantization->type == FLOAT32) {
+        memcpy(tensor->data, source, count * sizeof(float));
+        return;
+    }
+
+    /* Non-FLOAT32: route through convertTensor, mirroring the pattern in
+     * initTensorWithQSymInt32. Build a temporary FLOAT32 view over `source`
+     * and convert into `tensor`. The const-cast is safe: convertTensor only
+     * reads from inputTensor->data. */
+    quantization_t floatQ;
+    initFloat32Quantization(&floatQ);
+    tensor_t srcView;
+    srcView.data = (uint8_t *)(uintptr_t)source;
+    srcView.shape = tensor->shape;
+    srcView.quantization = &floatQ;
+    srcView.sparsity = NULL;
+
+    convertTensor(&srcView, tensor);
+}
+
 void initDistribution(tensor_t *tensor, const distribution_t *distribution) {
     if (tensor->quantization->type != FLOAT32) {
         PRINT_ERROR("initDistribution only supports FLOAT32 in this iteration");

--- a/src/userApi/tensor/TensorApi.c
+++ b/src/userApi/tensor/TensorApi.c
@@ -105,11 +105,15 @@ void tensorFillFromFloatBuffer(tensor_t *tensor, const float *source, size_t cou
 
     /* Non-FLOAT32: route through convertTensor, mirroring the pattern in
      * initTensorWithQSymInt32. Build a temporary FLOAT32 view over `source`
-     * and convert into `tensor`. The const-cast is safe because the only
-     * write convertTensor's helpers do back into `inputTensor` is through
-     * `copyDimsAndSparsityToTensor`, which assigns `outputTensor->shape =
-     * inputTensor->shape` — given that we set `srcView.shape = tensor->shape`,
-     * that write is a self-assignment of the same pointer back into tensor. */
+     * and convert into `tensor`. The const-cast is safe per converter:
+     *   - SYM_INT32: convertFloatTensorToSymInt32Tensor writes only to
+     *     outputTensor->data and outputTensor->quantization->qConfig->scale.
+     *   - INT32 / ASYM: convertFloatTensorTo{Int32,Asym}Tensor end with
+     *     copyDimsAndSparsityToTensor(input, output), which writes
+     *     outputTensor->shape = inputTensor->shape. Since we set
+     *     srcView.shape = tensor->shape, that write self-assigns the same
+     *     pointer back into tensor — harmless. srcView.sparsity is NULL so
+     *     the sparsity memcpy branch is skipped. */
     quantization_t floatQ;
     initFloat32Quantization(&floatQ);
     tensor_t srcView;

--- a/src/userApi/tensor/TensorApi.c
+++ b/src/userApi/tensor/TensorApi.c
@@ -1,20 +1,19 @@
 #define SOURCE_FILE "TENSOR_API"
 
 #include <math.h>
-#include <stdlib.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
-#include "Rounding.h"
-#include "TensorConversion.h"
-#include "TensorApiInternal.h"
-#include "TensorApi.h"
-#include "StorageApi.h"
-#include "QuantizationApi.h"
 #include "Common.h"
 #include "Distributions.h"
-
+#include "QuantizationApi.h"
+#include "Rounding.h"
+#include "StorageApi.h"
+#include "TensorApi.h"
+#include "TensorApiInternal.h"
+#include "TensorConversion.h"
 
 // tensor inits
 
@@ -77,6 +76,19 @@ tensor_t *tensorInit(float *data, size_t *dims, size_t numberOfDims, quantizatio
         PRINT_ERROR("Unknown QType");
         exit(1);
     }
+}
+
+tensor_t *initTensor(shape_t *shape, quantization_t *quantization, sparsity_t *sparsity) {
+    tensor_t *tensor = reserveMemory(sizeof(tensor_t));
+    tensor->shape = shape;
+    tensor->quantization = quantization;
+    tensor->sparsity = sparsity;
+
+    size_t numberOfElements = calcNumberOfElementsByShape(shape);
+    size_t bytes = calcNumberOfBytesForData(quantization, numberOfElements);
+    tensor->data = reserveMemory(bytes);
+
+    return tensor;
 }
 
 tensor_t *tensorInitWithDistribution(distributionType_t distributionType, float *data, size_t *dims,
@@ -343,7 +355,6 @@ void freeParameter(parameter_t *parameter) {
     freeTensor(parameter->grad);
     freeReservedMemory(parameter);
 }
-
 
 static tensor_t *initTensorWithQInt32(int32_t *data, size_t *dims, size_t numberOfDims,
                                       quantization_t *quantization, sparsity_t *sparsity) {

--- a/src/userApi/tensor/TensorApi.c
+++ b/src/userApi/tensor/TensorApi.c
@@ -105,8 +105,11 @@ void tensorFillFromFloatBuffer(tensor_t *tensor, const float *source, size_t cou
 
     /* Non-FLOAT32: route through convertTensor, mirroring the pattern in
      * initTensorWithQSymInt32. Build a temporary FLOAT32 view over `source`
-     * and convert into `tensor`. The const-cast is safe: convertTensor only
-     * reads from inputTensor->data. */
+     * and convert into `tensor`. The const-cast is safe because the only
+     * write convertTensor's helpers do back into `inputTensor` is through
+     * `copyDimsAndSparsityToTensor`, which assigns `outputTensor->shape =
+     * inputTensor->shape` — given that we set `srcView.shape = tensor->shape`,
+     * that write is a self-assignment of the same pointer back into tensor. */
     quantization_t floatQ;
     initFloat32Quantization(&floatQ);
     tensor_t srcView;

--- a/src/userApi/tensor/include/TensorApi.h
+++ b/src/userApi/tensor/include/TensorApi.h
@@ -96,6 +96,19 @@ tensor_t *tensorInitWithDistribution(distributionType_t distributionType, float 
  */
 tensor_t *initTensor(shape_t *shape, quantization_t *quantization, sparsity_t *sparsity);
 
+/*! Populates an already-initialized tensor's data buffer with values drawn
+ * from the given distribution. Tensor must be FLOAT32-quantized in this
+ * iteration; non-FLOAT32 support is a follow-up.
+ *
+ * The tensor must have its data buffer already allocated (via initTensor).
+ * The distribution value is read by `distribution->type`; the matching
+ * union member supplies the kind-specific parameters.
+ *
+ * \param tensor: Pre-initialized FLOAT32 tensor.
+ * \param distribution: Recipe for value generation. Read-only.
+ */
+void initDistribution(tensor_t *tensor, const distribution_t *distribution);
+
 /*! Initializes int32 gradient tensor to match given param tensor.
  *
  * \param param: Pointer to param tensor

--- a/src/userApi/tensor/include/TensorApi.h
+++ b/src/userApi/tensor/include/TensorApi.h
@@ -109,6 +109,16 @@ tensor_t *initTensor(shape_t *shape, quantization_t *quantization, sparsity_t *s
  */
 void initDistribution(tensor_t *tensor, const distribution_t *distribution);
 
+/*! Copies `count` floats from a caller-owned source into a tensor's data
+ * buffer. Caller retains ownership of `source`. If the tensor is non-FLOAT32
+ * quantized, values are converted via the tensor's quantization.
+ *
+ * \param tensor: Pre-initialized tensor.
+ * \param source: Caller-owned float array (any storage class).
+ * \param count: Number of floats; must equal the tensor's element count.
+ */
+void tensorFillFromFloatBuffer(tensor_t *tensor, const float *source, size_t count);
+
 /*! Initializes int32 gradient tensor to match given param tensor.
  *
  * \param param: Pointer to param tensor

--- a/src/userApi/tensor/include/TensorApi.h
+++ b/src/userApi/tensor/include/TensorApi.h
@@ -1,9 +1,8 @@
 #ifndef TENSOR_H
 #define TENSOR_H
 
-#include "Tensor.h"
 #include "Distributions.h"
-
+#include "Tensor.h"
 
 /*! Initializes int32 tensor with given data and shape.
  *
@@ -14,7 +13,7 @@
  *
  * \returns Pointer to initialized tensor
  */
-tensor_t* tensorInitInt32(int32_t* data, size_t* dims, size_t numberOfDims, sparsity_t* sparsity);
+tensor_t *tensorInitInt32(int32_t *data, size_t *dims, size_t numberOfDims, sparsity_t *sparsity);
 /*! Initializes float tensor with given data and shape.
  *
  * \param data: Data of tensor
@@ -24,7 +23,7 @@ tensor_t* tensorInitInt32(int32_t* data, size_t* dims, size_t numberOfDims, spar
  *
  * \returns Pointer to initialized tensor
  */
-tensor_t* tensorInitFloat(float* data, size_t* dims, size_t numberOfDims, sparsity_t* sparsity);
+tensor_t *tensorInitFloat(float *data, size_t *dims, size_t numberOfDims, sparsity_t *sparsity);
 /*! Initializes symInt32 tensor with given data and shape.
  *
  * \param data: Data of tensor
@@ -35,8 +34,8 @@ tensor_t* tensorInitFloat(float* data, size_t* dims, size_t numberOfDims, sparsi
  *
  * \returns Pointer to initialized tensor
  */
-tensor_t* tensorInitSymInt32(float* data, size_t* dims, size_t numberOfDims,
-                             roundingMode_t roundingMode, sparsity_t* sparsity);
+tensor_t *tensorInitSymInt32(float *data, size_t *dims, size_t numberOfDims,
+                             roundingMode_t roundingMode, sparsity_t *sparsity);
 /*! Initializes asym tensor with given data and shape.
  *
  * \param data: Data of tensor
@@ -48,8 +47,8 @@ tensor_t* tensorInitSymInt32(float* data, size_t* dims, size_t numberOfDims,
  *
  * \returns Pointer to initialized tensor
  */
-tensor_t* tensorInitAsym(float* data, size_t* dims, size_t numberOfDims, uint8_t qBits,
-                         roundingMode_t roundingMode, sparsity_t* sparsity);
+tensor_t *tensorInitAsym(float *data, size_t *dims, size_t numberOfDims, uint8_t qBits,
+                         roundingMode_t roundingMode, sparsity_t *sparsity);
 /*! Initializes tensor to match given quantization.
  *
  * \param data: Data of tensor
@@ -60,8 +59,8 @@ tensor_t* tensorInitAsym(float* data, size_t* dims, size_t numberOfDims, uint8_t
  *
  * \returns Pointer to initialized tensor
  */
-tensor_t* tensorInit(float* data, size_t* dims, size_t numberOfDims, quantization_t* quantization,
-                     sparsity_t* sparsity);
+tensor_t *tensorInit(float *data, size_t *dims, size_t numberOfDims, quantization_t *quantization,
+                     sparsity_t *sparsity);
 /*! Initializes tensor with distribution to match given quantization.
  *
  * \param distributionType: Type of distribution to be used
@@ -80,6 +79,23 @@ tensor_t *tensorInitWithDistribution(distributionType_t distributionType, float 
                                      sparsity_t *sparsity, size_t inputFeatures,
                                      size_t outputFeatures);
 
+/*! Initializes a tensor that owns its data buffer.
+ *
+ * The tensor takes ownership of `shape`, `quantization`, and `sparsity` (if non-NULL).
+ * The data buffer is allocated by initTensor itself (size derived from shape and
+ * quantization) and is zero-initialized.
+ *
+ * After this call, freeTensor(t) is unconditionally safe and frees all four
+ * ownership domains (data, shape, quantization, sparsity).
+ *
+ * \param shape: Caller-allocated shape; ownership transferred to the tensor.
+ * \param quantization: Caller-allocated quantization; ownership transferred.
+ * \param sparsity: Optional; ownership transferred (NULL means no sparsity).
+ *
+ * \returns Pointer to an initialized tensor with own-allocated zero data.
+ */
+tensor_t *initTensor(shape_t *shape, quantization_t *quantization, sparsity_t *sparsity);
+
 /*! Initializes int32 gradient tensor to match given param tensor.
  *
  * \param param: Pointer to param tensor
@@ -87,7 +103,7 @@ tensor_t *tensorInitWithDistribution(distributionType_t distributionType, float 
  *
  * \returns Pointer to initialized gradient tensor
  */
-tensor_t* gradInitInt32(tensor_t* param, sparsity_t* sparsity);
+tensor_t *gradInitInt32(tensor_t *param, sparsity_t *sparsity);
 /*! Initializes float gradient tensor to match given param tensor.
  *
  * \param param: Pointer to param tensor
@@ -95,7 +111,7 @@ tensor_t* gradInitInt32(tensor_t* param, sparsity_t* sparsity);
  *
  * \returns Pointer to initialized gradient tensor
  */
-tensor_t* gradInitFloat(tensor_t* param, sparsity_t* sparsity);
+tensor_t *gradInitFloat(tensor_t *param, sparsity_t *sparsity);
 /*! Initializes symInt32 gradient tensor to match given param tensor.
  *
  * \param param: Pointer to param tensor
@@ -103,7 +119,7 @@ tensor_t* gradInitFloat(tensor_t* param, sparsity_t* sparsity);
  *
  * \returns Pointer to initialized gradient tensor
  */
-tensor_t* gradInitSymInt32(tensor_t* param, roundingMode_t roundingMode, sparsity_t* sparsity);
+tensor_t *gradInitSymInt32(tensor_t *param, roundingMode_t roundingMode, sparsity_t *sparsity);
 /*! Initializes asym gradient tensor to match given param tensor.
  *
  * \param param: Pointer to param tensor
@@ -111,7 +127,8 @@ tensor_t* gradInitSymInt32(tensor_t* param, roundingMode_t roundingMode, sparsit
  *
  * \returns Pointer to initialized gradient tensor
  */
-tensor_t* gradInitAsym(tensor_t* param, uint8_t qBits, roundingMode_t roundingMode, sparsity_t* sparsity);
+tensor_t *gradInitAsym(tensor_t *param, uint8_t qBits, roundingMode_t roundingMode,
+                       sparsity_t *sparsity);
 
 /*! Initializes parameter with given param and graident tensor.
  *
@@ -120,7 +137,7 @@ tensor_t* gradInitAsym(tensor_t* param, uint8_t qBits, roundingMode_t roundingMo
  *
  * \returns Pointer to initialized parameter
  */
-parameter_t* parameterInit(tensor_t* param, tensor_t* grad);
+parameter_t *parameterInit(tensor_t *param, tensor_t *grad);
 
 /*! Gets quantization that matches a given quantization.
  *
@@ -128,14 +145,14 @@ parameter_t* parameterInit(tensor_t* param, tensor_t* grad);
  *
  * \returns Pointer to quantization with matching type and config
  */
-quantization_t* getQLike(quantization_t* quantization);
+quantization_t *getQLike(quantization_t *quantization);
 /*! Gets tensor that matches a given tensor.
  *
  * \param tensor: Pointer to tensor
  *
  * \returns Pointer to tensor with matching shape, sparsity and quantization
  */
-tensor_t* getTensorLike(tensor_t* tensor);
+tensor_t *getTensorLike(tensor_t *tensor);
 /*! Gets shape that matches a given shape.
  *
  * \param shape: Pointer to shape
@@ -159,34 +176,33 @@ uint8_t *getDataLike(quantization_t *quantization, size_t numberOfValues);
  */
 sparsity_t *getSparsityLike(sparsity_t *sparsity);
 
-
-
-// IMPORTANT: these are needed for trainingAPI.c to free gradTensors without freeing the actual Pointer
+// IMPORTANT: these are needed for trainingAPI.c to free gradTensors without freeing the actual
+// Pointer
 /*! Frees data of tensor.
  *
  * \param tensor: Pointer to tensor
  */
-void freeData(tensor_t* tensor);
+void freeData(tensor_t *tensor);
 /*! Frees shape of tensor.
  *
  * \param shape: Pointer to shape
  */
-void freeShape(shape_t* shape);
+void freeShape(shape_t *shape);
 /*! Frees quantization of tensor.
  *
  * \param quantization: Pointer to quantization
  */
-void freeQuantization(quantization_t* quantization);
+void freeQuantization(quantization_t *quantization);
 
 /*! Frees tensor.
  *
  * \param tensor: Pointer to tensor
  */
-void freeTensor(tensor_t* tensor);
+void freeTensor(tensor_t *tensor);
 /*! Frees parameter.
  *
  * \param parameter: Pointer to parameter
  */
 void freeParameter(parameter_t *parameter);
 
-#endif //TENSOR_H
+#endif // TENSOR_H

--- a/src/userApi/tensor/include/TensorApi.h
+++ b/src/userApi/tensor/include/TensorApi.h
@@ -13,7 +13,10 @@
  *
  * \returns Pointer to initialized tensor
  */
-tensor_t *tensorInitInt32(int32_t *data, size_t *dims, size_t numberOfDims, sparsity_t *sparsity);
+__attribute__((deprecated("Use initTensor(shape, quantization, sparsity) + "
+                          "tensorFillFromFloatBuffer or initDistribution instead. "
+                          "Old API will be removed in Phase 2."))) tensor_t *
+tensorInitInt32(int32_t *data, size_t *dims, size_t numberOfDims, sparsity_t *sparsity);
 /*! Initializes float tensor with given data and shape.
  *
  * \param data: Data of tensor
@@ -23,7 +26,10 @@ tensor_t *tensorInitInt32(int32_t *data, size_t *dims, size_t numberOfDims, spar
  *
  * \returns Pointer to initialized tensor
  */
-tensor_t *tensorInitFloat(float *data, size_t *dims, size_t numberOfDims, sparsity_t *sparsity);
+__attribute__((deprecated("Use initTensor(shape, quantization, sparsity) + "
+                          "tensorFillFromFloatBuffer or initDistribution instead. "
+                          "Old API will be removed in Phase 2."))) tensor_t *
+tensorInitFloat(float *data, size_t *dims, size_t numberOfDims, sparsity_t *sparsity);
 /*! Initializes symInt32 tensor with given data and shape.
  *
  * \param data: Data of tensor
@@ -34,8 +40,11 @@ tensor_t *tensorInitFloat(float *data, size_t *dims, size_t numberOfDims, sparsi
  *
  * \returns Pointer to initialized tensor
  */
-tensor_t *tensorInitSymInt32(float *data, size_t *dims, size_t numberOfDims,
-                             roundingMode_t roundingMode, sparsity_t *sparsity);
+__attribute__((deprecated("Use initTensor(shape, quantization, sparsity) + "
+                          "tensorFillFromFloatBuffer or initDistribution instead. "
+                          "Old API will be removed in Phase 2."))) tensor_t *
+tensorInitSymInt32(float *data, size_t *dims, size_t numberOfDims, roundingMode_t roundingMode,
+                   sparsity_t *sparsity);
 /*! Initializes asym tensor with given data and shape.
  *
  * \param data: Data of tensor
@@ -47,8 +56,11 @@ tensor_t *tensorInitSymInt32(float *data, size_t *dims, size_t numberOfDims,
  *
  * \returns Pointer to initialized tensor
  */
-tensor_t *tensorInitAsym(float *data, size_t *dims, size_t numberOfDims, uint8_t qBits,
-                         roundingMode_t roundingMode, sparsity_t *sparsity);
+__attribute__((deprecated("Use initTensor(shape, quantization, sparsity) + "
+                          "tensorFillFromFloatBuffer or initDistribution instead. "
+                          "Old API will be removed in Phase 2."))) tensor_t *
+tensorInitAsym(float *data, size_t *dims, size_t numberOfDims, uint8_t qBits,
+               roundingMode_t roundingMode, sparsity_t *sparsity);
 /*! Initializes tensor to match given quantization.
  *
  * \param data: Data of tensor
@@ -59,8 +71,11 @@ tensor_t *tensorInitAsym(float *data, size_t *dims, size_t numberOfDims, uint8_t
  *
  * \returns Pointer to initialized tensor
  */
-tensor_t *tensorInit(float *data, size_t *dims, size_t numberOfDims, quantization_t *quantization,
-                     sparsity_t *sparsity);
+__attribute__((deprecated("Use initTensor(shape, quantization, sparsity) + "
+                          "tensorFillFromFloatBuffer or initDistribution instead. "
+                          "Old API will be removed in Phase 2."))) tensor_t *
+tensorInit(float *data, size_t *dims, size_t numberOfDims, quantization_t *quantization,
+           sparsity_t *sparsity);
 /*! Initializes tensor with distribution to match given quantization.
  *
  * \param distributionType: Type of distribution to be used
@@ -74,10 +89,12 @@ tensor_t *tensorInit(float *data, size_t *dims, size_t numberOfDims, quantizatio
  *
  * \returns Pointer to initialized tensor
  */
-tensor_t *tensorInitWithDistribution(distributionType_t distributionType, float *data, size_t *dims,
-                                     size_t numberOfDims, quantization_t *quantization,
-                                     sparsity_t *sparsity, size_t inputFeatures,
-                                     size_t outputFeatures);
+__attribute__((deprecated("Use initTensor(shape, quantization, sparsity) + "
+                          "initDistribution(t, &distribution) instead. "
+                          "Old API will be removed in Phase 2."))) tensor_t *
+tensorInitWithDistribution(distributionType_t distributionType, float *data, size_t *dims,
+                           size_t numberOfDims, quantization_t *quantization, sparsity_t *sparsity,
+                           size_t inputFeatures, size_t outputFeatures);
 
 /*! Initializes a tensor that owns its data buffer.
  *

--- a/src/userApi/training_loop/TrainingLoopApi.c
+++ b/src/userApi/training_loop/TrainingLoopApi.c
@@ -2,15 +2,14 @@
 
 #include <stddef.h>
 
-#include "TrainingLoopApi.h"
-#include "TrainingEpochDefault.h"
-#include "InferenceApi.h"
-#include "TensorApi.h"
-#include "StorageApi.h"
 #include "Common.h"
 #include "DataLoaderApi.h"
+#include "InferenceApi.h"
 #include "Optimizer.h"
-
+#include "StorageApi.h"
+#include "TensorApi.h"
+#include "TrainingEpochDefault.h"
+#include "TrainingLoopApi.h"
 
 void freeTrainingStats(trainingStats_t *trainingStats) {
     freeTensor(trainingStats->output);
@@ -22,11 +21,11 @@ float evaluationBatch(layer_t **model, size_t modelSize, lossType_t lossType, ba
     float totalLoss = 0.0f;
 
     for (size_t i = 0; i < batch->size; i++) {
-        inferenceStats_t *stats =
-            inferenceFn(model, modelSize, batch->samples[i]->item, batch->samples[i]->label,
-                        lossType);
+        inferenceStats_t *stats = inferenceFn(model, modelSize, batch->samples[i]->item,
+                                              batch->samples[i]->label, lossType);
         totalLoss += stats->loss;
         freeInferenceStats(stats);
+        freeSample(batch->samples[i]);
     }
 
     return totalLoss / (float)batch->size;
@@ -61,15 +60,14 @@ float evaluationEpoch(layer_t **model, size_t modelSize, lossType_t lossType,
 }
 
 static float evaluateBatchInternal(layer_t **model, size_t modelSize, lossType_t lossType,
-                                    batch_t *batch, inferenceWithLossFn_t inferenceFn,
-                                    size_t *tp, size_t *predCount, size_t *actualCount,
-                                    size_t *confusionMatrix, size_t numClasses) {
+                                   batch_t *batch, inferenceWithLossFn_t inferenceFn, size_t *tp,
+                                   size_t *predCount, size_t *actualCount, size_t *confusionMatrix,
+                                   size_t numClasses) {
     float totalLoss = 0.0f;
 
     for (size_t i = 0; i < batch->size; i++) {
-        inferenceStats_t *stats =
-            inferenceFn(model, modelSize, batch->samples[i]->item, batch->samples[i]->label,
-                        lossType);
+        inferenceStats_t *stats = inferenceFn(model, modelSize, batch->samples[i]->item,
+                                              batch->samples[i]->label, lossType);
         totalLoss += stats->loss;
 
         float *outputData = (float *)stats->output->data;
@@ -77,7 +75,9 @@ static float evaluateBatchInternal(layer_t **model, size_t modelSize, lossType_t
         size_t predicted = argmax(outputData, numClasses);
         size_t target = argmax(labelData, numClasses);
 
-        if (predicted == target) tp[predicted]++;
+        if (predicted == target) {
+            tp[predicted]++;
+        }
         predCount[predicted]++;
         actualCount[target]++;
 
@@ -86,6 +86,7 @@ static float evaluateBatchInternal(layer_t **model, size_t modelSize, lossType_t
         }
 
         freeInferenceStats(stats);
+        freeSample(batch->samples[i]);
     }
 
     return totalLoss / (float)batch->size;
@@ -120,7 +121,7 @@ static float computeMacroRecall(const size_t *tp, const size_t *actualCount, siz
 }
 
 static float computeMacroF1(const size_t *tp, const size_t *predCount, const size_t *actualCount,
-                             size_t numClasses) {
+                            size_t numClasses) {
     float sum = 0.0f;
     for (size_t c = 0; c < numClasses; c++) {
         float prec = (predCount[c] > 0) ? (float)tp[c] / (float)predCount[c] : 0.0f;
@@ -133,9 +134,9 @@ static float computeMacroF1(const size_t *tp, const size_t *predCount, const siz
 }
 
 static epochStats_t evaluateEpochInternal(layer_t **model, size_t modelSize, lossType_t lossType,
-                                           dataLoader_t *dataLoader,
-                                           inferenceWithLossFn_t inferenceFn,
-                                           size_t *confusionMatrix, size_t numClasses) {
+                                          dataLoader_t *dataLoader,
+                                          inferenceWithLossFn_t inferenceFn,
+                                          size_t *confusionMatrix, size_t numClasses) {
     size_t datasetSize = dataLoader->getDatasetSize();
     size_t numberOfBatches = datasetSize / dataLoader->batchSize;
 
@@ -154,9 +155,8 @@ static epochStats_t evaluateEpochInternal(layer_t **model, size_t modelSize, los
 
     for (size_t i = 0; i < numberOfBatches; i++) {
         batch_t *batch = dataLoader->getBatch(dataLoader, i);
-        totalLoss += evaluateBatchInternal(model, modelSize, lossType, batch, inferenceFn,
-                                            tp, predCount, actualCount, confusionMatrix,
-                                            numClasses);
+        totalLoss += evaluateBatchInternal(model, modelSize, lossType, batch, inferenceFn, tp,
+                                           predCount, actualCount, confusionMatrix, numClasses);
         totalSamples += batch->size;
         freeBatch(batch);
     }
@@ -181,17 +181,19 @@ epochStats_t evaluationEpochWithMetrics(layer_t **model, size_t modelSize, lossT
     // Peek at first sample to derive numClasses from label shape
     batch_t *firstBatch = dataLoader->getBatch(dataLoader, 0);
     size_t numClasses = calcNumberOfElementsByTensor(firstBatch->samples[0]->label);
+    for (size_t i = 0; i < firstBatch->size; i++) {
+        freeSample(firstBatch->samples[i]);
+    }
     freeBatch(firstBatch);
 
-    return evaluateEpochInternal(model, modelSize, lossType, dataLoader, inferenceFn,
-                                  NULL, numClasses);
+    return evaluateEpochInternal(model, modelSize, lossType, dataLoader, inferenceFn, NULL,
+                                 numClasses);
 }
 
 classificationReport_t evaluationEpochWithReport(layer_t **model, size_t modelSize,
-                                                  lossType_t lossType,
-                                                  dataLoader_t *dataLoader,
-                                                  inferenceWithLossFn_t inferenceFn,
-                                                  size_t *cmBuffer, size_t numClasses) {
+                                                 lossType_t lossType, dataLoader_t *dataLoader,
+                                                 inferenceWithLossFn_t inferenceFn,
+                                                 size_t *cmBuffer, size_t numClasses) {
     // Zero the caller's CM buffer
     for (size_t i = 0; i < numClasses * numClasses; i++) {
         cmBuffer[i] = 0;
@@ -199,7 +201,7 @@ classificationReport_t evaluationEpochWithReport(layer_t **model, size_t modelSi
 
     classificationReport_t report;
     report.stats = evaluateEpochInternal(model, modelSize, lossType, dataLoader, inferenceFn,
-                                          cmBuffer, numClasses);
+                                         cmBuffer, numClasses);
     report.confusionMatrix = cmBuffer;
     report.numClasses = numClasses;
     return report;
@@ -209,21 +211,22 @@ trainingRunResult_t trainingRun(layer_t **model, size_t modelSize, lossType_t lo
                                 dataLoader_t *trainDataLoader, dataLoader_t *evalDataLoader,
                                 optimizer_t *optimizer, size_t numberOfEpochs,
                                 calculateGradsFn_t calculateGradsFn,
-                                inferenceWithLossFn_t inferenceFn,
-                                epochCallbackFn_t callback) {
+                                inferenceWithLossFn_t inferenceFn, epochCallbackFn_t callback) {
     trainingRunResult_t result = {0};
 
     // Derive numClasses from eval dataset labels
     batch_t *firstBatch = evalDataLoader->getBatch(evalDataLoader, 0);
     size_t numClasses = calcNumberOfElementsByTensor(firstBatch->samples[0]->label);
+    for (size_t i = 0; i < firstBatch->size; i++) {
+        freeSample(firstBatch->samples[i]);
+    }
     freeBatch(firstBatch);
 
     for (size_t epoch = 0; epoch < numberOfEpochs; epoch++) {
         float trainLoss = trainingEpochDefault(model, modelSize, lossType, trainDataLoader,
                                                optimizer, calculateGradsFn);
-        epochStats_t evalStats = evaluateEpochInternal(model, modelSize, lossType,
-                                                        evalDataLoader, inferenceFn,
-                                                        NULL, numClasses);
+        epochStats_t evalStats = evaluateEpochInternal(model, modelSize, lossType, evalDataLoader,
+                                                       inferenceFn, NULL, numClasses);
 
         if (callback != NULL) {
             callback(epoch, trainLoss, evalStats);

--- a/src/userApi/training_loop/TrainingLoopApi.c
+++ b/src/userApi/training_loop/TrainingLoopApi.c
@@ -139,9 +139,9 @@ static epochStats_t evaluateEpochInternal(layer_t **model, size_t modelSize, los
     size_t datasetSize = dataLoader->getDatasetSize();
     size_t numberOfBatches = datasetSize / dataLoader->batchSize;
 
-    size_t *tp = *reserveMemory(numClasses * sizeof(size_t));
-    size_t *predCount = *reserveMemory(numClasses * sizeof(size_t));
-    size_t *actualCount = *reserveMemory(numClasses * sizeof(size_t));
+    size_t *tp = reserveMemory(numClasses * sizeof(size_t));
+    size_t *predCount = reserveMemory(numClasses * sizeof(size_t));
+    size_t *actualCount = reserveMemory(numClasses * sizeof(size_t));
 
     for (size_t c = 0; c < numClasses; c++) {
         tp[c] = 0;

--- a/src/userApi/training_loop/calculate_grads/CalculateGradsSequential.c
+++ b/src/userApi/training_loop/calculate_grads/CalculateGradsSequential.c
@@ -2,215 +2,216 @@
 
 #include <stdbool.h>
 #include <stdio.h>
-#include <string.h>
 #include <stdlib.h>
+#include <string.h>
 
-#include "LossFunction.h"
-#include "Layer.h"
-#include "TensorApi.h"
-#include "StorageApi.h"
 #include "CalculateGradsSequential.h"
-#include "TrainingLoopApiInternal.h"
-#include "Linear.h"
-#include "Relu.h"
 #include "Common.h"
+#include "Layer.h"
+#include "Linear.h"
+#include "LossFunction.h"
+#include "Relu.h"
 #include "Softmax.h"
+#include "StorageApi.h"
+#include "TensorApi.h"
+#include "TrainingLoopApiInternal.h"
 
+trainingStats_t *calculateGradsSequential(layer_t **model, size_t modelSize, lossType_t lossType,
+                                          tensor_t *input, tensor_t *label) {
 
-trainingStats_t *calculateGradsSequential(layer_t **model, size_t modelSize,
-                                          lossType_t lossType, tensor_t *input,
-                                          tensor_t *label) {
+  tensor_t *layerOutputs[modelSize + 1];
+  layerOutputs[0] = input;
+  initLayerOutputs(layerOutputs, model, modelSize);
 
-    tensor_t *layerOutputs[modelSize + 1];
-    layerOutputs[0] = input;
-    initLayerOutputs(layerOutputs, model, modelSize);
+  // Forward pass
+  for (size_t i = 0; i < modelSize; i++) {
+    layer_t *currentLayer = model[i];
+    layerType_t currentLayerType = currentLayer->type;
+    forwardFn_t forward = layerFunctions[currentLayerType].forward;
+    forward(currentLayer, layerOutputs[i], layerOutputs[i + 1]);
+  }
 
-    // Forward pass
-    for (size_t i = 0; i < modelSize; i++) {
-        layer_t *currentLayer = model[i];
-        layerType_t currentLayerType = currentLayer->type;
-        forwardFn_t forward = layerFunctions[currentLayerType].forward;
-        forward(currentLayer, layerOutputs[i], layerOutputs[i + 1]);
-    }
+  trainingStats_t *trainingStats = initTrainingStats(layerOutputs[modelSize]);
+  copyTensor(trainingStats->output, layerOutputs[modelSize]);
 
-    trainingStats_t *trainingStats = initTrainingStats(layerOutputs[modelSize]);
-    copyTensor(trainingStats->output, layerOutputs[modelSize]);
+  // LOSS
 
-    // LOSS
+  lossFunctions_t lossFns = lossFunctions[lossType];
+  float loss = lossFns.forward(layerOutputs[modelSize], label);
+  trainingStats->loss = loss;
 
-    lossFunctions_t lossFns = lossFunctions[lossType];
-    float loss = lossFns.forward(layerOutputs[modelSize], label);
-    trainingStats->loss = loss;
+  // Backward pass
+  size_t backwardIndex = modelSize - 1;
+  if (lossType == CROSS_ENTROPY) {
+    backwardIndex -= 1;
+  }
 
-    // Backward pass
-    size_t backwardIndex = modelSize - 1;
-    if (lossType == CROSS_ENTROPY) {
-        backwardIndex -= 1;
-    }
+  tensor_t gradNext;
+  initGradTensor(&gradNext, layerOutputs[modelSize]);
+  lossFns.backward(layerOutputs[modelSize], label, &gradNext);
 
-    tensor_t gradNext;
-    initGradTensor(&gradNext, layerOutputs[modelSize]);
-    lossFns.backward(layerOutputs[modelSize], label, &gradNext);
+  for (int i = (int)backwardIndex; i >= 0; i--) {
+    tensor_t gradCurr;
+    initGradTensor(&gradCurr, layerOutputs[i]);
 
-    for (int i = (int)backwardIndex; i >= 0; i--) {
-        tensor_t gradCurr;
-        initGradTensor(&gradCurr, layerOutputs[i]);
+    layerType_t layerType = model[i]->type;
+    backwardFn_t backward = layerFunctions[layerType].backward;
 
-        layerType_t layerType = model[i]->type;
-        backwardFn_t backward = layerFunctions[layerType].backward;
-
-        backward(model[i], layerOutputs[i], &gradNext, &gradCurr);
-
-        deInitGradTensor(&gradNext);
-        gradNext = gradCurr;
-    }
+    backward(model[i], layerOutputs[i], &gradNext, &gradCurr);
 
     deInitGradTensor(&gradNext);
-    deInitLayerOutputs(layerOutputs, modelSize);
+    gradNext = gradCurr;
+  }
 
-    return trainingStats;
+  deInitGradTensor(&gradNext);
+  deInitLayerOutputs(layerOutputs, modelSize);
+
+  return trainingStats;
 }
-
 
 static void initLayerOutputs(tensor_t **layerOutputs, layer_t **model, size_t sizeNetwork) {
-    for (size_t i = 0; i < sizeNetwork; i++) {
-        layer_t *currentLayer = model[i];
-        quantization_t *currentQ = NULL;
+  for (size_t i = 0; i < sizeNetwork; i++) {
+    layer_t *currentLayer = model[i];
+    quantization_t *currentQ = NULL;
 
-        switch (currentLayer->type) {
-        case LINEAR:
-            linearConfig_t *linearConfig = currentLayer->config->linear;
-            currentQ = linearConfig->forwardQ;
-            break;
-        case RELU:
-            reluConfig_t *reluConfig = currentLayer->config->relu;
-            currentQ = reluConfig->forwardQ;
-            break;
-        case SOFTMAX:
-            softmaxConfig_t *softmaxConfig = currentLayer->config->softmax;
-            currentQ = softmaxConfig->forwardQ;
-            break;
-        default:
-            PRINT_ERROR("Unknown Layer Type!");
-            exit(1);
-        }
-
-        calcOutputShapeFn_t calcOutputShape = layerFunctions[currentLayer->type].calcOutputShape;
-        size_t numberOfDims = layerOutputs[i]->shape->numberOfDimensions;
-
-        size_t *dims = *reserveMemory(numberOfDims * sizeof(size_t));
-        size_t *order = *reserveMemory(numberOfDims * sizeof(size_t));
-        shape_t *outShape = *reserveMemory(sizeof(shape_t));
-
-        outShape->dimensions = dims;
-        outShape->numberOfDimensions = numberOfDims;
-        outShape->orderOfDimensions = order;
-
-        calcOutputShape(currentLayer, layerOutputs[i]->shape, outShape);
-
-        size_t numberOfValues = calcNumberOfElementsByShape(outShape);
-        size_t sizeData = calcNumberOfBytesForData(currentQ, numberOfValues);
-        uint8_t *data = *reserveMemory(sizeData);
-
-        quantization_t *q = *reserveMemory(sizeof(quantization_t));
-        switch (currentQ->type) {
-        case FLOAT32:
-            initFloat32Quantization(q);
-            break;
-        case SYM_INT32:
-            q->type = SYM_INT32;
-            symInt32QConfig_t *currentQC = currentQ->qConfig;
-            symInt32QConfig_t *qC = *reserveMemory(sizeof(symInt32QConfig_t));
-            initSymInt32QConfig(currentQC->roundingMode, qC);
-            initSymInt32Quantization(qC, q);
-            break;
-        default:
-            PRINT_ERROR("Unknown QType!");
-            exit(1);
-        }
-
-        tensor_t *tensor = *reserveMemory(sizeof(tensor_t));
-        tensor->data = data;
-        tensor->quantization = q;
-        tensor->shape = outShape;
-
-        tensor->sparsity = NULL;
-        if (layerOutputs[i]->sparsity != NULL) {
-            sparsity_t *sparsity = *reserveMemory(sizeof(sparsity_t));
-            tensor->sparsity = sparsity;
-        }
-
-        layerOutputs[i + 1] = tensor;
+    switch (currentLayer->type) {
+    case LINEAR:
+      linearConfig_t *linearConfig = currentLayer->config->linear;
+      currentQ = linearConfig->forwardQ;
+      break;
+    case RELU:
+      reluConfig_t *reluConfig = currentLayer->config->relu;
+      currentQ = reluConfig->forwardQ;
+      break;
+    case SOFTMAX:
+      softmaxConfig_t *softmaxConfig = currentLayer->config->softmax;
+      currentQ = softmaxConfig->forwardQ;
+      break;
+    case FLATTEN:
+      // Flatten has no per-layer quantization; output dtype equals input dtype.
+      currentQ = layerOutputs[i]->quantization;
+      break;
+    default:
+      PRINT_ERROR("Unknown Layer Type!");
+      exit(1);
     }
-}
 
-static void deInitLayerOutputs(tensor_t **layerOutputs, size_t modelSize) {
-    for (size_t i = 1; i <= modelSize; i++) {
-        freeTensor(layerOutputs[i]);
-    }
-}
+    calcOutputShapeFn_t calcOutputShape = layerFunctions[currentLayer->type].calcOutputShape;
+    size_t numberOfDims = layerOutputs[i]->shape->numberOfDimensions;
 
-static void initGradTensor(tensor_t *grad, tensor_t *layerOutput) {
-    shape_t *currentShape = layerOutput->shape;
-    quantization_t *currentQ = layerOutput->quantization;
+    size_t *dims = *reserveMemory(numberOfDims * sizeof(size_t));
+    size_t *order = *reserveMemory(numberOfDims * sizeof(size_t));
+    shape_t *outShape = *reserveMemory(sizeof(shape_t));
 
-    size_t *dims = *reserveMemory(currentShape->numberOfDimensions * sizeof(size_t));
-    size_t *order = *reserveMemory(currentShape->numberOfDimensions * sizeof(size_t));
-    shape_t *inShape = *reserveMemory(sizeof(shape_t));
+    outShape->dimensions = dims;
+    outShape->numberOfDimensions = numberOfDims;
+    outShape->orderOfDimensions = order;
 
-    inShape->dimensions = dims;
-    inShape->numberOfDimensions = currentShape->numberOfDimensions;
-    inShape->orderOfDimensions = order;
+    calcOutputShape(currentLayer, layerOutputs[i]->shape, outShape);
 
-    memcpy(inShape->dimensions, currentShape->dimensions,
-           currentShape->numberOfDimensions * sizeof(size_t));
-    memcpy(inShape->orderOfDimensions, currentShape->orderOfDimensions,
-           currentShape->numberOfDimensions * sizeof(size_t));
-
-    setOrderOfDimsForNewTensor(inShape->numberOfDimensions, inShape->orderOfDimensions);
-
-    size_t numberOfValues = calcNumberOfElementsByShape(currentShape);
+    size_t numberOfValues = calcNumberOfElementsByShape(outShape);
     size_t sizeData = calcNumberOfBytesForData(currentQ, numberOfValues);
     uint8_t *data = *reserveMemory(sizeData);
 
     quantization_t *q = *reserveMemory(sizeof(quantization_t));
     switch (currentQ->type) {
     case FLOAT32:
-        initFloat32Quantization(q);
-        break;
+      initFloat32Quantization(q);
+      break;
     case SYM_INT32:
-        symInt32QConfig_t *currentQC = currentQ->qConfig;
-        symInt32QConfig_t *qC = *reserveMemory(sizeof(symInt32QConfig_t));
-        initSymInt32QConfig(currentQC->roundingMode, qC);
-        initSymInt32Quantization(qC, q);
-        break;
+      q->type = SYM_INT32;
+      symInt32QConfig_t *currentQC = currentQ->qConfig;
+      symInt32QConfig_t *qC = *reserveMemory(sizeof(symInt32QConfig_t));
+      initSymInt32QConfig(currentQC->roundingMode, qC);
+      initSymInt32Quantization(qC, q);
+      break;
     default:
-        PRINT_ERROR("Unknown QType!");
-        exit(1);
+      PRINT_ERROR("Unknown QType!");
+      exit(1);
     }
 
-    grad->data = data;
-    grad->quantization = q;
-    grad->shape = inShape;
+    tensor_t *tensor = *reserveMemory(sizeof(tensor_t));
+    tensor->data = data;
+    tensor->quantization = q;
+    tensor->shape = outShape;
 
-    grad->sparsity = NULL;
-    if (layerOutput->sparsity != NULL) {
-        sparsity_t *sparsity = *reserveMemory(sizeof(sparsity_t));
-        grad->sparsity = sparsity;
+    tensor->sparsity = NULL;
+    if (layerOutputs[i]->sparsity != NULL) {
+      sparsity_t *sparsity = *reserveMemory(sizeof(sparsity_t));
+      tensor->sparsity = sparsity;
     }
+
+    layerOutputs[i + 1] = tensor;
+  }
+}
+
+static void deInitLayerOutputs(tensor_t **layerOutputs, size_t modelSize) {
+  for (size_t i = 1; i <= modelSize; i++) {
+    freeTensor(layerOutputs[i]);
+  }
+}
+
+static void initGradTensor(tensor_t *grad, tensor_t *layerOutput) {
+  shape_t *currentShape = layerOutput->shape;
+  quantization_t *currentQ = layerOutput->quantization;
+
+  size_t *dims = *reserveMemory(currentShape->numberOfDimensions * sizeof(size_t));
+  size_t *order = *reserveMemory(currentShape->numberOfDimensions * sizeof(size_t));
+  shape_t *inShape = *reserveMemory(sizeof(shape_t));
+
+  inShape->dimensions = dims;
+  inShape->numberOfDimensions = currentShape->numberOfDimensions;
+  inShape->orderOfDimensions = order;
+
+  memcpy(inShape->dimensions, currentShape->dimensions,
+         currentShape->numberOfDimensions * sizeof(size_t));
+  memcpy(inShape->orderOfDimensions, currentShape->orderOfDimensions,
+         currentShape->numberOfDimensions * sizeof(size_t));
+
+  setOrderOfDimsForNewTensor(inShape->numberOfDimensions, inShape->orderOfDimensions);
+
+  size_t numberOfValues = calcNumberOfElementsByShape(currentShape);
+  size_t sizeData = calcNumberOfBytesForData(currentQ, numberOfValues);
+  uint8_t *data = *reserveMemory(sizeData);
+
+  quantization_t *q = *reserveMemory(sizeof(quantization_t));
+  switch (currentQ->type) {
+  case FLOAT32:
+    initFloat32Quantization(q);
+    break;
+  case SYM_INT32:
+    symInt32QConfig_t *currentQC = currentQ->qConfig;
+    symInt32QConfig_t *qC = *reserveMemory(sizeof(symInt32QConfig_t));
+    initSymInt32QConfig(currentQC->roundingMode, qC);
+    initSymInt32Quantization(qC, q);
+    break;
+  default:
+    PRINT_ERROR("Unknown QType!");
+    exit(1);
+  }
+
+  grad->data = data;
+  grad->quantization = q;
+  grad->shape = inShape;
+
+  grad->sparsity = NULL;
+  if (layerOutput->sparsity != NULL) {
+    sparsity_t *sparsity = *reserveMemory(sizeof(sparsity_t));
+    grad->sparsity = sparsity;
+  }
 }
 
 static void deInitGradTensor(tensor_t *tensor) {
-    freeData(tensor);
-    freeShape(tensor->shape);
-    freeQuantization(tensor->quantization);
+  freeData(tensor);
+  freeShape(tensor->shape);
+  freeQuantization(tensor->quantization);
 }
 
 static trainingStats_t *initTrainingStats(tensor_t *output) {
-    trainingStats_t *trainingStats = *reserveMemory(sizeof(trainingStats_t));
+  trainingStats_t *trainingStats = *reserveMemory(sizeof(trainingStats_t));
 
-    tensor_t *o = getTensorLike(output);
-    trainingStats->output = o;
+  tensor_t *o = getTensorLike(output);
+  trainingStats->output = o;
 
-    return trainingStats;
+  return trainingStats;
 }

--- a/src/userApi/training_loop/calculate_grads/CalculateGradsSequential.c
+++ b/src/userApi/training_loop/calculate_grads/CalculateGradsSequential.c
@@ -19,199 +19,199 @@
 trainingStats_t *calculateGradsSequential(layer_t **model, size_t modelSize, lossType_t lossType,
                                           tensor_t *input, tensor_t *label) {
 
-  tensor_t *layerOutputs[modelSize + 1];
-  layerOutputs[0] = input;
-  initLayerOutputs(layerOutputs, model, modelSize);
+    tensor_t *layerOutputs[modelSize + 1];
+    layerOutputs[0] = input;
+    initLayerOutputs(layerOutputs, model, modelSize);
 
-  // Forward pass
-  for (size_t i = 0; i < modelSize; i++) {
-    layer_t *currentLayer = model[i];
-    layerType_t currentLayerType = currentLayer->type;
-    forwardFn_t forward = layerFunctions[currentLayerType].forward;
-    forward(currentLayer, layerOutputs[i], layerOutputs[i + 1]);
-  }
+    // Forward pass
+    for (size_t i = 0; i < modelSize; i++) {
+        layer_t *currentLayer = model[i];
+        layerType_t currentLayerType = currentLayer->type;
+        forwardFn_t forward = layerFunctions[currentLayerType].forward;
+        forward(currentLayer, layerOutputs[i], layerOutputs[i + 1]);
+    }
 
-  trainingStats_t *trainingStats = initTrainingStats(layerOutputs[modelSize]);
-  copyTensor(trainingStats->output, layerOutputs[modelSize]);
+    trainingStats_t *trainingStats = initTrainingStats(layerOutputs[modelSize]);
+    copyTensor(trainingStats->output, layerOutputs[modelSize]);
 
-  // LOSS
+    // LOSS
 
-  lossFunctions_t lossFns = lossFunctions[lossType];
-  float loss = lossFns.forward(layerOutputs[modelSize], label);
-  trainingStats->loss = loss;
+    lossFunctions_t lossFns = lossFunctions[lossType];
+    float loss = lossFns.forward(layerOutputs[modelSize], label);
+    trainingStats->loss = loss;
 
-  // Backward pass
-  size_t backwardIndex = modelSize - 1;
-  if (lossType == CROSS_ENTROPY) {
-    backwardIndex -= 1;
-  }
+    // Backward pass
+    size_t backwardIndex = modelSize - 1;
+    if (lossType == CROSS_ENTROPY) {
+        backwardIndex -= 1;
+    }
 
-  tensor_t gradNext;
-  initGradTensor(&gradNext, layerOutputs[modelSize]);
-  lossFns.backward(layerOutputs[modelSize], label, &gradNext);
+    tensor_t gradNext;
+    initGradTensor(&gradNext, layerOutputs[modelSize]);
+    lossFns.backward(layerOutputs[modelSize], label, &gradNext);
 
-  for (int i = (int)backwardIndex; i >= 0; i--) {
-    tensor_t gradCurr;
-    initGradTensor(&gradCurr, layerOutputs[i]);
+    for (int i = (int)backwardIndex; i >= 0; i--) {
+        tensor_t gradCurr;
+        initGradTensor(&gradCurr, layerOutputs[i]);
 
-    layerType_t layerType = model[i]->type;
-    backwardFn_t backward = layerFunctions[layerType].backward;
+        layerType_t layerType = model[i]->type;
+        backwardFn_t backward = layerFunctions[layerType].backward;
 
-    backward(model[i], layerOutputs[i], &gradNext, &gradCurr);
+        backward(model[i], layerOutputs[i], &gradNext, &gradCurr);
+
+        deInitGradTensor(&gradNext);
+        gradNext = gradCurr;
+    }
 
     deInitGradTensor(&gradNext);
-    gradNext = gradCurr;
-  }
+    deInitLayerOutputs(layerOutputs, modelSize);
 
-  deInitGradTensor(&gradNext);
-  deInitLayerOutputs(layerOutputs, modelSize);
-
-  return trainingStats;
+    return trainingStats;
 }
 
 static void initLayerOutputs(tensor_t **layerOutputs, layer_t **model, size_t sizeNetwork) {
-  for (size_t i = 0; i < sizeNetwork; i++) {
-    layer_t *currentLayer = model[i];
-    quantization_t *currentQ = NULL;
+    for (size_t i = 0; i < sizeNetwork; i++) {
+        layer_t *currentLayer = model[i];
+        quantization_t *currentQ = NULL;
 
-    switch (currentLayer->type) {
-    case LINEAR:
-      linearConfig_t *linearConfig = currentLayer->config->linear;
-      currentQ = linearConfig->forwardQ;
-      break;
-    case RELU:
-      reluConfig_t *reluConfig = currentLayer->config->relu;
-      currentQ = reluConfig->forwardQ;
-      break;
-    case SOFTMAX:
-      softmaxConfig_t *softmaxConfig = currentLayer->config->softmax;
-      currentQ = softmaxConfig->forwardQ;
-      break;
-    case FLATTEN:
-      // Flatten has no per-layer quantization; output dtype equals input dtype.
-      currentQ = layerOutputs[i]->quantization;
-      break;
-    default:
-      PRINT_ERROR("Unknown Layer Type!");
-      exit(1);
+        switch (currentLayer->type) {
+        case LINEAR:
+            linearConfig_t *linearConfig = currentLayer->config->linear;
+            currentQ = linearConfig->forwardQ;
+            break;
+        case RELU:
+            reluConfig_t *reluConfig = currentLayer->config->relu;
+            currentQ = reluConfig->forwardQ;
+            break;
+        case SOFTMAX:
+            softmaxConfig_t *softmaxConfig = currentLayer->config->softmax;
+            currentQ = softmaxConfig->forwardQ;
+            break;
+        case FLATTEN:
+            // Flatten has no per-layer quantization; output dtype equals input dtype.
+            currentQ = layerOutputs[i]->quantization;
+            break;
+        default:
+            PRINT_ERROR("Unknown Layer Type!");
+            exit(1);
+        }
+
+        calcOutputShapeFn_t calcOutputShape = layerFunctions[currentLayer->type].calcOutputShape;
+        size_t numberOfDims = layerOutputs[i]->shape->numberOfDimensions;
+
+        size_t *dims = *reserveMemory(numberOfDims * sizeof(size_t));
+        size_t *order = *reserveMemory(numberOfDims * sizeof(size_t));
+        shape_t *outShape = *reserveMemory(sizeof(shape_t));
+
+        outShape->dimensions = dims;
+        outShape->numberOfDimensions = numberOfDims;
+        outShape->orderOfDimensions = order;
+
+        calcOutputShape(currentLayer, layerOutputs[i]->shape, outShape);
+
+        size_t numberOfValues = calcNumberOfElementsByShape(outShape);
+        size_t sizeData = calcNumberOfBytesForData(currentQ, numberOfValues);
+        uint8_t *data = *reserveMemory(sizeData);
+
+        quantization_t *q = *reserveMemory(sizeof(quantization_t));
+        switch (currentQ->type) {
+        case FLOAT32:
+            initFloat32Quantization(q);
+            break;
+        case SYM_INT32:
+            q->type = SYM_INT32;
+            symInt32QConfig_t *currentQC = currentQ->qConfig;
+            symInt32QConfig_t *qC = *reserveMemory(sizeof(symInt32QConfig_t));
+            initSymInt32QConfig(currentQC->roundingMode, qC);
+            initSymInt32Quantization(qC, q);
+            break;
+        default:
+            PRINT_ERROR("Unknown QType!");
+            exit(1);
+        }
+
+        tensor_t *tensor = *reserveMemory(sizeof(tensor_t));
+        tensor->data = data;
+        tensor->quantization = q;
+        tensor->shape = outShape;
+
+        tensor->sparsity = NULL;
+        if (layerOutputs[i]->sparsity != NULL) {
+            sparsity_t *sparsity = *reserveMemory(sizeof(sparsity_t));
+            tensor->sparsity = sparsity;
+        }
+
+        layerOutputs[i + 1] = tensor;
     }
+}
 
-    calcOutputShapeFn_t calcOutputShape = layerFunctions[currentLayer->type].calcOutputShape;
-    size_t numberOfDims = layerOutputs[i]->shape->numberOfDimensions;
+static void deInitLayerOutputs(tensor_t **layerOutputs, size_t modelSize) {
+    for (size_t i = 1; i <= modelSize; i++) {
+        freeTensor(layerOutputs[i]);
+    }
+}
 
-    size_t *dims = *reserveMemory(numberOfDims * sizeof(size_t));
-    size_t *order = *reserveMemory(numberOfDims * sizeof(size_t));
-    shape_t *outShape = *reserveMemory(sizeof(shape_t));
+static void initGradTensor(tensor_t *grad, tensor_t *layerOutput) {
+    shape_t *currentShape = layerOutput->shape;
+    quantization_t *currentQ = layerOutput->quantization;
 
-    outShape->dimensions = dims;
-    outShape->numberOfDimensions = numberOfDims;
-    outShape->orderOfDimensions = order;
+    size_t *dims = *reserveMemory(currentShape->numberOfDimensions * sizeof(size_t));
+    size_t *order = *reserveMemory(currentShape->numberOfDimensions * sizeof(size_t));
+    shape_t *inShape = *reserveMemory(sizeof(shape_t));
 
-    calcOutputShape(currentLayer, layerOutputs[i]->shape, outShape);
+    inShape->dimensions = dims;
+    inShape->numberOfDimensions = currentShape->numberOfDimensions;
+    inShape->orderOfDimensions = order;
 
-    size_t numberOfValues = calcNumberOfElementsByShape(outShape);
+    memcpy(inShape->dimensions, currentShape->dimensions,
+           currentShape->numberOfDimensions * sizeof(size_t));
+    memcpy(inShape->orderOfDimensions, currentShape->orderOfDimensions,
+           currentShape->numberOfDimensions * sizeof(size_t));
+
+    setOrderOfDimsForNewTensor(inShape->numberOfDimensions, inShape->orderOfDimensions);
+
+    size_t numberOfValues = calcNumberOfElementsByShape(currentShape);
     size_t sizeData = calcNumberOfBytesForData(currentQ, numberOfValues);
     uint8_t *data = *reserveMemory(sizeData);
 
     quantization_t *q = *reserveMemory(sizeof(quantization_t));
     switch (currentQ->type) {
     case FLOAT32:
-      initFloat32Quantization(q);
-      break;
+        initFloat32Quantization(q);
+        break;
     case SYM_INT32:
-      q->type = SYM_INT32;
-      symInt32QConfig_t *currentQC = currentQ->qConfig;
-      symInt32QConfig_t *qC = *reserveMemory(sizeof(symInt32QConfig_t));
-      initSymInt32QConfig(currentQC->roundingMode, qC);
-      initSymInt32Quantization(qC, q);
-      break;
+        symInt32QConfig_t *currentQC = currentQ->qConfig;
+        symInt32QConfig_t *qC = *reserveMemory(sizeof(symInt32QConfig_t));
+        initSymInt32QConfig(currentQC->roundingMode, qC);
+        initSymInt32Quantization(qC, q);
+        break;
     default:
-      PRINT_ERROR("Unknown QType!");
-      exit(1);
+        PRINT_ERROR("Unknown QType!");
+        exit(1);
     }
 
-    tensor_t *tensor = *reserveMemory(sizeof(tensor_t));
-    tensor->data = data;
-    tensor->quantization = q;
-    tensor->shape = outShape;
+    grad->data = data;
+    grad->quantization = q;
+    grad->shape = inShape;
 
-    tensor->sparsity = NULL;
-    if (layerOutputs[i]->sparsity != NULL) {
-      sparsity_t *sparsity = *reserveMemory(sizeof(sparsity_t));
-      tensor->sparsity = sparsity;
+    grad->sparsity = NULL;
+    if (layerOutput->sparsity != NULL) {
+        sparsity_t *sparsity = *reserveMemory(sizeof(sparsity_t));
+        grad->sparsity = sparsity;
     }
-
-    layerOutputs[i + 1] = tensor;
-  }
-}
-
-static void deInitLayerOutputs(tensor_t **layerOutputs, size_t modelSize) {
-  for (size_t i = 1; i <= modelSize; i++) {
-    freeTensor(layerOutputs[i]);
-  }
-}
-
-static void initGradTensor(tensor_t *grad, tensor_t *layerOutput) {
-  shape_t *currentShape = layerOutput->shape;
-  quantization_t *currentQ = layerOutput->quantization;
-
-  size_t *dims = *reserveMemory(currentShape->numberOfDimensions * sizeof(size_t));
-  size_t *order = *reserveMemory(currentShape->numberOfDimensions * sizeof(size_t));
-  shape_t *inShape = *reserveMemory(sizeof(shape_t));
-
-  inShape->dimensions = dims;
-  inShape->numberOfDimensions = currentShape->numberOfDimensions;
-  inShape->orderOfDimensions = order;
-
-  memcpy(inShape->dimensions, currentShape->dimensions,
-         currentShape->numberOfDimensions * sizeof(size_t));
-  memcpy(inShape->orderOfDimensions, currentShape->orderOfDimensions,
-         currentShape->numberOfDimensions * sizeof(size_t));
-
-  setOrderOfDimsForNewTensor(inShape->numberOfDimensions, inShape->orderOfDimensions);
-
-  size_t numberOfValues = calcNumberOfElementsByShape(currentShape);
-  size_t sizeData = calcNumberOfBytesForData(currentQ, numberOfValues);
-  uint8_t *data = *reserveMemory(sizeData);
-
-  quantization_t *q = *reserveMemory(sizeof(quantization_t));
-  switch (currentQ->type) {
-  case FLOAT32:
-    initFloat32Quantization(q);
-    break;
-  case SYM_INT32:
-    symInt32QConfig_t *currentQC = currentQ->qConfig;
-    symInt32QConfig_t *qC = *reserveMemory(sizeof(symInt32QConfig_t));
-    initSymInt32QConfig(currentQC->roundingMode, qC);
-    initSymInt32Quantization(qC, q);
-    break;
-  default:
-    PRINT_ERROR("Unknown QType!");
-    exit(1);
-  }
-
-  grad->data = data;
-  grad->quantization = q;
-  grad->shape = inShape;
-
-  grad->sparsity = NULL;
-  if (layerOutput->sparsity != NULL) {
-    sparsity_t *sparsity = *reserveMemory(sizeof(sparsity_t));
-    grad->sparsity = sparsity;
-  }
 }
 
 static void deInitGradTensor(tensor_t *tensor) {
-  freeData(tensor);
-  freeShape(tensor->shape);
-  freeQuantization(tensor->quantization);
+    freeData(tensor);
+    freeShape(tensor->shape);
+    freeQuantization(tensor->quantization);
 }
 
 static trainingStats_t *initTrainingStats(tensor_t *output) {
-  trainingStats_t *trainingStats = *reserveMemory(sizeof(trainingStats_t));
+    trainingStats_t *trainingStats = *reserveMemory(sizeof(trainingStats_t));
 
-  tensor_t *o = getTensorLike(output);
-  trainingStats->output = o;
+    tensor_t *o = getTensorLike(output);
+    trainingStats->output = o;
 
-  return trainingStats;
+    return trainingStats;
 }

--- a/src/userApi/training_loop/calculate_grads/CalculateGradsSequential.c
+++ b/src/userApi/training_loop/calculate_grads/CalculateGradsSequential.c
@@ -102,9 +102,9 @@ static void initLayerOutputs(tensor_t **layerOutputs, layer_t **model, size_t si
             numberOfDims = 2;
         }
 
-        size_t *dims = *reserveMemory(numberOfDims * sizeof(size_t));
-        size_t *order = *reserveMemory(numberOfDims * sizeof(size_t));
-        shape_t *outShape = *reserveMemory(sizeof(shape_t));
+        size_t *dims = reserveMemory(numberOfDims * sizeof(size_t));
+        size_t *order = reserveMemory(numberOfDims * sizeof(size_t));
+        shape_t *outShape = reserveMemory(sizeof(shape_t));
 
         outShape->dimensions = dims;
         outShape->numberOfDimensions = numberOfDims;
@@ -114,9 +114,9 @@ static void initLayerOutputs(tensor_t **layerOutputs, layer_t **model, size_t si
 
         size_t numberOfValues = calcNumberOfElementsByShape(outShape);
         size_t sizeData = calcNumberOfBytesForData(currentQ, numberOfValues);
-        uint8_t *data = *reserveMemory(sizeData);
+        uint8_t *data = reserveMemory(sizeData);
 
-        quantization_t *q = *reserveMemory(sizeof(quantization_t));
+        quantization_t *q = reserveMemory(sizeof(quantization_t));
         switch (currentQ->type) {
         case FLOAT32:
             initFloat32Quantization(q);
@@ -124,7 +124,7 @@ static void initLayerOutputs(tensor_t **layerOutputs, layer_t **model, size_t si
         case SYM_INT32:
             q->type = SYM_INT32;
             symInt32QConfig_t *currentQC = currentQ->qConfig;
-            symInt32QConfig_t *qC = *reserveMemory(sizeof(symInt32QConfig_t));
+            symInt32QConfig_t *qC = reserveMemory(sizeof(symInt32QConfig_t));
             initSymInt32QConfig(currentQC->roundingMode, qC);
             initSymInt32Quantization(qC, q);
             break;
@@ -133,14 +133,14 @@ static void initLayerOutputs(tensor_t **layerOutputs, layer_t **model, size_t si
             exit(1);
         }
 
-        tensor_t *tensor = *reserveMemory(sizeof(tensor_t));
+        tensor_t *tensor = reserveMemory(sizeof(tensor_t));
         tensor->data = data;
         tensor->quantization = q;
         tensor->shape = outShape;
 
         tensor->sparsity = NULL;
         if (layerOutputs[i]->sparsity != NULL) {
-            sparsity_t *sparsity = *reserveMemory(sizeof(sparsity_t));
+            sparsity_t *sparsity = reserveMemory(sizeof(sparsity_t));
             tensor->sparsity = sparsity;
         }
 
@@ -158,9 +158,9 @@ static void initGradTensor(tensor_t *grad, tensor_t *layerOutput) {
     shape_t *currentShape = layerOutput->shape;
     quantization_t *currentQ = layerOutput->quantization;
 
-    size_t *dims = *reserveMemory(currentShape->numberOfDimensions * sizeof(size_t));
-    size_t *order = *reserveMemory(currentShape->numberOfDimensions * sizeof(size_t));
-    shape_t *inShape = *reserveMemory(sizeof(shape_t));
+    size_t *dims = reserveMemory(currentShape->numberOfDimensions * sizeof(size_t));
+    size_t *order = reserveMemory(currentShape->numberOfDimensions * sizeof(size_t));
+    shape_t *inShape = reserveMemory(sizeof(shape_t));
 
     inShape->dimensions = dims;
     inShape->numberOfDimensions = currentShape->numberOfDimensions;
@@ -175,16 +175,16 @@ static void initGradTensor(tensor_t *grad, tensor_t *layerOutput) {
 
     size_t numberOfValues = calcNumberOfElementsByShape(currentShape);
     size_t sizeData = calcNumberOfBytesForData(currentQ, numberOfValues);
-    uint8_t *data = *reserveMemory(sizeData);
+    uint8_t *data = reserveMemory(sizeData);
 
-    quantization_t *q = *reserveMemory(sizeof(quantization_t));
+    quantization_t *q = reserveMemory(sizeof(quantization_t));
     switch (currentQ->type) {
     case FLOAT32:
         initFloat32Quantization(q);
         break;
     case SYM_INT32:
         symInt32QConfig_t *currentQC = currentQ->qConfig;
-        symInt32QConfig_t *qC = *reserveMemory(sizeof(symInt32QConfig_t));
+        symInt32QConfig_t *qC = reserveMemory(sizeof(symInt32QConfig_t));
         initSymInt32QConfig(currentQC->roundingMode, qC);
         initSymInt32Quantization(qC, q);
         break;
@@ -199,7 +199,7 @@ static void initGradTensor(tensor_t *grad, tensor_t *layerOutput) {
 
     grad->sparsity = NULL;
     if (layerOutput->sparsity != NULL) {
-        sparsity_t *sparsity = *reserveMemory(sizeof(sparsity_t));
+        sparsity_t *sparsity = reserveMemory(sizeof(sparsity_t));
         grad->sparsity = sparsity;
     }
 }
@@ -211,7 +211,7 @@ static void deInitGradTensor(tensor_t *tensor) {
 }
 
 static trainingStats_t *initTrainingStats(tensor_t *output) {
-    trainingStats_t *trainingStats = *reserveMemory(sizeof(trainingStats_t));
+    trainingStats_t *trainingStats = reserveMemory(sizeof(trainingStats_t));
 
     tensor_t *o = getTensorLike(output);
     trainingStats->output = o;

--- a/src/userApi/training_loop/calculate_grads/CalculateGradsSequential.c
+++ b/src/userApi/training_loop/calculate_grads/CalculateGradsSequential.c
@@ -98,6 +98,9 @@ static void initLayerOutputs(tensor_t **layerOutputs, layer_t **model, size_t si
 
         calcOutputShapeFn_t calcOutputShape = layerFunctions[currentLayer->type].calcOutputShape;
         size_t numberOfDims = layerOutputs[i]->shape->numberOfDimensions;
+        if (currentLayer->type == FLATTEN) {
+            numberOfDims = 2;
+        }
 
         size_t *dims = *reserveMemory(numberOfDims * sizeof(size_t));
         size_t *order = *reserveMemory(numberOfDims * sizeof(size_t));

--- a/src/userApi/training_loop/training_batch/CMakeLists.txt
+++ b/src/userApi/training_loop/training_batch/CMakeLists.txt
@@ -9,5 +9,6 @@ target_link_libraries(TrainingBatchDefault PRIVATE
         LossFunction
         InferenceApi
         DataLoader
+        DataLoaderApi
         Common
 )

--- a/src/userApi/training_loop/training_batch/TrainingBatchDefault.c
+++ b/src/userApi/training_loop/training_batch/TrainingBatchDefault.c
@@ -2,17 +2,18 @@
 
 #include "TrainingBatchDefault.h"
 #include "Common.h"
+#include "DataLoaderApi.h"
 
-float trainingBatchDefault(layer_t **model, size_t modelSize, lossType_t lossType,
-                           batch_t *batch, calculateGradsFn_t calculateGradsFn) {
+float trainingBatchDefault(layer_t **model, size_t modelSize, lossType_t lossType, batch_t *batch,
+                           calculateGradsFn_t calculateGradsFn) {
     float totalLoss = 0.0f;
 
     for (size_t i = 0; i < batch->size; i++) {
-        trainingStats_t *stats =
-            calculateGradsFn(model, modelSize, lossType,
-                             batch->samples[i]->item, batch->samples[i]->label);
+        trainingStats_t *stats = calculateGradsFn(
+            model, modelSize, lossType, batch->samples[i]->item, batch->samples[i]->label);
         totalLoss += stats->loss;
         freeTrainingStats(stats);
+        freeSample(batch->samples[i]);
     }
 
     return totalLoss / (float)batch->size;

--- a/test/unit/arithmetic/CMakeLists.txt
+++ b/test/unit/arithmetic/CMakeLists.txt
@@ -6,6 +6,7 @@ add_elastic_ai_unit_test(
         TensorApi
         QuantizationApi
         Arithmetic
+        StorageApi
 )
 
 add_elastic_ai_unit_test(

--- a/test/unit/arithmetic/UnitTestAdd.c
+++ b/test/unit/arithmetic/UnitTestAdd.c
@@ -1,13 +1,13 @@
 #include <string.h>
 
 #include "Add.h"
-#include "Tensor.h"
-#include "unity.h"
-#include "TensorApi.h"
 #include "DTypes.h"
 #include "QuantizationApi.h"
+#include "StorageApi.h"
+#include "Tensor.h"
+#include "TensorApi.h"
 #include "TensorConversion.h"
-
+#include "unity.h"
 
 void setUp() {}
 void tearDown() {}
@@ -16,24 +16,18 @@ void testAddInt32TensorsInplace() {
     size_t numberOfElements = 24;
     size_t bytesPerElement = sizeof(int32_t);
 
-
-
-    int32_t aData[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
-                       22, 23};
+    int32_t aData[] = {0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11,
+                       12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23};
     uint8_t *aDataBytes = (uint8_t *)aData;
 
     size_t aNumberOfDims = 3;
     size_t aDims[] = {2, 3, 4};
     size_t aOrderOfDims[] = {0, 1, 2};
-    quantization_t aQ = {
-        .type = INT32
-    };
+    quantization_t aQ = {.type = INT32};
 
-    shape_t aShape = {
-        .dimensions = aDims,
-        .numberOfDimensions = aNumberOfDims,
-        .orderOfDimensions = aOrderOfDims
-    };
+    shape_t aShape = {.dimensions = aDims,
+                      .numberOfDimensions = aNumberOfDims,
+                      .orderOfDimensions = aOrderOfDims};
 
     tensor_t aTensor = {
         .data = aDataBytes,
@@ -42,22 +36,18 @@ void testAddInt32TensorsInplace() {
         .sparsity = NULL,
     };
 
-    int32_t bData[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
-                       22, 23};
+    int32_t bData[] = {0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11,
+                       12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23};
     uint8_t *bDataBytes = (uint8_t *)bData;
     size_t bNumberOfDims = 3;
     size_t bDims[] = {2, 3, 4};
     size_t bOrderOfDims[] = {1, 0, 2};
 
-    shape_t bShape = {
-        .dimensions = bDims,
-        .numberOfDimensions = bNumberOfDims,
-        .orderOfDimensions = bOrderOfDims
-    };
+    shape_t bShape = {.dimensions = bDims,
+                      .numberOfDimensions = bNumberOfDims,
+                      .orderOfDimensions = bOrderOfDims};
 
-    quantization_t bQ = {
-        .type = INT32
-    };
+    quantization_t bQ = {.type = INT32};
     tensor_t bTensor = {
         .data = bDataBytes,
         .shape = &bShape,
@@ -69,8 +59,8 @@ void testAddInt32TensorsInplace() {
 
     addInt32TensorsInplace(&aTensor, &bTensor);
 
-    int32_t expected[] = {0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36, 38,
-                          40, 42, 44, 46};
+    int32_t expected[] = {0,  2,  4,  6,  8,  10, 12, 14, 16, 18, 20, 22,
+                          24, 26, 28, 30, 32, 34, 36, 38, 40, 42, 44, 46};
 
     TEST_ASSERT_EQUAL_INT32_ARRAY(expected, aTensor.data, numberOfElements);
 }
@@ -83,15 +73,11 @@ void testAddInt32ElementWithInt32TensorInplace() {
     size_t aNumberOfDims = 2;
     size_t aDims[] = {2, 3};
     size_t aOrderOfDims[] = {0, 1};
-    quantization_t aQ = {
-        .type = INT32
-    };
+    quantization_t aQ = {.type = INT32};
 
-    shape_t aShape = {
-        .dimensions = aDims,
-        .numberOfDimensions = aNumberOfDims,
-        .orderOfDimensions = aOrderOfDims
-    };
+    shape_t aShape = {.dimensions = aDims,
+                      .numberOfDimensions = aNumberOfDims,
+                      .orderOfDimensions = aOrderOfDims};
 
     tensor_t aTensor = {
         .data = aDataBytes,
@@ -112,17 +98,15 @@ void testAddInt32ElementWithInt32TensorInplace() {
 void testAddFloat32TensorsInplace() {
     size_t numberOfElements = 24;
 
-    float aData[] = {0.f, 1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f, 10.f, 11.f, 12.f, 13.f, 14.f,
-                     15.f, 16.f, 17.f, 18.f, 19.f, 20.f, 21.f, 22.f, 23.f};
+    float aData[] = {0.f,  1.f,  2.f,  3.f,  4.f,  5.f,  6.f,  7.f,  8.f,  9.f,  10.f, 11.f,
+                     12.f, 13.f, 14.f, 15.f, 16.f, 17.f, 18.f, 19.f, 20.f, 21.f, 22.f, 23.f};
     uint8_t *aDataBytes = (uint8_t *)aData;
     size_t aNumberOfDims = 3;
     size_t aDims[] = {2, 3, 4};
     size_t aOrderOfDims[] = {0, 1, 2};
-    shape_t aShape = {
-        .dimensions = aDims,
-        .numberOfDimensions = aNumberOfDims,
-        .orderOfDimensions = aOrderOfDims
-    };
+    shape_t aShape = {.dimensions = aDims,
+                      .numberOfDimensions = aNumberOfDims,
+                      .orderOfDimensions = aOrderOfDims};
 
     quantization_t aQ;
     initFloat32Quantization(&aQ);
@@ -130,17 +114,15 @@ void testAddFloat32TensorsInplace() {
     tensor_t aTensor;
     setTensorValues(&aTensor, aDataBytes, &aShape, &aQ, NULL);
 
-    float bData[] = {0.f, 1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f, 10.f, 11.f, 12.f, 13.f, 14.f,
-                     15.f, 16.f, 17.f, 18.f, 19.f, 20.f, 21.f, 22.f, 23.f};
+    float bData[] = {0.f,  1.f,  2.f,  3.f,  4.f,  5.f,  6.f,  7.f,  8.f,  9.f,  10.f, 11.f,
+                     12.f, 13.f, 14.f, 15.f, 16.f, 17.f, 18.f, 19.f, 20.f, 21.f, 22.f, 23.f};
     uint8_t *bDataBytes = (uint8_t *)bData;
     size_t bNumberOfDims = 3;
     size_t bDims[] = {2, 3, 4};
     size_t bOrderOfDims[] = {1, 0, 2};
-    shape_t bShape = {
-        .dimensions = bDims,
-        .numberOfDimensions = bNumberOfDims,
-        .orderOfDimensions = bOrderOfDims
-    };
+    shape_t bShape = {.dimensions = bDims,
+                      .numberOfDimensions = bNumberOfDims,
+                      .orderOfDimensions = bOrderOfDims};
 
     quantization_t bQ;
     initFloat32Quantization(&bQ);
@@ -152,8 +134,8 @@ void testAddFloat32TensorsInplace() {
 
     addFloat32TensorsInplace(&aTensor, &bTensor);
 
-    float expected[] = {0.f, 2.f, 4.f, 6.f, 8.f, 10.f, 12.f, 14.f, 16.f, 18.f, 20.f, 22.f, 24.f,
-                        26.f, 28.f, 30.f, 32.f, 34.f, 36.f, 38.f, 40.f, 42.f, 44.f, 46.f};
+    float expected[] = {0.f,  2.f,  4.f,  6.f,  8.f,  10.f, 12.f, 14.f, 16.f, 18.f, 20.f, 22.f,
+                        24.f, 26.f, 28.f, 30.f, 32.f, 34.f, 36.f, 38.f, 40.f, 42.f, 44.f, 46.f};
 
     TEST_ASSERT_EQUAL_FLOAT_ARRAY(expected, aTensor.data, numberOfElements);
 }
@@ -175,10 +157,7 @@ void testAddSymInt32TensorsInplace() {
     size_t numberOfDims = 1;
     size_t orderOfDims[] = {0};
     shape_t shape = {
-        .dimensions = dims,
-        .numberOfDimensions = numberOfDims,
-        .orderOfDimensions = orderOfDims
-    };
+        .dimensions = dims, .numberOfDimensions = numberOfDims, .orderOfDimensions = orderOfDims};
 
     setTensorValues(&aTensor, aDataBytes, &shape, &aQ, NULL);
 
@@ -196,15 +175,32 @@ void testAddSymInt32TensorsInplace() {
 
     addSymInt32TensorsInplace(&aTensor, &bTensor);
 
-    float actual[numberOfValues];
-    quantization_t *floatQ = quantizationInitFloat();
-    tensor_t *floatTensor = tensorInit(actual, dims, numberOfDims, floatQ, NULL);
+    /* Build a heap Float32 output tensor for the convert-back step using the
+     * post-#106 primitives. The deprecated tensorInit(actual, dims, ...) form
+     * stored caller's data pointer; here, initTensor owns its own data buffer
+     * and convertTensor writes the result there. */
+    size_t *outputDims = reserveMemory(1 * sizeof(size_t));
+    outputDims[0] = numberOfValues;
+    size_t *outputOrder = reserveMemory(1 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(1, outputOrder);
+    shape_t *outputShape = reserveMemory(sizeof(shape_t));
+    setShape(outputShape, outputDims, 1, outputOrder);
+    tensor_t *floatTensor = initTensor(outputShape, quantizationInitFloat(), NULL);
     convertTensor(&aTensor, floatTensor);
 
-    float_t expected[] = {3, 6, 9, 12, 15, 18};
+    /* CAPTURE before free. */
+    float captured[numberOfValues];
+    for (size_t i = 0; i < numberOfValues; i++) {
+        captured[i] = ((float *)floatTensor->data)[i];
+    }
 
-    for(size_t i = 0; i < numberOfValues; i++) {
-        TEST_ASSERT_FLOAT_WITHIN(0.1f, expected[i], actual[i]);
+    /* FREE. */
+    freeTensor(floatTensor);
+
+    /* ASSERT. */
+    float_t expected[] = {3, 6, 9, 12, 15, 18};
+    for (size_t i = 0; i < numberOfValues; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(0.1f, expected[i], captured[i]);
     }
 }
 
@@ -223,10 +219,7 @@ void testAddInt32TensorWithSymInt32TensorInplace() {
     size_t numberOfDims = 1;
     size_t orderOfDims[] = {0};
     shape_t shape = {
-        .dimensions = dims,
-        .numberOfDimensions = numberOfDims,
-        .orderOfDimensions = orderOfDims
-    };
+        .dimensions = dims, .numberOfDimensions = numberOfDims, .orderOfDimensions = orderOfDims};
     setTensorValues(&aTensor, aDataBytes, &shape, &aQ, NULL);
 
     quantization_t bQ;
@@ -258,10 +251,7 @@ void testAddFloat32TensorToSymInt32TensorInplace() {
     size_t numberOfDims = 1;
     size_t orderOfDims[] = {0};
     shape_t shape = {
-        .dimensions = dims,
-        .numberOfDimensions = numberOfDims,
-        .orderOfDimensions = orderOfDims
-    };
+        .dimensions = dims, .numberOfDimensions = numberOfDims, .orderOfDimensions = orderOfDims};
     setTensorValues(&aTensor, aDataBytes, &shape, &aQ, NULL);
 
     quantization_t bQ;
@@ -277,7 +267,6 @@ void testAddFloat32TensorToSymInt32TensorInplace() {
 
     TEST_ASSERT_EQUAL_INT32_ARRAY(expected, aData, numberOfValues);
 }
-
 
 int main(void) {
     UNITY_BEGIN();

--- a/test/unit/data_loader/UnitTestDataLoader.c
+++ b/test/unit/data_loader/UnitTestDataLoader.c
@@ -1,88 +1,119 @@
+#include <stdbool.h>
 #include <stdlib.h>
 
-#include "Tensor.h"
-#include "TensorApi.h"
-#include "DataLoaderApi.h"
-#include "unity.h"
-#include "RNG.h"
 #include "DataLoader.h"
-#include "StorageApi.h"
+#include "DataLoaderApi.h"
 #include "Dataset.h"
 #include "NPYLoaderApi.h"
+#include "QuantizationApi.h"
+#include "RNG.h"
+#include "StorageApi.h"
+#include "Tensor.h"
+#include "TensorApi.h"
+#include "unity.h"
 
 #define PROXY_DATASET_SIZE 4
 #define PROXY_FEATURES 2
 
-static tensor_t *proxyItems[PROXY_DATASET_SIZE];
-static tensor_t *proxyLabels[PROXY_DATASET_SIZE];
-static tensorArray_t proxyItemsArr;
-static tensorArray_t proxyLabelsArr;
-static dataset_t proxyDataset;
-static bool proxyInit = false;
+/* Per-test fixture handle. Each test calls makeProxyDataset() at the start
+ * and freeProxyDataset() once it's captured every assertion value, in line
+ * with docs/CONVENTIONS.md "Test memory discipline" (heap-tier idiom). */
+typedef struct proxyFixture {
+    tensor_t *items[PROXY_DATASET_SIZE];
+    tensor_t *labels[PROXY_DATASET_SIZE];
+    tensorArray_t itemsArr;
+    tensorArray_t labelsArr;
+    dataset_t dataset;
+} proxyFixture_t;
 
-static void initProxyDataset() {
-    if (proxyInit) return;
+static proxyFixture_t g_proxy;
 
-    static float in0[] = {1.f, 2.f};
-    static float in1[] = {3.f, 4.f};
-    static float in2[] = {5.f, 6.f};
-    static float in3[] = {7.f, 8.f};
+static tensor_t *makeProxyTensor(const float *src, size_t count) {
+    /* Heap-tier construction per CONVENTIONS Rule 1: shape via reserveMemory,
+     * data populated by tensorFillFromFloatBuffer (caller-buffer-safe). */
+    size_t *dims = reserveMemory(2 * sizeof(size_t));
+    dims[0] = 1;
+    dims[1] = PROXY_FEATURES;
+    size_t *order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, order);
+    shape_t *shape = reserveMemory(sizeof(shape_t));
+    setShape(shape, dims, 2, order);
 
-    static float lb0[] = {0.f, 1.f};
-    static float lb1[] = {1.f, 0.f};
-    static float lb2[] = {0.f, 1.f};
-    static float lb3[] = {1.f, 0.f};
+    tensor_t *t = initTensor(shape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(t, src, count);
+    return t;
+}
 
-    static size_t inDims[] = {1, PROXY_FEATURES};
-    static size_t lbDims[] = {1, PROXY_FEATURES};
+static void makeProxyDataset(void) {
+    static const float in0[] = {1.f, 2.f};
+    static const float in1[] = {3.f, 4.f};
+    static const float in2[] = {5.f, 6.f};
+    static const float in3[] = {7.f, 8.f};
+    static const float lb0[] = {0.f, 1.f};
+    static const float lb1[] = {1.f, 0.f};
+    static const float lb2[] = {0.f, 1.f};
+    static const float lb3[] = {1.f, 0.f};
 
-    proxyItems[0] = tensorInitFloat(in0, inDims, 2, NULL);
-    proxyItems[1] = tensorInitFloat(in1, inDims, 2, NULL);
-    proxyItems[2] = tensorInitFloat(in2, inDims, 2, NULL);
-    proxyItems[3] = tensorInitFloat(in3, inDims, 2, NULL);
+    g_proxy.items[0] = makeProxyTensor(in0, PROXY_FEATURES);
+    g_proxy.items[1] = makeProxyTensor(in1, PROXY_FEATURES);
+    g_proxy.items[2] = makeProxyTensor(in2, PROXY_FEATURES);
+    g_proxy.items[3] = makeProxyTensor(in3, PROXY_FEATURES);
 
-    proxyLabels[0] = tensorInitFloat(lb0, lbDims, 2, NULL);
-    proxyLabels[1] = tensorInitFloat(lb1, lbDims, 2, NULL);
-    proxyLabels[2] = tensorInitFloat(lb2, lbDims, 2, NULL);
-    proxyLabels[3] = tensorInitFloat(lb3, lbDims, 2, NULL);
+    g_proxy.labels[0] = makeProxyTensor(lb0, PROXY_FEATURES);
+    g_proxy.labels[1] = makeProxyTensor(lb1, PROXY_FEATURES);
+    g_proxy.labels[2] = makeProxyTensor(lb2, PROXY_FEATURES);
+    g_proxy.labels[3] = makeProxyTensor(lb3, PROXY_FEATURES);
 
-    proxyItemsArr.array = proxyItems;
-    proxyItemsArr.size = PROXY_DATASET_SIZE;
-    proxyLabelsArr.array = proxyLabels;
-    proxyLabelsArr.size = PROXY_DATASET_SIZE;
+    g_proxy.itemsArr.array = g_proxy.items;
+    g_proxy.itemsArr.size = PROXY_DATASET_SIZE;
+    g_proxy.labelsArr.array = g_proxy.labels;
+    g_proxy.labelsArr.size = PROXY_DATASET_SIZE;
 
-    proxyDataset.items = &proxyItemsArr;
-    proxyDataset.labels = &proxyLabelsArr;
-    proxyInit = true;
+    g_proxy.dataset.items = &g_proxy.itemsArr;
+    g_proxy.dataset.labels = &g_proxy.labelsArr;
+}
+
+static void freeProxyDataset(void) {
+    /* Release each heap proxy tensor; the tensorArray_t and dataset_t
+     * containers themselves are stack/static (members of g_proxy) and
+     * need no free. */
+    for (size_t i = 0; i < PROXY_DATASET_SIZE; i++) {
+        freeTensor(g_proxy.items[i]);
+        freeTensor(g_proxy.labels[i]);
+    }
 }
 
 static sample_t *getProxySample(size_t id) {
     sample_t *s = reserveMemory(sizeof(sample_t));
-    s->item = proxyDataset.items->array[id];
-    s->label = proxyDataset.labels->array[id];
+    s->item = g_proxy.dataset.items->array[id];
+    s->label = g_proxy.dataset.labels->array[id];
     return s;
 }
 
-static size_t getProxyDatasetSize() {
+static size_t getProxyDatasetSize(void) {
     return PROXY_DATASET_SIZE;
 }
 
-static dataset_t npyProxyDataset;
-static bool npyProxyInit = false;
+/* NPY-backed dataset. Each test that uses it loads at start and frees with
+ * freeTensorArray (added in this batch) before exiting. */
+static dataset_t g_npyDataset;
 
-static void initNpyProxyDataset() {
-    if (npyProxyInit) return;
-    npyProxyDataset.items = npyLoad(PROXY_X_PATH);
-    npyProxyDataset.labels = npyLoad(PROXY_Y_PATH);
-    npyProxyInit = true;
+static void makeNpyDataset(void) {
+    g_npyDataset.items = npyLoad(PROXY_X_PATH);
+    g_npyDataset.labels = npyLoad(PROXY_Y_PATH);
+}
+
+static void freeNpyDataset(void) {
+    freeTensorArray(g_npyDataset.items);
+    freeTensorArray(g_npyDataset.labels);
 }
 
 static sample_t *getNpyProxySample(size_t id) {
-    return npyGetSample(&npyProxyDataset, id);
+    return npyGetSample(&g_npyDataset, id);
 }
 
-static size_t getNpyProxyDatasetSize() {
-    return npyProxyDataset.items->size;
+static size_t getNpyProxyDatasetSize(void) {
+    return g_npyDataset.items->size;
 }
 
 void setUp() {}
@@ -90,56 +121,89 @@ void setUp() {}
 void tearDown() {}
 
 void testGetSample() {
-    initProxyDataset();
+    makeProxyDataset();
 
-    dataLoader_t *dl = dataLoaderInit(getProxySample, getProxyDatasetSize, 1,
-                                      NULL, NULL, false, 0, true);
+    dataLoader_t *dl =
+        dataLoaderInit(getProxySample, getProxyDatasetSize, 1, NULL, NULL, false, 0, true);
 
     sample_t *s = dl->getSample(0);
 
-    TEST_ASSERT_EQUAL_FLOAT_ARRAY(proxyDataset.items->array[0]->data, s->item->data,
-                                  PROXY_FEATURES);
-    TEST_ASSERT_EQUAL_FLOAT_ARRAY(proxyDataset.labels->array[0]->data, s->label->data,
-                                  PROXY_FEATURES);
+    /* CAPTURE: copy data referenced by sample so we can assert after free. */
+    float capturedItem[PROXY_FEATURES];
+    float capturedLabel[PROXY_FEATURES];
+    for (size_t i = 0; i < PROXY_FEATURES; i++) {
+        capturedItem[i] = ((float *)s->item->data)[i];
+        capturedLabel[i] = ((float *)s->label->data)[i];
+    }
+    float expectedItem[PROXY_FEATURES];
+    float expectedLabel[PROXY_FEATURES];
+    for (size_t i = 0; i < PROXY_FEATURES; i++) {
+        expectedItem[i] = ((float *)g_proxy.dataset.items->array[0]->data)[i];
+        expectedLabel[i] = ((float *)g_proxy.dataset.labels->array[0]->data)[i];
+    }
 
+    /* FREE in reverse-init order. */
     freeSample(s);
     freeDataLoader(dl);
+    freeProxyDataset();
+
+    /* ASSERT on captured. */
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(expectedItem, capturedItem, PROXY_FEATURES);
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(expectedLabel, capturedLabel, PROXY_FEATURES);
 }
 
 void testGetBatch() {
-    initProxyDataset();
+    makeProxyDataset();
 
     size_t batchSize = 2;
     size_t numBatches = PROXY_DATASET_SIZE / batchSize;
-    dataLoader_t *dl = dataLoaderInit(getProxySample, getProxyDatasetSize, batchSize,
-                                      NULL, NULL, false, 0, true);
+    dataLoader_t *dl =
+        dataLoaderInit(getProxySample, getProxyDatasetSize, batchSize, NULL, NULL, false, 0, true);
+
+    /* CAPTURE: walk every batch, copy each sample's data side-by-side with
+     * the expected dataset values. Frees happen along the way (samples,
+     * batch struct) but assertions wait until everything is freed. */
+    float capturedItems[PROXY_DATASET_SIZE][PROXY_FEATURES];
+    float capturedLabels[PROXY_DATASET_SIZE][PROXY_FEATURES];
+    float expectedItems[PROXY_DATASET_SIZE][PROXY_FEATURES];
+    float expectedLabels[PROXY_DATASET_SIZE][PROXY_FEATURES];
 
     for (size_t b = 0; b < numBatches; b++) {
         batch_t *batch = dl->getBatch(dl, b);
 
         for (size_t i = 0; i < batchSize; i++) {
-            size_t sampleIndex = b * batchSize + i;
-            TEST_ASSERT_EQUAL_FLOAT_ARRAY(proxyDataset.items->array[sampleIndex]->data,
-                                          batch->samples[i]->item->data, PROXY_FEATURES);
-            TEST_ASSERT_EQUAL_FLOAT_ARRAY(proxyDataset.labels->array[sampleIndex]->data,
-                                          batch->samples[i]->label->data, PROXY_FEATURES);
+            size_t k = b * batchSize + i;
+            for (size_t f = 0; f < PROXY_FEATURES; f++) {
+                capturedItems[k][f] = ((float *)batch->samples[i]->item->data)[f];
+                capturedLabels[k][f] = ((float *)batch->samples[i]->label->data)[f];
+                expectedItems[k][f] = ((float *)g_proxy.dataset.items->array[k]->data)[f];
+                expectedLabels[k][f] = ((float *)g_proxy.dataset.labels->array[k]->data)[f];
+            }
             freeSample(batch->samples[i]);
         }
         freeBatch(batch);
     }
 
     freeDataLoader(dl);
+    freeProxyDataset();
+
+    /* ASSERT on captured. */
+    for (size_t k = 0; k < PROXY_DATASET_SIZE; k++) {
+        TEST_ASSERT_EQUAL_FLOAT_ARRAY(expectedItems[k], capturedItems[k], PROXY_FEATURES);
+        TEST_ASSERT_EQUAL_FLOAT_ARRAY(expectedLabels[k], capturedLabels[k], PROXY_FEATURES);
+    }
 }
 
 void testGetBatch_ShuffledMinibatchCoversAllSamples() {
-    initProxyDataset();
+    makeProxyDataset();
 
     size_t batchSize = 2;
     size_t numBatches = PROXY_DATASET_SIZE / batchSize;
-    dataLoader_t *dl = dataLoaderInit(getProxySample, getProxyDatasetSize, batchSize,
-                                      NULL, NULL, true, 42, true);
+    dataLoader_t *dl =
+        dataLoaderInit(getProxySample, getProxyDatasetSize, batchSize, NULL, NULL, true, 42, true);
 
-    // Collect first feature value from every sample across all batches
+    /* CAPTURE: collect first feature value from every sample across all
+     * batches; assertions wait until everything is freed. */
     float seen[PROXY_DATASET_SIZE];
     for (size_t b = 0; b < numBatches; b++) {
         batch_t *batch = dl->getBatch(dl, b);
@@ -150,8 +214,7 @@ void testGetBatch_ShuffledMinibatchCoversAllSamples() {
         freeBatch(batch);
     }
 
-    // Every original sample has a unique first feature: 1, 3, 5, 7
-    // Sort and verify all four are present (no duplicates, no zeros)
+    /* Sort the captured values so they can be compared against {1,3,5,7}. */
     for (size_t i = 0; i < PROXY_DATASET_SIZE; i++) {
         for (size_t j = i + 1; j < PROXY_DATASET_SIZE; j++) {
             if (seen[j] < seen[i]) {
@@ -162,55 +225,69 @@ void testGetBatch_ShuffledMinibatchCoversAllSamples() {
         }
     }
 
+    freeDataLoader(dl);
+    freeProxyDataset();
+
+    /* ASSERT on captured. */
     float expected[] = {1.f, 3.f, 5.f, 7.f};
     TEST_ASSERT_EQUAL_FLOAT_ARRAY(expected, seen, PROXY_DATASET_SIZE);
-
-    freeDataLoader(dl);
 }
 
 void testGetBatch_NpyBackedDataset() {
-    initProxyDataset();
-    initNpyProxyDataset();
+    makeProxyDataset();
+    makeNpyDataset();
 
-    TEST_ASSERT_EQUAL(PROXY_DATASET_SIZE, getNpyProxyDatasetSize());
+    size_t capturedNpySize = getNpyProxyDatasetSize();
 
     size_t batchSize = 2;
     size_t numBatches = PROXY_DATASET_SIZE / batchSize;
-    dataLoader_t *dl = dataLoaderInit(getNpyProxySample, getNpyProxyDatasetSize, batchSize,
-                                      NULL, NULL, false, 0, true);
+    dataLoader_t *dl = dataLoaderInit(getNpyProxySample, getNpyProxyDatasetSize, batchSize, NULL,
+                                      NULL, false, 0, true);
+
+    float capturedItems[PROXY_DATASET_SIZE][PROXY_FEATURES];
+    float capturedLabels[PROXY_DATASET_SIZE][PROXY_FEATURES];
+    float expectedItems[PROXY_DATASET_SIZE][PROXY_FEATURES];
+    float expectedLabels[PROXY_DATASET_SIZE][PROXY_FEATURES];
 
     for (size_t b = 0; b < numBatches; b++) {
         batch_t *batch = dl->getBatch(dl, b);
 
         for (size_t i = 0; i < batchSize; i++) {
-            size_t sampleIndex = b * batchSize + i;
-            TEST_ASSERT_EQUAL_FLOAT_ARRAY(proxyDataset.items->array[sampleIndex]->data,
-                                          batch->samples[i]->item->data, PROXY_FEATURES);
-            TEST_ASSERT_EQUAL_FLOAT_ARRAY(proxyDataset.labels->array[sampleIndex]->data,
-                                          batch->samples[i]->label->data, PROXY_FEATURES);
+            size_t k = b * batchSize + i;
+            for (size_t f = 0; f < PROXY_FEATURES; f++) {
+                capturedItems[k][f] = ((float *)batch->samples[i]->item->data)[f];
+                capturedLabels[k][f] = ((float *)batch->samples[i]->label->data)[f];
+                expectedItems[k][f] = ((float *)g_proxy.dataset.items->array[k]->data)[f];
+                expectedLabels[k][f] = ((float *)g_proxy.dataset.labels->array[k]->data)[f];
+            }
             freeSample(batch->samples[i]);
         }
         freeBatch(batch);
     }
 
     freeDataLoader(dl);
+    freeNpyDataset();
+    freeProxyDataset();
+
+    /* ASSERT on captured. */
+    TEST_ASSERT_EQUAL((size_t)PROXY_DATASET_SIZE, capturedNpySize);
+    for (size_t k = 0; k < PROXY_DATASET_SIZE; k++) {
+        TEST_ASSERT_EQUAL_FLOAT_ARRAY(expectedItems[k], capturedItems[k], PROXY_FEATURES);
+        TEST_ASSERT_EQUAL_FLOAT_ARRAY(expectedLabels[k], capturedLabels[k], PROXY_FEATURES);
+    }
 }
 
 void testShuffle() {
-    size_t numberOfIndices = 10;
+    /* Stack-only test: stays in the stack-only tier per CONVENTIONS Rule 1.
+     * No heap fixtures, no frees needed. Asserts directly. */
     size_t indices[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
     rngSetSeed(1);
     rngShuffleIndices(indices, 10);
 
-    /*for (size_t i = 0; i < numberOfIndices; i++) {
-        printf("%lu\n", indices[i]);
-    }*/
-
     size_t expected[] = {3, 1, 0, 2, 6, 7, 8, 5, 4, 9};
-    TEST_ASSERT_EQUAL_size_t_ARRAY(expected, indices, numberOfIndices);
+    TEST_ASSERT_EQUAL_size_t_ARRAY(expected, indices, 10);
 }
-
 
 int main() {
     UNITY_BEGIN();

--- a/test/unit/data_loader/UnitTestDataLoader.c
+++ b/test/unit/data_loader/UnitTestDataLoader.c
@@ -57,7 +57,7 @@ static void initProxyDataset() {
 }
 
 static sample_t *getProxySample(size_t id) {
-    sample_t *s = *reserveMemory(sizeof(sample_t));
+    sample_t *s = reserveMemory(sizeof(sample_t));
     s->item = proxyDataset.items->array[id];
     s->label = proxyDataset.labels->array[id];
     return s;

--- a/test/unit/layer/CMakeLists.txt
+++ b/test/unit/layer/CMakeLists.txt
@@ -40,4 +40,5 @@ add_elastic_ai_unit_test(
         FlattenApi
         TensorApi
         QuantizationApi
+        StorageApi
 )

--- a/test/unit/layer/CMakeLists.txt
+++ b/test/unit/layer/CMakeLists.txt
@@ -28,3 +28,13 @@ add_elastic_ai_unit_test(
         SoftmaxApi
         QuantizationApi
 )
+
+add_elastic_ai_unit_test(
+        LIB_UNDER_TEST
+        Flatten
+        MORE_LIBS
+        CommonLayerLibs
+        FlattenApi
+        TensorApi
+        QuantizationApi
+)

--- a/test/unit/layer/CMakeLists.txt
+++ b/test/unit/layer/CMakeLists.txt
@@ -6,6 +6,7 @@ add_elastic_ai_unit_test(
         TensorApi
         QuantizationApi
         LinearApi
+        StorageApi
 )
 
 
@@ -17,6 +18,7 @@ add_elastic_ai_unit_test(
         ReluApi
         TensorApi
         QuantizationApi
+        StorageApi
 )
 
 add_elastic_ai_unit_test(
@@ -27,6 +29,7 @@ add_elastic_ai_unit_test(
         TensorApi
         SoftmaxApi
         QuantizationApi
+        StorageApi
 )
 
 add_elastic_ai_unit_test(

--- a/test/unit/layer/UnitTestFlatten.c
+++ b/test/unit/layer/UnitTestFlatten.c
@@ -1,11 +1,14 @@
 #define SOURCE_FILE "UNIT_TEST_FLATTEN"
 
+#include <stdbool.h>
+
 #include "DTypes.h"
 #include "Flatten.h"
 #include "FlattenApi.h"
 #include "Layer.h"
 #include "Quantization.h"
 #include "QuantizationApi.h"
+#include "StorageApi.h"
 #include "Tensor.h"
 #include "TensorApi.h"
 #include "TensorConversion.h"
@@ -14,12 +17,19 @@
 void testFlattenLayerInit_ReturnsFlattenTypedLayer(void) {
     layer_t *flattenLayer = flattenLayerInit();
 
-    TEST_ASSERT_NOT_NULL(flattenLayer);
-    TEST_ASSERT_EQUAL_INT(FLATTEN, flattenLayer->type);
-    TEST_ASSERT_NULL_MESSAGE(flattenLayer->config,
-                             "FLATTEN carries no per-layer config; layer->config must be NULL");
+    /* CAPTURE before frees. */
+    bool capturedNotNull = (flattenLayer != NULL);
+    int capturedType = flattenLayer ? (int)flattenLayer->type : -1;
+    bool capturedConfigNull = flattenLayer ? (flattenLayer->config == NULL) : false;
 
+    /* FREE. */
     freeFlattenLayer(flattenLayer);
+
+    /* ASSERT. */
+    TEST_ASSERT_TRUE(capturedNotNull);
+    TEST_ASSERT_EQUAL_INT(FLATTEN, capturedType);
+    TEST_ASSERT_TRUE_MESSAGE(capturedConfigNull,
+                             "FLATTEN carries no per-layer config; layer->config must be NULL");
 }
 
 void testFlattenCalcOutputShape_NonSquareInput(void) {
@@ -38,121 +48,275 @@ void testFlattenCalcOutputShape_NonSquareInput(void) {
     layer_t *flatten = flattenLayerInit();
     flattenCalcOutputShape(flatten, &inputShape, &outputShape);
 
-    TEST_ASSERT_EQUAL_UINT(2, outputShape.numberOfDimensions);
-    TEST_ASSERT_EQUAL_UINT(1, outputShape.dimensions[0]);
-    TEST_ASSERT_EQUAL_UINT(60, outputShape.dimensions[1]);
-    TEST_ASSERT_EQUAL_UINT(0, outputShape.orderOfDimensions[0]);
-    TEST_ASSERT_EQUAL_UINT(1, outputShape.orderOfDimensions[1]);
+    /* CAPTURE before frees. */
+    size_t capturedNumDims = outputShape.numberOfDimensions;
+    size_t capturedDim0 = outputShape.dimensions[0];
+    size_t capturedDim1 = outputShape.dimensions[1];
+    size_t capturedOrder0 = outputShape.orderOfDimensions[0];
+    size_t capturedOrder1 = outputShape.orderOfDimensions[1];
 
+    /* FREE. */
     freeFlattenLayer(flatten);
+
+    /* ASSERT. */
+    TEST_ASSERT_EQUAL_UINT(2, capturedNumDims);
+    TEST_ASSERT_EQUAL_UINT(1, capturedDim0);
+    TEST_ASSERT_EQUAL_UINT(60, capturedDim1);
+    TEST_ASSERT_EQUAL_UINT(0, capturedOrder0);
+    TEST_ASSERT_EQUAL_UINT(1, capturedOrder1);
 }
 
 void testFlattenForwardFloat_PreservesBytesAndReshapes(void) {
     size_t n = 12; // 1 * 2 * 2 * 3
     float inputData[] = {1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f, 10.f, 11.f, 12.f};
-    size_t inputDims[] = {1, 2, 2, 3};
-    tensor_t *input = tensorInitFloat(inputData, inputDims, 4, NULL);
 
-    float outputData[12] = {0};
-    size_t outputDims[] = {1, 12};
-    tensor_t *output = tensorInitFloat(outputData, outputDims, 2, NULL);
+    /* 1. Build heap input tensor (shape 1x2x2x3). */
+    size_t *inputDims = reserveMemory(4 * sizeof(size_t));
+    inputDims[0] = 1;
+    inputDims[1] = 2;
+    inputDims[2] = 2;
+    inputDims[3] = 3;
+    size_t *inputOrder = reserveMemory(4 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(4, inputOrder);
+    shape_t *inputShape = reserveMemory(sizeof(shape_t));
+    setShape(inputShape, inputDims, 4, inputOrder);
+    tensor_t *input = initTensor(inputShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(input, inputData, n);
 
+    /* 2. Build heap output tensor (shape 1x12). */
+    size_t *outputDims = reserveMemory(2 * sizeof(size_t));
+    outputDims[0] = 1;
+    outputDims[1] = 12;
+    size_t *outputOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, outputOrder);
+    shape_t *outputShape = reserveMemory(sizeof(shape_t));
+    setShape(outputShape, outputDims, 2, outputOrder);
+    tensor_t *output = initTensor(outputShape, quantizationInitFloat(), NULL);
+
+    /* 3. Build flatten layer. */
     layer_t *flatten = flattenLayerInit();
     flattenForward(flatten, input, output);
 
-    float *actual = (float *)output->data;
-    TEST_ASSERT_EQUAL_FLOAT_ARRAY(inputData, actual, n);
+    /* 4. CAPTURE assertion values before frees. */
+    float captured[12];
+    for (size_t i = 0; i < n; i++) {
+        captured[i] = ((float *)output->data)[i];
+    }
 
+    /* 5. FREE in reverse-init order. */
     freeFlattenLayer(flatten);
+    freeTensor(output);
+    freeTensor(input);
+
+    /* 6. ASSERT on captured. */
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(inputData, captured, n);
 }
 
 void testFlattenForwardSymInt32_PropagatesScaleAndValues(void) {
     size_t n = 6;
     float inputFloatData[] = {1.f, 2.f, 3.f, 4.f, 5.f, 6.f};
-    size_t inputDims[] = {1, 2, 3};
-    tensor_t *input = tensorInitSymInt32(inputFloatData, inputDims, 3, HTE, NULL);
 
-    float outputFloatData[6] = {0};
-    size_t outputDims[] = {1, 6};
-    tensor_t *output = tensorInitSymInt32(outputFloatData, outputDims, 2, HTE, NULL);
+    /* 1. Build heap input tensor (SymInt32, shape 1x2x3). */
+    size_t *inputDims = reserveMemory(3 * sizeof(size_t));
+    inputDims[0] = 1;
+    inputDims[1] = 2;
+    inputDims[2] = 3;
+    size_t *inputOrder = reserveMemory(3 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(3, inputOrder);
+    shape_t *inputShape = reserveMemory(sizeof(shape_t));
+    setShape(inputShape, inputDims, 3, inputOrder);
+    tensor_t *input = initTensor(inputShape, quantizationInitSymInt32(HTE), NULL);
+    tensorFillFromFloatBuffer(input, inputFloatData, n);
 
-    // Clobber the output's scale so we can verify flattenForward writes it.
+    /* 2. Build heap output tensor (SymInt32, shape 1x6). */
+    size_t *outputDims = reserveMemory(2 * sizeof(size_t));
+    outputDims[0] = 1;
+    outputDims[1] = 6;
+    size_t *outputOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, outputOrder);
+    shape_t *outputShape = reserveMemory(sizeof(shape_t));
+    setShape(outputShape, outputDims, 2, outputOrder);
+    tensor_t *output = initTensor(outputShape, quantizationInitSymInt32(HTE), NULL);
+
+    /* Clobber the output's scale so we can verify flattenForward writes it. */
     symInt32QConfig_t *outputQC = output->quantization->qConfig;
     outputQC->scale = 0.0f;
 
     layer_t *flatten = flattenLayerInit();
     flattenForward(flatten, input, output);
 
+    /* 3. Capture scale-propagation observation before frees. */
     symInt32QConfig_t *inputQC = input->quantization->qConfig;
-    TEST_ASSERT_EQUAL_FLOAT(inputQC->scale, outputQC->scale);
+    float capturedInputScale = inputQC->scale;
+    float capturedOutputScale = outputQC->scale;
 
-    // Values round-trip through the same scale.
-    float roundTripData[6];
-    tensor_t *roundTrip = tensorInitFloat(roundTripData, outputDims, 2, NULL);
+    /* 4. Build heap roundtrip Float tensor (shape 1x6) and convert. */
+    size_t *roundTripDims = reserveMemory(2 * sizeof(size_t));
+    roundTripDims[0] = 1;
+    roundTripDims[1] = 6;
+    size_t *roundTripOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, roundTripOrder);
+    shape_t *roundTripShape = reserveMemory(sizeof(shape_t));
+    setShape(roundTripShape, roundTripDims, 2, roundTripOrder);
+    tensor_t *roundTrip = initTensor(roundTripShape, quantizationInitFloat(), NULL);
     convertTensor(output, roundTrip);
-    float *actual = (float *)roundTrip->data;
+
+    /* 5. CAPTURE roundtrip values before frees. */
+    float captured[6];
     for (size_t i = 0; i < n; i++) {
-        TEST_ASSERT_FLOAT_WITHIN(0.1f, inputFloatData[i], actual[i]);
+        captured[i] = ((float *)roundTrip->data)[i];
     }
 
+    /* 6. FREE in reverse-init order. */
+    freeTensor(roundTrip);
     freeFlattenLayer(flatten);
+    freeTensor(output);
+    freeTensor(input);
+
+    /* 7. ASSERT. */
+    TEST_ASSERT_EQUAL_FLOAT(capturedInputScale, capturedOutputScale);
+    for (size_t i = 0; i < n; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(0.1f, inputFloatData[i], captured[i]);
+    }
 }
 
 void testFlattenBackwardFloat_CopiesGradsUnchanged(void) {
     size_t n = 6;
-
-    size_t forwardDims[] = {1, 2, 3};
-    float forwardData[] = {-1.f, 0.f, 1.f, 2.f, 5.f, -6.f};
-    tensor_t *forwardInput = tensorInitFloat(forwardData, forwardDims, 3, NULL);
-
-    size_t lossDims[] = {1, 6};
     float lossData[] = {0.1f, 0.2f, -0.3f, 0.4f, 0.5f, 0.6f};
-    tensor_t *loss = tensorInitFloat(lossData, lossDims, 2, NULL);
 
-    float propLossData[6] = {0};
-    tensor_t *propLoss = tensorInitFloat(propLossData, forwardDims, 3, NULL);
+    /* 1. Build heap forwardInput tensor (shape 1x2x3). */
+    size_t *forwardDims = reserveMemory(3 * sizeof(size_t));
+    forwardDims[0] = 1;
+    forwardDims[1] = 2;
+    forwardDims[2] = 3;
+    size_t *forwardOrder = reserveMemory(3 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(3, forwardOrder);
+    shape_t *forwardShape = reserveMemory(sizeof(shape_t));
+    setShape(forwardShape, forwardDims, 3, forwardOrder);
+    tensor_t *forwardInput = initTensor(forwardShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(forwardInput, (float[]){-1.f, 0.f, 1.f, 2.f, 5.f, -6.f}, 6);
+
+    /* 2. Build heap loss tensor (shape 1x6). */
+    size_t *lossDims = reserveMemory(2 * sizeof(size_t));
+    lossDims[0] = 1;
+    lossDims[1] = 6;
+    size_t *lossOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, lossOrder);
+    shape_t *lossShape = reserveMemory(sizeof(shape_t));
+    setShape(lossShape, lossDims, 2, lossOrder);
+    tensor_t *loss = initTensor(lossShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(loss, lossData, n);
+
+    /* 3. Build heap propLoss tensor (shape 1x2x3 — same as forwardInput). */
+    size_t *propLossDims = reserveMemory(3 * sizeof(size_t));
+    propLossDims[0] = 1;
+    propLossDims[1] = 2;
+    propLossDims[2] = 3;
+    size_t *propLossOrder = reserveMemory(3 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(3, propLossOrder);
+    shape_t *propLossShape = reserveMemory(sizeof(shape_t));
+    setShape(propLossShape, propLossDims, 3, propLossOrder);
+    tensor_t *propLoss = initTensor(propLossShape, quantizationInitFloat(), NULL);
 
     layer_t *flatten = flattenLayerInit();
     flattenBackward(flatten, forwardInput, loss, propLoss);
 
-    float *actual = (float *)propLoss->data;
-    TEST_ASSERT_EQUAL_FLOAT_ARRAY(lossData, actual, n);
+    /* 4. CAPTURE before frees. */
+    float captured[6];
+    for (size_t i = 0; i < n; i++) {
+        captured[i] = ((float *)propLoss->data)[i];
+    }
 
+    /* 5. FREE. */
     freeFlattenLayer(flatten);
+    freeTensor(propLoss);
+    freeTensor(loss);
+    freeTensor(forwardInput);
+
+    /* 6. ASSERT. */
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(lossData, captured, n);
 }
 
 void testFlattenBackwardSymInt32_PropagatesScale(void) {
     size_t n = 6;
-
-    size_t forwardDims[] = {1, 2, 3};
-    float forwardData[] = {-1.f, 0.f, 1.f, 2.f, 5.f, -6.f};
-    tensor_t *forwardInput = tensorInitSymInt32(forwardData, forwardDims, 3, HTE, NULL);
-
-    size_t lossDims[] = {1, 6};
     float lossFloatData[] = {0.1f, 0.2f, -0.3f, 0.4f, 0.5f, 0.6f};
-    tensor_t *loss = tensorInitSymInt32(lossFloatData, lossDims, 2, HTE, NULL);
 
-    float propLossFloatData[6] = {0};
-    tensor_t *propLoss = tensorInitSymInt32(propLossFloatData, forwardDims, 3, HTE, NULL);
+    /* 1. Build heap forwardInput tensor (SymInt32, shape 1x2x3). */
+    size_t *forwardDims = reserveMemory(3 * sizeof(size_t));
+    forwardDims[0] = 1;
+    forwardDims[1] = 2;
+    forwardDims[2] = 3;
+    size_t *forwardOrder = reserveMemory(3 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(3, forwardOrder);
+    shape_t *forwardShape = reserveMemory(sizeof(shape_t));
+    setShape(forwardShape, forwardDims, 3, forwardOrder);
+    tensor_t *forwardInput = initTensor(forwardShape, quantizationInitSymInt32(HTE), NULL);
+    tensorFillFromFloatBuffer(forwardInput, (float[]){-1.f, 0.f, 1.f, 2.f, 5.f, -6.f}, 6);
 
+    /* 2. Build heap loss tensor (SymInt32, shape 1x6). */
+    size_t *lossDims = reserveMemory(2 * sizeof(size_t));
+    lossDims[0] = 1;
+    lossDims[1] = 6;
+    size_t *lossOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, lossOrder);
+    shape_t *lossShape = reserveMemory(sizeof(shape_t));
+    setShape(lossShape, lossDims, 2, lossOrder);
+    tensor_t *loss = initTensor(lossShape, quantizationInitSymInt32(HTE), NULL);
+    tensorFillFromFloatBuffer(loss, lossFloatData, n);
+
+    /* 3. Build heap propLoss tensor (SymInt32, shape 1x2x3). */
+    size_t *propLossDims = reserveMemory(3 * sizeof(size_t));
+    propLossDims[0] = 1;
+    propLossDims[1] = 2;
+    propLossDims[2] = 3;
+    size_t *propLossOrder = reserveMemory(3 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(3, propLossOrder);
+    shape_t *propLossShape = reserveMemory(sizeof(shape_t));
+    setShape(propLossShape, propLossDims, 3, propLossOrder);
+    tensor_t *propLoss = initTensor(propLossShape, quantizationInitSymInt32(HTE), NULL);
+
+    /* Clobber propLoss scale so we can verify flattenBackward writes it. */
     symInt32QConfig_t *propLossQC = propLoss->quantization->qConfig;
     propLossQC->scale = 0.0f;
 
     layer_t *flatten = flattenLayerInit();
     flattenBackward(flatten, forwardInput, loss, propLoss);
 
+    /* 4. Capture scale-propagation observation before frees. */
     symInt32QConfig_t *lossQC = loss->quantization->qConfig;
-    TEST_ASSERT_EQUAL_FLOAT(lossQC->scale, propLossQC->scale);
+    float capturedLossScale = lossQC->scale;
+    float capturedPropLossScale = propLossQC->scale;
 
-    float roundTripData[6];
-    tensor_t *roundTrip = tensorInitFloat(roundTripData, forwardDims, 3, NULL);
+    /* 5. Build heap roundtrip Float tensor (shape 1x2x3) and convert. */
+    size_t *roundTripDims = reserveMemory(3 * sizeof(size_t));
+    roundTripDims[0] = 1;
+    roundTripDims[1] = 2;
+    roundTripDims[2] = 3;
+    size_t *roundTripOrder = reserveMemory(3 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(3, roundTripOrder);
+    shape_t *roundTripShape = reserveMemory(sizeof(shape_t));
+    setShape(roundTripShape, roundTripDims, 3, roundTripOrder);
+    tensor_t *roundTrip = initTensor(roundTripShape, quantizationInitFloat(), NULL);
     convertTensor(propLoss, roundTrip);
-    float *actual = (float *)roundTrip->data;
+
+    /* 6. CAPTURE roundtrip values before frees. */
+    float captured[6];
     for (size_t i = 0; i < n; i++) {
-        TEST_ASSERT_FLOAT_WITHIN(0.1f, lossFloatData[i], actual[i]);
+        captured[i] = ((float *)roundTrip->data)[i];
     }
 
+    /* 7. FREE in reverse-init order. */
+    freeTensor(roundTrip);
     freeFlattenLayer(flatten);
+    freeTensor(propLoss);
+    freeTensor(loss);
+    freeTensor(forwardInput);
+
+    /* 8. ASSERT. */
+    TEST_ASSERT_EQUAL_FLOAT(capturedLossScale, capturedPropLossScale);
+    for (size_t i = 0; i < n; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(0.1f, lossFloatData[i], captured[i]);
+    }
 }
 
 void setUp(void) {}

--- a/test/unit/layer/UnitTestFlatten.c
+++ b/test/unit/layer/UnitTestFlatten.c
@@ -23,7 +23,7 @@ void testFlattenLayerInit_ReturnsFlattenTypedLayer(void) {
 }
 
 void testFlattenCalcOutputShape_NonSquareInput(void) {
-    // Regression test for the old flattenItemDims bug (dim[2]*dim[2])
+    // Regression: product of all trailing dims, not the squared last dim.
     // Input [1, 3, 4, 5] must flatten to [1, 60], NOT [1, 25] or similar.
     size_t inputDims[] = {1, 3, 4, 5};
     size_t inputOrder[] = {0, 1, 2, 3};

--- a/test/unit/layer/UnitTestFlatten.c
+++ b/test/unit/layer/UnitTestFlatten.c
@@ -22,11 +22,37 @@ void testFlattenLayerInit_ReturnsFlattenTypedLayer(void) {
   freeFlattenLayer(flattenLayer);
 }
 
+void testFlattenCalcOutputShape_NonSquareInput(void) {
+  // Regression test for the old flattenItemDims bug (dim[2]*dim[2])
+  // Input [1, 3, 4, 5] must flatten to [1, 60], NOT [1, 25] or similar.
+  size_t inputDims[] = {1, 3, 4, 5};
+  size_t inputOrder[] = {0, 1, 2, 3};
+  shape_t inputShape = {
+      .dimensions = inputDims, .orderOfDimensions = inputOrder, .numberOfDimensions = 4};
+
+  size_t outputDimsBuf[4] = {0};
+  size_t outputOrderBuf[4] = {0};
+  shape_t outputShape = {
+      .dimensions = outputDimsBuf, .orderOfDimensions = outputOrderBuf, .numberOfDimensions = 0};
+
+  layer_t *flatten = flattenLayerInit();
+  flattenCalcOutputShape(flatten, &inputShape, &outputShape);
+
+  TEST_ASSERT_EQUAL_UINT(2, outputShape.numberOfDimensions);
+  TEST_ASSERT_EQUAL_UINT(1, outputShape.dimensions[0]);
+  TEST_ASSERT_EQUAL_UINT(60, outputShape.dimensions[1]);
+  TEST_ASSERT_EQUAL_UINT(0, outputShape.orderOfDimensions[0]);
+  TEST_ASSERT_EQUAL_UINT(1, outputShape.orderOfDimensions[1]);
+
+  freeFlattenLayer(flatten);
+}
+
 void setUp(void) {}
 void tearDown(void) {}
 
 int main(void) {
   UNITY_BEGIN();
   RUN_TEST(testFlattenLayerInit_ReturnsFlattenTypedLayer);
+  RUN_TEST(testFlattenCalcOutputShape_NonSquareInput);
   return UNITY_END();
 }

--- a/test/unit/layer/UnitTestFlatten.c
+++ b/test/unit/layer/UnitTestFlatten.c
@@ -12,159 +12,159 @@
 #include "unity.h"
 
 void testFlattenLayerInit_ReturnsFlattenTypedLayer(void) {
-  layer_t *flattenLayer = flattenLayerInit();
+    layer_t *flattenLayer = flattenLayerInit();
 
-  TEST_ASSERT_NOT_NULL(flattenLayer);
-  TEST_ASSERT_EQUAL_INT(FLATTEN, flattenLayer->type);
-  TEST_ASSERT_NULL_MESSAGE(flattenLayer->config,
-                           "FLATTEN carries no per-layer config; layer->config must be NULL");
+    TEST_ASSERT_NOT_NULL(flattenLayer);
+    TEST_ASSERT_EQUAL_INT(FLATTEN, flattenLayer->type);
+    TEST_ASSERT_NULL_MESSAGE(flattenLayer->config,
+                             "FLATTEN carries no per-layer config; layer->config must be NULL");
 
-  freeFlattenLayer(flattenLayer);
+    freeFlattenLayer(flattenLayer);
 }
 
 void testFlattenCalcOutputShape_NonSquareInput(void) {
-  // Regression test for the old flattenItemDims bug (dim[2]*dim[2])
-  // Input [1, 3, 4, 5] must flatten to [1, 60], NOT [1, 25] or similar.
-  size_t inputDims[] = {1, 3, 4, 5};
-  size_t inputOrder[] = {0, 1, 2, 3};
-  shape_t inputShape = {
-      .dimensions = inputDims, .orderOfDimensions = inputOrder, .numberOfDimensions = 4};
+    // Regression test for the old flattenItemDims bug (dim[2]*dim[2])
+    // Input [1, 3, 4, 5] must flatten to [1, 60], NOT [1, 25] or similar.
+    size_t inputDims[] = {1, 3, 4, 5};
+    size_t inputOrder[] = {0, 1, 2, 3};
+    shape_t inputShape = {
+        .dimensions = inputDims, .orderOfDimensions = inputOrder, .numberOfDimensions = 4};
 
-  size_t outputDimsBuf[4] = {0};
-  size_t outputOrderBuf[4] = {0};
-  shape_t outputShape = {
-      .dimensions = outputDimsBuf, .orderOfDimensions = outputOrderBuf, .numberOfDimensions = 0};
+    size_t outputDimsBuf[4] = {0};
+    size_t outputOrderBuf[4] = {0};
+    shape_t outputShape = {
+        .dimensions = outputDimsBuf, .orderOfDimensions = outputOrderBuf, .numberOfDimensions = 0};
 
-  layer_t *flatten = flattenLayerInit();
-  flattenCalcOutputShape(flatten, &inputShape, &outputShape);
+    layer_t *flatten = flattenLayerInit();
+    flattenCalcOutputShape(flatten, &inputShape, &outputShape);
 
-  TEST_ASSERT_EQUAL_UINT(2, outputShape.numberOfDimensions);
-  TEST_ASSERT_EQUAL_UINT(1, outputShape.dimensions[0]);
-  TEST_ASSERT_EQUAL_UINT(60, outputShape.dimensions[1]);
-  TEST_ASSERT_EQUAL_UINT(0, outputShape.orderOfDimensions[0]);
-  TEST_ASSERT_EQUAL_UINT(1, outputShape.orderOfDimensions[1]);
+    TEST_ASSERT_EQUAL_UINT(2, outputShape.numberOfDimensions);
+    TEST_ASSERT_EQUAL_UINT(1, outputShape.dimensions[0]);
+    TEST_ASSERT_EQUAL_UINT(60, outputShape.dimensions[1]);
+    TEST_ASSERT_EQUAL_UINT(0, outputShape.orderOfDimensions[0]);
+    TEST_ASSERT_EQUAL_UINT(1, outputShape.orderOfDimensions[1]);
 
-  freeFlattenLayer(flatten);
+    freeFlattenLayer(flatten);
 }
 
 void testFlattenForwardFloat_PreservesBytesAndReshapes(void) {
-  size_t n = 12; // 1 * 2 * 2 * 3
-  float inputData[] = {1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f, 10.f, 11.f, 12.f};
-  size_t inputDims[] = {1, 2, 2, 3};
-  tensor_t *input = tensorInitFloat(inputData, inputDims, 4, NULL);
+    size_t n = 12; // 1 * 2 * 2 * 3
+    float inputData[] = {1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f, 10.f, 11.f, 12.f};
+    size_t inputDims[] = {1, 2, 2, 3};
+    tensor_t *input = tensorInitFloat(inputData, inputDims, 4, NULL);
 
-  float outputData[12] = {0};
-  size_t outputDims[] = {1, 12};
-  tensor_t *output = tensorInitFloat(outputData, outputDims, 2, NULL);
+    float outputData[12] = {0};
+    size_t outputDims[] = {1, 12};
+    tensor_t *output = tensorInitFloat(outputData, outputDims, 2, NULL);
 
-  layer_t *flatten = flattenLayerInit();
-  flattenForward(flatten, input, output);
+    layer_t *flatten = flattenLayerInit();
+    flattenForward(flatten, input, output);
 
-  float *actual = (float *)output->data;
-  TEST_ASSERT_EQUAL_FLOAT_ARRAY(inputData, actual, n);
+    float *actual = (float *)output->data;
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(inputData, actual, n);
 
-  freeFlattenLayer(flatten);
+    freeFlattenLayer(flatten);
 }
 
 void testFlattenForwardSymInt32_PropagatesScaleAndValues(void) {
-  size_t n = 6;
-  float inputFloatData[] = {1.f, 2.f, 3.f, 4.f, 5.f, 6.f};
-  size_t inputDims[] = {1, 2, 3};
-  tensor_t *input = tensorInitSymInt32(inputFloatData, inputDims, 3, HTE, NULL);
+    size_t n = 6;
+    float inputFloatData[] = {1.f, 2.f, 3.f, 4.f, 5.f, 6.f};
+    size_t inputDims[] = {1, 2, 3};
+    tensor_t *input = tensorInitSymInt32(inputFloatData, inputDims, 3, HTE, NULL);
 
-  float outputFloatData[6] = {0};
-  size_t outputDims[] = {1, 6};
-  tensor_t *output = tensorInitSymInt32(outputFloatData, outputDims, 2, HTE, NULL);
+    float outputFloatData[6] = {0};
+    size_t outputDims[] = {1, 6};
+    tensor_t *output = tensorInitSymInt32(outputFloatData, outputDims, 2, HTE, NULL);
 
-  // Clobber the output's scale so we can verify flattenForward writes it.
-  symInt32QConfig_t *outputQC = output->quantization->qConfig;
-  outputQC->scale = 0.0f;
+    // Clobber the output's scale so we can verify flattenForward writes it.
+    symInt32QConfig_t *outputQC = output->quantization->qConfig;
+    outputQC->scale = 0.0f;
 
-  layer_t *flatten = flattenLayerInit();
-  flattenForward(flatten, input, output);
+    layer_t *flatten = flattenLayerInit();
+    flattenForward(flatten, input, output);
 
-  symInt32QConfig_t *inputQC = input->quantization->qConfig;
-  TEST_ASSERT_EQUAL_FLOAT(inputQC->scale, outputQC->scale);
+    symInt32QConfig_t *inputQC = input->quantization->qConfig;
+    TEST_ASSERT_EQUAL_FLOAT(inputQC->scale, outputQC->scale);
 
-  // Values round-trip through the same scale.
-  float roundTripData[6];
-  tensor_t *roundTrip = tensorInitFloat(roundTripData, outputDims, 2, NULL);
-  convertTensor(output, roundTrip);
-  float *actual = (float *)roundTrip->data;
-  for (size_t i = 0; i < n; i++) {
-    TEST_ASSERT_FLOAT_WITHIN(0.1f, inputFloatData[i], actual[i]);
-  }
+    // Values round-trip through the same scale.
+    float roundTripData[6];
+    tensor_t *roundTrip = tensorInitFloat(roundTripData, outputDims, 2, NULL);
+    convertTensor(output, roundTrip);
+    float *actual = (float *)roundTrip->data;
+    for (size_t i = 0; i < n; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(0.1f, inputFloatData[i], actual[i]);
+    }
 
-  freeFlattenLayer(flatten);
+    freeFlattenLayer(flatten);
 }
 
 void testFlattenBackwardFloat_CopiesGradsUnchanged(void) {
-  size_t n = 6;
+    size_t n = 6;
 
-  size_t forwardDims[] = {1, 2, 3};
-  float forwardData[] = {-1.f, 0.f, 1.f, 2.f, 5.f, -6.f};
-  tensor_t *forwardInput = tensorInitFloat(forwardData, forwardDims, 3, NULL);
+    size_t forwardDims[] = {1, 2, 3};
+    float forwardData[] = {-1.f, 0.f, 1.f, 2.f, 5.f, -6.f};
+    tensor_t *forwardInput = tensorInitFloat(forwardData, forwardDims, 3, NULL);
 
-  size_t lossDims[] = {1, 6};
-  float lossData[] = {0.1f, 0.2f, -0.3f, 0.4f, 0.5f, 0.6f};
-  tensor_t *loss = tensorInitFloat(lossData, lossDims, 2, NULL);
+    size_t lossDims[] = {1, 6};
+    float lossData[] = {0.1f, 0.2f, -0.3f, 0.4f, 0.5f, 0.6f};
+    tensor_t *loss = tensorInitFloat(lossData, lossDims, 2, NULL);
 
-  float propLossData[6] = {0};
-  tensor_t *propLoss = tensorInitFloat(propLossData, forwardDims, 3, NULL);
+    float propLossData[6] = {0};
+    tensor_t *propLoss = tensorInitFloat(propLossData, forwardDims, 3, NULL);
 
-  layer_t *flatten = flattenLayerInit();
-  flattenBackward(flatten, forwardInput, loss, propLoss);
+    layer_t *flatten = flattenLayerInit();
+    flattenBackward(flatten, forwardInput, loss, propLoss);
 
-  float *actual = (float *)propLoss->data;
-  TEST_ASSERT_EQUAL_FLOAT_ARRAY(lossData, actual, n);
+    float *actual = (float *)propLoss->data;
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(lossData, actual, n);
 
-  freeFlattenLayer(flatten);
+    freeFlattenLayer(flatten);
 }
 
 void testFlattenBackwardSymInt32_PropagatesScale(void) {
-  size_t n = 6;
+    size_t n = 6;
 
-  size_t forwardDims[] = {1, 2, 3};
-  float forwardData[] = {-1.f, 0.f, 1.f, 2.f, 5.f, -6.f};
-  tensor_t *forwardInput = tensorInitSymInt32(forwardData, forwardDims, 3, HTE, NULL);
+    size_t forwardDims[] = {1, 2, 3};
+    float forwardData[] = {-1.f, 0.f, 1.f, 2.f, 5.f, -6.f};
+    tensor_t *forwardInput = tensorInitSymInt32(forwardData, forwardDims, 3, HTE, NULL);
 
-  size_t lossDims[] = {1, 6};
-  float lossFloatData[] = {0.1f, 0.2f, -0.3f, 0.4f, 0.5f, 0.6f};
-  tensor_t *loss = tensorInitSymInt32(lossFloatData, lossDims, 2, HTE, NULL);
+    size_t lossDims[] = {1, 6};
+    float lossFloatData[] = {0.1f, 0.2f, -0.3f, 0.4f, 0.5f, 0.6f};
+    tensor_t *loss = tensorInitSymInt32(lossFloatData, lossDims, 2, HTE, NULL);
 
-  float propLossFloatData[6] = {0};
-  tensor_t *propLoss = tensorInitSymInt32(propLossFloatData, forwardDims, 3, HTE, NULL);
+    float propLossFloatData[6] = {0};
+    tensor_t *propLoss = tensorInitSymInt32(propLossFloatData, forwardDims, 3, HTE, NULL);
 
-  symInt32QConfig_t *propLossQC = propLoss->quantization->qConfig;
-  propLossQC->scale = 0.0f;
+    symInt32QConfig_t *propLossQC = propLoss->quantization->qConfig;
+    propLossQC->scale = 0.0f;
 
-  layer_t *flatten = flattenLayerInit();
-  flattenBackward(flatten, forwardInput, loss, propLoss);
+    layer_t *flatten = flattenLayerInit();
+    flattenBackward(flatten, forwardInput, loss, propLoss);
 
-  symInt32QConfig_t *lossQC = loss->quantization->qConfig;
-  TEST_ASSERT_EQUAL_FLOAT(lossQC->scale, propLossQC->scale);
+    symInt32QConfig_t *lossQC = loss->quantization->qConfig;
+    TEST_ASSERT_EQUAL_FLOAT(lossQC->scale, propLossQC->scale);
 
-  float roundTripData[6];
-  tensor_t *roundTrip = tensorInitFloat(roundTripData, forwardDims, 3, NULL);
-  convertTensor(propLoss, roundTrip);
-  float *actual = (float *)roundTrip->data;
-  for (size_t i = 0; i < n; i++) {
-    TEST_ASSERT_FLOAT_WITHIN(0.1f, lossFloatData[i], actual[i]);
-  }
+    float roundTripData[6];
+    tensor_t *roundTrip = tensorInitFloat(roundTripData, forwardDims, 3, NULL);
+    convertTensor(propLoss, roundTrip);
+    float *actual = (float *)roundTrip->data;
+    for (size_t i = 0; i < n; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(0.1f, lossFloatData[i], actual[i]);
+    }
 
-  freeFlattenLayer(flatten);
+    freeFlattenLayer(flatten);
 }
 
 void setUp(void) {}
 void tearDown(void) {}
 
 int main(void) {
-  UNITY_BEGIN();
-  RUN_TEST(testFlattenLayerInit_ReturnsFlattenTypedLayer);
-  RUN_TEST(testFlattenCalcOutputShape_NonSquareInput);
-  RUN_TEST(testFlattenForwardFloat_PreservesBytesAndReshapes);
-  RUN_TEST(testFlattenForwardSymInt32_PropagatesScaleAndValues);
-  RUN_TEST(testFlattenBackwardFloat_CopiesGradsUnchanged);
-  RUN_TEST(testFlattenBackwardSymInt32_PropagatesScale);
-  return UNITY_END();
+    UNITY_BEGIN();
+    RUN_TEST(testFlattenLayerInit_ReturnsFlattenTypedLayer);
+    RUN_TEST(testFlattenCalcOutputShape_NonSquareInput);
+    RUN_TEST(testFlattenForwardFloat_PreservesBytesAndReshapes);
+    RUN_TEST(testFlattenForwardSymInt32_PropagatesScaleAndValues);
+    RUN_TEST(testFlattenBackwardFloat_CopiesGradsUnchanged);
+    RUN_TEST(testFlattenBackwardSymInt32_PropagatesScale);
+    return UNITY_END();
 }

--- a/test/unit/layer/UnitTestFlatten.c
+++ b/test/unit/layer/UnitTestFlatten.c
@@ -66,6 +66,38 @@ void testFlattenForwardFloat_PreservesBytesAndReshapes(void) {
   freeFlattenLayer(flatten);
 }
 
+void testFlattenForwardSymInt32_PropagatesScaleAndValues(void) {
+  size_t n = 6;
+  float inputFloatData[] = {1.f, 2.f, 3.f, 4.f, 5.f, 6.f};
+  size_t inputDims[] = {1, 2, 3};
+  tensor_t *input = tensorInitSymInt32(inputFloatData, inputDims, 3, HTE, NULL);
+
+  float outputFloatData[6] = {0};
+  size_t outputDims[] = {1, 6};
+  tensor_t *output = tensorInitSymInt32(outputFloatData, outputDims, 2, HTE, NULL);
+
+  // Clobber the output's scale so we can verify flattenForward writes it.
+  symInt32QConfig_t *outputQC = output->quantization->qConfig;
+  outputQC->scale = 0.0f;
+
+  layer_t *flatten = flattenLayerInit();
+  flattenForward(flatten, input, output);
+
+  symInt32QConfig_t *inputQC = input->quantization->qConfig;
+  TEST_ASSERT_EQUAL_FLOAT(inputQC->scale, outputQC->scale);
+
+  // Values round-trip through the same scale.
+  float roundTripData[6];
+  tensor_t *roundTrip = tensorInitFloat(roundTripData, outputDims, 2, NULL);
+  convertTensor(output, roundTrip);
+  float *actual = (float *)roundTrip->data;
+  for (size_t i = 0; i < n; i++) {
+    TEST_ASSERT_FLOAT_WITHIN(0.1f, inputFloatData[i], actual[i]);
+  }
+
+  freeFlattenLayer(flatten);
+}
+
 void setUp(void) {}
 void tearDown(void) {}
 
@@ -74,5 +106,6 @@ int main(void) {
   RUN_TEST(testFlattenLayerInit_ReturnsFlattenTypedLayer);
   RUN_TEST(testFlattenCalcOutputShape_NonSquareInput);
   RUN_TEST(testFlattenForwardFloat_PreservesBytesAndReshapes);
+  RUN_TEST(testFlattenForwardSymInt32_PropagatesScaleAndValues);
   return UNITY_END();
 }

--- a/test/unit/layer/UnitTestFlatten.c
+++ b/test/unit/layer/UnitTestFlatten.c
@@ -121,6 +121,40 @@ void testFlattenBackwardFloat_CopiesGradsUnchanged(void) {
   freeFlattenLayer(flatten);
 }
 
+void testFlattenBackwardSymInt32_PropagatesScale(void) {
+  size_t n = 6;
+
+  size_t forwardDims[] = {1, 2, 3};
+  float forwardData[] = {-1.f, 0.f, 1.f, 2.f, 5.f, -6.f};
+  tensor_t *forwardInput = tensorInitSymInt32(forwardData, forwardDims, 3, HTE, NULL);
+
+  size_t lossDims[] = {1, 6};
+  float lossFloatData[] = {0.1f, 0.2f, -0.3f, 0.4f, 0.5f, 0.6f};
+  tensor_t *loss = tensorInitSymInt32(lossFloatData, lossDims, 2, HTE, NULL);
+
+  float propLossFloatData[6] = {0};
+  tensor_t *propLoss = tensorInitSymInt32(propLossFloatData, forwardDims, 3, HTE, NULL);
+
+  symInt32QConfig_t *propLossQC = propLoss->quantization->qConfig;
+  propLossQC->scale = 0.0f;
+
+  layer_t *flatten = flattenLayerInit();
+  flattenBackward(flatten, forwardInput, loss, propLoss);
+
+  symInt32QConfig_t *lossQC = loss->quantization->qConfig;
+  TEST_ASSERT_EQUAL_FLOAT(lossQC->scale, propLossQC->scale);
+
+  float roundTripData[6];
+  tensor_t *roundTrip = tensorInitFloat(roundTripData, forwardDims, 3, NULL);
+  convertTensor(propLoss, roundTrip);
+  float *actual = (float *)roundTrip->data;
+  for (size_t i = 0; i < n; i++) {
+    TEST_ASSERT_FLOAT_WITHIN(0.1f, lossFloatData[i], actual[i]);
+  }
+
+  freeFlattenLayer(flatten);
+}
+
 void setUp(void) {}
 void tearDown(void) {}
 
@@ -131,5 +165,6 @@ int main(void) {
   RUN_TEST(testFlattenForwardFloat_PreservesBytesAndReshapes);
   RUN_TEST(testFlattenForwardSymInt32_PropagatesScaleAndValues);
   RUN_TEST(testFlattenBackwardFloat_CopiesGradsUnchanged);
+  RUN_TEST(testFlattenBackwardSymInt32_PropagatesScale);
   return UNITY_END();
 }

--- a/test/unit/layer/UnitTestFlatten.c
+++ b/test/unit/layer/UnitTestFlatten.c
@@ -47,6 +47,25 @@ void testFlattenCalcOutputShape_NonSquareInput(void) {
   freeFlattenLayer(flatten);
 }
 
+void testFlattenForwardFloat_PreservesBytesAndReshapes(void) {
+  size_t n = 12; // 1 * 2 * 2 * 3
+  float inputData[] = {1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f, 10.f, 11.f, 12.f};
+  size_t inputDims[] = {1, 2, 2, 3};
+  tensor_t *input = tensorInitFloat(inputData, inputDims, 4, NULL);
+
+  float outputData[12] = {0};
+  size_t outputDims[] = {1, 12};
+  tensor_t *output = tensorInitFloat(outputData, outputDims, 2, NULL);
+
+  layer_t *flatten = flattenLayerInit();
+  flattenForward(flatten, input, output);
+
+  float *actual = (float *)output->data;
+  TEST_ASSERT_EQUAL_FLOAT_ARRAY(inputData, actual, n);
+
+  freeFlattenLayer(flatten);
+}
+
 void setUp(void) {}
 void tearDown(void) {}
 
@@ -54,5 +73,6 @@ int main(void) {
   UNITY_BEGIN();
   RUN_TEST(testFlattenLayerInit_ReturnsFlattenTypedLayer);
   RUN_TEST(testFlattenCalcOutputShape_NonSquareInput);
+  RUN_TEST(testFlattenForwardFloat_PreservesBytesAndReshapes);
   return UNITY_END();
 }

--- a/test/unit/layer/UnitTestFlatten.c
+++ b/test/unit/layer/UnitTestFlatten.c
@@ -1,0 +1,32 @@
+#define SOURCE_FILE "UNIT_TEST_FLATTEN"
+
+#include "DTypes.h"
+#include "Flatten.h"
+#include "FlattenApi.h"
+#include "Layer.h"
+#include "Quantization.h"
+#include "QuantizationApi.h"
+#include "Tensor.h"
+#include "TensorApi.h"
+#include "TensorConversion.h"
+#include "unity.h"
+
+void testFlattenLayerInit_ReturnsFlattenTypedLayer(void) {
+  layer_t *flattenLayer = flattenLayerInit();
+
+  TEST_ASSERT_NOT_NULL(flattenLayer);
+  TEST_ASSERT_EQUAL_INT(FLATTEN, flattenLayer->type);
+  TEST_ASSERT_NULL_MESSAGE(flattenLayer->config,
+                           "FLATTEN carries no per-layer config; layer->config must be NULL");
+
+  freeFlattenLayer(flattenLayer);
+}
+
+void setUp(void) {}
+void tearDown(void) {}
+
+int main(void) {
+  UNITY_BEGIN();
+  RUN_TEST(testFlattenLayerInit_ReturnsFlattenTypedLayer);
+  return UNITY_END();
+}

--- a/test/unit/layer/UnitTestFlatten.c
+++ b/test/unit/layer/UnitTestFlatten.c
@@ -98,6 +98,29 @@ void testFlattenForwardSymInt32_PropagatesScaleAndValues(void) {
   freeFlattenLayer(flatten);
 }
 
+void testFlattenBackwardFloat_CopiesGradsUnchanged(void) {
+  size_t n = 6;
+
+  size_t forwardDims[] = {1, 2, 3};
+  float forwardData[] = {-1.f, 0.f, 1.f, 2.f, 5.f, -6.f};
+  tensor_t *forwardInput = tensorInitFloat(forwardData, forwardDims, 3, NULL);
+
+  size_t lossDims[] = {1, 6};
+  float lossData[] = {0.1f, 0.2f, -0.3f, 0.4f, 0.5f, 0.6f};
+  tensor_t *loss = tensorInitFloat(lossData, lossDims, 2, NULL);
+
+  float propLossData[6] = {0};
+  tensor_t *propLoss = tensorInitFloat(propLossData, forwardDims, 3, NULL);
+
+  layer_t *flatten = flattenLayerInit();
+  flattenBackward(flatten, forwardInput, loss, propLoss);
+
+  float *actual = (float *)propLoss->data;
+  TEST_ASSERT_EQUAL_FLOAT_ARRAY(lossData, actual, n);
+
+  freeFlattenLayer(flatten);
+}
+
 void setUp(void) {}
 void tearDown(void) {}
 
@@ -107,5 +130,6 @@ int main(void) {
   RUN_TEST(testFlattenCalcOutputShape_NonSquareInput);
   RUN_TEST(testFlattenForwardFloat_PreservesBytesAndReshapes);
   RUN_TEST(testFlattenForwardSymInt32_PropagatesScaleAndValues);
+  RUN_TEST(testFlattenBackwardFloat_CopiesGradsUnchanged);
   return UNITY_END();
 }

--- a/test/unit/layer/UnitTestLinear.c
+++ b/test/unit/layer/UnitTestLinear.c
@@ -6,6 +6,7 @@
 #include "LinearApi.h"
 #include "QuantizationApi.h"
 #include "Rounding.h"
+#include "StorageApi.h"
 #include "Tensor.h"
 #include "TensorApi.h"
 #include "TensorConversion.h"
@@ -15,473 +16,610 @@ void setUp() {}
 void tearDown() {}
 
 void testLinearForwardFloat() {
-    parameter_t weights;
-    tensor_t weightsParam;
-    float weightData[] = {-1.f, 2.f, -3.f, 4.f, 5.f, -6.f};
-    size_t weightDims[] = {2, 3};
-    size_t weightNumberOfDims = 2;
-    size_t weightOrderOfDims[] = {0, 1};
-    shape_t weightShape = {.dimensions = weightDims,
-                           .orderOfDimensions = weightOrderOfDims,
-                           .numberOfDimensions = weightNumberOfDims};
-    quantization_t weightQ;
-    initFloat32Quantization(&weightQ);
-    setTensorValues(&weightsParam, (uint8_t *)weightData, &weightShape, &weightQ, NULL);
+    /* 1. Build heap weights tensor (shape 2x3) wrapped in a parameter (no grad). */
+    size_t *weightDims = reserveMemory(2 * sizeof(size_t));
+    weightDims[0] = 2;
+    weightDims[1] = 3;
+    size_t *weightOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, weightOrder);
+    shape_t *weightShape = reserveMemory(sizeof(shape_t));
+    setShape(weightShape, weightDims, 2, weightOrder);
+    tensor_t *weightsParam = initTensor(weightShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(weightsParam, (float[]){-1.f, 2.f, -3.f, 4.f, 5.f, -6.f}, 6);
+    parameter_t *weights = parameterInit(weightsParam, NULL);
 
-    setParameterValues(&weights, &weightsParam, NULL);
+    /* 2. Build heap bias tensor (shape 2,). */
+    size_t *biasDims = reserveMemory(1 * sizeof(size_t));
+    biasDims[0] = 2;
+    size_t *biasOrder = reserveMemory(1 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(1, biasOrder);
+    shape_t *biasShape = reserveMemory(sizeof(shape_t));
+    setShape(biasShape, biasDims, 1, biasOrder);
+    tensor_t *biasParam = initTensor(biasShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(biasParam, (float[]){-1.f, 3.f}, 2);
+    parameter_t *bias = parameterInit(biasParam, NULL);
 
-    parameter_t bias;
-    tensor_t biasParam;
-    float biasData[] = {-1.f, 3.f};
-    size_t biasDims[] = {2};
-    size_t biasNumberOfDims = 1;
-    size_t biasOrderOfDims[] = {0};
-    shape_t biasShape = {.dimensions = biasDims,
-                         .orderOfDimensions = biasOrderOfDims,
-                         .numberOfDimensions = biasNumberOfDims};
-    quantization_t biasQ;
-    initFloat32Quantization(&biasQ);
-    setTensorValues(&biasParam, (uint8_t *)biasData, &biasShape, &biasQ, NULL);
-    setParameterValues(&bias, &biasParam, NULL);
+    /* 3. Build heap input tensor (shape 1x3). */
+    size_t *inputDims = reserveMemory(2 * sizeof(size_t));
+    inputDims[0] = 1;
+    inputDims[1] = 3;
+    size_t *inputOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, inputOrder);
+    shape_t *inputShape = reserveMemory(sizeof(shape_t));
+    setShape(inputShape, inputDims, 2, inputOrder);
+    tensor_t *input = initTensor(inputShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(input, (float[]){0.f, 1.f, 2.f}, 3);
 
-    tensor_t input;
-    float inputData[] = {0.f, 1.f, 2.f};
-    size_t inputDims[] = {1, 3};
-    size_t inputNumberOfDims = 2;
-    size_t inputOrderOfDims[] = {0, 1};
-    shape_t inputShape = {.dimensions = inputDims,
-                          .orderOfDimensions = inputOrderOfDims,
-                          .numberOfDimensions = inputNumberOfDims};
-    quantization_t inputQ;
-    initFloat32Quantization(&inputQ);
-    setTensorValues(&input, (uint8_t *)inputData, &inputShape, &inputQ, NULL);
+    /* 4. Build heap output tensor (shape 2,). */
+    size_t *outputDims = reserveMemory(1 * sizeof(size_t));
+    outputDims[0] = 2;
+    size_t *outputOrder = reserveMemory(1 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(1, outputOrder);
+    shape_t *outputShape = reserveMemory(sizeof(shape_t));
+    setShape(outputShape, outputDims, 1, outputOrder);
+    tensor_t *output = initTensor(outputShape, quantizationInitFloat(), NULL);
 
-    float outputData[2] = {0, 0};
-    size_t outputDims[] = {2};
-    size_t outputNumberOfDims = 1;
-    size_t outputOrderOfDims[] = {0};
-    shape_t outputShape = {.dimensions = outputDims,
-                           .orderOfDimensions = outputOrderOfDims,
-                           .numberOfDimensions = outputNumberOfDims};
-    quantization_t outputQ;
-    initFloat32Quantization(&outputQ);
-    tensor_t output;
-    setTensorValues(&output, (uint8_t *)outputData, &outputShape, &outputQ, NULL);
+    /* 5. Build the layer with shared float quantization. */
+    quantization_t *testQ = quantizationInitFloat();
+    layer_t *linearLayer = linearLayerInit(weights, bias, testQ, testQ, testQ, testQ);
 
-    layer_t linearLayer;
-    layerConfig_t linearConfig;
-    linearConfig_t linCfg;
-    linearConfig.linear = &linCfg;
-    quantization_t testQ;
-    initFloat32Quantization(&testQ);
-    linearInitConfig(linearConfig.linear, &weights, &bias, &testQ, &testQ, &testQ, &testQ);
+    linearForward(linearLayer, input, output);
 
-    initLayer(&linearLayer, LINEAR, &linearConfig);
+    /* 6. CAPTURE. */
+    float captured[2];
+    captured[0] = ((float *)output->data)[0];
+    captured[1] = ((float *)output->data)[1];
 
-    linearForward(&linearLayer, &input, &output);
+    /* 7. FREE. freeLinearLayer releases only the layer config wrapper. */
+    freeLinearLayer(linearLayer);
+    freeTensor(output);
+    freeTensor(input);
+    freeParameter(bias);
+    freeParameter(weights);
+    freeQuantization(testQ);
 
+    /* 8. ASSERT. */
     float expected[] = {-5.f, -4.f};
-
-    TEST_ASSERT_EQUAL_FLOAT_ARRAY(expected, output.data, 2);
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(expected, captured, 2);
 }
 
 void testLinearBackwardFloat() {
-    parameter_t weights;
-    tensor_t weightsParam;
-    tensor_t weightsGrad;
+    /* 1. Build heap weights parameter (param + grad), shape 2x3. */
+    size_t *weightDims = reserveMemory(2 * sizeof(size_t));
+    weightDims[0] = 2;
+    weightDims[1] = 3;
+    size_t *weightOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, weightOrder);
+    shape_t *weightShape = reserveMemory(sizeof(shape_t));
+    setShape(weightShape, weightDims, 2, weightOrder);
+    tensor_t *weightsParam = initTensor(weightShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(weightsParam, (float[]){-1.f, 2.f, -3.f, 4.f, 5.f, -6.f}, 6);
+    tensor_t *weightsGrad = gradInitFloat(weightsParam, NULL);
+    parameter_t *weights = parameterInit(weightsParam, weightsGrad);
 
-    float weightData[] = {-1.f, 2.f, -3.f, 4.f, 5.f, -6.f};
-    size_t weightDims[] = {2, 3};
-    size_t weightNumberOfDims = 2;
-    size_t weightOrderOfDims[] = {0, 1};
-    shape_t weightShape = {.dimensions = weightDims,
-                           .orderOfDimensions = weightOrderOfDims,
-                           .numberOfDimensions = weightNumberOfDims};
-    quantization_t weightQ;
-    initFloat32Quantization(&weightQ);
-    setTensorValues(&weightsParam, (uint8_t *)weightData, &weightShape, &weightQ, NULL);
-    float weightGradData[] = {0.f, 0.f, 0.f, 0.f, 0.f, 0.f};
-    quantization_t weightGradQ;
-    initFloat32Quantization(&weightGradQ);
-    setTensorValues(&weightsGrad, (uint8_t *)weightGradData, &weightShape, &weightGradQ, NULL);
-    setParameterValues(&weights, &weightsParam, &weightsGrad);
+    /* 2. Build heap bias parameter (param + grad), shape 1x2. */
+    size_t *biasDims = reserveMemory(2 * sizeof(size_t));
+    biasDims[0] = 1;
+    biasDims[1] = 2;
+    size_t *biasOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, biasOrder);
+    shape_t *biasShape = reserveMemory(sizeof(shape_t));
+    setShape(biasShape, biasDims, 2, biasOrder);
+    tensor_t *biasParam = initTensor(biasShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(biasParam, (float[]){-1.f, 3.f}, 2);
+    tensor_t *biasGrad = gradInitFloat(biasParam, NULL);
+    parameter_t *bias = parameterInit(biasParam, biasGrad);
 
-    parameter_t bias;
-    tensor_t biasParam;
-    tensor_t biasGrad;
+    /* 3. Build heap forwardInput tensor, shape 1x3. */
+    size_t *fwdDims = reserveMemory(2 * sizeof(size_t));
+    fwdDims[0] = 1;
+    fwdDims[1] = 3;
+    size_t *fwdOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, fwdOrder);
+    shape_t *fwdShape = reserveMemory(sizeof(shape_t));
+    setShape(fwdShape, fwdDims, 2, fwdOrder);
+    tensor_t *forwardInput = initTensor(fwdShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(forwardInput, (float[]){0.f, 1.f, 2.f}, 3);
 
-    float biasData[] = {-1.f, 3.f};
-    size_t biasDims[] = {1, 2};
-    size_t biasNumberOfDims = 2;
-    size_t biasOrderOfDims[] = {0, 1};
-    shape_t biasShape = {.dimensions = biasDims,
-                         .orderOfDimensions = biasOrderOfDims,
-                         .numberOfDimensions = biasNumberOfDims};
-    quantization_t biasQ;
-    initFloat32Quantization(&biasQ);
-    setTensorValues(&biasParam, (uint8_t *)biasData, &biasShape, &biasQ, NULL);
-    float biasGradData[] = {0.f, 0.f};
-    quantization_t biasGradQ;
-    initFloat32Quantization(&biasGradQ);
-    setTensorValues(&biasGrad, (uint8_t *)biasGradData, &biasShape, &biasGradQ, NULL);
-    setParameterValues(&bias, &biasParam, &biasGrad);
+    /* 4. Build heap loss tensor, shape 1x2. */
+    size_t *lossDims = reserveMemory(2 * sizeof(size_t));
+    lossDims[0] = 1;
+    lossDims[1] = 2;
+    size_t *lossOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, lossOrder);
+    shape_t *lossShape = reserveMemory(sizeof(shape_t));
+    setShape(lossShape, lossDims, 2, lossOrder);
+    tensor_t *loss = initTensor(lossShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(loss, (float[]){-4.f, -3.f}, 2);
 
-    tensor_t forwardInput;
-    float forwardInputData[] = {0.f, 1.f, 2.f};
-    size_t forwardInputDims[] = {1, 3};
-    size_t forwardInputNumberOfDims = 2;
-    size_t forwardInputOrderOfDims[] = {0, 1};
-    shape_t forwardInputShape = {.dimensions = forwardInputDims,
-                                 .orderOfDimensions = forwardInputOrderOfDims,
-                                 .numberOfDimensions = forwardInputNumberOfDims};
-    quantization_t forwardInputQ;
-    initFloat32Quantization(&forwardInputQ);
-    setTensorValues(&forwardInput, (uint8_t *)forwardInputData, &forwardInputShape, &forwardInputQ,
-                    NULL);
+    /* 5. Build heap propLoss tensor, shape 1x3. */
+    size_t *propLossDims = reserveMemory(2 * sizeof(size_t));
+    propLossDims[0] = 1;
+    propLossDims[1] = 3;
+    size_t *propLossOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, propLossOrder);
+    shape_t *propLossShape = reserveMemory(sizeof(shape_t));
+    setShape(propLossShape, propLossDims, 2, propLossOrder);
+    tensor_t *propLoss = initTensor(propLossShape, quantizationInitFloat(), NULL);
 
-    tensor_t loss;
-    float lossData[] = {-4.f, -3.f};
-    size_t lossDims[] = {1, 2};
-    size_t lossNumberOfDims = 2;
-    size_t lossOrderOfDims[] = {0, 1};
-    shape_t lossShape = {.dimensions = lossDims,
-                         .orderOfDimensions = lossOrderOfDims,
-                         .numberOfDimensions = lossNumberOfDims};
-    quantization_t lossQ;
-    initFloat32Quantization(&lossQ);
-    setTensorValues(&loss, (uint8_t *)lossData, &lossShape, &lossQ, NULL);
+    /* 6. Build the layer. */
+    quantization_t *testQ = quantizationInitFloat();
+    layer_t *linearLayer = linearLayerInit(weights, bias, testQ, testQ, testQ, testQ);
 
-    tensor_t propLoss;
-    float propLossData[3];
-    size_t propLossDims[] = {1, 3};
-    size_t propLossNumberOfDims = 2;
-    size_t propLossOrderOfDims[] = {0, 1};
-    shape_t propLossShape = {.dimensions = propLossDims,
-                             .orderOfDimensions = propLossOrderOfDims,
-                             .numberOfDimensions = propLossNumberOfDims};
-    quantization_t propLossQ;
-    initFloat32Quantization(&propLossQ);
-    setTensorValues(&propLoss, (uint8_t *)propLossData, &propLossShape, &propLossQ, NULL);
+    linearBackward(linearLayer, forwardInput, loss, propLoss);
 
-    layer_t linearLayer;
-    layerConfig_t linearConfig;
-    linearConfig_t linCfg;
-    linearConfig.linear = &linCfg;
-    quantization_t testQ;
-    initFloat32Quantization(&testQ);
-    linearInitConfig(linearConfig.linear, &weights, &bias, &testQ, &testQ, &testQ, &testQ);
-    initLayer(&linearLayer, LINEAR, &linearConfig);
+    /* 7. CAPTURE. */
+    size_t numWeightElements = calcNumberOfElementsByShape(weights->param->shape);
+    size_t numBiasElements = calcNumberOfElementsByShape(bias->param->shape);
+    size_t numPropLossElements = calcNumberOfElementsByTensor(propLoss);
 
-    linearBackward(&linearLayer, &forwardInput, &loss, &propLoss);
+    float capturedWeightGrad[6];
+    for (size_t i = 0; i < numWeightElements; i++) {
+        capturedWeightGrad[i] = ((float *)weights->grad->data)[i];
+    }
+    float capturedBiasGrad[2];
+    for (size_t i = 0; i < numBiasElements; i++) {
+        capturedBiasGrad[i] = ((float *)bias->grad->data)[i];
+    }
+    float capturedPropLoss[3];
+    for (size_t i = 0; i < numPropLossElements; i++) {
+        capturedPropLoss[i] = ((float *)propLoss->data)[i];
+    }
 
-    float expected_propagated_loss[] = {-8.f, -23.f, 30.f};
+    /* 8. FREE. */
+    freeLinearLayer(linearLayer);
+    freeTensor(propLoss);
+    freeTensor(loss);
+    freeTensor(forwardInput);
+    freeParameter(bias);
+    freeParameter(weights);
+    freeQuantization(testQ);
+
+    /* 9. ASSERT. */
     float expected_weight_grad[] = {0.f, -4.f, -8.f, 0.f, -3.f, -6.f};
     float expected_bias_grad[] = {-4.f, -3.f};
+    float expected_propagated_loss[] = {-8.f, -23.f, 30.f};
 
-    TEST_ASSERT_EQUAL_FLOAT_ARRAY(
-        expected_weight_grad, linearConfig.linear->weights->grad->data,
-        calcNumberOfElementsByShape(linearConfig.linear->weights->param->shape));
-
-    TEST_ASSERT_EQUAL_FLOAT_ARRAY(expected_propagated_loss, propLoss.data,
-                                  sizeof(expected_propagated_loss) / sizeof(float));
-
-    TEST_ASSERT_EQUAL_FLOAT_ARRAY(
-        expected_bias_grad, linearConfig.linear->bias->grad->data,
-        calcNumberOfElementsByShape(linearConfig.linear->bias->param->shape));
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(expected_weight_grad, capturedWeightGrad, numWeightElements);
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(expected_propagated_loss, capturedPropLoss, numPropLossElements);
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(expected_bias_grad, capturedBiasGrad, numBiasElements);
 }
 
 void testLinearForwardSymInt32() {
-    size_t numberOfInputs = 3;
     size_t numberOfOutputs = 2;
 
-    float weightData[] = {-1.f, 2.f, -3.f, 4.f, 5.f, -6.f};
-    size_t weightDims[] = {2, 3};
-    size_t weightNumberOfDims = 2;
-    tensor_t *weightsParam =
-        tensorInitSymInt32(weightData, weightDims, weightNumberOfDims, HTE, NULL);
+    /* 1. Build heap weights parameter (SymInt32, shape 2x3) with grad. */
+    size_t *weightDims = reserveMemory(2 * sizeof(size_t));
+    weightDims[0] = 2;
+    weightDims[1] = 3;
+    size_t *weightOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, weightOrder);
+    shape_t *weightShape = reserveMemory(sizeof(shape_t));
+    setShape(weightShape, weightDims, 2, weightOrder);
+    tensor_t *weightsParam = initTensor(weightShape, quantizationInitSymInt32(HTE), NULL);
+    tensorFillFromFloatBuffer(weightsParam, (float[]){-1.f, 2.f, -3.f, 4.f, 5.f, -6.f}, 6);
     tensor_t *weightsGrad = gradInitSymInt32(weightsParam, HTE, NULL);
     parameter_t *weights = parameterInit(weightsParam, weightsGrad);
 
-    float biasData[] = {-1, 3};
-    size_t biasDims[] = {1, 2};
-    size_t biasNumberOfDims = 2;
-    tensor_t *biasParam = tensorInitSymInt32(biasData, biasDims, biasNumberOfDims, HTE, NULL);
+    /* 2. Build heap bias parameter (SymInt32, shape 1x2) with grad. */
+    size_t *biasDims = reserveMemory(2 * sizeof(size_t));
+    biasDims[0] = 1;
+    biasDims[1] = 2;
+    size_t *biasOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, biasOrder);
+    shape_t *biasShape = reserveMemory(sizeof(shape_t));
+    setShape(biasShape, biasDims, 2, biasOrder);
+    tensor_t *biasParam = initTensor(biasShape, quantizationInitSymInt32(HTE), NULL);
+    tensorFillFromFloatBuffer(biasParam, (float[]){-1.f, 3.f}, 2);
     tensor_t *biasGrad = gradInitSymInt32(biasParam, HTE, NULL);
     parameter_t *bias = parameterInit(biasParam, biasGrad);
 
-    float inputData[] = {0.f, 1.f, 2.f};
-    size_t inputDims[] = {1, 3};
-    size_t inputNumberOfDims = 2;
-    tensor_t *input = tensorInitSymInt32(inputData, inputDims, inputNumberOfDims, HTE, NULL);
+    /* 3. Build heap input tensor (SymInt32, shape 1x3). */
+    size_t *inputDims = reserveMemory(2 * sizeof(size_t));
+    inputDims[0] = 1;
+    inputDims[1] = 3;
+    size_t *inputOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, inputOrder);
+    shape_t *inputShape = reserveMemory(sizeof(shape_t));
+    setShape(inputShape, inputDims, 2, inputOrder);
+    tensor_t *input = initTensor(inputShape, quantizationInitSymInt32(HTE), NULL);
+    tensorFillFromFloatBuffer(input, (float[]){0.f, 1.f, 2.f}, 3);
 
-    float outputData[numberOfOutputs];
-    memset(outputData, 0, sizeof(outputData));
-    size_t outputDims[] = {1, 2};
-    size_t outputNumberOfDims = 2;
-    tensor_t *output = tensorInitSymInt32(outputData, outputDims, outputNumberOfDims, HTE, NULL);
+    /* 4. Build heap output tensor (SymInt32, shape 1x2). */
+    size_t *outputDims = reserveMemory(2 * sizeof(size_t));
+    outputDims[0] = 1;
+    outputDims[1] = 2;
+    size_t *outputOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, outputOrder);
+    shape_t *outputShape = reserveMemory(sizeof(shape_t));
+    setShape(outputShape, outputDims, 2, outputOrder);
+    tensor_t *output = initTensor(outputShape, quantizationInitSymInt32(HTE), NULL);
 
+    /* 5. Build layer (shared SymInt32 quantization). */
     quantization_t *test = quantizationInitSymInt32(HTE);
     layer_t *linearLayer = linearLayerInit(weights, bias, test, test, test, test);
 
     linearForward(linearLayer, input, output);
 
-    float outputFloatData[numberOfOutputs];
-    tensor_t *outputFloat = tensorInitFloat(outputFloatData, outputDims, outputNumberOfDims, NULL);
+    /* 6. Convert SymInt32 output back to Float for comparison. */
+    size_t *outFloatDims = reserveMemory(2 * sizeof(size_t));
+    outFloatDims[0] = 1;
+    outFloatDims[1] = 2;
+    size_t *outFloatOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, outFloatOrder);
+    shape_t *outFloatShape = reserveMemory(sizeof(shape_t));
+    setShape(outFloatShape, outFloatDims, 2, outFloatOrder);
+    tensor_t *outputFloat = initTensor(outFloatShape, quantizationInitFloat(), NULL);
     convertTensor(output, outputFloat);
-    float *actual = (float *)outputFloat->data;
-    float expected[] = {-5, -4};
 
+    /* 7. CAPTURE. */
+    float captured[2];
     for (size_t i = 0; i < numberOfOutputs; i++) {
-        TEST_ASSERT_FLOAT_WITHIN(0.1f, expected[i], actual[i]);
+        captured[i] = ((float *)outputFloat->data)[i];
+    }
+
+    /* 8. FREE. */
+    freeTensor(outputFloat);
+    freeLinearLayer(linearLayer);
+    freeTensor(output);
+    freeTensor(input);
+    freeParameter(bias);
+    freeParameter(weights);
+    freeQuantization(test);
+
+    /* 9. ASSERT. */
+    float expected[] = {-5, -4};
+    for (size_t i = 0; i < numberOfOutputs; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(0.1f, expected[i], captured[i]);
     }
 }
 
 void testLinearBackwardSymInt32() {
-
     size_t numberOfWeights = 6;
     size_t numberOfBiases = 2;
     size_t numberOfForwardInputs = 3;
 
-    float weightFloatData[] = {-1.f, 2.f, -3.f, 4.f, 5.f, -6.f};
-    size_t weightDims[] = {2, 3};
-    size_t weightNumberOfDims = 2;
-    tensor_t *weightsParam =
-        tensorInitSymInt32(weightFloatData, weightDims, weightNumberOfDims, HTE, NULL);
+    /* 1. Build heap weights parameter (SymInt32, shape 2x3) with grad. */
+    size_t *weightDims = reserveMemory(2 * sizeof(size_t));
+    weightDims[0] = 2;
+    weightDims[1] = 3;
+    size_t *weightOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, weightOrder);
+    shape_t *weightShape = reserveMemory(sizeof(shape_t));
+    setShape(weightShape, weightDims, 2, weightOrder);
+    tensor_t *weightsParam = initTensor(weightShape, quantizationInitSymInt32(HTE), NULL);
+    tensorFillFromFloatBuffer(weightsParam, (float[]){-1.f, 2.f, -3.f, 4.f, 5.f, -6.f}, 6);
     tensor_t *weightsGrad = gradInitSymInt32(weightsParam, HTE, NULL);
     parameter_t *weights = parameterInit(weightsParam, weightsGrad);
 
-    float biasData[] = {-1, 3};
-    size_t biasDims[] = {1, 2};
-    size_t biasNumberOfDims = 2;
-    tensor_t *biasParam = tensorInitSymInt32(biasData, biasDims, biasNumberOfDims, HTE, NULL);
+    /* 2. Build heap bias parameter (SymInt32, shape 1x2) with grad. */
+    size_t *biasDims = reserveMemory(2 * sizeof(size_t));
+    biasDims[0] = 1;
+    biasDims[1] = 2;
+    size_t *biasOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, biasOrder);
+    shape_t *biasShape = reserveMemory(sizeof(shape_t));
+    setShape(biasShape, biasDims, 2, biasOrder);
+    tensor_t *biasParam = initTensor(biasShape, quantizationInitSymInt32(HTE), NULL);
+    tensorFillFromFloatBuffer(biasParam, (float[]){-1.f, 3.f}, 2);
     tensor_t *biasGrad = gradInitSymInt32(biasParam, HTE, NULL);
     parameter_t *bias = parameterInit(biasParam, biasGrad);
 
-    float forwardInputData[] = {0.f, 1.f, 2.f};
-    size_t forwardInputDims[] = {1, 3};
-    size_t forwardInputNumberOfDims = 2;
-    tensor_t *forwardInput =
-        tensorInitSymInt32(forwardInputData, forwardInputDims, forwardInputNumberOfDims, HTE, NULL);
+    /* 3. Build heap forwardInput tensor (SymInt32, shape 1x3). */
+    size_t *fwdDims = reserveMemory(2 * sizeof(size_t));
+    fwdDims[0] = 1;
+    fwdDims[1] = 3;
+    size_t *fwdOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, fwdOrder);
+    shape_t *fwdShape = reserveMemory(sizeof(shape_t));
+    setShape(fwdShape, fwdDims, 2, fwdOrder);
+    tensor_t *forwardInput = initTensor(fwdShape, quantizationInitSymInt32(HTE), NULL);
+    tensorFillFromFloatBuffer(forwardInput, (float[]){0.f, 1.f, 2.f}, 3);
 
-    float lossData[] = {-4.f, -3.f};
-    size_t lossDims[] = {1, 2};
-    size_t lossNumberOfDims = 2;
-    tensor_t *loss = tensorInitSymInt32(lossData, lossDims, lossNumberOfDims, HTE, NULL);
+    /* 4. Build heap loss tensor (SymInt32, shape 1x2). */
+    size_t *lossDims = reserveMemory(2 * sizeof(size_t));
+    lossDims[0] = 1;
+    lossDims[1] = 2;
+    size_t *lossOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, lossOrder);
+    shape_t *lossShape = reserveMemory(sizeof(shape_t));
+    setShape(lossShape, lossDims, 2, lossOrder);
+    tensor_t *loss = initTensor(lossShape, quantizationInitSymInt32(HTE), NULL);
+    tensorFillFromFloatBuffer(loss, (float[]){-4.f, -3.f}, 2);
 
-    float propLossData[numberOfForwardInputs];
-    memset(propLossData, 0, sizeof(propLossData));
-    size_t propLossDims[] = {numberOfForwardInputs};
-    size_t propLossNumberOfDims = 1;
-    tensor_t *propLoss =
-        tensorInitSymInt32(propLossData, propLossDims, propLossNumberOfDims, HTE, NULL);
+    /* 5. Build heap propLoss tensor (SymInt32, shape (3,)). */
+    size_t *propLossDims = reserveMemory(1 * sizeof(size_t));
+    propLossDims[0] = numberOfForwardInputs;
+    size_t *propLossOrder = reserveMemory(1 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(1, propLossOrder);
+    shape_t *propLossShape = reserveMemory(sizeof(shape_t));
+    setShape(propLossShape, propLossDims, 1, propLossOrder);
+    tensor_t *propLoss = initTensor(propLossShape, quantizationInitSymInt32(HTE), NULL);
 
+    /* 6. Build layer (shared SymInt32 quantization). */
     quantization_t *test = quantizationInitSymInt32(HTE);
     layer_t *linearLayer = linearLayerInit(weights, bias, test, test, test, test);
 
     linearBackward(linearLayer, forwardInput, loss, propLoss);
 
-    linearConfig_t *linearConfig = linearLayer->config->linear;
-    tensor_t weightGradsFloat;
-    float weightGradFloatData[numberOfWeights];
-    quantization_t weightGradFloatQ;
-    initFloat32Quantization(&weightGradFloatQ);
-    setTensorValuesForConversion((uint8_t *)weightGradFloatData, &weightGradFloatQ,
-                                 linearConfig->weights->grad, &weightGradsFloat);
-    convertTensor(linearConfig->weights->grad, &weightGradsFloat);
+    /* 7. Convert SymInt32 grads back to Float for comparison. The convert-back
+     *    output buffers are heap-allocated to keep us in the heap-tier idiom. */
+    size_t *wgDims = reserveMemory(2 * sizeof(size_t));
+    wgDims[0] = 2;
+    wgDims[1] = 3;
+    size_t *wgOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, wgOrder);
+    shape_t *wgShape = reserveMemory(sizeof(shape_t));
+    setShape(wgShape, wgDims, 2, wgOrder);
+    tensor_t *weightGradFloat = initTensor(wgShape, quantizationInitFloat(), NULL);
+    convertTensor(weights->grad, weightGradFloat);
 
-    float expectedWeightGrads[] = {0.f, -4.f, -8.f, 0.f, -3.f, -6.f};
-    float *actualWeightGrads = (float *)weightGradsFloat.data;
+    size_t *bgDims = reserveMemory(2 * sizeof(size_t));
+    bgDims[0] = 1;
+    bgDims[1] = 2;
+    size_t *bgOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, bgOrder);
+    shape_t *bgShape = reserveMemory(sizeof(shape_t));
+    setShape(bgShape, bgDims, 2, bgOrder);
+    tensor_t *biasGradFloat = initTensor(bgShape, quantizationInitFloat(), NULL);
+    convertTensor(bias->grad, biasGradFloat);
 
+    size_t *plDims = reserveMemory(1 * sizeof(size_t));
+    plDims[0] = numberOfForwardInputs;
+    size_t *plOrder = reserveMemory(1 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(1, plOrder);
+    shape_t *plShape = reserveMemory(sizeof(shape_t));
+    setShape(plShape, plDims, 1, plOrder);
+    tensor_t *propLossFloat = initTensor(plShape, quantizationInitFloat(), NULL);
+    convertTensor(propLoss, propLossFloat);
+
+    /* 8. CAPTURE. */
+    float capturedWeightGrad[6];
     for (size_t i = 0; i < numberOfWeights; i++) {
-        TEST_ASSERT_FLOAT_WITHIN(0.1f, expectedWeightGrads[i], actualWeightGrads[i]);
+        capturedWeightGrad[i] = ((float *)weightGradFloat->data)[i];
+    }
+    float capturedBiasGrad[2];
+    for (size_t i = 0; i < numberOfBiases; i++) {
+        capturedBiasGrad[i] = ((float *)biasGradFloat->data)[i];
+    }
+    float capturedPropLoss[3];
+    for (size_t i = 0; i < numberOfForwardInputs; i++) {
+        capturedPropLoss[i] = ((float *)propLossFloat->data)[i];
     }
 
-    tensor_t biasGradsFloat;
-    float biasGradFloatData[numberOfBiases];
-    quantization_t biasGradFloatQ;
-    initFloat32Quantization(&biasGradFloatQ);
-    setTensorValuesForConversion((uint8_t *)biasGradFloatData, &biasGradFloatQ,
-                                 linearConfig->bias->grad, &biasGradsFloat);
-    convertTensor(linearConfig->bias->grad, &biasGradsFloat);
+    /* 9. FREE. */
+    freeTensor(propLossFloat);
+    freeTensor(biasGradFloat);
+    freeTensor(weightGradFloat);
+    freeLinearLayer(linearLayer);
+    freeTensor(propLoss);
+    freeTensor(loss);
+    freeTensor(forwardInput);
+    freeParameter(bias);
+    freeParameter(weights);
+    freeQuantization(test);
+
+    /* 10. ASSERT. */
+    float expectedWeightGrads[] = {0.f, -4.f, -8.f, 0.f, -3.f, -6.f};
+    for (size_t i = 0; i < numberOfWeights; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(0.1f, expectedWeightGrads[i], capturedWeightGrad[i]);
+    }
 
     float expectedBiasGrads[] = {-4.f, -3.f};
-    float *actualBiasGrads = (float *)biasGradsFloat.data;
     for (size_t i = 0; i < numberOfBiases; i++) {
-        TEST_ASSERT_FLOAT_WITHIN(0.1f, expectedBiasGrads[i], actualBiasGrads[i]);
+        TEST_ASSERT_FLOAT_WITHIN(0.1f, expectedBiasGrads[i], capturedBiasGrad[i]);
     }
 
-    tensor_t propLossFloat;
-    float propLossFloatData[numberOfForwardInputs];
-    quantization_t propLossFloatQ;
-    initFloat32Quantization(&propLossFloatQ);
-    setTensorValuesForConversion((uint8_t *)propLossFloatData, &propLossFloatQ, propLoss,
-                                 &propLossFloat);
-    convertTensor(propLoss, &propLossFloat);
-
-    float *propLossFloatArr = (float *)propLossFloat.data;
-
     float expectedPropagatedLoss[] = {-8.f, -23.f, 30.f};
-
     for (size_t i = 0; i < numberOfForwardInputs; i++) {
-        TEST_ASSERT_FLOAT_WITHIN(.2f, expectedPropagatedLoss[i], propLossFloatArr[i]);
+        TEST_ASSERT_FLOAT_WITHIN(.2f, expectedPropagatedLoss[i], capturedPropLoss[i]);
     }
 }
 
 void testLinearBackwardFloatWithMismatchedQuantizations() {
-    parameter_t weights;
-    tensor_t weightsParam;
-    tensor_t weightsGrad;
+    /* Mismatched-quantization variant of testLinearBackwardFloat: the loss
+     * arrives in ASYM form, while the layer's parameters and propLoss are
+     * Float. Validates that linearBackward routes the loss through a
+     * conversion before applying it. */
 
-    float weightData[] = {-1.f, 2.f, -3.f, 4.f, 5.f, -6.f};
-    size_t weightDims[] = {2, 3};
-    size_t weightNumberOfDims = 2;
-    size_t weightOrderOfDims[] = {0, 1};
-    shape_t weightShape = {.dimensions = weightDims,
-                           .orderOfDimensions = weightOrderOfDims,
-                           .numberOfDimensions = weightNumberOfDims};
-    quantization_t weightQ;
-    initFloat32Quantization(&weightQ);
-    setTensorValues(&weightsParam, (uint8_t *)weightData, &weightShape, &weightQ, NULL);
-    float weightGradData[] = {0.f, 0.f, 0.f, 0.f, 0.f, 0.f};
-    quantization_t weightGradQ;
-    initFloat32Quantization(&weightGradQ);
-    setTensorValues(&weightsGrad, (uint8_t *)weightGradData, &weightShape, &weightGradQ, NULL);
-    setParameterValues(&weights, &weightsParam, &weightsGrad);
+    /* 1. Build heap weights parameter (Float, shape 2x3) with grad. */
+    size_t *weightDims = reserveMemory(2 * sizeof(size_t));
+    weightDims[0] = 2;
+    weightDims[1] = 3;
+    size_t *weightOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, weightOrder);
+    shape_t *weightShape = reserveMemory(sizeof(shape_t));
+    setShape(weightShape, weightDims, 2, weightOrder);
+    tensor_t *weightsParam = initTensor(weightShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(weightsParam, (float[]){-1.f, 2.f, -3.f, 4.f, 5.f, -6.f}, 6);
+    tensor_t *weightsGrad = gradInitFloat(weightsParam, NULL);
+    parameter_t *weights = parameterInit(weightsParam, weightsGrad);
 
-    parameter_t bias;
-    tensor_t biasParam;
-    tensor_t biasGrad;
+    /* 2. Build heap bias parameter (Float, shape 1x2) with grad. */
+    size_t *biasDims = reserveMemory(2 * sizeof(size_t));
+    biasDims[0] = 1;
+    biasDims[1] = 2;
+    size_t *biasOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, biasOrder);
+    shape_t *biasShape = reserveMemory(sizeof(shape_t));
+    setShape(biasShape, biasDims, 2, biasOrder);
+    tensor_t *biasParam = initTensor(biasShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(biasParam, (float[]){-1.f, 3.f}, 2);
+    tensor_t *biasGrad = gradInitFloat(biasParam, NULL);
+    parameter_t *bias = parameterInit(biasParam, biasGrad);
 
-    float biasData[] = {-1.f, 3.f};
-    size_t biasDims[] = {1, 2};
-    size_t biasNumberOfDims = 2;
-    size_t biasOrderOfDims[] = {0, 1};
-    shape_t biasShape = {.dimensions = biasDims,
-                         .orderOfDimensions = biasOrderOfDims,
-                         .numberOfDimensions = biasNumberOfDims};
-    quantization_t biasQ;
-    initFloat32Quantization(&biasQ);
-    setTensorValues(&biasParam, (uint8_t *)biasData, &biasShape, &biasQ, NULL);
-    float biasGradData[] = {0.f, 0.f};
-    quantization_t biasGradQ;
-    initFloat32Quantization(&biasGradQ);
-    setTensorValues(&biasGrad, (uint8_t *)biasGradData, &biasShape, &biasGradQ, NULL);
-    setParameterValues(&bias, &biasParam, &biasGrad);
+    /* 3. Build heap forwardInput tensor (Float, shape 1x3). */
+    size_t *fwdDims = reserveMemory(2 * sizeof(size_t));
+    fwdDims[0] = 1;
+    fwdDims[1] = 3;
+    size_t *fwdOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, fwdOrder);
+    shape_t *fwdShape = reserveMemory(sizeof(shape_t));
+    setShape(fwdShape, fwdDims, 2, fwdOrder);
+    tensor_t *forwardInput = initTensor(fwdShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(forwardInput, (float[]){0.f, 1.f, 2.f}, 3);
 
-    tensor_t forwardInput;
-    float forwardInputData[] = {0.f, 1.f, 2.f};
-    size_t forwardInputDims[] = {1, 3};
-    size_t forwardInputNumberOfDims = 2;
-    size_t forwardInputOrderOfDims[] = {0, 1};
-    shape_t forwardInputShape = {.dimensions = forwardInputDims,
-                                 .orderOfDimensions = forwardInputOrderOfDims,
-                                 .numberOfDimensions = forwardInputNumberOfDims};
-    quantization_t forwardInputQ;
-    initFloat32Quantization(&forwardInputQ);
-    setTensorValues(&forwardInput, (uint8_t *)forwardInputData, &forwardInputShape, &forwardInputQ,
-                    NULL);
+    /* 4. Build heap ASYM loss tensor directly via tensorFillFromFloatBuffer.
+     *    Going through an intermediate Float tensor + convertTensor would alias
+     *    the two shape pointers (copyDimsAndSparsityToTensor in
+     *    convertFloatTensorToAsymTensor writes outputTensor->shape =
+     *    inputTensor->shape), which then causes a double-free. The fill helper
+     *    builds an internal Float view that aliases tensor->shape, so the
+     *    self-assignment is harmless. */
+    size_t *lossAsymDims = reserveMemory(2 * sizeof(size_t));
+    lossAsymDims[0] = 1;
+    lossAsymDims[1] = 2;
+    size_t *lossAsymOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, lossAsymOrder);
+    shape_t *lossAsymShape = reserveMemory(sizeof(shape_t));
+    setShape(lossAsymShape, lossAsymDims, 2, lossAsymOrder);
+    tensor_t *lossAsym = initTensor(lossAsymShape, quantizationInitAsym(8, HTE), NULL);
+    tensorFillFromFloatBuffer(lossAsym, (float[]){-4.f, -3.f}, 2);
 
-    tensor_t loss;
-    float lossData[] = {-4.f, -3.f};
-    size_t lossDims[] = {1, 2};
-    size_t lossNumberOfDims = 2;
-    size_t lossOrderOfDims[] = {0, 1};
-    shape_t lossShape = {.dimensions = lossDims,
-                         .orderOfDimensions = lossOrderOfDims,
-                         .numberOfDimensions = lossNumberOfDims};
-    quantization_t lossQ;
-    initFloat32Quantization(&lossQ);
-    setTensorValues(&loss, (uint8_t *)lossData, &lossShape, &lossQ, NULL);
+    /* 5. Build heap propLoss tensor (Float, shape 1x3). */
+    size_t *propLossDims = reserveMemory(2 * sizeof(size_t));
+    propLossDims[0] = 1;
+    propLossDims[1] = 3;
+    size_t *propLossOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, propLossOrder);
+    shape_t *propLossShape = reserveMemory(sizeof(shape_t));
+    setShape(propLossShape, propLossDims, 2, propLossOrder);
+    tensor_t *propLoss = initTensor(propLossShape, quantizationInitFloat(), NULL);
 
-    tensor_t lossAsym;
-    uint8_t lossAsymData[2];
-    quantization_t lossAsymQ;
-    asymQConfig_t lossAsymQC;
-    initAsymQConfig(8, HTE, &lossAsymQC);
-    initAsymQuantization(&lossAsymQC, &lossAsymQ);
-    setTensorValuesForConversion(lossAsymData, &lossAsymQ, &loss, &lossAsym);
-    convertTensor(&loss, &lossAsym);
+    /* 6. Build the layer with shared float quantization. */
+    quantization_t *testQ = quantizationInitFloat();
+    layer_t *linearLayer = linearLayerInit(weights, bias, testQ, testQ, testQ, testQ);
 
-    tensor_t propLoss;
-    float propLossData[3];
-    size_t propLossDims[] = {1, 3};
-    size_t propLossNumberOfDims = 2;
-    size_t propLossOrderOfDims[] = {0, 1};
-    shape_t propLossShape = {.dimensions = propLossDims,
-                             .orderOfDimensions = propLossOrderOfDims,
-                             .numberOfDimensions = propLossNumberOfDims};
-    quantization_t propLossQ;
-    initFloat32Quantization(&propLossQ);
-    setTensorValues(&propLoss, (uint8_t *)propLossData, &propLossShape, &propLossQ, NULL);
+    linearBackward(linearLayer, forwardInput, lossAsym, propLoss);
 
-    layer_t linearLayer;
-    layerConfig_t linearConfig;
-    linearConfig_t linCfg;
-    linearConfig.linear = &linCfg;
-    quantization_t testQ;
-    initFloat32Quantization(&testQ);
-    linearInitConfig(linearConfig.linear, &weights, &bias, &testQ, &testQ, &testQ, &testQ);
-    initLayer(&linearLayer, LINEAR, &linearConfig);
+    /* 7. CAPTURE. */
+    size_t sizeWeights = calcNumberOfElementsByParameter(weights);
+    size_t sizeBias = calcNumberOfElementsByParameter(bias);
+    size_t sizePropLoss = calcNumberOfElementsByTensor(propLoss);
 
-    linearBackward(&linearLayer, &forwardInput, &lossAsym, &propLoss);
+    float capturedWeightGrad[6];
+    for (size_t i = 0; i < sizeWeights; i++) {
+        capturedWeightGrad[i] = ((float *)weights->grad->data)[i];
+    }
+    float capturedBiasGrad[2];
+    for (size_t i = 0; i < sizeBias; i++) {
+        capturedBiasGrad[i] = ((float *)bias->grad->data)[i];
+    }
+    float capturedPropLoss[3];
+    for (size_t i = 0; i < sizePropLoss; i++) {
+        capturedPropLoss[i] = ((float *)propLoss->data)[i];
+    }
+
+    /* 8. FREE. */
+    freeLinearLayer(linearLayer);
+    freeTensor(propLoss);
+    freeTensor(lossAsym);
+    freeTensor(forwardInput);
+    freeParameter(bias);
+    freeParameter(weights);
+    freeQuantization(testQ);
+
+    /* 9. ASSERT. */
+    float expectedWeightGrad[] = {0.f, -4.f, -8.f, 0.f, -3.f, -6.f};
+    for (size_t i = 0; i < sizeWeights; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(0.1f, expectedWeightGrad[i], capturedWeightGrad[i]);
+    }
+
+    float expectedBiasGrad[] = {-4.f, -3.f};
+    for (size_t i = 0; i < sizeBias; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(0.1f, expectedBiasGrad[i], capturedBiasGrad[i]);
+    }
 
     float expectedPropagatedLoss[] = {-8.f, -23.f, 30.f};
-    float expectedWeightGrad[] = {0.f, -4.f, -8.f, 0.f, -3.f, -6.f};
-    float expectedBiasGrad[] = {-4.f, -3.f};
-
-    size_t sizeWeights = calcNumberOfElementsByParameter(&weights);
-    float *actualWeightGrad = (float *)linearConfig.linear->weights->grad->data;
-    for (size_t i = 0; i < sizeWeights; i++) {
-        TEST_ASSERT_FLOAT_WITHIN(0.1f, expectedWeightGrad[i], actualWeightGrad[i]);
-    }
-
-    size_t sizeBias = calcNumberOfElementsByParameter(&bias);
-    float *actualBiasGrad = (float *)linearConfig.linear->bias->grad->data;
-    for (size_t i = 0; i < sizeBias; i++) {
-        TEST_ASSERT_FLOAT_WITHIN(0.1f, expectedBiasGrad[i], actualBiasGrad[i]);
-    }
-
-    size_t sizePropLoss = calcNumberOfElementsByTensor(&propLoss);
-    float *actualPropLoss = (float *)propLoss.data;
     for (size_t i = 0; i < sizePropLoss; i++) {
-        TEST_ASSERT_FLOAT_WITHIN(0.1f, expectedPropagatedLoss[i], actualPropLoss[i]);
+        TEST_ASSERT_FLOAT_WITHIN(0.1f, expectedPropagatedLoss[i], capturedPropLoss[i]);
     }
 }
 
 void testLinearLayerInitNonTrainable(void) {
-    float weightData[] = {-1.f, 2.f, -3.f, 4.f, 5.f, -6.f};
-    size_t weightDims[] = {2, 3};
-    tensor_t *weights = tensorInitFloat(weightData, weightDims, 2, NULL);
+    /* 1. Build heap weights tensor. linearLayerInitNonTrainable wraps it
+     *    in parameter_t internally with grad=NULL. The post-#106 NULL-guard
+     *    in freeParameter makes that wrapper safe to free. */
+    size_t *weightDims = reserveMemory(2 * sizeof(size_t));
+    weightDims[0] = 2;
+    weightDims[1] = 3;
+    size_t *weightOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, weightOrder);
+    shape_t *weightShape = reserveMemory(sizeof(shape_t));
+    setShape(weightShape, weightDims, 2, weightOrder);
+    tensor_t *weights = initTensor(weightShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(weights, (float[]){-1.f, 2.f, -3.f, 4.f, 5.f, -6.f}, 6);
 
-    float biasData[] = {-1.f, 3.f};
-    size_t biasDims[] = {1, 2};
-    tensor_t *bias = tensorInitFloat(biasData, biasDims, 2, NULL);
+    /* 2. Build heap bias tensor. */
+    size_t *biasDims = reserveMemory(2 * sizeof(size_t));
+    biasDims[0] = 1;
+    biasDims[1] = 2;
+    size_t *biasOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, biasOrder);
+    shape_t *biasShape = reserveMemory(sizeof(shape_t));
+    setShape(biasShape, biasDims, 2, biasOrder);
+    tensor_t *bias = initTensor(biasShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(bias, (float[]){-1.f, 3.f}, 2);
 
+    /* 3. Build the non-trainable layer. */
     quantization_t *forwardQ = quantizationInitFloat();
-
     layer_t *layer = linearLayerInitNonTrainable(weights, bias, forwardQ);
 
-    TEST_ASSERT_NOT_NULL(layer);
-    TEST_ASSERT_EQUAL(LINEAR, layer->type);
-
+    /* Wiring asserts (read into stack locals before any free). */
+    int capturedLayerNotNull = (layer != NULL);
+    int capturedTypeOk = (layer != NULL) && (layer->type == LINEAR);
     linearConfig_t *config = layer->config->linear;
-    TEST_ASSERT_NULL(config->weights->grad);
-    TEST_ASSERT_NULL(config->bias->grad);
+    int capturedWeightGradNull = (config->weights->grad == NULL);
+    int capturedBiasGradNull = (config->bias->grad == NULL);
 
-    // Forward pass should work
-    float inputData[] = {0.f, 1.f, 2.f};
-    size_t inputDims[] = {1, 3};
-    tensor_t *input = tensorInitFloat(inputData, inputDims, 2, NULL);
+    /* 4. Build heap input tensor (shape 1x3). */
+    size_t *inputDims = reserveMemory(2 * sizeof(size_t));
+    inputDims[0] = 1;
+    inputDims[1] = 3;
+    size_t *inputOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, inputOrder);
+    shape_t *inputShape = reserveMemory(sizeof(shape_t));
+    setShape(inputShape, inputDims, 2, inputOrder);
+    tensor_t *input = initTensor(inputShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(input, (float[]){0.f, 1.f, 2.f}, 3);
 
-    float outputData[2];
-    size_t outputDims[] = {1, 2};
-    tensor_t *output = tensorInitFloat(outputData, outputDims, 2, NULL);
+    /* 5. Build heap output tensor (shape 1x2). */
+    size_t *outputDims = reserveMemory(2 * sizeof(size_t));
+    outputDims[0] = 1;
+    outputDims[1] = 2;
+    size_t *outputOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, outputOrder);
+    shape_t *outputShape = reserveMemory(sizeof(shape_t));
+    setShape(outputShape, outputDims, 2, outputOrder);
+    tensor_t *output = initTensor(outputShape, quantizationInitFloat(), NULL);
 
     linearForward(layer, input, output);
 
-    float *actual = (float *)output->data;
-    TEST_ASSERT_FLOAT_WITHIN(0.001f, -5.f, actual[0]);
-    TEST_ASSERT_FLOAT_WITHIN(0.001f, -4.f, actual[1]);
+    /* 6. CAPTURE. */
+    float capturedOutput[2];
+    capturedOutput[0] = ((float *)output->data)[0];
+    capturedOutput[1] = ((float *)output->data)[1];
+
+    /* 7. FREE. linearLayerInitNonTrainable wrapped weights/bias into
+     *    parameter_t* via parameterInit; freeing those parameters
+     *    cascades to freeTensor(weights) and freeTensor(bias).
+     *    freeParameter is NULL-grad-safe (post-#106, H3). */
+    parameter_t *weightsParam = config->weights;
+    parameter_t *biasParam = config->bias;
+    freeLinearLayer(layer);
+    freeTensor(output);
+    freeTensor(input);
+    freeParameter(biasParam);
+    freeParameter(weightsParam);
+    freeQuantization(forwardQ);
+
+    /* 8. ASSERT. */
+    TEST_ASSERT_TRUE(capturedLayerNotNull);
+    TEST_ASSERT_TRUE(capturedTypeOk);
+    TEST_ASSERT_TRUE(capturedWeightGradNull);
+    TEST_ASSERT_TRUE(capturedBiasGradNull);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, -5.f, capturedOutput[0]);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, -4.f, capturedOutput[1]);
 }
 
 void testLinearLayerInitAndFreeRoundTrip(void) {

--- a/test/unit/layer/UnitTestLinear.c
+++ b/test/unit/layer/UnitTestLinear.c
@@ -484,6 +484,27 @@ void testLinearLayerInitNonTrainable(void) {
     TEST_ASSERT_FLOAT_WITHIN(0.001f, -4.f, actual[1]);
 }
 
+void testLinearLayerInitAndFreeRoundTrip(void) {
+    /* Roundtrip: linearLayerInit allocates layer + outer layerConfig +
+     * inner linearConfig (3 reserveMemory calls). freeLinearLayer must
+     * release all three. Pre-fix this test runs to completion but leaks
+     * the outer layerConfig wrapper; post-fix it is leak-clean (verified
+     * via the LSan sweep).
+     *
+     * linearLayerInit only stores the parameter and quantization pointers
+     * without dereferencing them, and freeLinearLayer does not touch
+     * parameters/quantization (those are externally owned). So NULL is a
+     * valid stand-in here — keeps the test focused on the StorageApi
+     * lifecycle, not on tensor ownership. */
+    layer_t *linearLayer = linearLayerInit(NULL, NULL, NULL, NULL, NULL, NULL);
+    TEST_ASSERT_NOT_NULL(linearLayer);
+    TEST_ASSERT_EQUAL_INT(LINEAR, linearLayer->type);
+    TEST_ASSERT_NOT_NULL(linearLayer->config);
+    TEST_ASSERT_NOT_NULL(linearLayer->config->linear);
+
+    freeLinearLayer(linearLayer);
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(testLinearForwardFloat);
@@ -491,6 +512,7 @@ int main(void) {
 
     RUN_TEST(testLinearForwardSymInt32);
     RUN_TEST(testLinearBackwardSymInt32);
+    RUN_TEST(testLinearLayerInitAndFreeRoundTrip);
 
     RUN_TEST(testLinearBackwardFloatWithMismatchedQuantizations);
     RUN_TEST(testLinearLayerInitNonTrainable);

--- a/test/unit/layer/UnitTestLinear.c
+++ b/test/unit/layer/UnitTestLinear.c
@@ -1,13 +1,15 @@
+#include <string.h>
+
 #include "DTypes.h"
 #include "Layer.h"
 #include "Linear.h"
+#include "LinearApi.h"
+#include "QuantizationApi.h"
 #include "Rounding.h"
 #include "Tensor.h"
+#include "TensorApi.h"
 #include "TensorConversion.h"
 #include "unity.h"
-#include "TensorApi.h"
-#include "QuantizationApi.h"
-#include "LinearApi.h"
 
 void setUp() {}
 void tearDown() {}
@@ -134,7 +136,8 @@ void testLinearBackwardFloat() {
                                  .numberOfDimensions = forwardInputNumberOfDims};
     quantization_t forwardInputQ;
     initFloat32Quantization(&forwardInputQ);
-    setTensorValues(&forwardInput, (uint8_t *)forwardInputData, &forwardInputShape, &forwardInputQ, NULL);
+    setTensorValues(&forwardInput, (uint8_t *)forwardInputData, &forwardInputShape, &forwardInputQ,
+                    NULL);
 
     tensor_t loss;
     float lossData[] = {-4.f, -3.f};
@@ -194,7 +197,8 @@ void testLinearForwardSymInt32() {
     float weightData[] = {-1.f, 2.f, -3.f, 4.f, 5.f, -6.f};
     size_t weightDims[] = {2, 3};
     size_t weightNumberOfDims = 2;
-    tensor_t *weightsParam = tensorInitSymInt32(weightData, weightDims, weightNumberOfDims, HTE, NULL);
+    tensor_t *weightsParam =
+        tensorInitSymInt32(weightData, weightDims, weightNumberOfDims, HTE, NULL);
     tensor_t *weightsGrad = gradInitSymInt32(weightsParam, HTE, NULL);
     parameter_t *weights = parameterInit(weightsParam, weightsGrad);
 
@@ -211,6 +215,7 @@ void testLinearForwardSymInt32() {
     tensor_t *input = tensorInitSymInt32(inputData, inputDims, inputNumberOfDims, HTE, NULL);
 
     float outputData[numberOfOutputs];
+    memset(outputData, 0, sizeof(outputData));
     size_t outputDims[] = {1, 2};
     size_t outputNumberOfDims = 2;
     tensor_t *output = tensorInitSymInt32(outputData, outputDims, outputNumberOfDims, HTE, NULL);
@@ -240,10 +245,10 @@ void testLinearBackwardSymInt32() {
     float weightFloatData[] = {-1.f, 2.f, -3.f, 4.f, 5.f, -6.f};
     size_t weightDims[] = {2, 3};
     size_t weightNumberOfDims = 2;
-    tensor_t *weightsParam = tensorInitSymInt32(weightFloatData, weightDims, weightNumberOfDims, HTE, NULL);
+    tensor_t *weightsParam =
+        tensorInitSymInt32(weightFloatData, weightDims, weightNumberOfDims, HTE, NULL);
     tensor_t *weightsGrad = gradInitSymInt32(weightsParam, HTE, NULL);
     parameter_t *weights = parameterInit(weightsParam, weightsGrad);
-
 
     float biasData[] = {-1, 3};
     size_t biasDims[] = {1, 2};
@@ -255,7 +260,8 @@ void testLinearBackwardSymInt32() {
     float forwardInputData[] = {0.f, 1.f, 2.f};
     size_t forwardInputDims[] = {1, 3};
     size_t forwardInputNumberOfDims = 2;
-    tensor_t *forwardInput = tensorInitSymInt32(forwardInputData, forwardInputDims, forwardInputNumberOfDims, HTE, NULL);
+    tensor_t *forwardInput =
+        tensorInitSymInt32(forwardInputData, forwardInputDims, forwardInputNumberOfDims, HTE, NULL);
 
     float lossData[] = {-4.f, -3.f};
     size_t lossDims[] = {1, 2};
@@ -263,9 +269,11 @@ void testLinearBackwardSymInt32() {
     tensor_t *loss = tensorInitSymInt32(lossData, lossDims, lossNumberOfDims, HTE, NULL);
 
     float propLossData[numberOfForwardInputs];
+    memset(propLossData, 0, sizeof(propLossData));
     size_t propLossDims[] = {numberOfForwardInputs};
     size_t propLossNumberOfDims = 1;
-    tensor_t *propLoss = tensorInitSymInt32(propLossData, propLossDims, propLossNumberOfDims, HTE, NULL);
+    tensor_t *propLoss =
+        tensorInitSymInt32(propLossData, propLossDims, propLossNumberOfDims, HTE, NULL);
 
     quantization_t *test = quantizationInitSymInt32(HTE);
     layer_t *linearLayer = linearLayerInit(weights, bias, test, test, test, test);
@@ -277,8 +285,8 @@ void testLinearBackwardSymInt32() {
     float weightGradFloatData[numberOfWeights];
     quantization_t weightGradFloatQ;
     initFloat32Quantization(&weightGradFloatQ);
-    setTensorValuesForConversion((uint8_t *)weightGradFloatData, &weightGradFloatQ, linearConfig->weights->grad,
-                                 &weightGradsFloat);
+    setTensorValuesForConversion((uint8_t *)weightGradFloatData, &weightGradFloatQ,
+                                 linearConfig->weights->grad, &weightGradsFloat);
     convertTensor(linearConfig->weights->grad, &weightGradsFloat);
 
     float expectedWeightGrads[] = {0.f, -4.f, -8.f, 0.f, -3.f, -6.f};
@@ -292,13 +300,13 @@ void testLinearBackwardSymInt32() {
     float biasGradFloatData[numberOfBiases];
     quantization_t biasGradFloatQ;
     initFloat32Quantization(&biasGradFloatQ);
-    setTensorValuesForConversion((uint8_t *)biasGradFloatData, &biasGradFloatQ, linearConfig->bias->grad,
-                                 &biasGradsFloat);
+    setTensorValuesForConversion((uint8_t *)biasGradFloatData, &biasGradFloatQ,
+                                 linearConfig->bias->grad, &biasGradsFloat);
     convertTensor(linearConfig->bias->grad, &biasGradsFloat);
 
     float expectedBiasGrads[] = {-4.f, -3.f};
     float *actualBiasGrads = (float *)biasGradsFloat.data;
-    for(size_t i = 0; i < numberOfBiases; i++) {
+    for (size_t i = 0; i < numberOfBiases; i++) {
         TEST_ASSERT_FLOAT_WITHIN(0.1f, expectedBiasGrads[i], actualBiasGrads[i]);
     }
 
@@ -306,7 +314,8 @@ void testLinearBackwardSymInt32() {
     float propLossFloatData[numberOfForwardInputs];
     quantization_t propLossFloatQ;
     initFloat32Quantization(&propLossFloatQ);
-    setTensorValuesForConversion((uint8_t *)propLossFloatData, &propLossFloatQ, propLoss, &propLossFloat);
+    setTensorValuesForConversion((uint8_t *)propLossFloatData, &propLossFloatQ, propLoss,
+                                 &propLossFloat);
     convertTensor(propLoss, &propLossFloat);
 
     float *propLossFloatArr = (float *)propLossFloat.data;
@@ -369,7 +378,8 @@ void testLinearBackwardFloatWithMismatchedQuantizations() {
                                  .numberOfDimensions = forwardInputNumberOfDims};
     quantization_t forwardInputQ;
     initFloat32Quantization(&forwardInputQ);
-    setTensorValues(&forwardInput, (uint8_t *)forwardInputData, &forwardInputShape, &forwardInputQ, NULL);
+    setTensorValues(&forwardInput, (uint8_t *)forwardInputData, &forwardInputShape, &forwardInputQ,
+                    NULL);
 
     tensor_t loss;
     float lossData[] = {-4.f, -3.f};
@@ -419,22 +429,21 @@ void testLinearBackwardFloatWithMismatchedQuantizations() {
     float expectedWeightGrad[] = {0.f, -4.f, -8.f, 0.f, -3.f, -6.f};
     float expectedBiasGrad[] = {-4.f, -3.f};
 
-
     size_t sizeWeights = calcNumberOfElementsByParameter(&weights);
     float *actualWeightGrad = (float *)linearConfig.linear->weights->grad->data;
-    for(size_t i = 0; i < sizeWeights; i++) {
+    for (size_t i = 0; i < sizeWeights; i++) {
         TEST_ASSERT_FLOAT_WITHIN(0.1f, expectedWeightGrad[i], actualWeightGrad[i]);
     }
 
     size_t sizeBias = calcNumberOfElementsByParameter(&bias);
     float *actualBiasGrad = (float *)linearConfig.linear->bias->grad->data;
-    for(size_t i = 0; i < sizeBias; i++) {
+    for (size_t i = 0; i < sizeBias; i++) {
         TEST_ASSERT_FLOAT_WITHIN(0.1f, expectedBiasGrad[i], actualBiasGrad[i]);
     }
 
     size_t sizePropLoss = calcNumberOfElementsByTensor(&propLoss);
     float *actualPropLoss = (float *)propLoss.data;
-    for(size_t i = 0; i < sizePropLoss; i++) {
+    for (size_t i = 0; i < sizePropLoss; i++) {
         TEST_ASSERT_FLOAT_WITHIN(0.1f, expectedPropagatedLoss[i], actualPropLoss[i]);
     }
 }

--- a/test/unit/layer/UnitTestRelu.c
+++ b/test/unit/layer/UnitTestRelu.c
@@ -1,12 +1,12 @@
-#include "Relu.h"
-#include "Quantization.h"
-#include "unity.h"
 #include "DTypes.h"
-#include "Tensor.h"
-#include "TensorConversion.h"
-#include "ReluApi.h"
-#include "TensorApi.h"
+#include "Quantization.h"
 #include "QuantizationApi.h"
+#include "Relu.h"
+#include "ReluApi.h"
+#include "Tensor.h"
+#include "TensorApi.h"
+#include "TensorConversion.h"
+#include "unity.h"
 
 void testReluForwardFloat() {
     size_t numberOfElements = 6;
@@ -16,26 +16,21 @@ void testReluForwardFloat() {
     size_t inputDims[] = {2, 3};
     size_t inputNumberOfDims = 2;
     size_t inputOrderOfDims[] = {0, 1};
-    shape_t inputShape = {
-        .dimensions = inputDims,
-        .orderOfDimensions = inputOrderOfDims,
-        .numberOfDimensions = inputNumberOfDims
-    };
+    shape_t inputShape = {.dimensions = inputDims,
+                          .orderOfDimensions = inputOrderOfDims,
+                          .numberOfDimensions = inputNumberOfDims};
     quantization_t inputQ;
     initFloat32Quantization(&inputQ);
-    setTensorValues(&input, (uint8_t *)inputData, &inputShape,
-                    &inputQ, NULL);
+    setTensorValues(&input, (uint8_t *)inputData, &inputShape, &inputQ, NULL);
 
     tensor_t output;
     float outputData[numberOfElements];
     size_t outputDims[] = {2, 3};
     size_t outputNumberOfDims = 2;
     size_t outputOrderOfDims[] = {0, 1};
-    shape_t outputShape = {
-        .dimensions = outputDims,
-        .orderOfDimensions = outputOrderOfDims,
-        .numberOfDimensions = outputNumberOfDims
-    };
+    shape_t outputShape = {.dimensions = outputDims,
+                           .orderOfDimensions = outputOrderOfDims,
+                           .numberOfDimensions = outputNumberOfDims};
     quantization_t outputQ;
     initFloat32Quantization(&outputQ);
     setTensorValues(&output, (uint8_t *)outputData, &outputShape, &outputQ, NULL);
@@ -62,7 +57,7 @@ void testReluForwardSymInt32() {
     float inputData[] = {-1.f, 0.f, 1.f, 2.f, 5.f, -6.f};
     tensor_t *input = tensorInitSymInt32(inputData, dims, numberOfDims, HTE, NULL);
 
-    float outputData[6];
+    float outputData[6] = {0};
     tensor_t *output = tensorInitSymInt32(outputData, dims, numberOfDims, HTE, NULL);
 
     quantization_t *symIntQ = quantizationInitSymInt32(HTE);
@@ -77,7 +72,7 @@ void testReluForwardSymInt32() {
     float expected[] = {0, 0, 1, 2, 5, 0};
     float *actual = (float *)outputFloat->data;
 
-    for(size_t i = 0; i < numberOfValues; i++) {
+    for (size_t i = 0; i < numberOfValues; i++) {
         TEST_ASSERT_FLOAT_WITHIN(0.1f, expected[i], actual[i]);
     }
 }
@@ -136,11 +131,10 @@ void testReluBackwardSymInt32() {
     convertTensor(propLoss, propLossFloat);
     float *actual = (float *)propLossFloat->data;
 
-    for(size_t i = 0; i < numberOfValues; i++) {
+    for (size_t i = 0; i < numberOfValues; i++) {
         TEST_ASSERT_FLOAT_WITHIN(0.1f, expected[i], actual[i]);
     }
 }
-
 
 void setUp() {}
 void tearDown() {}

--- a/test/unit/layer/UnitTestRelu.c
+++ b/test/unit/layer/UnitTestRelu.c
@@ -3,6 +3,7 @@
 #include "QuantizationApi.h"
 #include "Relu.h"
 #include "ReluApi.h"
+#include "StorageApi.h"
 #include "Tensor.h"
 #include "TensorApi.h"
 #include "TensorConversion.h"
@@ -11,128 +12,234 @@
 void testReluForwardFloat() {
     size_t numberOfElements = 6;
 
-    tensor_t input;
-    float inputData[] = {-1.f, 0.f, 1.f, 2.f, 5.f, -6.f};
-    size_t inputDims[] = {2, 3};
-    size_t inputNumberOfDims = 2;
-    size_t inputOrderOfDims[] = {0, 1};
-    shape_t inputShape = {.dimensions = inputDims,
-                          .orderOfDimensions = inputOrderOfDims,
-                          .numberOfDimensions = inputNumberOfDims};
-    quantization_t inputQ;
-    initFloat32Quantization(&inputQ);
-    setTensorValues(&input, (uint8_t *)inputData, &inputShape, &inputQ, NULL);
+    /* 1. Build heap input tensor (shape 2x3). */
+    size_t *inputDims = reserveMemory(2 * sizeof(size_t));
+    inputDims[0] = 2;
+    inputDims[1] = 3;
+    size_t *inputOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, inputOrder);
+    shape_t *inputShape = reserveMemory(sizeof(shape_t));
+    setShape(inputShape, inputDims, 2, inputOrder);
+    tensor_t *input = initTensor(inputShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(input, (float[]){-1.f, 0.f, 1.f, 2.f, 5.f, -6.f}, 6);
 
-    tensor_t output;
-    float outputData[numberOfElements];
-    size_t outputDims[] = {2, 3};
-    size_t outputNumberOfDims = 2;
-    size_t outputOrderOfDims[] = {0, 1};
-    shape_t outputShape = {.dimensions = outputDims,
-                           .orderOfDimensions = outputOrderOfDims,
-                           .numberOfDimensions = outputNumberOfDims};
-    quantization_t outputQ;
-    initFloat32Quantization(&outputQ);
-    setTensorValues(&output, (uint8_t *)outputData, &outputShape, &outputQ, NULL);
+    /* 2. Build heap output tensor (shape 2x3). */
+    size_t *outputDims = reserveMemory(2 * sizeof(size_t));
+    outputDims[0] = 2;
+    outputDims[1] = 3;
+    size_t *outputOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, outputOrder);
+    shape_t *outputShape = reserveMemory(sizeof(shape_t));
+    setShape(outputShape, outputDims, 2, outputOrder);
+    tensor_t *output = initTensor(outputShape, quantizationInitFloat(), NULL);
 
-    quantization_t floatQ;
-    initFloat32Quantization(&floatQ);
-    layer_t *reluLayer = reluLayerInit(&floatQ, &floatQ);
+    /* 3. Build shared float quantization for the layer. */
+    quantization_t *floatQ = quantizationInitFloat();
+    layer_t *reluLayer = reluLayerInit(floatQ, floatQ);
 
-    reluForward(reluLayer, &input, &output);
+    /* 4. Exercise. */
+    reluForward(reluLayer, input, output);
 
+    /* 5. CAPTURE assertion values. */
+    float captured[6];
+    readBytesAsFloatArray(numberOfElements, output->data, captured);
+
+    /* 6. FREE in reverse-init order. freeReluLayer releases only the layer
+     *    config wrapper; the shared floatQ is freed exactly once at the end. */
+    freeReluLayer(reluLayer);
+    freeTensor(output);
+    freeTensor(input);
+    freeQuantization(floatQ);
+
+    /* 7. ASSERT on captured. */
     float expected[] = {0.f, 0.f, 1.f, 2.f, 5.f, 0.f};
-
-    float actual[numberOfElements];
-    readBytesAsFloatArray(numberOfElements, output.data, actual);
-
-    TEST_ASSERT_EQUAL_FLOAT_ARRAY(expected, actual, numberOfElements);
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(expected, captured, numberOfElements);
 }
 
 void testReluForwardSymInt32() {
     size_t numberOfValues = 6;
-    size_t dims[] = {2, 3};
-    size_t numberOfDims = 2;
 
-    float inputData[] = {-1.f, 0.f, 1.f, 2.f, 5.f, -6.f};
-    tensor_t *input = tensorInitSymInt32(inputData, dims, numberOfDims, HTE, NULL);
+    /* 1. Build heap input tensor (SymInt32, shape 2x3). */
+    size_t *inputDims = reserveMemory(2 * sizeof(size_t));
+    inputDims[0] = 2;
+    inputDims[1] = 3;
+    size_t *inputOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, inputOrder);
+    shape_t *inputShape = reserveMemory(sizeof(shape_t));
+    setShape(inputShape, inputDims, 2, inputOrder);
+    tensor_t *input = initTensor(inputShape, quantizationInitSymInt32(HTE), NULL);
+    tensorFillFromFloatBuffer(input, (float[]){-1.f, 0.f, 1.f, 2.f, 5.f, -6.f}, 6);
 
-    float outputData[6] = {0};
-    tensor_t *output = tensorInitSymInt32(outputData, dims, numberOfDims, HTE, NULL);
+    /* 2. Build heap output tensor (SymInt32, shape 2x3). */
+    size_t *outputDims = reserveMemory(2 * sizeof(size_t));
+    outputDims[0] = 2;
+    outputDims[1] = 3;
+    size_t *outputOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, outputOrder);
+    shape_t *outputShape = reserveMemory(sizeof(shape_t));
+    setShape(outputShape, outputDims, 2, outputOrder);
+    tensor_t *output = initTensor(outputShape, quantizationInitSymInt32(HTE), NULL);
 
+    /* 3. Shared SymInt32 quantization for the layer. */
     quantization_t *symIntQ = quantizationInitSymInt32(HTE);
     layer_t *reluLayer = reluLayerInit(symIntQ, symIntQ);
     layerFunctions_t reluFns = layerFunctions[RELU];
     reluFns.forward(reluLayer, input, output);
 
-    float outputFloatData[6];
-    tensor_t *outputFloat = tensorInitFloat(outputFloatData, dims, numberOfDims, NULL);
+    /* 4. Convert SymInt32 output back to Float for comparison; output buffer
+     *    is heap-allocated to keep us in the heap-tier idiom. */
+    size_t *outFloatDims = reserveMemory(2 * sizeof(size_t));
+    outFloatDims[0] = 2;
+    outFloatDims[1] = 3;
+    size_t *outFloatOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, outFloatOrder);
+    shape_t *outFloatShape = reserveMemory(sizeof(shape_t));
+    setShape(outFloatShape, outFloatDims, 2, outFloatOrder);
+    tensor_t *outputFloat = initTensor(outFloatShape, quantizationInitFloat(), NULL);
     convertTensor(output, outputFloat);
 
-    float expected[] = {0, 0, 1, 2, 5, 0};
-    float *actual = (float *)outputFloat->data;
-
+    /* 5. CAPTURE. */
+    float captured[6];
     for (size_t i = 0; i < numberOfValues; i++) {
-        TEST_ASSERT_FLOAT_WITHIN(0.1f, expected[i], actual[i]);
+        captured[i] = ((float *)outputFloat->data)[i];
+    }
+
+    /* 6. FREE. */
+    freeTensor(outputFloat);
+    freeReluLayer(reluLayer);
+    freeTensor(output);
+    freeTensor(input);
+    freeQuantization(symIntQ);
+
+    /* 7. ASSERT. */
+    float expected[] = {0, 0, 1, 2, 5, 0};
+    for (size_t i = 0; i < numberOfValues; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(0.1f, expected[i], captured[i]);
     }
 }
 
 void testReluBackwardFloat() {
     size_t numberOfElements = 6;
 
-    size_t dims[] = {numberOfElements};
-    size_t numberOfDims = 1;
+    /* 1. Build heap forwardInput tensor. */
+    size_t *fwdDims = reserveMemory(1 * sizeof(size_t));
+    fwdDims[0] = numberOfElements;
+    size_t *fwdOrder = reserveMemory(1 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(1, fwdOrder);
+    shape_t *fwdShape = reserveMemory(sizeof(shape_t));
+    setShape(fwdShape, fwdDims, 1, fwdOrder);
+    tensor_t *forwardInput = initTensor(fwdShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(forwardInput, (float[]){-1.f, 0.f, 1.f, 2.f, 5.f, -6.f}, 6);
 
-    float forwardInputData[] = {-1.f, 0.f, 1.f, 2.f, 5.f, -6.f};
-    tensor_t *forwardInput = tensorInitFloat(forwardInputData, dims, numberOfDims, NULL);
+    /* 2. Build heap loss tensor. */
+    size_t *lossDims = reserveMemory(1 * sizeof(size_t));
+    lossDims[0] = numberOfElements;
+    size_t *lossOrder = reserveMemory(1 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(1, lossOrder);
+    shape_t *lossShape = reserveMemory(sizeof(shape_t));
+    setShape(lossShape, lossDims, 1, lossOrder);
+    tensor_t *loss = initTensor(lossShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(loss, (float[]){0.f, 2.f, -4.f, 6.f, 3.f, 2.f}, 6);
 
-    float lossData[] = {0.f, 2.f, -4.f, 6.f, 3.f, 2.f};
-    tensor_t *loss = tensorInitFloat(lossData, dims, numberOfDims, NULL);
+    /* 3. Build heap propLoss tensor (output of backward). */
+    size_t *propLossDims = reserveMemory(1 * sizeof(size_t));
+    propLossDims[0] = numberOfElements;
+    size_t *propLossOrder = reserveMemory(1 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(1, propLossOrder);
+    shape_t *propLossShape = reserveMemory(sizeof(shape_t));
+    setShape(propLossShape, propLossDims, 1, propLossOrder);
+    tensor_t *propLoss = initTensor(propLossShape, quantizationInitFloat(), NULL);
 
-    float propLossData[numberOfElements];
-    tensor_t *propLoss = tensorInitFloat(propLossData, dims, numberOfDims, NULL);
-
+    /* 4. Build the layer with shared float quantization. */
     quantization_t *floatQ = quantizationInitFloat();
     layer_t *reluLayer = reluLayerInit(floatQ, floatQ);
     layerFunctions_t reluFns = layerFunctions[RELU];
     reluFns.backward(reluLayer, forwardInput, loss, propLoss);
 
+    /* 5. CAPTURE. */
+    float captured[6];
+    for (size_t i = 0; i < numberOfElements; i++) {
+        captured[i] = ((float *)propLoss->data)[i];
+    }
+
+    /* 6. FREE. */
+    freeReluLayer(reluLayer);
+    freeTensor(propLoss);
+    freeTensor(loss);
+    freeTensor(forwardInput);
+    freeQuantization(floatQ);
+
+    /* 7. ASSERT. */
     float expected[] = {0.f, 0.f, -4.f, 6.f, 3.f, 0.f};
-
-    float *actual = (float *)propLoss->data;
-
-    TEST_ASSERT_EQUAL_FLOAT_ARRAY(expected, actual, numberOfElements);
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(expected, captured, numberOfElements);
 }
 
 void testReluBackwardSymInt32() {
     size_t numberOfValues = 6;
 
-    size_t dims[] = {6};
-    size_t numberOfDims = 1;
+    /* 1. Build heap forwardInput tensor (SymInt32). */
+    size_t *fwdDims = reserveMemory(1 * sizeof(size_t));
+    fwdDims[0] = numberOfValues;
+    size_t *fwdOrder = reserveMemory(1 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(1, fwdOrder);
+    shape_t *fwdShape = reserveMemory(sizeof(shape_t));
+    setShape(fwdShape, fwdDims, 1, fwdOrder);
+    tensor_t *forwardInput = initTensor(fwdShape, quantizationInitSymInt32(HTE), NULL);
+    tensorFillFromFloatBuffer(forwardInput, (float[]){-1.f, 0.f, 1.f, 2.f, 5.f, -6.f}, 6);
 
-    float forwardInputData[] = {-1.f, 0.f, 1.f, 2.f, 5.f, -6.f};
-    tensor_t *forwardInput = tensorInitSymInt32(forwardInputData, dims, numberOfDims, HTE, NULL);
+    /* 2. Build heap loss tensor (SymInt32). */
+    size_t *lossDims = reserveMemory(1 * sizeof(size_t));
+    lossDims[0] = numberOfValues;
+    size_t *lossOrder = reserveMemory(1 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(1, lossOrder);
+    shape_t *lossShape = reserveMemory(sizeof(shape_t));
+    setShape(lossShape, lossDims, 1, lossOrder);
+    tensor_t *loss = initTensor(lossShape, quantizationInitSymInt32(HTE), NULL);
+    tensorFillFromFloatBuffer(loss, (float[]){0.f, 2.f, -4.f, 6.f, 3.f, 2.f}, 6);
 
-    float lossData[] = {0.f, 2.f, -4.f, 6.f, 3.f, 2.f};
-    tensor_t *loss = tensorInitSymInt32(lossData, dims, numberOfDims, HTE, NULL);
+    /* 3. Build heap propLoss tensor (SymInt32). */
+    size_t *propLossDims = reserveMemory(1 * sizeof(size_t));
+    propLossDims[0] = numberOfValues;
+    size_t *propLossOrder = reserveMemory(1 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(1, propLossOrder);
+    shape_t *propLossShape = reserveMemory(sizeof(shape_t));
+    setShape(propLossShape, propLossDims, 1, propLossOrder);
+    tensor_t *propLoss = initTensor(propLossShape, quantizationInitSymInt32(HTE), NULL);
 
-    float propLossData[numberOfValues];
-    tensor_t *propLoss = tensorInitSymInt32(propLossData, dims, numberOfDims, HTE, NULL);
-
+    /* 4. Build layer with shared SymInt32 quantization. */
     quantization_t *symIntQ = quantizationInitSymInt32(HTE);
     layer_t *reluLayer = reluLayerInit(symIntQ, symIntQ);
     layerFunctions_t reluFns = layerFunctions[RELU];
     reluFns.backward(reluLayer, forwardInput, loss, propLoss);
 
-    float expected[] = {0, 0, -4, 6, 3, 0};
-
-    float propLossFloatData[6];
-    tensor_t *propLossFloat = tensorInitFloat(propLossFloatData, dims, numberOfDims, NULL);
+    /* 5. Convert SymInt32 propLoss back to Float for comparison. */
+    size_t *propLossFloatDims = reserveMemory(1 * sizeof(size_t));
+    propLossFloatDims[0] = numberOfValues;
+    size_t *propLossFloatOrder = reserveMemory(1 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(1, propLossFloatOrder);
+    shape_t *propLossFloatShape = reserveMemory(sizeof(shape_t));
+    setShape(propLossFloatShape, propLossFloatDims, 1, propLossFloatOrder);
+    tensor_t *propLossFloat = initTensor(propLossFloatShape, quantizationInitFloat(), NULL);
     convertTensor(propLoss, propLossFloat);
-    float *actual = (float *)propLossFloat->data;
 
+    /* 6. CAPTURE. */
+    float captured[6];
     for (size_t i = 0; i < numberOfValues; i++) {
-        TEST_ASSERT_FLOAT_WITHIN(0.1f, expected[i], actual[i]);
+        captured[i] = ((float *)propLossFloat->data)[i];
+    }
+
+    /* 7. FREE. */
+    freeTensor(propLossFloat);
+    freeReluLayer(reluLayer);
+    freeTensor(propLoss);
+    freeTensor(loss);
+    freeTensor(forwardInput);
+    freeQuantization(symIntQ);
+
+    /* 8. ASSERT. */
+    float expected[] = {0, 0, -4, 6, 3, 0};
+    for (size_t i = 0; i < numberOfValues; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(0.1f, expected[i], captured[i]);
     }
 }
 

--- a/test/unit/layer/UnitTestRelu.c
+++ b/test/unit/layer/UnitTestRelu.c
@@ -136,6 +136,22 @@ void testReluBackwardSymInt32() {
     }
 }
 
+void testReluLayerInitAndFreeRoundTrip(void) {
+    /* Roundtrip: reluLayerInit allocates layer + outer layerConfig +
+     * inner reluConfig (3 reserveMemory calls). freeReluLayer must
+     * release all three. Pre-fix this test runs to completion but leaks
+     * the inner reluConfig; post-fix it is leak-clean (verified via the
+     * LSan sweep). NULL is acceptable for the quantization arguments —
+     * reluLayerInit only stores them, freeReluLayer doesn't touch them. */
+    layer_t *reluLayer = reluLayerInit(NULL, NULL);
+    TEST_ASSERT_NOT_NULL(reluLayer);
+    TEST_ASSERT_EQUAL_INT(RELU, reluLayer->type);
+    TEST_ASSERT_NOT_NULL(reluLayer->config);
+    TEST_ASSERT_NOT_NULL(reluLayer->config->relu);
+
+    freeReluLayer(reluLayer);
+}
+
 void setUp() {}
 void tearDown() {}
 
@@ -146,5 +162,7 @@ int main(void) {
 
     RUN_TEST(testReluBackwardFloat);
     RUN_TEST(testReluBackwardSymInt32);
+
+    RUN_TEST(testReluLayerInitAndFreeRoundTrip);
     return UNITY_END();
 }

--- a/test/unit/layer/UnitTestSoftmax.c
+++ b/test/unit/layer/UnitTestSoftmax.c
@@ -140,6 +140,26 @@ void unitTestSoftmaxBackwardSymInt32() {
     }
 }
 
+void testSoftmaxLayerInitAndFreeRoundTrip(void) {
+    /* Roundtrip: softmaxLayerInit allocates layer + outer layerConfig +
+     * inner softmaxConfig (3 reserveMemory calls). freeSoftmaxLayer must
+     * release all three. Leak verification is delegated to the LSan
+     * sweep — this test asserts only that the round-trip completes
+     * without a crash and that the layer was wired correctly. */
+    quantization_t *floatQ = quantizationInitFloat();
+    layer_t *softmaxLayer = softmaxLayerInit(floatQ, floatQ);
+    TEST_ASSERT_NOT_NULL(softmaxLayer);
+    TEST_ASSERT_EQUAL_INT(SOFTMAX, softmaxLayer->type);
+    TEST_ASSERT_NOT_NULL(softmaxLayer->config);
+    TEST_ASSERT_NOT_NULL(softmaxLayer->config->softmax);
+
+    freeSoftmaxLayer(softmaxLayer);
+
+    /* floatQ is owned by the test; freeSoftmaxLayer must not have freed
+     * it (quantization configs are externally owned and shared). */
+    freeQuantization(floatQ);
+}
+
 void setUp() {}
 void tearDown() {}
 
@@ -150,5 +170,7 @@ int main() {
 
     RUN_TEST(unitTestSoftmaxBackwardFloat);
     RUN_TEST(unitTestSoftmaxBackwardSymInt32);
+
+    RUN_TEST(testSoftmaxLayerInitAndFreeRoundTrip);
     return UNITY_END();
 }

--- a/test/unit/layer/UnitTestSoftmax.c
+++ b/test/unit/layer/UnitTestSoftmax.c
@@ -4,6 +4,8 @@
 #include "QuantizationApi.h"
 #include "Softmax.h"
 #include "SoftmaxApi.h"
+#include "StorageApi.h"
+#include "Tensor.h"
 #include "TensorApi.h"
 #include "TensorConversion.h"
 #include "unity.h"
@@ -11,132 +13,252 @@
 void unitTestSoftmaxForwardFloat() {
     size_t inputSize = 6;
 
-    float inputData[] = {-1.f, 0.f, 1.f, 2.f, 5.f, -6.f};
-    size_t inputDims[] = {2, 3};
-    size_t inputNumberOfDims = 2;
-    tensor_t *input = tensorInitFloat(inputData, inputDims, inputNumberOfDims, NULL);
+    /* 1. Build heap input tensor (shape 2x3). */
+    size_t *inputDims = reserveMemory(2 * sizeof(size_t));
+    inputDims[0] = 2;
+    inputDims[1] = 3;
+    size_t *inputOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, inputOrder);
+    shape_t *inputShape = reserveMemory(sizeof(shape_t));
+    setShape(inputShape, inputDims, 2, inputOrder);
+    tensor_t *input = initTensor(inputShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(input, (float[]){-1.f, 0.f, 1.f, 2.f, 5.f, -6.f}, 6);
 
-    float outputData[inputSize];
-    size_t outputDims[] = {2, 3};
-    size_t outputNumberOfDims = 2;
-    tensor_t *output = tensorInitFloat(outputData, outputDims, outputNumberOfDims, NULL);
+    /* 2. Build heap output tensor (shape 2x3). */
+    size_t *outputDims = reserveMemory(2 * sizeof(size_t));
+    outputDims[0] = 2;
+    outputDims[1] = 3;
+    size_t *outputOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, outputOrder);
+    shape_t *outputShape = reserveMemory(sizeof(shape_t));
+    setShape(outputShape, outputDims, 2, outputOrder);
+    tensor_t *output = initTensor(outputShape, quantizationInitFloat(), NULL);
 
+    /* 3. Build the layer with shared float quantization. */
     quantization_t *floatQ = quantizationInitFloat();
     layer_t *softmaxLayer = softmaxLayerInit(floatQ, floatQ);
     layerFunctions_t softmaxFns = layerFunctions[SOFTMAX];
     softmaxFns.forward(softmaxLayer, input, output);
 
+    /* 4. CAPTURE. */
+    float captured[6];
+    for (size_t i = 0; i < inputSize; i++) {
+        captured[i] = ((float *)output->data)[i];
+    }
+
+    /* 5. FREE. */
+    freeSoftmaxLayer(softmaxLayer);
+    freeTensor(output);
+    freeTensor(input);
+    freeQuantization(floatQ);
+
+    /* 6. ASSERT. */
     float expected[] = {2.3008e-03f, 6.2543e-03f, 1.7001e-02f,
                         4.6213e-02f, 9.2822e-01f, 1.5503e-05f};
-
-    float *actual = (float *)output->data;
-
     for (size_t i = 0; i < inputSize; i++) {
-        TEST_ASSERT_FLOAT_WITHIN(0.0001f, expected[i], actual[i]);
+        TEST_ASSERT_FLOAT_WITHIN(0.0001f, expected[i], captured[i]);
     }
 }
 
 void unitTestSoftmaxForwardSymInt32() {
     size_t inputSize = 6;
 
-    size_t dims[] = {2, 3};
-    size_t numberOfDims = 2;
+    /* 1. Build heap input tensor (SymInt32, shape 2x3). */
+    size_t *inputDims = reserveMemory(2 * sizeof(size_t));
+    inputDims[0] = 2;
+    inputDims[1] = 3;
+    size_t *inputOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, inputOrder);
+    shape_t *inputShape = reserveMemory(sizeof(shape_t));
+    setShape(inputShape, inputDims, 2, inputOrder);
+    tensor_t *input = initTensor(inputShape, quantizationInitSymInt32(HTE), NULL);
+    tensorFillFromFloatBuffer(input, (float[]){-1.f, 0.f, 1.f, 2.f, 5.f, -6.f}, 6);
 
-    float inputData[] = {-1.f, 0.f, 1.f, 2.f, 5.f, -6.f};
+    /* 2. Build heap output tensor (SymInt32, shape 2x3). */
+    size_t *outputDims = reserveMemory(2 * sizeof(size_t));
+    outputDims[0] = 2;
+    outputDims[1] = 3;
+    size_t *outputOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, outputOrder);
+    shape_t *outputShape = reserveMemory(sizeof(shape_t));
+    setShape(outputShape, outputDims, 2, outputOrder);
+    tensor_t *output = initTensor(outputShape, quantizationInitSymInt32(HTE), NULL);
 
-    tensor_t *input = tensorInitSymInt32(inputData, dims, numberOfDims, HTE, NULL);
-
-    float outputData[inputSize];
-    tensor_t *output = tensorInitSymInt32(outputData, dims, numberOfDims, HTE, NULL);
-
+    /* 3. Shared SymInt32 quantization for the layer. */
     quantization_t *symIntQ = quantizationInitSymInt32(HTE);
     layer_t *softmaxLayer = softmaxLayerInit(symIntQ, symIntQ);
     layerFunctions_t softmaxFns = layerFunctions[SOFTMAX];
     softmaxFns.forward(softmaxLayer, input, output);
 
-    float outputFloatData[inputSize];
-    tensor_t *outputFloat = tensorInitFloat(outputFloatData, dims, numberOfDims, NULL);
+    /* 4. Convert SymInt32 output back to Float for comparison. */
+    size_t *outFloatDims = reserveMemory(2 * sizeof(size_t));
+    outFloatDims[0] = 2;
+    outFloatDims[1] = 3;
+    size_t *outFloatOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, outFloatOrder);
+    shape_t *outFloatShape = reserveMemory(sizeof(shape_t));
+    setShape(outFloatShape, outFloatDims, 2, outFloatOrder);
+    tensor_t *outputFloat = initTensor(outFloatShape, quantizationInitFloat(), NULL);
     convertTensor(output, outputFloat);
 
+    /* 5. CAPTURE. */
+    float captured[6];
+    for (size_t i = 0; i < inputSize; i++) {
+        captured[i] = ((float *)outputFloat->data)[i];
+    }
+
+    /* 6. FREE. */
+    freeTensor(outputFloat);
+    freeSoftmaxLayer(softmaxLayer);
+    freeTensor(output);
+    freeTensor(input);
+    freeQuantization(symIntQ);
+
+    /* 7. ASSERT. */
     float expected[] = {2.3008e-03f, 6.2543e-03f, 1.7001e-02f,
                         4.6213e-02f, 9.2822e-01f, 1.5503e-05f};
-    float *actual = (float *)outputFloat->data;
-
     for (size_t i = 0; i < inputSize; i++) {
-        TEST_ASSERT_FLOAT_WITHIN(0.1f, expected[i], actual[i]);
+        TEST_ASSERT_FLOAT_WITHIN(0.1f, expected[i], captured[i]);
     }
 }
 
 void unitTestSoftmaxBackwardFloat() {
     size_t inputSize = 6;
 
-    float inputData[] = {2.3008e-03, 6.2543e-03, 1.7001e-02, 4.6213e-02, 9.2822e-01, 1.5503e-05};
-    size_t inputDims[] = {2, 3};
-    size_t inputNumberOfDims = 2;
-    tensor_t *input = tensorInitFloat(inputData, inputDims, inputNumberOfDims, NULL);
+    /* 1. Build heap input tensor. */
+    size_t *inputDims = reserveMemory(2 * sizeof(size_t));
+    inputDims[0] = 2;
+    inputDims[1] = 3;
+    size_t *inputOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, inputOrder);
+    shape_t *inputShape = reserveMemory(sizeof(shape_t));
+    setShape(inputShape, inputDims, 2, inputOrder);
+    tensor_t *input = initTensor(inputShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(
+        input,
+        (float[]){2.3008e-03f, 6.2543e-03f, 1.7001e-02f, 4.6213e-02f, 9.2822e-01f, 1.5503e-05f}, 6);
 
-    float lossData[] = {0.f, 2.f, -4.f, 6.f, 3.f, 2.f};
-    size_t lossDims[] = {2, 3};
-    size_t lossNumberOfDims = 2;
-    tensor_t *loss = tensorInitFloat(lossData, lossDims, lossNumberOfDims, NULL);
+    /* 2. Build heap loss tensor. */
+    size_t *lossDims = reserveMemory(2 * sizeof(size_t));
+    lossDims[0] = 2;
+    lossDims[1] = 3;
+    size_t *lossOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, lossOrder);
+    shape_t *lossShape = reserveMemory(sizeof(shape_t));
+    setShape(lossShape, lossDims, 2, lossOrder);
+    tensor_t *loss = initTensor(lossShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(loss, (float[]){0.f, 2.f, -4.f, 6.f, 3.f, 2.f}, 6);
 
-    float propLossData[inputSize];
-    size_t propLossDims[] = {2, 3};
-    size_t propLossNumberOfDims = 2;
-    tensor_t *propLoss = tensorInitFloat(propLossData, propLossDims, propLossNumberOfDims, NULL);
+    /* 3. Build heap propLoss tensor. */
+    size_t *propLossDims = reserveMemory(2 * sizeof(size_t));
+    propLossDims[0] = 2;
+    propLossDims[1] = 3;
+    size_t *propLossOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, propLossOrder);
+    shape_t *propLossShape = reserveMemory(sizeof(shape_t));
+    setShape(propLossShape, propLossDims, 2, propLossOrder);
+    tensor_t *propLoss = initTensor(propLossShape, quantizationInitFloat(), NULL);
 
+    /* 4. Build layer. */
     quantization_t *floatQ = quantizationInitFloat();
     layer_t *softmaxLayer = softmaxLayerInit(floatQ, floatQ);
     layerFunctions_t softmaxFns = layerFunctions[SOFTMAX];
     softmaxFns.backward(softmaxLayer, input, loss, propLoss);
 
+    /* 5. CAPTURE. */
+    float captured[6];
+    for (size_t i = 0; i < inputSize; i++) {
+        captured[i] = ((float *)propLoss->data)[i];
+    }
+
+    /* 6. FREE. */
+    freeSoftmaxLayer(softmaxLayer);
+    freeTensor(propLoss);
+    freeTensor(loss);
+    freeTensor(input);
+    freeQuantization(floatQ);
+
+    /* 7. ASSERT. */
     float expected[] = {-6.9173e-03f, -6.2947e-03f, -1.1912e-01f,
                         1.3834e-01f,  -5.9973e-03f, -1.5603e-05f};
-
-    float *actual = (float *)propLoss->data;
-
     for (size_t i = 0; i < inputSize; i++) {
-        TEST_ASSERT_FLOAT_WITHIN(0.0001f, expected[i], actual[i]);
+        TEST_ASSERT_FLOAT_WITHIN(0.0001f, expected[i], captured[i]);
     }
 }
 
 void unitTestSoftmaxBackwardSymInt32() {
     size_t inputSize = 6;
 
-    float inputData[] = {2.3008e-03f, 6.2543e-03f, 1.7001e-02f,
-                         4.6213e-02f, 9.2822e-01f, 1.5503e-05f};
-    size_t inputDims[] = {2, 3};
-    size_t inputNumberOfDims = 2;
-    tensor_t *input = tensorInitSymInt32(inputData, inputDims, inputNumberOfDims, HTE, NULL);
+    /* 1. Build heap input tensor (SymInt32). */
+    size_t *inputDims = reserveMemory(2 * sizeof(size_t));
+    inputDims[0] = 2;
+    inputDims[1] = 3;
+    size_t *inputOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, inputOrder);
+    shape_t *inputShape = reserveMemory(sizeof(shape_t));
+    setShape(inputShape, inputDims, 2, inputOrder);
+    tensor_t *input = initTensor(inputShape, quantizationInitSymInt32(HTE), NULL);
+    tensorFillFromFloatBuffer(
+        input,
+        (float[]){2.3008e-03f, 6.2543e-03f, 1.7001e-02f, 4.6213e-02f, 9.2822e-01f, 1.5503e-05f}, 6);
 
-    float lossData[] = {0.f, 2.f, -4.f, 6.f, 3.f, 2.f};
-    size_t lossDims[] = {2, 3};
-    size_t lossNumberOfDims = 2;
-    tensor_t *loss = tensorInitSymInt32(lossData, lossDims, lossNumberOfDims, HTE, NULL);
+    /* 2. Build heap loss tensor (SymInt32). */
+    size_t *lossDims = reserveMemory(2 * sizeof(size_t));
+    lossDims[0] = 2;
+    lossDims[1] = 3;
+    size_t *lossOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, lossOrder);
+    shape_t *lossShape = reserveMemory(sizeof(shape_t));
+    setShape(lossShape, lossDims, 2, lossOrder);
+    tensor_t *loss = initTensor(lossShape, quantizationInitSymInt32(HTE), NULL);
+    tensorFillFromFloatBuffer(loss, (float[]){0.f, 2.f, -4.f, 6.f, 3.f, 2.f}, 6);
 
-    float propLossData[inputSize];
-    memset(propLossData, 0, sizeof(propLossData));
-    size_t propLossDims[] = {2, 3};
-    size_t propLossNumberOfDims = 2;
-    tensor_t *propLoss =
-        tensorInitSymInt32(propLossData, propLossDims, propLossNumberOfDims, HTE, NULL);
+    /* 3. Build heap propLoss tensor (SymInt32). */
+    size_t *propLossDims = reserveMemory(2 * sizeof(size_t));
+    propLossDims[0] = 2;
+    propLossDims[1] = 3;
+    size_t *propLossOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, propLossOrder);
+    shape_t *propLossShape = reserveMemory(sizeof(shape_t));
+    setShape(propLossShape, propLossDims, 2, propLossOrder);
+    tensor_t *propLoss = initTensor(propLossShape, quantizationInitSymInt32(HTE), NULL);
 
+    /* 4. Build layer. */
     quantization_t *symIntQ = quantizationInitSymInt32(HTE);
     layer_t *softmaxLayer = softmaxLayerInit(symIntQ, symIntQ);
     layerFunctions_t softmaxFns = layerFunctions[SOFTMAX];
     softmaxFns.backward(softmaxLayer, input, loss, propLoss);
 
+    /* 5. Convert SymInt32 propLoss back to Float for comparison. */
+    size_t *propLossFloatDims = reserveMemory(2 * sizeof(size_t));
+    propLossFloatDims[0] = 2;
+    propLossFloatDims[1] = 3;
+    size_t *propLossFloatOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, propLossFloatOrder);
+    shape_t *propLossFloatShape = reserveMemory(sizeof(shape_t));
+    setShape(propLossFloatShape, propLossFloatDims, 2, propLossFloatOrder);
+    tensor_t *propLossFloat = initTensor(propLossFloatShape, quantizationInitFloat(), NULL);
+    convertTensor(propLoss, propLossFloat);
+
+    /* 6. CAPTURE. */
+    float captured[6];
+    for (size_t i = 0; i < inputSize; i++) {
+        captured[i] = ((float *)propLossFloat->data)[i];
+    }
+
+    /* 7. FREE. */
+    freeTensor(propLossFloat);
+    freeSoftmaxLayer(softmaxLayer);
+    freeTensor(propLoss);
+    freeTensor(loss);
+    freeTensor(input);
+    freeQuantization(symIntQ);
+
+    /* 8. ASSERT. */
     float expected[] = {-6.9173e-03f, -6.2947e-03f, -1.1912e-01f,
                         1.3834e-01f,  -5.9973e-03f, -1.5603e-05f};
-
-    float propLossDataFloat[inputSize];
-    tensor_t *propLossFloat =
-        tensorInitFloat(propLossDataFloat, propLossDims, propLossNumberOfDims, NULL);
-    convertTensor(propLoss, propLossFloat);
-    float *actual = (float *)propLossFloat->data;
-
     for (size_t i = 0; i < inputSize; i++) {
-        TEST_ASSERT_FLOAT_WITHIN(0.01f, expected[i], actual[i]);
+        TEST_ASSERT_FLOAT_WITHIN(0.01f, expected[i], captured[i]);
     }
 }
 

--- a/test/unit/layer/UnitTestSoftmax.c
+++ b/test/unit/layer/UnitTestSoftmax.c
@@ -1,11 +1,12 @@
 #include <stdlib.h>
+#include <string.h>
 
+#include "QuantizationApi.h"
 #include "Softmax.h"
-#include "unity.h"
-#include "TensorConversion.h"
 #include "SoftmaxApi.h"
 #include "TensorApi.h"
-#include "QuantizationApi.h"
+#include "TensorConversion.h"
+#include "unity.h"
 
 void unitTestSoftmaxForwardFloat() {
     size_t inputSize = 6;
@@ -25,7 +26,8 @@ void unitTestSoftmaxForwardFloat() {
     layerFunctions_t softmaxFns = layerFunctions[SOFTMAX];
     softmaxFns.forward(softmaxLayer, input, output);
 
-    float expected[] = {2.3008e-03f, 6.2543e-03f, 1.7001e-02f, 4.6213e-02f, 9.2822e-01f, 1.5503e-05f};
+    float expected[] = {2.3008e-03f, 6.2543e-03f, 1.7001e-02f,
+                        4.6213e-02f, 9.2822e-01f, 1.5503e-05f};
 
     float *actual = (float *)output->data;
 
@@ -56,10 +58,11 @@ void unitTestSoftmaxForwardSymInt32() {
     tensor_t *outputFloat = tensorInitFloat(outputFloatData, dims, numberOfDims, NULL);
     convertTensor(output, outputFloat);
 
-    float expected[] = {2.3008e-03f, 6.2543e-03f, 1.7001e-02f, 4.6213e-02f, 9.2822e-01f, 1.5503e-05f};
+    float expected[] = {2.3008e-03f, 6.2543e-03f, 1.7001e-02f,
+                        4.6213e-02f, 9.2822e-01f, 1.5503e-05f};
     float *actual = (float *)outputFloat->data;
 
-    for(size_t i = 0; i < inputSize; i++) {
+    for (size_t i = 0; i < inputSize; i++) {
         TEST_ASSERT_FLOAT_WITHIN(0.1f, expected[i], actual[i]);
     }
 }
@@ -71,7 +74,6 @@ void unitTestSoftmaxBackwardFloat() {
     size_t inputDims[] = {2, 3};
     size_t inputNumberOfDims = 2;
     tensor_t *input = tensorInitFloat(inputData, inputDims, inputNumberOfDims, NULL);
-
 
     float lossData[] = {0.f, 2.f, -4.f, 6.f, 3.f, 2.f};
     size_t lossDims[] = {2, 3};
@@ -88,8 +90,8 @@ void unitTestSoftmaxBackwardFloat() {
     layerFunctions_t softmaxFns = layerFunctions[SOFTMAX];
     softmaxFns.backward(softmaxLayer, input, loss, propLoss);
 
-    float expected[] = {-6.9173e-03f, -6.2947e-03f, -1.1912e-01f, 1.3834e-01f, -5.9973e-03f,
-                        -1.5603e-05f};
+    float expected[] = {-6.9173e-03f, -6.2947e-03f, -1.1912e-01f,
+                        1.3834e-01f,  -5.9973e-03f, -1.5603e-05f};
 
     float *actual = (float *)propLoss->data;
 
@@ -101,7 +103,8 @@ void unitTestSoftmaxBackwardFloat() {
 void unitTestSoftmaxBackwardSymInt32() {
     size_t inputSize = 6;
 
-    float inputData[] = {2.3008e-03f, 6.2543e-03f, 1.7001e-02f, 4.6213e-02f, 9.2822e-01f, 1.5503e-05f};
+    float inputData[] = {2.3008e-03f, 6.2543e-03f, 1.7001e-02f,
+                         4.6213e-02f, 9.2822e-01f, 1.5503e-05f};
     size_t inputDims[] = {2, 3};
     size_t inputNumberOfDims = 2;
     tensor_t *input = tensorInitSymInt32(inputData, inputDims, inputNumberOfDims, HTE, NULL);
@@ -109,23 +112,26 @@ void unitTestSoftmaxBackwardSymInt32() {
     float lossData[] = {0.f, 2.f, -4.f, 6.f, 3.f, 2.f};
     size_t lossDims[] = {2, 3};
     size_t lossNumberOfDims = 2;
-    tensor_t *loss = tensorInitSymInt32(lossData, lossDims, lossNumberOfDims,HTE, NULL);
+    tensor_t *loss = tensorInitSymInt32(lossData, lossDims, lossNumberOfDims, HTE, NULL);
 
     float propLossData[inputSize];
+    memset(propLossData, 0, sizeof(propLossData));
     size_t propLossDims[] = {2, 3};
     size_t propLossNumberOfDims = 2;
-    tensor_t *propLoss = tensorInitSymInt32(propLossData, propLossDims, propLossNumberOfDims, HTE, NULL);
+    tensor_t *propLoss =
+        tensorInitSymInt32(propLossData, propLossDims, propLossNumberOfDims, HTE, NULL);
 
     quantization_t *symIntQ = quantizationInitSymInt32(HTE);
     layer_t *softmaxLayer = softmaxLayerInit(symIntQ, symIntQ);
     layerFunctions_t softmaxFns = layerFunctions[SOFTMAX];
     softmaxFns.backward(softmaxLayer, input, loss, propLoss);
 
-    float expected[] = {-6.9173e-03f, -6.2947e-03f, -1.1912e-01f, 1.3834e-01f, -5.9973e-03f,
-                        -1.5603e-05f};
+    float expected[] = {-6.9173e-03f, -6.2947e-03f, -1.1912e-01f,
+                        1.3834e-01f,  -5.9973e-03f, -1.5603e-05f};
 
     float propLossDataFloat[inputSize];
-    tensor_t *propLossFloat = tensorInitFloat(propLossDataFloat, propLossDims, propLossNumberOfDims, NULL);
+    tensor_t *propLossFloat =
+        tensorInitFloat(propLossDataFloat, propLossDims, propLossNumberOfDims, NULL);
     convertTensor(propLoss, propLossFloat);
     float *actual = (float *)propLossFloat->data;
 

--- a/test/unit/loss_functions/CMakeLists.txt
+++ b/test/unit/loss_functions/CMakeLists.txt
@@ -6,6 +6,7 @@ add_elastic_ai_unit_test(
         Log
         SoftmaxApi
         QuantizationApi
+        TensorApi
 )
 
 add_elastic_ai_unit_test(
@@ -14,4 +15,6 @@ add_elastic_ai_unit_test(
         MORE_LIBS
         CommonLayerLibs
         TensorApi
+        StorageApi
+        QuantizationApi
 )

--- a/test/unit/loss_functions/UnitTestCrossEntropy.c
+++ b/test/unit/loss_functions/UnitTestCrossEntropy.c
@@ -1,9 +1,9 @@
-#include "unity.h"
-#include "Softmax.h"
 #include "CrossEntropy.h"
 #include "QuantizationApi.h"
+#include "Softmax.h"
 #include "SoftmaxApi.h"
-
+#include "TensorApi.h"
+#include "unity.h"
 
 void unitTestCrossEntropyForward() {
     tensor_t logits;
@@ -44,11 +44,18 @@ void unitTestCrossEntropyForward() {
     initFloat32Quantization(&distQ);
     setTensorValues(&distribution, (uint8_t *)distData, &distShape, &distQ, NULL);
 
+    /* CAPTURE. */
+    float capturedActual = crossEntropyForwardFloat(&softmaxOutput, &distribution);
+
+    /* FREE. freeSoftmaxLayer releases the layer config wrapper only; it does
+     * NOT touch the stored forwardQ/backwardQ pointer (which is floatQ). So
+     * floatQ is safe to free after. */
+    freeSoftmaxLayer(softmaxLayer);
+    freeQuantization(floatQ);
+
+    /* ASSERT. */
     float expected = 0.5170299410820007f;
-    float actual = crossEntropyForwardFloat(&softmaxOutput, &distribution);
-
-    TEST_ASSERT_EQUAL_FLOAT(expected, actual);
-
+    TEST_ASSERT_EQUAL_FLOAT(expected, capturedActual);
 }
 
 void unitTestCrossEntropySoftmaxBackward() {
@@ -106,14 +113,23 @@ void unitTestCrossEntropySoftmaxBackward() {
 
     crossEntropySoftmaxBackward(&softmaxOutput, &distribution, &propLoss);
 
-    float expected[] = {-0.2410f, 0.1424f, 0.0986f};
-
-    float *actual = (float *)propLoss.data;
-
+    /* CAPTURE. propLoss.data is stack memory (propLossData[]); copy into a
+     * dedicated capture array so the assertions read from a buffer that
+     * doesn't depend on freeing softmaxLayer/floatQ first. */
+    float capturedActual[3];
     for (size_t i = 0; i < inputSize; i++) {
-        TEST_ASSERT_FLOAT_WITHIN(0.0001f, expected[i], actual[i]);
+        capturedActual[i] = ((float *)propLoss.data)[i];
     }
 
+    /* FREE. */
+    freeSoftmaxLayer(softmaxLayer);
+    freeQuantization(floatQ);
+
+    /* ASSERT. */
+    float expected[] = {-0.2410f, 0.1424f, 0.0986f};
+    for (size_t i = 0; i < inputSize; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(0.0001f, expected[i], capturedActual[i]);
+    }
 }
 
 void setUp() {}

--- a/test/unit/loss_functions/UnitTestMSE.c
+++ b/test/unit/loss_functions/UnitTestMSE.c
@@ -1,26 +1,43 @@
-#include "Tensor.h"
-#include "Rounding.h"
 #include "MSE.h"
-#include "unity.h"
-#include "TensorConversion.h"
+#include "QuantizationApi.h"
+#include "Rounding.h"
+#include "StorageApi.h"
+#include "Tensor.h"
 #include "TensorApi.h"
+#include "TensorConversion.h"
+#include "unity.h"
 
 void testMSEForward() {
-    float outputData[] = {1.f, 2.f, 3.f};
-    size_t outputDims[] = {3};
-    size_t outputNumberOfDims = 1;
-    tensor_t *output = tensorInitFloat(outputData, outputDims, outputNumberOfDims, NULL);
+    /* Output (1D, 3 elements). */
+    size_t *outputDims = reserveMemory(1 * sizeof(size_t));
+    outputDims[0] = 3;
+    size_t *outputOrder = reserveMemory(1 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(1, outputOrder);
+    shape_t *outputShape = reserveMemory(sizeof(shape_t));
+    setShape(outputShape, outputDims, 1, outputOrder);
+    tensor_t *output = initTensor(outputShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(output, (float[]){1.f, 2.f, 3.f}, 3);
 
-    float labelData[] = {2.f, 4.f, 6.f};
-    size_t labelDims[] = {3};
-    size_t labelNumberOfDims = 1;
-    tensor_t *label = tensorInitFloat(labelData, labelDims, labelNumberOfDims, NULL);
+    /* Label (1D, 3 elements). */
+    size_t *labelDims = reserveMemory(1 * sizeof(size_t));
+    labelDims[0] = 3;
+    size_t *labelOrder = reserveMemory(1 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(1, labelOrder);
+    shape_t *labelShape = reserveMemory(sizeof(shape_t));
+    setShape(labelShape, labelDims, 1, labelOrder);
+    tensor_t *label = initTensor(labelShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(label, (float[]){2.f, 4.f, 6.f}, 3);
 
-    float loss = mseLossForward(output, label);
+    /* CAPTURE. */
+    float capturedLoss = mseLossForward(output, label);
 
+    /* FREE. */
+    freeTensor(label);
+    freeTensor(output);
+
+    /* ASSERT. */
     float expected = 4.67f;
-
-    TEST_ASSERT_FLOAT_WITHIN(0.01f, expected, loss);
+    TEST_ASSERT_FLOAT_WITHIN(0.01f, expected, capturedLoss);
 }
 
 void testMSELossBackwardFloat() {
@@ -30,10 +47,7 @@ void testMSELossBackwardFloat() {
     size_t numberOfDims = 1;
     size_t orderOfDims[] = {0};
     shape_t shape = {
-        .dimensions = dims,
-        .orderOfDimensions = orderOfDims,
-        .numberOfDimensions = numberOfDims
-    };
+        .dimensions = dims, .orderOfDimensions = orderOfDims, .numberOfDimensions = numberOfDims};
 
     tensor_t modelOutput;
     quantization_t modelOutputQ;
@@ -59,7 +73,7 @@ void testMSELossBackwardFloat() {
 
     float *actual = (float *)result.data;
 
-    for(size_t i = 0; i < 3; i++) {
+    for (size_t i = 0; i < 3; i++) {
         TEST_ASSERT_FLOAT_WITHIN(0.0001f, expected[i], actual[i]);
     }
 }
@@ -71,10 +85,7 @@ void testMSELossBackwardSymInt32() {
     size_t numberOfDims = 1;
     size_t orderOfDims[] = {0};
     shape_t shape = {
-        .dimensions = dims,
-        .orderOfDimensions = orderOfDims,
-        .numberOfDimensions = numberOfDims
-    };
+        .dimensions = dims, .orderOfDimensions = orderOfDims, .numberOfDimensions = numberOfDims};
 
     tensor_t modelOutput;
     quantization_t modelOutputQ;
@@ -88,7 +99,8 @@ void testMSELossBackwardSymInt32() {
     quantization_t modelOutputSymInt32Q;
     initSymInt32Quantization(&modelOutputSymInt32QC, &modelOutputSymInt32Q);
     uint8_t modelOutputSymInt32Data[numberOfElements * sizeof(int32_t)];
-    setTensorValuesForConversion(modelOutputSymInt32Data, &modelOutputSymInt32Q, &modelOutput, &modelOutputSymInt32);
+    setTensorValuesForConversion(modelOutputSymInt32Data, &modelOutputSymInt32Q, &modelOutput,
+                                 &modelOutputSymInt32);
     convertTensor(&modelOutput, &modelOutputSymInt32);
 
     tensor_t label;
@@ -106,7 +118,6 @@ void testMSELossBackwardSymInt32() {
     setTensorValuesForConversion(labelSymInt32Data, &labelSymInt32Q, &label, &labelSymInt32);
     convertTensor(&label, &labelSymInt32);
 
-
     tensor_t result;
     quantization_t resultQ;
     initFloat32Quantization(&resultQ);
@@ -122,7 +133,6 @@ void testMSELossBackwardSymInt32() {
     setTensorValuesForConversion(resultSymInt32Data, &resultSymInt32Q, &result, &resultSymInt32);
     convertTensor(&result, &resultSymInt32);
 
-
     mseLossBackward(&modelOutputSymInt32, &labelSymInt32, &resultSymInt32);
 
     convertTensor(&resultSymInt32, &result);
@@ -131,13 +141,13 @@ void testMSELossBackwardSymInt32() {
 
     float *actual = (float *)result.data;
 
-    for(size_t i = 0; i < numberOfElements; i++) {
+    for (size_t i = 0; i < numberOfElements; i++) {
         TEST_ASSERT_FLOAT_WITHIN(0.5f, expected[i], actual[i]);
     }
 }
 
-void setUp(){}
-void tearDown(){}
+void setUp() {}
+void tearDown() {}
 
 int main(void) {
     UNITY_BEGIN();

--- a/test/unit/optimizer/CMakeLists.txt
+++ b/test/unit/optimizer/CMakeLists.txt
@@ -5,6 +5,8 @@ add_elastic_ai_unit_test(
         CommonLayerLibs
         SgdApi
         TensorApi
+        QuantizationApi
+        StorageApi
         LinearApi
         ReluApi
 )

--- a/test/unit/optimizer/UnitTestSgd.c
+++ b/test/unit/optimizer/UnitTestSgd.c
@@ -1,15 +1,17 @@
 #define SOURCE_FILE "SGD-UTEST"
 #include <stdlib.h>
 
-#include "Linear.h"
-#include "unity.h"
 #include "Layer.h"
-#include "Tensor.h"
+#include "Linear.h"
+#include "LinearApi.h"
+#include "OptimizerApi.h"
+#include "QuantizationApi.h"
 #include "Sgd.h"
 #include "SgdApi.h"
-#include "LinearApi.h"
+#include "StorageApi.h"
+#include "Tensor.h"
 #include "TensorApi.h"
-#include "OptimizerApi.h"
+#include "unity.h"
 
 #include <ReluApi.h>
 
@@ -17,30 +19,70 @@ void setUp() {}
 void tearDown() {}
 
 void testSgdMCreateOptim() {
+    /* Shared layer-config quantization (caller-owned). */
+    quantization_t *layerQ = quantizationInitFloat();
 
-    float weightData[] = {0.f, 1.f, 2.f};
-    size_t weightDims[] = {1, 3};
-    size_t weightNumberOfDims = 2;
-    tensor_t *weightParam = tensorInitFloat(weightData, weightDims, weightNumberOfDims, NULL);
-    float weightGradData[] = {0.f, 0.f, 0.f};
-    tensor_t *weightGrad = tensorInitFloat(weightGradData, weightDims, weightNumberOfDims, NULL);
-    parameter_t *weights = parameterInit(weightParam, weightGrad);
+    /* linear0 weights (heap shape, FLOAT32, dims {1, 3}, ndims=2). */
+    size_t *w0Dims = reserveMemory(2 * sizeof(size_t));
+    w0Dims[0] = 1;
+    w0Dims[1] = 3;
+    size_t *w0Order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, w0Order);
+    shape_t *w0Shape = reserveMemory(sizeof(shape_t));
+    setShape(w0Shape, w0Dims, 2, w0Order);
+    tensor_t *w0Param = initTensor(w0Shape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(w0Param, (float[]){0.f, 1.f, 2.f}, 3);
+    tensor_t *w0Grad = gradInitFloat(w0Param, NULL);
+    tensorFillFromFloatBuffer(w0Grad, (float[]){0.f, 0.f, 0.f}, 3);
+    parameter_t *weights0 = parameterInit(w0Param, w0Grad);
 
-    float biasData[] = {0.f, 1.f, -1.f};
-    size_t biasDims[] = {1, 3};
-    size_t biasNumberOfDims = 1;
-    tensor_t *biasParam = tensorInitFloat(biasData, biasDims, biasNumberOfDims, NULL);
-    float biasGradData[] = {0.f, 0.f, 0.f};
-    tensor_t *biasGrad = tensorInitFloat(biasGradData, biasDims, biasNumberOfDims, NULL);
-    parameter_t *bias = parameterInit(biasParam, biasGrad);
+    /* linear0 bias (heap shape, FLOAT32, dims {1, 3}, ndims=1 -> 1 element). */
+    size_t *b0Dims = reserveMemory(1 * sizeof(size_t));
+    b0Dims[0] = 1;
+    size_t *b0Order = reserveMemory(1 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(1, b0Order);
+    shape_t *b0Shape = reserveMemory(sizeof(shape_t));
+    setShape(b0Shape, b0Dims, 1, b0Order);
+    tensor_t *b0Param = initTensor(b0Shape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(b0Param, (float[]){0.f}, 1);
+    tensor_t *b0Grad = gradInitFloat(b0Param, NULL);
+    tensorFillFromFloatBuffer(b0Grad, (float[]){0.f}, 1);
+    parameter_t *bias0 = parameterInit(b0Param, b0Grad);
 
-    quantization_t testQ;
-    initFloat32Quantization(&testQ);
-    layer_t *linear0 = linearLayerInit(weights, bias, &testQ, &testQ, &testQ, &testQ);
+    /* linear1 needs its OWN weights/bias parameters (Bug 1 fix): freeOptimSgdM
+     * will walk optim->parameter[] and freeParameter each entry once. Sharing
+     * the same parameter_t pointers across linear0 and linear1 would cause a
+     * double-free. The pointer-equality assertions below still hold because
+     * they compare layer config slots against optim->parameter slots, both
+     * of which now point to whichever parameter object the layer was given. */
+    size_t *w1Dims = reserveMemory(2 * sizeof(size_t));
+    w1Dims[0] = 1;
+    w1Dims[1] = 3;
+    size_t *w1Order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, w1Order);
+    shape_t *w1Shape = reserveMemory(sizeof(shape_t));
+    setShape(w1Shape, w1Dims, 2, w1Order);
+    tensor_t *w1Param = initTensor(w1Shape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(w1Param, (float[]){0.f, 1.f, 2.f}, 3);
+    tensor_t *w1Grad = gradInitFloat(w1Param, NULL);
+    tensorFillFromFloatBuffer(w1Grad, (float[]){0.f, 0.f, 0.f}, 3);
+    parameter_t *weights1 = parameterInit(w1Param, w1Grad);
 
-    layer_t *relu0 = reluLayerInit(&testQ, &testQ);
+    size_t *b1Dims = reserveMemory(1 * sizeof(size_t));
+    b1Dims[0] = 1;
+    size_t *b1Order = reserveMemory(1 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(1, b1Order);
+    shape_t *b1Shape = reserveMemory(sizeof(shape_t));
+    setShape(b1Shape, b1Dims, 1, b1Order);
+    tensor_t *b1Param = initTensor(b1Shape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(b1Param, (float[]){0.f}, 1);
+    tensor_t *b1Grad = gradInitFloat(b1Param, NULL);
+    tensorFillFromFloatBuffer(b1Grad, (float[]){0.f}, 1);
+    parameter_t *bias1 = parameterInit(b1Param, b1Grad);
 
-    layer_t *linear1 = linearLayerInit(weights, bias, &testQ, &testQ, &testQ, &testQ);
+    layer_t *linear0 = linearLayerInit(weights0, bias0, layerQ, layerQ, layerQ, layerQ);
+    layer_t *relu0 = reluLayerInit(layerQ, layerQ);
+    layer_t *linear1 = linearLayerInit(weights1, bias1, layerQ, layerQ, layerQ, layerQ);
 
     layer_t *model[] = {linear0, relu0, linear1};
     size_t sizeModel = sizeof(model) / sizeof(model[0]);
@@ -48,60 +90,121 @@ void testSgdMCreateOptim() {
     float momentumFactor = 0.9f;
     float weightDecay = 0.5f;
 
-    optimizer_t *optim = sgdMCreateOptim(lr, momentumFactor, weightDecay, model, sizeModel, FLOAT32);
+    optimizer_t *optim =
+        sgdMCreateOptim(lr, momentumFactor, weightDecay, model, sizeModel, FLOAT32);
     sgd_t *sgd = optim->impl->sgd;
 
     linearConfig_t *linear0Conf = linear0->config->linear;
     linearConfig_t *linear1Conf = linear1->config->linear;
 
-    TEST_ASSERT_EQUAL_FLOAT(lr, sgd->learningRate);
-    TEST_ASSERT_EQUAL_FLOAT(momentumFactor, sgd->momentumFactor);
-    TEST_ASSERT_EQUAL_FLOAT(weightDecay, sgd->weightDecay);
-    TEST_ASSERT_EQUAL_size_t(4, optim->sizeStates);
+    /* CAPTURE before frees. */
+    float capturedLr = sgd->learningRate;
+    float capturedMomentum = sgd->momentumFactor;
+    float capturedWeightDecay = sgd->weightDecay;
+    size_t capturedSizeStates = optim->sizeStates;
 
-    TEST_ASSERT_EQUAL_PTR(linear0Conf->weights, optim->parameter[0]);
-    TEST_ASSERT_EQUAL_PTR(linear0Conf->bias, optim->parameter[1]);
-    TEST_ASSERT_EQUAL_PTR(linear1Conf->weights, optim->parameter[2]);
-    TEST_ASSERT_EQUAL_PTR(linear1Conf->bias, optim->parameter[3]);
+    parameter_t *capturedL0Weights = linear0Conf->weights;
+    parameter_t *capturedL0Bias = linear0Conf->bias;
+    parameter_t *capturedL1Weights = linear1Conf->weights;
+    parameter_t *capturedL1Bias = linear1Conf->bias;
+    parameter_t *capturedOptimP0 = optim->parameter[0];
+    parameter_t *capturedOptimP1 = optim->parameter[1];
+    parameter_t *capturedOptimP2 = optim->parameter[2];
+    parameter_t *capturedOptimP3 = optim->parameter[3];
 
-    TEST_ASSERT_EQUAL_FLOAT_ARRAY(linear0Conf->weights->grad->data,
-                                  optim->states[0]->stateBuffers[0]->data,
-                                  calcNumberOfElementsByParameter(linear0Conf->weights));
+    size_t l0WeightsN = calcNumberOfElementsByParameter(linear0Conf->weights);
+    size_t l0BiasN = calcNumberOfElementsByParameter(linear0Conf->bias);
+    size_t l1WeightsN = calcNumberOfElementsByParameter(linear1Conf->weights);
+    size_t l1BiasN = calcNumberOfElementsByParameter(linear1Conf->bias);
 
-    TEST_ASSERT_EQUAL_FLOAT_ARRAY(linear0Conf->bias->grad->data,
-                                  optim->states[1]->stateBuffers[0]->data,
-                                  calcNumberOfElementsByParameter(linear0Conf->bias));
+    /* l0WeightsN=3, l0BiasN=1, l1WeightsN=3, l1BiasN=1 (per shape semantics above). */
+    float capturedL0WGrad[3];
+    float capturedL0WState[3];
+    for (size_t i = 0; i < l0WeightsN; i++) {
+        capturedL0WGrad[i] = ((float *)linear0Conf->weights->grad->data)[i];
+        capturedL0WState[i] = ((float *)optim->states[0]->stateBuffers[0]->data)[i];
+    }
 
-    TEST_ASSERT_EQUAL_FLOAT_ARRAY(linear1Conf->weights->grad->data,
-                                  optim->states[2]->stateBuffers[0]->data,
-                                  calcNumberOfElementsByParameter(linear1Conf->weights));
-    TEST_ASSERT_EQUAL_FLOAT_ARRAY(linear1Conf->bias->grad->data,
-                                  optim->states[3]->stateBuffers[0]->data,
-                                  calcNumberOfElementsByParameter(linear1Conf->bias));
+    float capturedL0BGrad[1];
+    float capturedL0BState[1];
+    for (size_t i = 0; i < l0BiasN; i++) {
+        capturedL0BGrad[i] = ((float *)linear0Conf->bias->grad->data)[i];
+        capturedL0BState[i] = ((float *)optim->states[1]->stateBuffers[0]->data)[i];
+    }
+
+    float capturedL1WGrad[3];
+    float capturedL1WState[3];
+    for (size_t i = 0; i < l1WeightsN; i++) {
+        capturedL1WGrad[i] = ((float *)linear1Conf->weights->grad->data)[i];
+        capturedL1WState[i] = ((float *)optim->states[2]->stateBuffers[0]->data)[i];
+    }
+
+    float capturedL1BGrad[1];
+    float capturedL1BState[1];
+    for (size_t i = 0; i < l1BiasN; i++) {
+        capturedL1BGrad[i] = ((float *)linear1Conf->bias->grad->data)[i];
+        capturedL1BState[i] = ((float *)optim->states[3]->stateBuffers[0]->data)[i];
+    }
+
+    /* FREE in reverse-init order. freeOptimSgdM cascades to all parameters
+     * (and their grads) registered with the optimizer (per SgdApi.c:85-93,
+     * mirroring the post-#110 ownership contract). */
+    freeOptimSgdM(optim);
+    freeLinearLayer(linear1);
+    freeReluLayer(relu0);
+    freeLinearLayer(linear0);
+    freeQuantization(layerQ);
+
+    /* ASSERT. */
+    TEST_ASSERT_EQUAL_FLOAT(lr, capturedLr);
+    TEST_ASSERT_EQUAL_FLOAT(momentumFactor, capturedMomentum);
+    TEST_ASSERT_EQUAL_FLOAT(weightDecay, capturedWeightDecay);
+    TEST_ASSERT_EQUAL_size_t(4, capturedSizeStates);
+
+    TEST_ASSERT_EQUAL_PTR(capturedL0Weights, capturedOptimP0);
+    TEST_ASSERT_EQUAL_PTR(capturedL0Bias, capturedOptimP1);
+    TEST_ASSERT_EQUAL_PTR(capturedL1Weights, capturedOptimP2);
+    TEST_ASSERT_EQUAL_PTR(capturedL1Bias, capturedOptimP3);
+
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(capturedL0WGrad, capturedL0WState, l0WeightsN);
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(capturedL0BGrad, capturedL0BState, l0BiasN);
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(capturedL1WGrad, capturedL1WState, l1WeightsN);
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(capturedL1BGrad, capturedL1BState, l1BiasN);
 }
 
 void testSGDStep() {
-    float weightData[] = {1.f, 2.f, -3.f};
-    size_t weightDims[] = {3, 1};
-    size_t weightNumberOfDims = 1;
-    tensor_t *weightParam = tensorInitFloat(weightData, weightDims, weightNumberOfDims, NULL);
+    quantization_t *layerQ = quantizationInitFloat();
+
+    /* weights (heap shape, FLOAT32, dims {3, 1}, ndims=1 -> 3 elements). */
+    size_t *wDims = reserveMemory(1 * sizeof(size_t));
+    wDims[0] = 3;
+    size_t *wOrder = reserveMemory(1 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(1, wOrder);
+    shape_t *wShape = reserveMemory(sizeof(shape_t));
+    setShape(wShape, wDims, 1, wOrder);
+    tensor_t *weightParam = initTensor(wShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(weightParam, (float[]){1.f, 2.f, -3.f}, 3);
     tensor_t *weightGrad = gradInitFloat(weightParam, NULL);
-    float weightGradData[] = {1.f, -1.f, 2.f};
-    weightGrad->data = (uint8_t *)weightGradData;
+    /* Bug 2 fix: populate the heap-allocated grad buffer rather than
+     * overwriting weightGrad->data with a stack pointer (which would leak
+     * the heap buffer and make freeTensor UB on the dangling stack ptr). */
+    tensorFillFromFloatBuffer(weightGrad, (float[]){1.f, -1.f, 2.f}, 3);
     parameter_t *weights = parameterInit(weightParam, weightGrad);
 
-    float biasData[] = {-1.f, 3.f};
-    size_t biasDims[] = {2, 1};
-    size_t biasNumberOfDims = 1;
-    tensor_t *biasParam = tensorInitFloat(biasData, biasDims, biasNumberOfDims, NULL);
+    /* bias (heap shape, FLOAT32, dims {2, 1}, ndims=1 -> 2 elements). */
+    size_t *bDims = reserveMemory(1 * sizeof(size_t));
+    bDims[0] = 2;
+    size_t *bOrder = reserveMemory(1 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(1, bOrder);
+    shape_t *bShape = reserveMemory(sizeof(shape_t));
+    setShape(bShape, bDims, 1, bOrder);
+    tensor_t *biasParam = initTensor(bShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(biasParam, (float[]){-1.f, 3.f}, 2);
     tensor_t *biasGrad = gradInitFloat(biasParam, NULL);
-    float biasGradData[] = {1.f, 3.f};
-    biasGrad->data = (uint8_t *) biasGradData;
+    tensorFillFromFloatBuffer(biasGrad, (float[]){1.f, 3.f}, 2);
     parameter_t *bias = parameterInit(biasParam, biasGrad);
 
-    quantization_t testQ;
-    initFloat32Quantization(&testQ);
-    layer_t *linear = linearLayerInit(weights, bias, &testQ, &testQ, &testQ, &testQ);
+    layer_t *linear = linearLayerInit(weights, bias, layerQ, layerQ, layerQ, layerQ);
 
     layer_t *model[] = {linear};
     size_t modelSize = 1;
@@ -114,48 +217,80 @@ void testSGDStep() {
     optimizerFunctions_t sgdFns = optimizerFunctions[sgd->type];
     sgdFns.step(sgd);
 
-    float wPExpected[] = {0.899f, 2.098f, -3.197f};
-    float bPExpected[] = {-1.099f, 2.697f};
-
-    TEST_ASSERT_EQUAL_FLOAT_ARRAY(wPExpected, linear->config->linear->weights->param->data,
-                                  sizeof(wPExpected)/sizeof(float));
-    TEST_ASSERT_EQUAL_FLOAT_ARRAY(bPExpected, linear->config->linear->bias->param->data,
-                                  sizeof(bPExpected)/sizeof(float));
+    /* CAPTURE first-step values before second step. */
+    float capturedWAfterStep1[3];
+    for (size_t i = 0; i < 3; i++) {
+        capturedWAfterStep1[i] = ((float *)linear->config->linear->weights->param->data)[i];
+    }
+    float capturedBAfterStep1[2];
+    for (size_t i = 0; i < 2; i++) {
+        capturedBAfterStep1[i] = ((float *)linear->config->linear->bias->param->data)[i];
+    }
 
     sgdFns.step(sgd);
 
+    /* CAPTURE second-step values before frees. */
+    float capturedWAfterStep2[3];
+    for (size_t i = 0; i < 3; i++) {
+        capturedWAfterStep2[i] = ((float *)linear->config->linear->weights->param->data)[i];
+    }
+    float capturedBAfterStep2[2];
+    for (size_t i = 0; i < 2; i++) {
+        capturedBAfterStep2[i] = ((float *)linear->config->linear->bias->param->data)[i];
+    }
+
+    /* FREE in reverse-init order. */
+    freeOptimSgdM(sgd);
+    freeLinearLayer(linear);
+    freeQuantization(layerQ);
+
+    /* ASSERT. */
+    float wPExpected[] = {0.899f, 2.098f, -3.197f};
+    float bPExpected[] = {-1.099f, 2.697f};
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(wPExpected, capturedWAfterStep1, 3);
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(bPExpected, capturedBAfterStep1, 2);
+
     float wPExpected2[] = {0.707201f, 2.284102f, -3.571103f};
     float bPExpected2[] = {-1.287001f, 2.121603f};
-
-    TEST_ASSERT_EQUAL_FLOAT_ARRAY(wPExpected2, linear->config->linear->weights->param->data,
-                                  sizeof(wPExpected2)/sizeof(float));
-    TEST_ASSERT_EQUAL_FLOAT_ARRAY(bPExpected2, linear->config->linear->bias->param->data,
-                                  sizeof(bPExpected2)/sizeof(float));
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(wPExpected2, capturedWAfterStep2, 3);
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(bPExpected2, capturedBAfterStep2, 2);
 }
 
 void testSGDZeroGrad() {
-    float weightData[] = {1.f, 2.f, -3.f};
-    size_t weightDims[] = {3, 1};
-    size_t weightNumberOfDims = 2;
-    tensor_t *weightParam = tensorInitFloat(weightData, weightDims, weightNumberOfDims, NULL);
+    quantization_t *layerQ = quantizationInitFloat();
+
+    /* weights (heap shape, FLOAT32, dims {3, 1}, ndims=2 -> 3 elements). */
+    size_t *wDims = reserveMemory(2 * sizeof(size_t));
+    wDims[0] = 3;
+    wDims[1] = 1;
+    size_t *wOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, wOrder);
+    shape_t *wShape = reserveMemory(sizeof(shape_t));
+    setShape(wShape, wDims, 2, wOrder);
+    tensor_t *weightParam = initTensor(wShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(weightParam, (float[]){1.f, 2.f, -3.f}, 3);
     tensor_t *weightGrad = gradInitFloat(weightParam, NULL);
-    float weightGradData[] = {1.f, -1.f, 2.f};
-    weightGrad->data = (uint8_t *)weightGradData;
+    /* Bug 2 fix: same as testSGDStep. */
+    tensorFillFromFloatBuffer(weightGrad, (float[]){1.f, -1.f, 2.f}, 3);
     parameter_t *weights = parameterInit(weightParam, weightGrad);
 
-
-    float biasData[] = {-1.f, 3.f};
-    size_t biasDims[] = {2, 1};
-    size_t biasNumberOfDims = 2;
-    tensor_t *biasParam = tensorInitFloat(biasData, biasDims, biasNumberOfDims, NULL);
-    tensor_t *biasGrad = gradInitFloat(weightParam, NULL);
-    float biasGradData[] = {1.f, 3.f};
-    biasGrad->data = (uint8_t *)biasGradData;
+    /* bias (heap shape, FLOAT32, dims {2, 1}, ndims=2 -> 2 elements). */
+    size_t *bDims = reserveMemory(2 * sizeof(size_t));
+    bDims[0] = 2;
+    bDims[1] = 1;
+    size_t *bOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, bOrder);
+    shape_t *bShape = reserveMemory(sizeof(shape_t));
+    setShape(bShape, bDims, 2, bOrder);
+    tensor_t *biasParam = initTensor(bShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(biasParam, (float[]){-1.f, 3.f}, 2);
+    /* Bug 3 fix: gradInitFloat must take biasParam (not weightParam) so the
+     * grad's shape matches bias (2 elements), not weight (3 elements). */
+    tensor_t *biasGrad = gradInitFloat(biasParam, NULL);
+    tensorFillFromFloatBuffer(biasGrad, (float[]){1.f, 3.f}, 2);
     parameter_t *bias = parameterInit(biasParam, biasGrad);
 
-    quantization_t testQ;
-    initFloat32Quantization(&testQ);
-    layer_t *linear = linearLayerInit(weights, bias, &testQ, &testQ, &testQ, &testQ);
+    layer_t *linear = linearLayerInit(weights, bias, layerQ, layerQ, layerQ, layerQ);
 
     layer_t *model[] = {linear};
     size_t modelSize = 1;
@@ -166,14 +301,27 @@ void testSGDZeroGrad() {
     optimizer_t *sgd = sgdMCreateOptim(lr, momentumFactor, weightDecay, model, modelSize, FLOAT32);
 
     sgdZeroGrad(sgd);
+
+    /* CAPTURE before frees. */
+    float capturedWGrad[3];
+    for (size_t i = 0; i < 3; i++) {
+        capturedWGrad[i] = ((float *)weights->grad->data)[i];
+    }
+    float capturedBGrad[2];
+    for (size_t i = 0; i < 2; i++) {
+        capturedBGrad[i] = ((float *)bias->grad->data)[i];
+    }
+
+    /* FREE in reverse-init order. */
+    freeOptimSgdM(sgd);
+    freeLinearLayer(linear);
+    freeQuantization(layerQ);
+
+    /* ASSERT. */
     float wGradExpected[] = {0.f, 0.f, 0.f};
     float bGradExpected[] = {0.f, 0.f};
-
-    TEST_ASSERT_EQUAL_FLOAT_ARRAY(wGradExpected, weights->grad->data,
-                                  sizeof(wGradExpected)/sizeof(float));
-    TEST_ASSERT_EQUAL_FLOAT_ARRAY(bGradExpected, bias->grad->data,
-                                  sizeof(bGradExpected)/sizeof(float));
-
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(wGradExpected, capturedWGrad, 3);
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(bGradExpected, capturedBGrad, 2);
 }
 
 int main() {

--- a/test/unit/serial/CMakeLists.txt
+++ b/test/unit/serial/CMakeLists.txt
@@ -16,4 +16,12 @@ add_elastic_ai_unit_test(
         ReluApi
         Softmax
         SoftmaxApi
+
+        StorageApi
+)
+
+# Absolute scratch-file path so the test runs from any working directory
+# (host build dir vs. Docker /work, see Phase 2 LSan migration).
+target_compile_definitions(UnitTestDeserialize PRIVATE
+        SERIALIZE_TEST_FILE_PATH="${CMAKE_CURRENT_BINARY_DIR}/SerializeTestFile.bin"
 )

--- a/test/unit/serial/UnitTestDeserialize.c
+++ b/test/unit/serial/UnitTestDeserialize.c
@@ -1,78 +1,106 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include "TensorApi.h"
-#include "Tensor.h"
-#include "unity.h"
-#include "Serialize.h"
 #include "Deserialize.h"
-
-#include "QuantizationApi.h"
 #include "Linear.h"
 #include "LinearApi.h"
-#include "ReluApi.h"
-#include "SoftmaxApi.h"
+#include "QuantizationApi.h"
 #include "Relu.h"
+#include "ReluApi.h"
+#include "Serialize.h"
+#include "Softmax.h"
+#include "SoftmaxApi.h"
+#include "StorageApi.h"
+#include "Tensor.h"
+#include "TensorApi.h"
+#include "unity.h"
 
-#include <Softmax.h>
+/* SERIALIZE_TEST_FILE_PATH is injected by the CMake target_compile_definitions
+ * in test/unit/serial/CMakeLists.txt as an absolute path so the test does not
+ * depend on the working directory (which differs between host runs and Docker
+ * LSan runs). */
+#define FILE_PATH SERIALIZE_TEST_FILE_PATH
 
-#define FILE_PATH "../../../../../test/unit/serial/SerializeTestFile.bin"
+static tensor_t *makeFloatTensor2D(size_t d0, size_t d1, const float *src, size_t count) {
+    /* Heap-tier construction per CONVENTIONS Rule 1. */
+    size_t *dims = reserveMemory(2 * sizeof(size_t));
+    dims[0] = d0;
+    dims[1] = d1;
+    size_t *order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, order);
+    shape_t *shape = reserveMemory(sizeof(shape_t));
+    setShape(shape, dims, 2, order);
+
+    tensor_t *t = initTensor(shape, quantizationInitFloat(), NULL);
+    if (src != NULL) {
+        tensorFillFromFloatBuffer(t, src, count);
+    }
+    return t;
+}
 
 void testSerializeAndDeserializeTensor() {
     size_t numberOfValues = 6;
     float data[] = {9, 9, 9, 4.5f, 2.1112f, 999.123f};
-    size_t dims[] = {2, 3};
-    size_t numberOfDims = 2;
 
-    tensor_t *serialTensor = tensorInitFloat(data, dims, numberOfDims, NULL);
+    tensor_t *serialTensor = makeFloatTensor2D(2, 3, data, numberOfValues);
 
     FILE *f = fopen(FILE_PATH, "wb");
     serializeTensor(serialTensor, f);
     fclose(f);
 
-    float deserialData[6] = {0};
-    size_t deserialDims[2] = {0};
-    size_t deserialOrder[2] = {0};
-    shape_t deserialShape = {
-        .dimensions = deserialDims,
-        .numberOfDimensions = 0,
-        .orderOfDimensions = deserialOrder
-    };
-    quantization_t deserialQ;
-
-    tensor_t deserialTensor = {
-        .shape = &deserialShape,
-        .data = (uint8_t *)deserialData,
-        .sparsity = NULL,
-        .quantization = &deserialQ
-    };
+    /* Heap-allocated zero-init buffer destination via initTensor. */
+    tensor_t *deserialTensor = makeFloatTensor2D(2, 3, NULL, 0);
 
     f = fopen(FILE_PATH, "rb");
-    deserializeTensor(&deserialTensor, f);
+    deserializeTensor(deserialTensor, f);
     fclose(f);
 
-    TEST_ASSERT_EQUAL_FLOAT_ARRAY(data, deserialTensor.data, numberOfValues);
-    TEST_ASSERT_EQUAL(serialTensor->quantization->type, deserialTensor.quantization->type);
-    TEST_ASSERT_EQUAL(serialTensor->shape->numberOfDimensions,
-                      deserialTensor.shape->numberOfDimensions);
-    TEST_ASSERT_EQUAL_size_t_ARRAY(serialTensor->shape->dimensions,
-                                   deserialTensor.shape->dimensions, numberOfDims);
-    TEST_ASSERT_EQUAL_size_t_ARRAY(serialTensor->shape->orderOfDimensions,
-                                   deserialTensor.shape->orderOfDimensions, numberOfDims);
+    /* CAPTURE every assertion value before any free. */
+    float capturedDeserialData[6];
+    for (size_t i = 0; i < numberOfValues; i++) {
+        capturedDeserialData[i] = ((float *)deserialTensor->data)[i];
+    }
+    qtype_t capturedSerialQType = serialTensor->quantization->type;
+    qtype_t capturedDeserialQType = deserialTensor->quantization->type;
+    size_t capturedSerialNumDims = serialTensor->shape->numberOfDimensions;
+    size_t capturedDeserialNumDims = deserialTensor->shape->numberOfDimensions;
+
+    size_t capturedSerialDims[2];
+    size_t capturedDeserialDims[2];
+    size_t capturedSerialOrder[2];
+    size_t capturedDeserialOrder[2];
+    for (size_t i = 0; i < 2; i++) {
+        capturedSerialDims[i] = serialTensor->shape->dimensions[i];
+        capturedDeserialDims[i] = deserialTensor->shape->dimensions[i];
+        capturedSerialOrder[i] = serialTensor->shape->orderOfDimensions[i];
+        capturedDeserialOrder[i] = deserialTensor->shape->orderOfDimensions[i];
+    }
+
+    /* FREE in reverse-init order. */
+    freeTensor(deserialTensor);
+    freeTensor(serialTensor);
+
+    /* ASSERT on captured. */
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(data, capturedDeserialData, numberOfValues);
+    TEST_ASSERT_EQUAL(capturedSerialQType, capturedDeserialQType);
+    TEST_ASSERT_EQUAL(capturedSerialNumDims, capturedDeserialNumDims);
+    TEST_ASSERT_EQUAL_size_t_ARRAY(capturedSerialDims, capturedDeserialDims, 2);
+    TEST_ASSERT_EQUAL_size_t_ARRAY(capturedSerialOrder, capturedDeserialOrder, 2);
 }
 
 void testSerializeAndDeserializeModel() {
-    quantization_t *serialQ = quantizationInitFloat();
+    /* One shared layer-config quantization per side. Layer free-functions
+     * release only the wrapper, so layerQ stays alive across the layer
+     * frees and is freed once with freeQuantization at the end. */
+    quantization_t *serialLayerQ = quantizationInitFloat();
+    quantization_t *deserialLayerQ = quantizationInitFloat();
 
+    /* === Serial side: Linear (20 x 28*28) -> ReLU -> Linear (10 x 20) -> Softmax === */
     float serialWeight0Data[20 * 28 * 28];
     for (size_t i = 0; i < 28 * 28 * 20; i++) {
-        serialWeight0Data[i] = (float) i;
+        serialWeight0Data[i] = (float)i;
     }
-
-    size_t serialWeight0Dims[] = {20, 28 * 28};
-    size_t serialWeight0NumberOfDims = 2;
-    tensor_t *serialWeight0Param = tensorInitFloat(serialWeight0Data, serialWeight0Dims,
-                                                   serialWeight0NumberOfDims, NULL);
+    tensor_t *serialWeight0Param = makeFloatTensor2D(20, 28 * 28, serialWeight0Data, 20 * 28 * 28);
     tensor_t *serialWeight0Grad = gradInitFloat(serialWeight0Param, NULL);
     parameter_t *serialWeight0 = parameterInit(serialWeight0Param, serialWeight0Grad);
 
@@ -80,26 +108,19 @@ void testSerializeAndDeserializeModel() {
     for (size_t i = 0; i < 20; i++) {
         serialBias0Data[i] = (float)i;
     }
-    size_t serialBias0Dims[] = {1, 20};
-    size_t serialBias0NumberOfDims = 2;
-    tensor_t *serialBias0Param = tensorInitFloat(serialBias0Data, serialBias0Dims,
-                                                 serialBias0NumberOfDims, NULL);
+    tensor_t *serialBias0Param = makeFloatTensor2D(1, 20, serialBias0Data, 20);
     tensor_t *serialBias0Grad = gradInitFloat(serialBias0Param, NULL);
     parameter_t *serialBias0 = parameterInit(serialBias0Param, serialBias0Grad);
 
-    layer_t *serialLinear0 = linearLayerInit(serialWeight0, serialBias0, serialQ, serialQ, serialQ,
-                                             serialQ);
-
-    layer_t *serialRelu = reluLayerInit(serialQ, serialQ);
+    layer_t *serialLinear0 = linearLayerInit(serialWeight0, serialBias0, serialLayerQ, serialLayerQ,
+                                             serialLayerQ, serialLayerQ);
+    layer_t *serialRelu = reluLayerInit(serialLayerQ, serialLayerQ);
 
     float serialWeight1Data[10 * 20];
     for (size_t i = 0; i < 10 * 20; i++) {
         serialWeight1Data[i] = (float)i;
     }
-    size_t serialWeight1Dims[] = {10, 20};
-    size_t serialWeight1NumberOfDims = 2;
-    tensor_t *serialWeight1Param = tensorInitFloat(serialWeight1Data, serialWeight1Dims,
-                                                   serialWeight1NumberOfDims, NULL);
+    tensor_t *serialWeight1Param = makeFloatTensor2D(10, 20, serialWeight1Data, 10 * 20);
     tensor_t *serialWeight1Grad = gradInitFloat(serialWeight1Param, NULL);
     parameter_t *serialWeight1 = parameterInit(serialWeight1Param, serialWeight1Grad);
 
@@ -107,17 +128,13 @@ void testSerializeAndDeserializeModel() {
     for (size_t i = 0; i < 10; i++) {
         serialBias1Data[i] = (float)i;
     }
-    size_t serialBias1Dims[] = {1, 10};
-    size_t serialBias1NumberOfDims = 2;
-    tensor_t *serialBias1Param = tensorInitFloat(serialBias1Data, serialBias1Dims,
-                                                 serialBias1NumberOfDims, NULL);
+    tensor_t *serialBias1Param = makeFloatTensor2D(1, 10, serialBias1Data, 10);
     tensor_t *serialBias1Grad = gradInitFloat(serialBias1Param, NULL);
     parameter_t *serialBias1 = parameterInit(serialBias1Param, serialBias1Grad);
 
-    layer_t *serialLinear1 = linearLayerInit(serialWeight1, serialBias1, serialQ, serialQ, serialQ,
-                                             serialQ);
-
-    layer_t *serialSoftmax = softmaxLayerInit(serialQ, serialQ);
+    layer_t *serialLinear1 = linearLayerInit(serialWeight1, serialBias1, serialLayerQ, serialLayerQ,
+                                             serialLayerQ, serialLayerQ);
+    layer_t *serialSoftmax = softmaxLayerInit(serialLayerQ, serialLayerQ);
 
     layer_t *serialModel[] = {serialLinear0, serialRelu, serialLinear1, serialSoftmax};
     size_t sizeModel = 4;
@@ -126,50 +143,30 @@ void testSerializeAndDeserializeModel() {
     serializeModel(serialModel, sizeModel, f);
     fclose(f);
 
-    quantization_t deserialQ;
-
-    float deserialWeight0Data[20 * 28 * 28] = {0};
-    size_t deserialWeight0Dims[] = {20, 28 * 28};
-    size_t deserialWeight0NumberOfDims = 2;
-    tensor_t *deserialWeight0Param = tensorInitFloat(deserialWeight0Data, deserialWeight0Dims,
-                                                     deserialWeight0NumberOfDims, NULL);
+    /* === Deserial side: zero-init mirror with the same layer topology. === */
+    tensor_t *deserialWeight0Param = makeFloatTensor2D(20, 28 * 28, NULL, 0);
     tensor_t *deserialWeight0Grad = gradInitFloat(deserialWeight0Param, NULL);
     parameter_t *deserialWeight0 = parameterInit(deserialWeight0Param, deserialWeight0Grad);
 
-    float deserialBias0Data[20] = {0};
-    size_t deserialBias0Dims[] = {1, 20};
-    size_t deserialBias0NumberOfDims = 2;
-    tensor_t *deserialBias0Param = tensorInitFloat(deserialBias0Data, deserialBias0Dims,
-                                                   deserialBias0NumberOfDims, NULL);
+    tensor_t *deserialBias0Param = makeFloatTensor2D(1, 20, NULL, 0);
     tensor_t *deserialBias0Grad = gradInitFloat(deserialBias0Param, NULL);
     parameter_t *deserialBias0 = parameterInit(deserialBias0Param, deserialBias0Grad);
 
-    layer_t *deserialLinear0 = linearLayerInit(deserialWeight0, deserialBias0, &deserialQ,
-                                               &deserialQ,
-                                               &deserialQ, &deserialQ);
+    layer_t *deserialLinear0 = linearLayerInit(deserialWeight0, deserialBias0, deserialLayerQ,
+                                               deserialLayerQ, deserialLayerQ, deserialLayerQ);
+    layer_t *deserialRelu = reluLayerInit(deserialLayerQ, deserialLayerQ);
 
-    layer_t *deserialRelu = reluLayerInit(&deserialQ, &deserialQ);
-
-    float deserialWeight1Data[10 * 20] = {0};
-    size_t deserialWeight1Dims[] = {10, 20};
-    size_t deserialWeight1NumberOfDims = 2;
-    tensor_t *deserialWeight1Param = tensorInitFloat(deserialWeight1Data, deserialWeight1Dims,
-                                                     deserialWeight1NumberOfDims, NULL);
+    tensor_t *deserialWeight1Param = makeFloatTensor2D(10, 20, NULL, 0);
     tensor_t *deserialWeight1Grad = gradInitFloat(deserialWeight1Param, NULL);
     parameter_t *deserialWeight1 = parameterInit(deserialWeight1Param, deserialWeight1Grad);
 
-    float deserialBias1Data[10] = {0};
-    size_t deserialBias1Dims[] = {1, 10};
-    size_t deserialBias1NumberOfDims = 2;
-    tensor_t *deserialBias1Param = tensorInitFloat(deserialBias1Data, deserialBias1Dims,
-                                                   deserialBias1NumberOfDims, NULL);
+    tensor_t *deserialBias1Param = makeFloatTensor2D(1, 10, NULL, 0);
     tensor_t *deserialBias1Grad = gradInitFloat(deserialBias1Param, NULL);
     parameter_t *deserialBias1 = parameterInit(deserialBias1Param, deserialBias1Grad);
 
-    layer_t *deserialLinear1 = linearLayerInit(deserialWeight1, deserialBias1, &deserialQ,
-                                               &deserialQ, &deserialQ, &deserialQ);
-
-    layer_t *deserialSoftmax = softmaxLayerInit(&deserialQ, &deserialQ);
+    layer_t *deserialLinear1 = linearLayerInit(deserialWeight1, deserialBias1, deserialLayerQ,
+                                               deserialLayerQ, deserialLayerQ, deserialLayerQ);
+    layer_t *deserialSoftmax = softmaxLayerInit(deserialLayerQ, deserialLayerQ);
 
     layer_t *deserialModel[] = {deserialLinear0, deserialRelu, deserialLinear1, deserialSoftmax};
 
@@ -177,56 +174,127 @@ void testSerializeAndDeserializeModel() {
     deserializeModel(deserialModel, sizeModel, f);
     fclose(f);
 
-    size_t numberOfWeights0 = calcNumberOfElementsByTensor(
-        serialModel[0]->config->linear->weights->param);
-    float *serialLinear0Weights = (float *)serialModel[0]->config->linear->weights->param->data;
-    float *deserialLinear0Weights = (float *)deserialModel[0]->config->linear->weights->param->data;
-    TEST_ASSERT_EQUAL_FLOAT_ARRAY(serialLinear0Weights, deserialLinear0Weights, numberOfWeights0);
+    /* CAPTURE every assertion value before any free. */
+    size_t numberOfWeights0 =
+        calcNumberOfElementsByTensor(serialModel[0]->config->linear->weights->param);
+    size_t numberOfBiases0 =
+        calcNumberOfElementsByTensor(serialModel[0]->config->linear->bias->param);
+    size_t numberOfWeights1 =
+        calcNumberOfElementsByTensor(serialModel[2]->config->linear->weights->param);
+    size_t numberOfBiases1 =
+        calcNumberOfElementsByTensor(serialModel[2]->config->linear->bias->param);
 
-    size_t numberOfBiases0 = calcNumberOfElementsByTensor(
-        serialModel[0]->config->linear->bias->param);
-    float *serialLinear0Biases = (float *)serialModel[0]->config->linear->bias->param->data;
-    float *deserialLinear0Biases = (float *)deserialModel[0]->config->linear->bias->param->data;
-    TEST_ASSERT_EQUAL_FLOAT_ARRAY(serialLinear0Biases, deserialLinear0Biases, numberOfBiases0);
+    /* Capture weight/bias arrays into heap buffers (sizes vary per layer). */
+    float *capturedSerialW0 = reserveMemory(numberOfWeights0 * sizeof(float));
+    float *capturedDeserialW0 = reserveMemory(numberOfWeights0 * sizeof(float));
+    float *capturedSerialB0 = reserveMemory(numberOfBiases0 * sizeof(float));
+    float *capturedDeserialB0 = reserveMemory(numberOfBiases0 * sizeof(float));
+    float *capturedSerialW1 = reserveMemory(numberOfWeights1 * sizeof(float));
+    float *capturedDeserialW1 = reserveMemory(numberOfWeights1 * sizeof(float));
+    float *capturedSerialB1 = reserveMemory(numberOfBiases1 * sizeof(float));
+    float *capturedDeserialB1 = reserveMemory(numberOfBiases1 * sizeof(float));
 
-    TEST_ASSERT_EQUAL(serialModel[0]->config->linear->forwardQ->type,
-                      deserialModel[0]->config->linear->forwardQ->type);
-    TEST_ASSERT_EQUAL(serialModel[0]->config->linear->weightGradQ->type,
-                      deserialModel[0]->config->linear->weightGradQ->type);
-    TEST_ASSERT_EQUAL(serialModel[0]->config->linear->biasGradQ->type,
-                      deserialModel[0]->config->linear->biasGradQ->type);
-    TEST_ASSERT_EQUAL(serialModel[0]->config->linear->propLossQ->type,
-                      deserialModel[0]->config->linear->propLossQ->type);
+    for (size_t i = 0; i < numberOfWeights0; i++) {
+        capturedSerialW0[i] = ((float *)serialModel[0]->config->linear->weights->param->data)[i];
+        capturedDeserialW0[i] =
+            ((float *)deserialModel[0]->config->linear->weights->param->data)[i];
+    }
+    for (size_t i = 0; i < numberOfBiases0; i++) {
+        capturedSerialB0[i] = ((float *)serialModel[0]->config->linear->bias->param->data)[i];
+        capturedDeserialB0[i] = ((float *)deserialModel[0]->config->linear->bias->param->data)[i];
+    }
+    for (size_t i = 0; i < numberOfWeights1; i++) {
+        capturedSerialW1[i] = ((float *)serialModel[2]->config->linear->weights->param->data)[i];
+        capturedDeserialW1[i] =
+            ((float *)deserialModel[2]->config->linear->weights->param->data)[i];
+    }
+    for (size_t i = 0; i < numberOfBiases1; i++) {
+        capturedSerialB1[i] = ((float *)serialModel[2]->config->linear->bias->param->data)[i];
+        capturedDeserialB1[i] = ((float *)deserialModel[2]->config->linear->bias->param->data)[i];
+    }
 
-    TEST_ASSERT_EQUAL(serialModel[1]->config->relu->forwardQ->type,
-                      deserialModel[1]->config->relu->forwardQ->type);
-    TEST_ASSERT_EQUAL(serialModel[1]->config->relu->backwardQ->type,
-                      deserialModel[1]->config->relu->backwardQ->type);
+    qtype_t capturedSerialL0FwdQ = serialModel[0]->config->linear->forwardQ->type;
+    qtype_t capturedDeserialL0FwdQ = deserialModel[0]->config->linear->forwardQ->type;
+    qtype_t capturedSerialL0WGQ = serialModel[0]->config->linear->weightGradQ->type;
+    qtype_t capturedDeserialL0WGQ = deserialModel[0]->config->linear->weightGradQ->type;
+    qtype_t capturedSerialL0BGQ = serialModel[0]->config->linear->biasGradQ->type;
+    qtype_t capturedDeserialL0BGQ = deserialModel[0]->config->linear->biasGradQ->type;
+    qtype_t capturedSerialL0PLQ = serialModel[0]->config->linear->propLossQ->type;
+    qtype_t capturedDeserialL0PLQ = deserialModel[0]->config->linear->propLossQ->type;
 
-    size_t numberOfWeights1 = calcNumberOfElementsByTensor(
-    serialModel[2]->config->linear->weights->param);
-    float *serialLinear1Weights = (float *)serialModel[2]->config->linear->weights->param->data;
-    float *deserialLinear1Weights = (float *)deserialModel[2]->config->linear->weights->param->data;
-    TEST_ASSERT_EQUAL_FLOAT_ARRAY(serialLinear1Weights, deserialLinear1Weights, numberOfWeights1);
+    qtype_t capturedSerialReluFwdQ = serialModel[1]->config->relu->forwardQ->type;
+    qtype_t capturedDeserialReluFwdQ = deserialModel[1]->config->relu->forwardQ->type;
+    qtype_t capturedSerialReluBwdQ = serialModel[1]->config->relu->backwardQ->type;
+    qtype_t capturedDeserialReluBwdQ = deserialModel[1]->config->relu->backwardQ->type;
 
-    size_t numberOfBiases1 = calcNumberOfElementsByTensor(
-        serialModel[2]->config->linear->bias->param);
-    float *serialLinear1Biases = (float *)serialModel[2]->config->linear->bias->param->data;
-    float *deserialLinear1Biases = (float *)deserialModel[2]->config->linear->bias->param->data;
-    TEST_ASSERT_EQUAL_FLOAT_ARRAY(serialLinear1Biases, deserialLinear1Biases, numberOfBiases1);
+    qtype_t capturedSerialL1FwdQ = serialModel[2]->config->linear->forwardQ->type;
+    qtype_t capturedDeserialL1FwdQ = deserialModel[2]->config->linear->forwardQ->type;
+    qtype_t capturedSerialL1WGQ = serialModel[2]->config->linear->weightGradQ->type;
+    qtype_t capturedDeserialL1WGQ = deserialModel[2]->config->linear->weightGradQ->type;
+    qtype_t capturedSerialL1BGQ = serialModel[2]->config->linear->biasGradQ->type;
+    qtype_t capturedDeserialL1BGQ = deserialModel[2]->config->linear->biasGradQ->type;
+    qtype_t capturedSerialL1PLQ = serialModel[2]->config->linear->propLossQ->type;
+    qtype_t capturedDeserialL1PLQ = deserialModel[2]->config->linear->propLossQ->type;
 
-    TEST_ASSERT_EQUAL(serialModel[2]->config->linear->forwardQ->type,
-                      deserialModel[2]->config->linear->forwardQ->type);
-    TEST_ASSERT_EQUAL(serialModel[2]->config->linear->weightGradQ->type,
-                      deserialModel[2]->config->linear->weightGradQ->type);
-    TEST_ASSERT_EQUAL(serialModel[2]->config->linear->biasGradQ->type,
-                      deserialModel[2]->config->linear->biasGradQ->type);
-    TEST_ASSERT_EQUAL(serialModel[2]->config->linear->propLossQ->type,
-                      deserialModel[2]->config->linear->propLossQ->type);
+    qtype_t capturedSerialSoftFwdQ = serialModel[3]->config->softmax->forwardQ->type;
+    qtype_t capturedDeserialSoftFwdQ = deserialModel[3]->config->softmax->forwardQ->type;
+    qtype_t capturedSerialSoftBwdQ = serialModel[3]->config->softmax->backwardQ->type;
+    qtype_t capturedDeserialSoftBwdQ = deserialModel[3]->config->softmax->backwardQ->type;
 
+    /* FREE in reverse-init order. Layer free-functions release only the
+     * wrapper; parameters and the shared layerQ are caller-managed (per
+     * docs/CONVENTIONS.md "Test memory discipline"). */
+    freeSoftmaxLayer(deserialSoftmax);
+    freeLinearLayer(deserialLinear1);
+    freeParameter(deserialBias1);
+    freeParameter(deserialWeight1);
+    freeReluLayer(deserialRelu);
+    freeLinearLayer(deserialLinear0);
+    freeParameter(deserialBias0);
+    freeParameter(deserialWeight0);
+    freeQuantization(deserialLayerQ);
 
-    TEST_ASSERT_EQUAL(serialModel[3]->config->softmax->forwardQ->type, deserialModel[3]->config->softmax->forwardQ->type);
-    TEST_ASSERT_EQUAL(serialModel[3]->config->softmax->backwardQ->type, deserialModel[3]->config->softmax->backwardQ->type);
+    freeSoftmaxLayer(serialSoftmax);
+    freeLinearLayer(serialLinear1);
+    freeParameter(serialBias1);
+    freeParameter(serialWeight1);
+    freeReluLayer(serialRelu);
+    freeLinearLayer(serialLinear0);
+    freeParameter(serialBias0);
+    freeParameter(serialWeight0);
+    freeQuantization(serialLayerQ);
+
+    /* ASSERT on captured. */
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(capturedSerialW0, capturedDeserialW0, numberOfWeights0);
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(capturedSerialB0, capturedDeserialB0, numberOfBiases0);
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(capturedSerialW1, capturedDeserialW1, numberOfWeights1);
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(capturedSerialB1, capturedDeserialB1, numberOfBiases1);
+
+    TEST_ASSERT_EQUAL(capturedSerialL0FwdQ, capturedDeserialL0FwdQ);
+    TEST_ASSERT_EQUAL(capturedSerialL0WGQ, capturedDeserialL0WGQ);
+    TEST_ASSERT_EQUAL(capturedSerialL0BGQ, capturedDeserialL0BGQ);
+    TEST_ASSERT_EQUAL(capturedSerialL0PLQ, capturedDeserialL0PLQ);
+
+    TEST_ASSERT_EQUAL(capturedSerialReluFwdQ, capturedDeserialReluFwdQ);
+    TEST_ASSERT_EQUAL(capturedSerialReluBwdQ, capturedDeserialReluBwdQ);
+
+    TEST_ASSERT_EQUAL(capturedSerialL1FwdQ, capturedDeserialL1FwdQ);
+    TEST_ASSERT_EQUAL(capturedSerialL1WGQ, capturedDeserialL1WGQ);
+    TEST_ASSERT_EQUAL(capturedSerialL1BGQ, capturedDeserialL1BGQ);
+    TEST_ASSERT_EQUAL(capturedSerialL1PLQ, capturedDeserialL1PLQ);
+
+    TEST_ASSERT_EQUAL(capturedSerialSoftFwdQ, capturedDeserialSoftFwdQ);
+    TEST_ASSERT_EQUAL(capturedSerialSoftBwdQ, capturedDeserialSoftBwdQ);
+
+    /* Release the assertion-buffer scratch space last. */
+    freeReservedMemory(capturedSerialW0);
+    freeReservedMemory(capturedDeserialW0);
+    freeReservedMemory(capturedSerialB0);
+    freeReservedMemory(capturedDeserialB0);
+    freeReservedMemory(capturedSerialW1);
+    freeReservedMemory(capturedDeserialW1);
+    freeReservedMemory(capturedSerialB1);
+    freeReservedMemory(capturedDeserialB1);
 }
 
 void setUp() {}

--- a/test/unit/tensor/CMakeLists.txt
+++ b/test/unit/tensor/CMakeLists.txt
@@ -28,5 +28,6 @@ add_elastic_ai_unit_test(
         Tensor
         Rounding
         Quantization
+        QuantizationApi
         StorageApi
 )

--- a/test/unit/tensor/CMakeLists.txt
+++ b/test/unit/tensor/CMakeLists.txt
@@ -12,6 +12,7 @@ add_elastic_ai_unit_test(
         MORE_LIBS
         Rounding
         Quantization
+        StorageApi
 )
 add_elastic_ai_unit_test(
         LIB_UNDER_TEST

--- a/test/unit/tensor/UnitTestTensor.c
+++ b/test/unit/tensor/UnitTestTensor.c
@@ -1,9 +1,10 @@
 #include "DTypes.h"
+#include "StorageApi.h"
 #include "Tensor.h"
 #include "unity.h"
 
 #include <stdlib.h>
-
+#include <string.h>
 
 void testGetBitmask() {
     uint8_t startbit = 1;
@@ -54,47 +55,62 @@ void testByteFlattening() {
     size_t dataOutBits = 19;
     size_t numValues = 3;
     size_t numBytesDataOut = (dataOutBits * numValues - 1) / 8 + 1;
-    uint8_t *dataOut = calloc(numBytesDataOut, sizeof(uint8_t));
+    uint8_t *dataOut = reserveMemory(numBytesDataOut);
     byteConversion(dataIn, dataInBits, dataOut, dataOutBits, numValues);
 
-    uint8_t expectedBytes[] = {0b000000001, 0b00000000, 0b00011000, 0b00000000, 0b10000000,
-                               0b00010011, 0b00000000, 0b00000000};
+    /* CAPTURE before free. */
+    uint8_t captured[numBytesDataOut];
+    memcpy(captured, dataOut, numBytesDataOut);
+    freeReservedMemory(dataOut);
 
-    TEST_ASSERT_EQUAL_UINT8_ARRAY(expectedBytes, dataOut, numBytesDataOut);
+    uint8_t expectedBytes[] = {0b000000001, 0b00000000, 0b00011000, 0b00000000,
+                               0b10000000,  0b00010011, 0b00000000, 0b00000000};
+
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(expectedBytes, captured, numBytesDataOut);
 }
 
 void testByteFlattening2() {
     // {1, 2, 78}
-    uint8_t dataIn[] = {0b000000001, 0b00000000, 0b00011000, 0b00000000, 0b10000000, 0b00010011,
-                        0b00000000, 0b00000000};
+    uint8_t dataIn[] = {0b000000001, 0b00000000, 0b00011000, 0b00000000,
+                        0b10000000,  0b00010011, 0b00000000, 0b00000000};
     size_t dataInBits = 19;
 
     size_t dataOutBits = 9;
     size_t numValues = 3;
     size_t numBytesDataOut = (dataOutBits * numValues - 1) / 8 + 1;
-    uint8_t *dataOut = calloc(numBytesDataOut, sizeof(uint8_t));
+    uint8_t *dataOut = reserveMemory(numBytesDataOut);
     byteConversion(dataIn, dataInBits, dataOut, dataOutBits, numValues);
+
+    /* CAPTURE before free. */
+    uint8_t captured[numBytesDataOut];
+    memcpy(captured, dataOut, numBytesDataOut);
+    freeReservedMemory(dataOut);
 
     uint8_t expectedBytes[] = {0b000000001, 0b00000110, 0b00111000, 0b00000001};
 
-    TEST_ASSERT_EQUAL_UINT8_ARRAY(expectedBytes, dataOut, numBytesDataOut);
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(expectedBytes, captured, numBytesDataOut);
 }
 
 void testByteFlattening3() {
     // {1, 2, 78}
-    uint8_t dataIn[] = {0b000000001, 0b00000000, 0b00001100, 0b00000000, 0b00000100, 0b00001011,
-                        0b00000000, 0b00000000};
+    uint8_t dataIn[] = {0b000000001, 0b00000000, 0b00001100, 0b00000000,
+                        0b00000100,  0b00001011, 0b00000000, 0b00000000};
     size_t dataInBits = 8;
 
     size_t dataOutBits = 4;
     size_t numValues = 8;
     size_t numBytesDataOut = (dataOutBits * numValues - 1) / 8 + 1;
-    uint8_t *dataOut = calloc(numBytesDataOut, sizeof(uint8_t));
+    uint8_t *dataOut = reserveMemory(numBytesDataOut);
     byteConversion(dataIn, dataInBits, dataOut, dataOutBits, numValues);
+
+    /* CAPTURE before free. */
+    uint8_t captured[numBytesDataOut];
+    memcpy(captured, dataOut, numBytesDataOut);
+    freeReservedMemory(dataOut);
 
     uint8_t expectedBytes[] = {0b000000001, 0b00001100, 0b10110100, 0b00000000};
 
-    TEST_ASSERT_EQUAL_UINT8_ARRAY(expectedBytes, dataOut, numBytesDataOut);
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(expectedBytes, captured, numBytesDataOut);
 }
 
 void testByteFlattening4() {
@@ -102,10 +118,16 @@ void testByteFlattening4() {
     size_t dataInBits = 5;
     size_t dataOutBits = 8;
     size_t numBytesDataOut = 6;
-    uint8_t *dataOut = calloc(numBytesDataOut, sizeof(uint8_t));
+    uint8_t *dataOut = reserveMemory(numBytesDataOut);
     byteConversion(dataIn, dataInBits, dataOut, dataOutBits, numBytesDataOut);
+
+    /* CAPTURE before free. */
+    uint8_t captured[numBytesDataOut];
+    memcpy(captured, dataOut, numBytesDataOut);
+    freeReservedMemory(dataOut);
+
     uint8_t expectedBytes[] = {16, 22, 27, 31, 6, 0};
-    TEST_ASSERT_EQUAL_UINT8_ARRAY(expectedBytes, dataOut, numBytesDataOut);
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(expectedBytes, captured, numBytesDataOut);
 }
 
 void testByteFlattening5() {
@@ -114,12 +136,12 @@ void testByteFlattening5() {
     size_t dataOutBits = 32;
     size_t numValues = 6;
     size_t numBytesDataOut = 4 * numValues;
-    uint8_t dataOut[numBytesDataOut];;
+    uint8_t dataOut[numBytesDataOut];
+    ;
     byteConversion(dataIn, dataInBits, dataOut, dataOutBits, numValues);
-    uint8_t expectedBytes[] = {16, 0, 0, 0, 22, 0, 0, 0, 27, 0, 0, 0, 31, 0, 0, 0, 6, 0, 0, 0, 0, 0,
-                               0, 0};
+    uint8_t expectedBytes[] = {16, 0, 0, 0, 22, 0, 0, 0, 27, 0, 0, 0,
+                               31, 0, 0, 0, 6,  0, 0, 0, 0,  0, 0, 0};
     TEST_ASSERT_EQUAL_UINT8_ARRAY(expectedBytes, dataOut, numBytesDataOut);
-
 }
 
 void testCopyTensor() {
@@ -130,10 +152,7 @@ void testCopyTensor() {
     size_t numberOfDims = 2;
     size_t orderOfDims[] = {0, 1};
     shape_t shape = {
-        .dimensions = dims,
-        .numberOfDimensions = numberOfDims,
-        .orderOfDimensions = orderOfDims
-    };
+        .dimensions = dims, .numberOfDimensions = numberOfDims, .orderOfDimensions = orderOfDims};
     quantization_t q;
     initFloat32Quantization(&q);
 
@@ -144,11 +163,9 @@ void testCopyTensor() {
     size_t destDims[2];
     size_t destNumberOfDims;
     size_t destOrderOfDims[2];
-    shape_t destShape = {
-        .dimensions = destDims,
-        .numberOfDimensions = destNumberOfDims,
-        .orderOfDimensions = destOrderOfDims
-    };
+    shape_t destShape = {.dimensions = destDims,
+                         .numberOfDimensions = destNumberOfDims,
+                         .orderOfDimensions = destOrderOfDims};
     setTensorValues(&dest, (uint8_t *)destData, &destShape, &q, NULL);
 
     copyTensor(&dest, &src);

--- a/test/unit/tensor/UnitTestTensorApi.c
+++ b/test/unit/tensor/UnitTestTensorApi.c
@@ -1,5 +1,7 @@
 #define SOURCE_FILE "UNIT_TEST_TENSOR_API"
 
+#include <math.h>
+#include <stdbool.h>
 #include <stddef.h>
 #include <string.h>
 
@@ -16,6 +18,12 @@ _Static_assert(_Generic((&initTensor),
                    tensor_t *(*)(shape_t *, quantization_t *, sparsity_t *): 1,
                    default: 0),
                "initTensor must take (shape_t *, quantization_t *, sparsity_t *)");
+
+/* Compile-time contract: initDistribution takes tensor_t * and const distribution_t *. */
+_Static_assert(_Generic((&initDistribution),
+                   void (*)(tensor_t *, const distribution_t *): 1,
+                   default: 0),
+               "initDistribution must take (tensor_t *, const distribution_t *)");
 
 void setUp() {}
 void tearDown() {}
@@ -98,6 +106,147 @@ void testTensorInitWithDistribution_ShapeIsCorrect() {
     TEST_ASSERT_EQUAL_UINT(6, numElements);
 }
 
+static tensor_t *makeFloatTensorForDistTest(size_t d0, size_t d1) {
+    size_t *dims = reserveMemory(2 * sizeof(size_t));
+    dims[0] = d0;
+    dims[1] = d1;
+    size_t *order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, order);
+    shape_t *shape = reserveMemory(sizeof(shape_t));
+    setShape(shape, dims, 2, order);
+    return initTensor(shape, quantizationInitFloat(), NULL);
+}
+
+void testInitDistribution_Zeros_AllValuesAreZero(void) {
+    tensor_t *t = makeFloatTensorForDistTest(3, 4);
+    /* Pre-write a sentinel so we can prove ZEROS overwrites. */
+    float *vals = (float *)t->data;
+    for (size_t i = 0; i < 12; ++i) {
+        vals[i] = 42.0f;
+    }
+
+    distribution_t d = {.type = ZEROS};
+    initDistribution(t, &d);
+
+    for (size_t i = 0; i < 12; ++i) {
+        TEST_ASSERT_FLOAT_WITHIN(1e-9f, 0.0f, vals[i]);
+    }
+    freeTensor(t);
+}
+
+void testInitDistribution_Ones_AllValuesAreOne(void) {
+    tensor_t *t = makeFloatTensorForDistTest(3, 4);
+    distribution_t d = {.type = ONES};
+    initDistribution(t, &d);
+    float *vals = (float *)t->data;
+    for (size_t i = 0; i < 12; ++i) {
+        TEST_ASSERT_FLOAT_WITHIN(1e-9f, 1.0f, vals[i]);
+    }
+    freeTensor(t);
+}
+
+void testInitDistribution_Uniform_AllValuesInRange(void) {
+    tensor_t *t = makeFloatTensorForDistTest(4, 5);
+    distribution_t d = {.type = UNIFORM, .params.uniform = {-0.5f, 0.5f}};
+    initDistribution(t, &d);
+    float *vals = (float *)t->data;
+    bool any_nonzero = false;
+    for (size_t i = 0; i < 20; ++i) {
+        TEST_ASSERT_TRUE(vals[i] >= -0.5f && vals[i] <= 0.5f);
+        if (vals[i] != 0.0f) {
+            any_nonzero = true;
+        }
+    }
+    TEST_ASSERT_TRUE(any_nonzero);
+    freeTensor(t);
+}
+
+void testInitDistribution_Normal_NotAllSentinel(void) {
+    tensor_t *t = makeFloatTensorForDistTest(4, 5);
+    float *vals = (float *)t->data;
+    for (size_t i = 0; i < 20; ++i) {
+        vals[i] = -999.0f;
+    }
+    distribution_t d = {.type = NORMAL, .params.normal = {0.0f, 0.01f}};
+    initDistribution(t, &d);
+    size_t sentinelCount = 0;
+    for (size_t i = 0; i < 20; ++i) {
+        if (vals[i] == -999.0f) {
+            sentinelCount++;
+        }
+    }
+    TEST_ASSERT_EQUAL_UINT(0, sentinelCount);
+    freeTensor(t);
+}
+
+void testInitDistribution_XavierUniform_NotAllZero(void) {
+    tensor_t *t = makeFloatTensorForDistTest(4, 5);
+    distribution_t d = {.type = XAVIER_UNIFORM,
+                        .params.xavier = {.gain = 1.0f, .fanIn = 4, .fanOut = 5}};
+    initDistribution(t, &d);
+    float *vals = (float *)t->data;
+    bool any_nonzero = false;
+    for (size_t i = 0; i < 20; ++i) {
+        if (vals[i] != 0.0f) {
+            any_nonzero = true;
+            break;
+        }
+    }
+    TEST_ASSERT_TRUE(any_nonzero);
+    freeTensor(t);
+}
+
+void testInitDistribution_XavierNormal_NotAllZero(void) {
+    tensor_t *t = makeFloatTensorForDistTest(4, 5);
+    distribution_t d = {.type = XAVIER_NORMAL,
+                        .params.xavier = {.gain = 1.0f, .fanIn = 4, .fanOut = 5}};
+    initDistribution(t, &d);
+    float *vals = (float *)t->data;
+    bool any_nonzero = false;
+    for (size_t i = 0; i < 20; ++i) {
+        if (vals[i] != 0.0f) {
+            any_nonzero = true;
+            break;
+        }
+    }
+    TEST_ASSERT_TRUE(any_nonzero);
+    freeTensor(t);
+}
+
+void testInitDistribution_KaimingUniform_NotAllZero(void) {
+    tensor_t *t = makeFloatTensorForDistTest(4, 5);
+    distribution_t d = {.type = KAIMING_UNIFORM,
+                        .params.kaiming = {.gain = sqrtf(2.0f), .fanMode = 4}};
+    initDistribution(t, &d);
+    float *vals = (float *)t->data;
+    bool any_nonzero = false;
+    for (size_t i = 0; i < 20; ++i) {
+        if (vals[i] != 0.0f) {
+            any_nonzero = true;
+            break;
+        }
+    }
+    TEST_ASSERT_TRUE(any_nonzero);
+    freeTensor(t);
+}
+
+void testInitDistribution_KaimingNormal_NotAllZero(void) {
+    tensor_t *t = makeFloatTensorForDistTest(4, 5);
+    distribution_t d = {.type = KAIMING_NORMAL,
+                        .params.kaiming = {.gain = sqrtf(2.0f), .fanMode = 4}};
+    initDistribution(t, &d);
+    float *vals = (float *)t->data;
+    bool any_nonzero = false;
+    for (size_t i = 0; i < 20; ++i) {
+        if (vals[i] != 0.0f) {
+            any_nonzero = true;
+            break;
+        }
+    }
+    TEST_ASSERT_TRUE(any_nonzero);
+    freeTensor(t);
+}
+
 void testInitTensor_AllocatesOwnZeroDataBuffer_FreeTensorIsSafe(void) {
     /* Build shape via reserveMemory so caller doesn't bypass the locality rule. */
     size_t *dims = reserveMemory(2 * sizeof(size_t));
@@ -137,5 +286,13 @@ int main(void) {
     RUN_TEST(testTensorInitWithDistribution_Normal_InitializesAllValues);
     RUN_TEST(testTensorInitWithDistribution_ShapeIsCorrect);
     RUN_TEST(testInitTensor_AllocatesOwnZeroDataBuffer_FreeTensorIsSafe);
+    RUN_TEST(testInitDistribution_Zeros_AllValuesAreZero);
+    RUN_TEST(testInitDistribution_Ones_AllValuesAreOne);
+    RUN_TEST(testInitDistribution_Uniform_AllValuesInRange);
+    RUN_TEST(testInitDistribution_Normal_NotAllSentinel);
+    RUN_TEST(testInitDistribution_XavierUniform_NotAllZero);
+    RUN_TEST(testInitDistribution_XavierNormal_NotAllZero);
+    RUN_TEST(testInitDistribution_KaimingUniform_NotAllZero);
+    RUN_TEST(testInitDistribution_KaimingNormal_NotAllZero);
     return UNITY_END();
 }

--- a/test/unit/tensor/UnitTestTensorApi.c
+++ b/test/unit/tensor/UnitTestTensorApi.c
@@ -247,6 +247,30 @@ void testInitDistribution_KaimingNormal_NotAllZero(void) {
     freeTensor(t);
 }
 
+void testInitTensor_Int32_AllocatesFourBytesPerElement(void) {
+    /* Closes the calcNumberOfBytesForData gap surfaced by code-review on Task A:
+     * the INT32 arm was missing, which would have made gradInitInt32 (Task D)
+     * exit(1) on its first call. */
+    size_t *dims = reserveMemory(2 * sizeof(size_t));
+    dims[0] = 2;
+    dims[1] = 3;
+    size_t *order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, order);
+    shape_t *shape = reserveMemory(sizeof(shape_t));
+    setShape(shape, dims, 2, order);
+
+    quantization_t *q = quantizationInitInt32();
+    tensor_t *t = initTensor(shape, q, NULL);
+
+    TEST_ASSERT_NOT_NULL(t);
+    TEST_ASSERT_NOT_NULL(t->data);
+    /* 6 elements × 4 bytes = 24 bytes; all zero. */
+    for (size_t i = 0; i < 24; ++i) {
+        TEST_ASSERT_EQUAL_UINT8(0, t->data[i]);
+    }
+    freeTensor(t);
+}
+
 void testInitTensor_AllocatesOwnZeroDataBuffer_FreeTensorIsSafe(void) {
     /* Build shape via reserveMemory so caller doesn't bypass the locality rule. */
     size_t *dims = reserveMemory(2 * sizeof(size_t));
@@ -286,6 +310,7 @@ int main(void) {
     RUN_TEST(testTensorInitWithDistribution_Normal_InitializesAllValues);
     RUN_TEST(testTensorInitWithDistribution_ShapeIsCorrect);
     RUN_TEST(testInitTensor_AllocatesOwnZeroDataBuffer_FreeTensorIsSafe);
+    RUN_TEST(testInitTensor_Int32_AllocatesFourBytesPerElement);
     RUN_TEST(testInitDistribution_Zeros_AllValuesAreZero);
     RUN_TEST(testInitDistribution_Ones_AllValuesAreOne);
     RUN_TEST(testInitDistribution_Uniform_AllValuesInRange);

--- a/test/unit/tensor/UnitTestTensorApi.c
+++ b/test/unit/tensor/UnitTestTensorApi.c
@@ -288,6 +288,92 @@ void testTensorFillFromFloatBuffer_CopiesValues_SourceCanGoOutOfScope(void) {
     freeTensor(t);
 }
 
+void testGradInitFloat_DoesNotAliasParentShape(void) {
+    /* H2 regression: gradInit* must allocate a fresh shape instead of aliasing
+     * the parent tensor's shape. */
+    size_t *dims = reserveMemory(2 * sizeof(size_t));
+    dims[0] = 3;
+    dims[1] = 4;
+    size_t *order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, order);
+    shape_t *shape = reserveMemory(sizeof(shape_t));
+    setShape(shape, dims, 2, order);
+
+    tensor_t *param = initTensor(shape, quantizationInitFloat(), NULL);
+
+    tensor_t *grad = gradInitFloat(param, NULL);
+
+    TEST_ASSERT_TRUE_MESSAGE(grad->shape != param->shape,
+                             "gradInitFloat aliases parent shape (H2 hazard)");
+
+    /* Free grad first — must not corrupt parent. */
+    freeTensor(grad);
+
+    /* Parent's shape must still be readable. */
+    TEST_ASSERT_EQUAL_UINT(2, param->shape->numberOfDimensions);
+    TEST_ASSERT_EQUAL_UINT(3, param->shape->dimensions[0]);
+    TEST_ASSERT_EQUAL_UINT(4, param->shape->dimensions[1]);
+
+    freeTensor(param);
+}
+
+void testGradInitInt32_DoesNotAliasParentShape(void) {
+    size_t *dims = reserveMemory(2 * sizeof(size_t));
+    dims[0] = 3;
+    dims[1] = 4;
+    size_t *order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, order);
+    shape_t *shape = reserveMemory(sizeof(shape_t));
+    setShape(shape, dims, 2, order);
+
+    tensor_t *param = initTensor(shape, quantizationInitInt32(), NULL);
+    tensor_t *grad = gradInitInt32(param, NULL);
+
+    TEST_ASSERT_TRUE_MESSAGE(grad->shape != param->shape,
+                             "gradInitInt32 aliases parent shape (H2 hazard)");
+    freeTensor(grad);
+    TEST_ASSERT_EQUAL_UINT(3, param->shape->dimensions[0]);
+    freeTensor(param);
+}
+
+void testGradInitSymInt32_DoesNotAliasParentShape(void) {
+    size_t *dims = reserveMemory(2 * sizeof(size_t));
+    dims[0] = 3;
+    dims[1] = 4;
+    size_t *order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, order);
+    shape_t *shape = reserveMemory(sizeof(shape_t));
+    setShape(shape, dims, 2, order);
+
+    tensor_t *param = initTensor(shape, quantizationInitSymInt32(HTE), NULL);
+    tensor_t *grad = gradInitSymInt32(param, HTE, NULL);
+
+    TEST_ASSERT_TRUE_MESSAGE(grad->shape != param->shape,
+                             "gradInitSymInt32 aliases parent shape (H2 hazard)");
+    freeTensor(grad);
+    TEST_ASSERT_EQUAL_UINT(3, param->shape->dimensions[0]);
+    freeTensor(param);
+}
+
+void testGradInitAsym_DoesNotAliasParentShape(void) {
+    size_t *dims = reserveMemory(2 * sizeof(size_t));
+    dims[0] = 3;
+    dims[1] = 4;
+    size_t *order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, order);
+    shape_t *shape = reserveMemory(sizeof(shape_t));
+    setShape(shape, dims, 2, order);
+
+    tensor_t *param = initTensor(shape, quantizationInitAsym(8, HTE), NULL);
+    tensor_t *grad = gradInitAsym(param, 8, HTE, NULL);
+
+    TEST_ASSERT_TRUE_MESSAGE(grad->shape != param->shape,
+                             "gradInitAsym aliases parent shape (H2 hazard)");
+    freeTensor(grad);
+    TEST_ASSERT_EQUAL_UINT(3, param->shape->dimensions[0]);
+    freeTensor(param);
+}
+
 void testInitTensor_Int32_AllocatesFourBytesPerElement(void) {
     /* Closes the calcNumberOfBytesForData gap surfaced by code-review on Task A:
      * the INT32 arm was missing, which would have made gradInitInt32 (Task D)
@@ -353,6 +439,10 @@ int main(void) {
     RUN_TEST(testInitTensor_AllocatesOwnZeroDataBuffer_FreeTensorIsSafe);
     RUN_TEST(testInitTensor_Int32_AllocatesFourBytesPerElement);
     RUN_TEST(testTensorFillFromFloatBuffer_CopiesValues_SourceCanGoOutOfScope);
+    RUN_TEST(testGradInitFloat_DoesNotAliasParentShape);
+    RUN_TEST(testGradInitInt32_DoesNotAliasParentShape);
+    RUN_TEST(testGradInitSymInt32_DoesNotAliasParentShape);
+    RUN_TEST(testGradInitAsym_DoesNotAliasParentShape);
     RUN_TEST(testInitDistribution_Zeros_AllValuesAreZero);
     RUN_TEST(testInitDistribution_Ones_AllValuesAreOne);
     RUN_TEST(testInitDistribution_Uniform_AllValuesInRange);

--- a/test/unit/tensor/UnitTestTensorApi.c
+++ b/test/unit/tensor/UnitTestTensorApi.c
@@ -134,10 +134,17 @@ void testInitDistribution_Zeros_AllValuesAreZero(void) {
     distribution_t d = {.type = ZEROS};
     initDistribution(t, &d);
 
+    /* CAPTURE values before free. */
+    float captured[12];
     for (size_t i = 0; i < 12; ++i) {
-        TEST_ASSERT_FLOAT_WITHIN(1e-9f, 0.0f, vals[i]);
+        captured[i] = vals[i];
     }
     freeTensor(t);
+
+    /* ASSERT on captured. */
+    for (size_t i = 0; i < 12; ++i) {
+        TEST_ASSERT_FLOAT_WITHIN(1e-9f, 0.0f, captured[i]);
+    }
 }
 
 void testInitDistribution_Ones_AllValuesAreOne(void) {
@@ -145,10 +152,18 @@ void testInitDistribution_Ones_AllValuesAreOne(void) {
     distribution_t d = {.type = ONES};
     initDistribution(t, &d);
     float *vals = (float *)t->data;
+
+    /* CAPTURE. */
+    float captured[12];
     for (size_t i = 0; i < 12; ++i) {
-        TEST_ASSERT_FLOAT_WITHIN(1e-9f, 1.0f, vals[i]);
+        captured[i] = vals[i];
     }
     freeTensor(t);
+
+    /* ASSERT. */
+    for (size_t i = 0; i < 12; ++i) {
+        TEST_ASSERT_FLOAT_WITHIN(1e-9f, 1.0f, captured[i]);
+    }
 }
 
 void testInitDistribution_Uniform_AllValuesInRange(void) {
@@ -156,15 +171,23 @@ void testInitDistribution_Uniform_AllValuesInRange(void) {
     distribution_t d = {.type = UNIFORM, .params.uniform = {-0.5f, 0.5f}};
     initDistribution(t, &d);
     float *vals = (float *)t->data;
+
+    /* CAPTURE values + derived bool flag. */
+    float captured[20];
     bool any_nonzero = false;
     for (size_t i = 0; i < 20; ++i) {
-        TEST_ASSERT_TRUE(vals[i] >= -0.5f && vals[i] <= 0.5f);
+        captured[i] = vals[i];
         if (vals[i] != 0.0f) {
             any_nonzero = true;
         }
     }
-    TEST_ASSERT_TRUE(any_nonzero);
     freeTensor(t);
+
+    /* ASSERT on captured. */
+    for (size_t i = 0; i < 20; ++i) {
+        TEST_ASSERT_TRUE(captured[i] >= -0.5f && captured[i] <= 0.5f);
+    }
+    TEST_ASSERT_TRUE(any_nonzero);
 }
 
 void testInitDistribution_Normal_NotAllSentinel(void) {
@@ -175,14 +198,18 @@ void testInitDistribution_Normal_NotAllSentinel(void) {
     }
     distribution_t d = {.type = NORMAL, .params.normal = {0.0f, 0.01f}};
     initDistribution(t, &d);
+
+    /* CAPTURE the derived sentinel count. */
     size_t sentinelCount = 0;
     for (size_t i = 0; i < 20; ++i) {
         if (vals[i] == -999.0f) {
             sentinelCount++;
         }
     }
-    TEST_ASSERT_EQUAL_UINT(0, sentinelCount);
     freeTensor(t);
+
+    /* ASSERT on captured. */
+    TEST_ASSERT_EQUAL_UINT(0, sentinelCount);
 }
 
 void testInitDistribution_XavierUniform_NotAllZero(void) {
@@ -191,6 +218,8 @@ void testInitDistribution_XavierUniform_NotAllZero(void) {
                         .params.xavier = {.gain = 1.0f, .fanIn = 4, .fanOut = 5}};
     initDistribution(t, &d);
     float *vals = (float *)t->data;
+
+    /* CAPTURE the derived bool flag. */
     bool any_nonzero = false;
     for (size_t i = 0; i < 20; ++i) {
         if (vals[i] != 0.0f) {
@@ -198,8 +227,10 @@ void testInitDistribution_XavierUniform_NotAllZero(void) {
             break;
         }
     }
-    TEST_ASSERT_TRUE(any_nonzero);
     freeTensor(t);
+
+    /* ASSERT on captured. */
+    TEST_ASSERT_TRUE(any_nonzero);
 }
 
 void testInitDistribution_XavierNormal_NotAllZero(void) {
@@ -208,6 +239,8 @@ void testInitDistribution_XavierNormal_NotAllZero(void) {
                         .params.xavier = {.gain = 1.0f, .fanIn = 4, .fanOut = 5}};
     initDistribution(t, &d);
     float *vals = (float *)t->data;
+
+    /* CAPTURE. */
     bool any_nonzero = false;
     for (size_t i = 0; i < 20; ++i) {
         if (vals[i] != 0.0f) {
@@ -215,8 +248,10 @@ void testInitDistribution_XavierNormal_NotAllZero(void) {
             break;
         }
     }
-    TEST_ASSERT_TRUE(any_nonzero);
     freeTensor(t);
+
+    /* ASSERT. */
+    TEST_ASSERT_TRUE(any_nonzero);
 }
 
 void testInitDistribution_KaimingUniform_NotAllZero(void) {
@@ -225,6 +260,8 @@ void testInitDistribution_KaimingUniform_NotAllZero(void) {
                         .params.kaiming = {.gain = sqrtf(2.0f), .fanMode = 4}};
     initDistribution(t, &d);
     float *vals = (float *)t->data;
+
+    /* CAPTURE. */
     bool any_nonzero = false;
     for (size_t i = 0; i < 20; ++i) {
         if (vals[i] != 0.0f) {
@@ -232,8 +269,10 @@ void testInitDistribution_KaimingUniform_NotAllZero(void) {
             break;
         }
     }
-    TEST_ASSERT_TRUE(any_nonzero);
     freeTensor(t);
+
+    /* ASSERT. */
+    TEST_ASSERT_TRUE(any_nonzero);
 }
 
 void testInitDistribution_KaimingNormal_NotAllZero(void) {
@@ -242,6 +281,8 @@ void testInitDistribution_KaimingNormal_NotAllZero(void) {
                         .params.kaiming = {.gain = sqrtf(2.0f), .fanMode = 4}};
     initDistribution(t, &d);
     float *vals = (float *)t->data;
+
+    /* CAPTURE. */
     bool any_nonzero = false;
     for (size_t i = 0; i < 20; ++i) {
         if (vals[i] != 0.0f) {
@@ -249,8 +290,10 @@ void testInitDistribution_KaimingNormal_NotAllZero(void) {
             break;
         }
     }
-    TEST_ASSERT_TRUE(any_nonzero);
     freeTensor(t);
+
+    /* ASSERT. */
+    TEST_ASSERT_TRUE(any_nonzero);
 }
 
 static void fillTensorFromStackArrayThatGoesOutOfScope(tensor_t *t) {

--- a/test/unit/tensor/UnitTestTensorApi.c
+++ b/test/unit/tensor/UnitTestTensorApi.c
@@ -3,10 +3,19 @@
 #include <stddef.h>
 #include <string.h>
 
-#include "TensorApi.h"
-#include "Tensor.h"
 #include "Quantization.h"
+#include "QuantizationApi.h"
+#include "StorageApi.h"
+#include "Tensor.h"
+#include "TensorApi.h"
 #include "unity.h"
+
+/* Compile-time contract: initTensor takes shape_t *, quantization_t *,
+ * sparsity_t * and returns tensor_t *. No data buffer parameter. */
+_Static_assert(_Generic((&initTensor),
+                   tensor_t *(*)(shape_t *, quantization_t *, sparsity_t *): 1,
+                   default: 0),
+               "initTensor must take (shape_t *, quantization_t *, sparsity_t *)");
 
 void setUp() {}
 void tearDown() {}
@@ -89,11 +98,44 @@ void testTensorInitWithDistribution_ShapeIsCorrect() {
     TEST_ASSERT_EQUAL_UINT(6, numElements);
 }
 
+void testInitTensor_AllocatesOwnZeroDataBuffer_FreeTensorIsSafe(void) {
+    /* Build shape via reserveMemory so caller doesn't bypass the locality rule. */
+    size_t *dims = reserveMemory(2 * sizeof(size_t));
+    dims[0] = 3;
+    dims[1] = 4;
+    size_t *order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, order);
+    shape_t *shape = reserveMemory(sizeof(shape_t));
+    setShape(shape, dims, 2, order);
+
+    quantization_t *q = quantizationInitFloat();
+
+    tensor_t *t = initTensor(shape, q, NULL);
+
+    TEST_ASSERT_NOT_NULL(t);
+    TEST_ASSERT_NOT_NULL(t->data);
+    TEST_ASSERT_EQUAL_PTR(shape, t->shape);
+    TEST_ASSERT_EQUAL_PTR(q, t->quantization);
+    TEST_ASSERT_NULL(t->sparsity);
+
+    /* All bytes of the data buffer must be zero (calloc semantics). */
+    size_t bytes = calcBytesPerTensor(t);
+    for (size_t i = 0; i < bytes; ++i) {
+        TEST_ASSERT_EQUAL_UINT8(0, t->data[i]);
+    }
+
+    /* freeTensor must release everything cleanly without external buffers. */
+    freeTensor(t);
+    /* If we reach here without an abort/segfault, freeTensor is unconditional-safe
+     * for an initTensor-allocated tensor. */
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(testTensorInitWithDistribution_Zeros_InitializesProductOfDimsValues);
     RUN_TEST(testTensorInitWithDistribution_Ones_InitializesAllValues);
     RUN_TEST(testTensorInitWithDistribution_Normal_InitializesAllValues);
     RUN_TEST(testTensorInitWithDistribution_ShapeIsCorrect);
+    RUN_TEST(testInitTensor_AllocatesOwnZeroDataBuffer_FreeTensorIsSafe);
     return UNITY_END();
 }

--- a/test/unit/tensor/UnitTestTensorApi.c
+++ b/test/unit/tensor/UnitTestTensorApi.c
@@ -288,6 +288,25 @@ void testTensorFillFromFloatBuffer_CopiesValues_SourceCanGoOutOfScope(void) {
     freeTensor(t);
 }
 
+void testFreeParameter_NullGrad_DoesNotSegfault(void) {
+    /* H3 regression: linearLayerInitNonTrainable passes NULL for grad into
+     * parameterInit; today freeParameter dereferences it and crashes. */
+    size_t *dims = reserveMemory(2 * sizeof(size_t));
+    dims[0] = 1;
+    dims[1] = 2;
+    size_t *order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, order);
+    shape_t *shape = reserveMemory(sizeof(shape_t));
+    setShape(shape, dims, 2, order);
+
+    tensor_t *param = initTensor(shape, quantizationInitFloat(), NULL);
+    parameter_t *p = parameterInit(param, NULL);
+
+    freeParameter(p);
+    /* If we reach here, the H3 fix worked. */
+    TEST_PASS();
+}
+
 void testGradInitFloat_DoesNotAliasParentShape(void) {
     /* H2 regression: gradInit* must allocate a fresh shape instead of aliasing
      * the parent tensor's shape. */
@@ -439,6 +458,7 @@ int main(void) {
     RUN_TEST(testInitTensor_AllocatesOwnZeroDataBuffer_FreeTensorIsSafe);
     RUN_TEST(testInitTensor_Int32_AllocatesFourBytesPerElement);
     RUN_TEST(testTensorFillFromFloatBuffer_CopiesValues_SourceCanGoOutOfScope);
+    RUN_TEST(testFreeParameter_NullGrad_DoesNotSegfault);
     RUN_TEST(testGradInitFloat_DoesNotAliasParentShape);
     RUN_TEST(testGradInitInt32_DoesNotAliasParentShape);
     RUN_TEST(testGradInitSymInt32_DoesNotAliasParentShape);

--- a/test/unit/tensor/UnitTestTensorApi.c
+++ b/test/unit/tensor/UnitTestTensorApi.c
@@ -25,6 +25,12 @@ _Static_assert(_Generic((&initDistribution),
                    default: 0),
                "initDistribution must take (tensor_t *, const distribution_t *)");
 
+/* Compile-time contract: tensorFillFromFloatBuffer takes (tensor_t *, const float *, size_t). */
+_Static_assert(_Generic((&tensorFillFromFloatBuffer),
+                   void (*)(tensor_t *, const float *, size_t): 1,
+                   default: 0),
+               "tensorFillFromFloatBuffer must take (tensor_t *, const float *, size_t)");
+
 void setUp() {}
 void tearDown() {}
 
@@ -247,6 +253,41 @@ void testInitDistribution_KaimingNormal_NotAllZero(void) {
     freeTensor(t);
 }
 
+static void fillTensorFromStackArrayThatGoesOutOfScope(tensor_t *t) {
+    /* Local stack array — exits scope when this function returns. */
+    float src[6] = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
+    tensorFillFromFloatBuffer(t, src, 6);
+    /* `src` goes out of scope on return; tensor must keep its own copy. */
+}
+
+void testTensorFillFromFloatBuffer_CopiesValues_SourceCanGoOutOfScope(void) {
+    size_t *dims = reserveMemory(2 * sizeof(size_t));
+    dims[0] = 2;
+    dims[1] = 3;
+    size_t *order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, order);
+    shape_t *shape = reserveMemory(sizeof(shape_t));
+    setShape(shape, dims, 2, order);
+
+    tensor_t *t = initTensor(shape, quantizationInitFloat(), NULL);
+
+    fillTensorFromStackArrayThatGoesOutOfScope(t);
+
+    /* Force stack reuse — analogous to issue #93's regression pattern. */
+    for (int i = 0; i < 100; ++i) {
+        volatile float junk[6] = {(float)i, (float)~i, 0, 0, 0, 0};
+        (void)junk;
+    }
+
+    float *vals = (float *)t->data;
+    float expected[6] = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
+    for (size_t i = 0; i < 6; ++i) {
+        TEST_ASSERT_FLOAT_WITHIN(1e-9f, expected[i], vals[i]);
+    }
+
+    freeTensor(t);
+}
+
 void testInitTensor_Int32_AllocatesFourBytesPerElement(void) {
     /* Closes the calcNumberOfBytesForData gap surfaced by code-review on Task A:
      * the INT32 arm was missing, which would have made gradInitInt32 (Task D)
@@ -311,6 +352,7 @@ int main(void) {
     RUN_TEST(testTensorInitWithDistribution_ShapeIsCorrect);
     RUN_TEST(testInitTensor_AllocatesOwnZeroDataBuffer_FreeTensorIsSafe);
     RUN_TEST(testInitTensor_Int32_AllocatesFourBytesPerElement);
+    RUN_TEST(testTensorFillFromFloatBuffer_CopiesValues_SourceCanGoOutOfScope);
     RUN_TEST(testInitDistribution_Zeros_AllValuesAreZero);
     RUN_TEST(testInitDistribution_Ones_AllValuesAreOne);
     RUN_TEST(testInitDistribution_Uniform_AllValuesInRange);

--- a/test/unit/tensor/UnitTestTensorApi.c
+++ b/test/unit/tensor/UnitTestTensorApi.c
@@ -34,82 +34,102 @@ _Static_assert(_Generic((&tensorFillFromFloatBuffer),
 void setUp() {}
 void tearDown() {}
 
+/* Forward decl for the file-local factory (definition further down). */
+static tensor_t *makeFloatTensorForDistTest(size_t d0, size_t d1);
+
 void testTensorInitWithDistribution_Zeros_InitializesProductOfDimsValues() {
-    // dims = {2, 5} → product = 10, sum = 7
-    // Bug: += gives 7, *= gives 10
-    // Fill data with sentinel 42.0f, then ZEROS should overwrite exactly 10 values
-    float data[10];
+    /* dims = {2, 5} -> product = 10, sum = 7. Pre-fill with sentinel 42.0f,
+     * then ZEROS should overwrite exactly 10 values (loop bound = product,
+     * not sum). */
+    tensor_t *t = makeFloatTensorForDistTest(2, 5);
+    float *vals = (float *)t->data;
     for (size_t i = 0; i < 10; i++) {
-        data[i] = 42.0f;
+        vals[i] = 42.0f;
     }
-    size_t dims[] = {2, 5};
-    quantization_t q;
-    initFloat32Quantization(&q);
 
-    tensor_t *t = tensorInitWithDistribution(ZEROS, data, dims, 2, &q, NULL, 2, 5);
+    distribution_t d = {.type = ZEROS};
+    initDistribution(t, &d);
 
-    // All 10 values should be zero
-    float *values = (float *)t->data;
+    /* CAPTURE before free. */
+    float captured[10];
     for (size_t i = 0; i < 10; i++) {
-        TEST_ASSERT_FLOAT_WITHIN(1e-9f, 0.0f, values[i]);
+        captured[i] = vals[i];
+    }
+    freeTensor(t);
+
+    /* ASSERT on captured. */
+    for (size_t i = 0; i < 10; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(1e-9f, 0.0f, captured[i]);
     }
 }
 
 void testTensorInitWithDistribution_Ones_InitializesAllValues() {
-    // dims = {3, 4} → product = 12, sum = 7
-    // Fill data with 0.0f, then ONES should set exactly 12 values to 1.0f
-    float data[12];
-    memset(data, 0, sizeof(data));
-    size_t dims[] = {3, 4};
-    quantization_t q;
-    initFloat32Quantization(&q);
-
-    tensor_t *t = tensorInitWithDistribution(ONES, data, dims, 2, &q, NULL, 3, 4);
-
-    float *values = (float *)t->data;
+    /* dims = {3, 4} -> product = 12. Pre-fill with 0.0f, then ONES sets all
+     * 12 values to 1.0f. */
+    tensor_t *t = makeFloatTensorForDistTest(3, 4);
+    float *vals = (float *)t->data;
+    /* initTensor zero-initializes data; explicit pre-fill kept for clarity. */
     for (size_t i = 0; i < 12; i++) {
-        TEST_ASSERT_FLOAT_WITHIN(1e-9f, 1.0f, values[i]);
+        vals[i] = 0.0f;
+    }
+
+    distribution_t d = {.type = ONES};
+    initDistribution(t, &d);
+
+    /* CAPTURE. */
+    float captured[12];
+    for (size_t i = 0; i < 12; i++) {
+        captured[i] = vals[i];
+    }
+    freeTensor(t);
+
+    /* ASSERT. */
+    for (size_t i = 0; i < 12; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(1e-9f, 1.0f, captured[i]);
     }
 }
 
 void testTensorInitWithDistribution_Normal_InitializesAllValues() {
-    // dims = {4, 5} → product = 20, sum = 9
-    // If only 9 values are initialized, remaining 11 stay at sentinel
-    float data[20];
+    /* dims = {4, 5} -> product = 20, sum = 9. If the loop runs sum-many
+     * iterations only, the trailing 11 values stay at sentinel. */
+    tensor_t *t = makeFloatTensorForDistTest(4, 5);
+    float *vals = (float *)t->data;
     float sentinel = -999.0f;
     for (size_t i = 0; i < 20; i++) {
-        data[i] = sentinel;
+        vals[i] = sentinel;
     }
-    size_t dims[] = {4, 5};
-    quantization_t q;
-    initFloat32Quantization(&q);
 
-    tensor_t *t = tensorInitWithDistribution(NORMAL, data, dims, 2, &q, NULL, 4, 5);
+    distribution_t d = {.type = NORMAL, .params.normal = {0.0f, 0.01f}};
+    initDistribution(t, &d);
 
-    // With NORMAL distribution, values should NOT be the sentinel
-    float *values = (float *)t->data;
+    /* CAPTURE the derived sentinel count. */
     size_t sentinelCount = 0;
     for (size_t i = 0; i < 20; i++) {
-        if (values[i] == sentinel) {
+        if (vals[i] == sentinel) {
             sentinelCount++;
         }
     }
-    // All 20 values should have been overwritten — none should remain as sentinel
+    freeTensor(t);
+
+    /* ASSERT on captured. */
     TEST_ASSERT_EQUAL_UINT(0, sentinelCount);
 }
 
 void testTensorInitWithDistribution_ShapeIsCorrect() {
-    // Verify the resulting tensor has the correct shape dimensions
-    float data[6] = {0};
-    size_t dims[] = {2, 3};
-    quantization_t q;
-    initFloat32Quantization(&q);
+    /* Verify the resulting tensor has the correct shape dimensions after
+     * initDistribution runs. */
+    tensor_t *t = makeFloatTensorForDistTest(2, 3);
+    distribution_t d = {.type = ZEROS};
+    initDistribution(t, &d);
 
-    tensor_t *t = tensorInitWithDistribution(ZEROS, data, dims, 2, &q, NULL, 2, 3);
+    /* CAPTURE shape data before free. */
+    size_t capturedNumDims = t->shape->numberOfDimensions;
+    size_t capturedNumElements = calcNumberOfElementsByTensor(t);
+    freeTensor(t);
 
-    TEST_ASSERT_EQUAL_UINT(2, t->shape->numberOfDimensions);
-    size_t numElements = calcNumberOfElementsByTensor(t);
-    TEST_ASSERT_EQUAL_UINT(6, numElements);
+    /* ASSERT on captured. */
+    TEST_ASSERT_EQUAL_UINT(2, capturedNumDims);
+    TEST_ASSERT_EQUAL_UINT(6, capturedNumElements);
 }
 
 static tensor_t *makeFloatTensorForDistTest(size_t d0, size_t d1) {

--- a/test/unit/userAPI/CMakeLists.txt
+++ b/test/unit/userAPI/CMakeLists.txt
@@ -1,5 +1,11 @@
 add_elastic_ai_unit_test(
         LIB_UNDER_TEST
+        StorageApi
+)
+
+
+add_elastic_ai_unit_test(
+        LIB_UNDER_TEST
         InferenceApi
         MORE_LIBS
         CommonLayerLibs

--- a/test/unit/userAPI/CMakeLists.txt
+++ b/test/unit/userAPI/CMakeLists.txt
@@ -75,3 +75,21 @@ target_link_libraries(UnitTestMnistSmoke PRIVATE
         StorageApi
 )
 __register_target_as_unit_test(UnitTestMnistSmoke)
+
+add_executable(UnitTestFlattenIntegration UnitTestFlattenIntegration.c)
+target_link_libraries(UnitTestFlattenIntegration PRIVATE
+        unity
+        TrainingLoopApi
+        CalculateGradsSequential
+        CommonLayerLibs
+        FlattenApi
+        LinearApi
+        SoftmaxApi
+        TensorApi
+        QuantizationApi
+        LossFunction
+        InferenceApi
+        DataLoader
+        StorageApi
+)
+__register_target_as_unit_test(UnitTestFlattenIntegration)

--- a/test/unit/userAPI/CMakeLists.txt
+++ b/test/unit/userAPI/CMakeLists.txt
@@ -91,6 +91,7 @@ target_link_libraries(UnitTestFlattenIntegration PRIVATE
         FlattenApi
         LinearApi
         SoftmaxApi
+        SgdApi
         TensorApi
         QuantizationApi
         LossFunction

--- a/test/unit/userAPI/UnitTestFlattenIntegration.c
+++ b/test/unit/userAPI/UnitTestFlattenIntegration.c
@@ -1,0 +1,65 @@
+#define SOURCE_FILE "UNIT_TEST_FLATTEN_INTEGRATION"
+
+#include <stdlib.h>
+
+#include "CalculateGradsSequential.h"
+#include "FlattenApi.h"
+#include "Layer.h"
+#include "LinearApi.h"
+#include "LossFunction.h"
+#include "QuantizationApi.h"
+#include "SoftmaxApi.h"
+#include "TensorApi.h"
+#include "unity.h"
+
+// Trains [Flatten → Linear(6,2) → Softmax] for one step with MSE loss.
+// Main point: initLayerOutputs FLATTEN case must derive output-Q from input tensor.
+// If that case is missing, initLayerOutputs hits `default: exit(1)`.
+void testCalculateGradsSequential_WithFlattenFirst_DoesNotCrash(void) {
+  quantization_t *q = quantizationInitFloat();
+
+  // Linear weights (6 -> 2)
+  static float w0Data[2 * 6] = {0};
+  static size_t w0Dims[] = {2, 6};
+  tensor_t *w0P = tensorInitWithDistribution(XAVIER_UNIFORM, w0Data, w0Dims, 2, q, NULL, 6, 2);
+  tensor_t *w0G = gradInitFloat(w0P, NULL);
+  parameter_t *w0 = parameterInit(w0P, w0G);
+
+  static float b0Data[2] = {0};
+  static size_t b0Dims[] = {1, 2};
+  tensor_t *b0P = tensorInitWithDistribution(ZEROS, b0Data, b0Dims, 2, q, NULL, 1, 2);
+  tensor_t *b0G = gradInitFloat(b0P, NULL);
+  parameter_t *b0 = parameterInit(b0P, b0G);
+
+  layer_t *model[3];
+  model[0] = flattenLayerInit();
+  model[1] = linearLayerInit(w0, b0, q, q, q, q);
+  model[2] = softmaxLayerInit(q, q);
+
+  // Input [1, 2, 3] = 6 elements
+  size_t inputDims[] = {1, 2, 3};
+  float inputData[] = {0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f};
+  tensor_t *input = tensorInitFloat(inputData, inputDims, 3, NULL);
+
+  // Label [1, 2]
+  size_t labelDims[] = {1, 2};
+  float labelData[] = {1.0f, 0.0f};
+  tensor_t *label = tensorInitFloat(labelData, labelDims, 2, NULL);
+
+  trainingStats_t *stats = calculateGradsSequential(model, 3, MSE, input, label);
+
+  TEST_ASSERT_NOT_NULL(stats);
+  TEST_ASSERT_NOT_NULL(stats->output);
+  TEST_ASSERT_EQUAL_UINT(2, stats->output->shape->numberOfDimensions);
+  TEST_ASSERT_EQUAL_UINT(1, stats->output->shape->dimensions[0]);
+  TEST_ASSERT_EQUAL_UINT(2, stats->output->shape->dimensions[1]);
+}
+
+void setUp(void) {}
+void tearDown(void) {}
+
+int main(void) {
+  UNITY_BEGIN();
+  RUN_TEST(testCalculateGradsSequential_WithFlattenFirst_DoesNotCrash);
+  return UNITY_END();
+}

--- a/test/unit/userAPI/UnitTestFlattenIntegration.c
+++ b/test/unit/userAPI/UnitTestFlattenIntegration.c
@@ -16,50 +16,98 @@
 // Main point: initLayerOutputs FLATTEN case must derive output-Q from input tensor.
 // If that case is missing, initLayerOutputs hits `default: exit(1)`.
 void testCalculateGradsSequential_WithFlattenFirst_DoesNotCrash(void) {
-  quantization_t *q = quantizationInitFloat();
+    quantization_t *q = quantizationInitFloat();
 
-  // Linear weights (6 -> 2)
-  static float w0Data[2 * 6] = {0};
-  static size_t w0Dims[] = {2, 6};
-  tensor_t *w0P = tensorInitWithDistribution(XAVIER_UNIFORM, w0Data, w0Dims, 2, q, NULL, 6, 2);
-  tensor_t *w0G = gradInitFloat(w0P, NULL);
-  parameter_t *w0 = parameterInit(w0P, w0G);
+    // Linear weights (6 -> 2)
+    static float w0Data[2 * 6] = {0};
+    static size_t w0Dims[] = {2, 6};
+    tensor_t *w0P = tensorInitWithDistribution(XAVIER_UNIFORM, w0Data, w0Dims, 2, q, NULL, 6, 2);
+    tensor_t *w0G = gradInitFloat(w0P, NULL);
+    parameter_t *w0 = parameterInit(w0P, w0G);
 
-  static float b0Data[2] = {0};
-  static size_t b0Dims[] = {1, 2};
-  tensor_t *b0P = tensorInitWithDistribution(ZEROS, b0Data, b0Dims, 2, q, NULL, 1, 2);
-  tensor_t *b0G = gradInitFloat(b0P, NULL);
-  parameter_t *b0 = parameterInit(b0P, b0G);
+    static float b0Data[2] = {0};
+    static size_t b0Dims[] = {1, 2};
+    tensor_t *b0P = tensorInitWithDistribution(ZEROS, b0Data, b0Dims, 2, q, NULL, 1, 2);
+    tensor_t *b0G = gradInitFloat(b0P, NULL);
+    parameter_t *b0 = parameterInit(b0P, b0G);
 
-  layer_t *model[3];
-  model[0] = flattenLayerInit();
-  model[1] = linearLayerInit(w0, b0, q, q, q, q);
-  model[2] = softmaxLayerInit(q, q);
+    layer_t *model[3];
+    model[0] = flattenLayerInit();
+    model[1] = linearLayerInit(w0, b0, q, q, q, q);
+    model[2] = softmaxLayerInit(q, q);
 
-  // Input [1, 2, 3] = 6 elements
-  size_t inputDims[] = {1, 2, 3};
-  float inputData[] = {0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f};
-  tensor_t *input = tensorInitFloat(inputData, inputDims, 3, NULL);
+    // Input [1, 2, 3] = 6 elements
+    size_t inputDims[] = {1, 2, 3};
+    float inputData[] = {0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f};
+    tensor_t *input = tensorInitFloat(inputData, inputDims, 3, NULL);
 
-  // Label [1, 2]
-  size_t labelDims[] = {1, 2};
-  float labelData[] = {1.0f, 0.0f};
-  tensor_t *label = tensorInitFloat(labelData, labelDims, 2, NULL);
+    // Label [1, 2]
+    size_t labelDims[] = {1, 2};
+    float labelData[] = {1.0f, 0.0f};
+    tensor_t *label = tensorInitFloat(labelData, labelDims, 2, NULL);
 
-  trainingStats_t *stats = calculateGradsSequential(model, 3, MSE, input, label);
+    trainingStats_t *stats = calculateGradsSequential(model, 3, MSE, input, label);
 
-  TEST_ASSERT_NOT_NULL(stats);
-  TEST_ASSERT_NOT_NULL(stats->output);
-  TEST_ASSERT_EQUAL_UINT(2, stats->output->shape->numberOfDimensions);
-  TEST_ASSERT_EQUAL_UINT(1, stats->output->shape->dimensions[0]);
-  TEST_ASSERT_EQUAL_UINT(2, stats->output->shape->dimensions[1]);
+    TEST_ASSERT_NOT_NULL(stats);
+    TEST_ASSERT_NOT_NULL(stats->output);
+    TEST_ASSERT_EQUAL_UINT(2, stats->output->shape->numberOfDimensions);
+    TEST_ASSERT_EQUAL_UINT(1, stats->output->shape->dimensions[0]);
+    TEST_ASSERT_EQUAL_UINT(2, stats->output->shape->dimensions[1]);
+}
+
+void testCalculateGradsSequential_FlattenRank1_DoesNotOOB(void) {
+    // Regression: initLayerOutputs sized output-shape buffers by INPUT rank, but
+    // flattenCalcOutputShape always writes 2 slots. For rank-1 input this is OOB.
+    size_t inputDims[] = {5};
+    float inputData[] = {1.f, 2.f, 3.f, 4.f, 5.f};
+    tensor_t *input = tensorInitFloat(inputData, inputDims, 1, NULL);
+
+    size_t labelDims[] = {5, 1};
+    float labelData[] = {0.f, 0.f, 0.f, 0.f, 0.f};
+    tensor_t *label = tensorInitFloat(labelData, labelDims, 2, NULL);
+
+    layer_t *model[1];
+    model[0] = flattenLayerInit();
+
+    trainingStats_t *stats = calculateGradsSequential(model, 1, MSE, input, label);
+
+    TEST_ASSERT_NOT_NULL(stats);
+    TEST_ASSERT_EQUAL_UINT(2, stats->output->shape->numberOfDimensions);
+    TEST_ASSERT_EQUAL_UINT(5, stats->output->shape->dimensions[0]);
+    TEST_ASSERT_EQUAL_UINT(1, stats->output->shape->dimensions[1]);
+}
+
+void testCalculateGradsSequential_FlattenOnly_PreservesValues(void) {
+    // FLATTEN is identity on values; stats->output must equal input, reshaped.
+    size_t inputDims[] = {1, 2, 3};
+    float inputData[] = {1.f, 2.f, 3.f, 4.f, 5.f, 6.f};
+    tensor_t *input = tensorInitFloat(inputData, inputDims, 3, NULL);
+
+    size_t labelDims[] = {1, 6};
+    float labelData[] = {0.f, 0.f, 0.f, 0.f, 0.f, 0.f};
+    tensor_t *label = tensorInitFloat(labelData, labelDims, 2, NULL);
+
+    layer_t *model[1];
+    model[0] = flattenLayerInit();
+
+    trainingStats_t *stats = calculateGradsSequential(model, 1, MSE, input, label);
+
+    TEST_ASSERT_NOT_NULL(stats);
+    TEST_ASSERT_EQUAL_UINT(2, stats->output->shape->numberOfDimensions);
+    TEST_ASSERT_EQUAL_UINT(1, stats->output->shape->dimensions[0]);
+    TEST_ASSERT_EQUAL_UINT(6, stats->output->shape->dimensions[1]);
+
+    float *actual = (float *)stats->output->data;
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(inputData, actual, 6);
 }
 
 void setUp(void) {}
 void tearDown(void) {}
 
 int main(void) {
-  UNITY_BEGIN();
-  RUN_TEST(testCalculateGradsSequential_WithFlattenFirst_DoesNotCrash);
-  return UNITY_END();
+    UNITY_BEGIN();
+    RUN_TEST(testCalculateGradsSequential_WithFlattenFirst_DoesNotCrash);
+    RUN_TEST(testCalculateGradsSequential_FlattenRank1_DoesNotOOB);
+    RUN_TEST(testCalculateGradsSequential_FlattenOnly_PreservesValues);
+    return UNITY_END();
 }

--- a/test/unit/userAPI/UnitTestFlattenIntegration.c
+++ b/test/unit/userAPI/UnitTestFlattenIntegration.c
@@ -1,5 +1,6 @@
 #define SOURCE_FILE "UNIT_TEST_FLATTEN_INTEGRATION"
 
+#include <stdbool.h>
 #include <stdlib.h>
 
 #include "CalculateGradsSequential.h"
@@ -9,96 +10,204 @@
 #include "LossFunction.h"
 #include "QuantizationApi.h"
 #include "SoftmaxApi.h"
+#include "StorageApi.h"
 #include "TensorApi.h"
 #include "unity.h"
 
-// Trains [Flatten → Linear(6,2) → Softmax] for one step with MSE loss.
+// Trains [Flatten -> Linear(6,2) -> Softmax] for one step with MSE loss.
 // Main point: initLayerOutputs FLATTEN case must derive output-Q from input tensor.
 // If that case is missing, initLayerOutputs hits `default: exit(1)`.
 void testCalculateGradsSequential_WithFlattenFirst_DoesNotCrash(void) {
     quantization_t *q = quantizationInitFloat();
 
-    // Linear weights (6 -> 2)
-    static float w0Data[2 * 6] = {0};
-    static size_t w0Dims[] = {2, 6};
-    tensor_t *w0P = tensorInitWithDistribution(XAVIER_UNIFORM, w0Data, w0Dims, 2, q, NULL, 6, 2);
-    tensor_t *w0G = gradInitFloat(w0P, NULL);
-    parameter_t *w0 = parameterInit(w0P, w0G);
+    /* Linear weights w0 (2x6, XAVIER_UNIFORM). */
+    size_t *w0Dims = reserveMemory(2 * sizeof(size_t));
+    w0Dims[0] = 2;
+    w0Dims[1] = 6;
+    size_t *w0Order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, w0Order);
+    shape_t *w0Shape = reserveMemory(sizeof(shape_t));
+    setShape(w0Shape, w0Dims, 2, w0Order);
+    tensor_t *w0Param = initTensor(w0Shape, quantizationInitFloat(), NULL);
+    distribution_t xavier = {.type = XAVIER_UNIFORM,
+                             .params.xavier = {.gain = 1.0f, .fanIn = 6, .fanOut = 2}};
+    initDistribution(w0Param, &xavier);
+    tensor_t *w0Grad = gradInitFloat(w0Param, NULL);
+    parameter_t *w0 = parameterInit(w0Param, w0Grad);
 
-    static float b0Data[2] = {0};
-    static size_t b0Dims[] = {1, 2};
-    tensor_t *b0P = tensorInitWithDistribution(ZEROS, b0Data, b0Dims, 2, q, NULL, 1, 2);
-    tensor_t *b0G = gradInitFloat(b0P, NULL);
-    parameter_t *b0 = parameterInit(b0P, b0G);
+    /* Linear bias b0 (1x2, ZEROS). */
+    size_t *b0Dims = reserveMemory(2 * sizeof(size_t));
+    b0Dims[0] = 1;
+    b0Dims[1] = 2;
+    size_t *b0Order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, b0Order);
+    shape_t *b0Shape = reserveMemory(sizeof(shape_t));
+    setShape(b0Shape, b0Dims, 2, b0Order);
+    tensor_t *b0Param = initTensor(b0Shape, quantizationInitFloat(), NULL);
+    distribution_t zeros = {.type = ZEROS};
+    initDistribution(b0Param, &zeros);
+    tensor_t *b0Grad = gradInitFloat(b0Param, NULL);
+    parameter_t *b0 = parameterInit(b0Param, b0Grad);
 
-    layer_t *model[3];
-    model[0] = flattenLayerInit();
-    model[1] = linearLayerInit(w0, b0, q, q, q, q);
-    model[2] = softmaxLayerInit(q, q);
+    layer_t *flatten = flattenLayerInit();
+    layer_t *linear = linearLayerInit(w0, b0, q, q, q, q);
+    layer_t *softmax = softmaxLayerInit(q, q);
+    layer_t *model[3] = {flatten, linear, softmax};
 
-    // Input [1, 2, 3] = 6 elements
-    size_t inputDims[] = {1, 2, 3};
-    float inputData[] = {0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f};
-    tensor_t *input = tensorInitFloat(inputData, inputDims, 3, NULL);
+    /* Input [1, 2, 3] = 6 elements. */
+    size_t *inputDims = reserveMemory(3 * sizeof(size_t));
+    inputDims[0] = 1;
+    inputDims[1] = 2;
+    inputDims[2] = 3;
+    size_t *inputOrder = reserveMemory(3 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(3, inputOrder);
+    shape_t *inputShape = reserveMemory(sizeof(shape_t));
+    setShape(inputShape, inputDims, 3, inputOrder);
+    tensor_t *input = initTensor(inputShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(input, (float[]){0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f}, 6);
 
-    // Label [1, 2]
-    size_t labelDims[] = {1, 2};
-    float labelData[] = {1.0f, 0.0f};
-    tensor_t *label = tensorInitFloat(labelData, labelDims, 2, NULL);
+    /* Label [1, 2]. */
+    size_t *labelDims = reserveMemory(2 * sizeof(size_t));
+    labelDims[0] = 1;
+    labelDims[1] = 2;
+    size_t *labelOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, labelOrder);
+    shape_t *labelShape = reserveMemory(sizeof(shape_t));
+    setShape(labelShape, labelDims, 2, labelOrder);
+    tensor_t *label = initTensor(labelShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(label, (float[]){1.0f, 0.0f}, 2);
 
     trainingStats_t *stats = calculateGradsSequential(model, 3, MSE, input, label);
 
-    TEST_ASSERT_NOT_NULL(stats);
-    TEST_ASSERT_NOT_NULL(stats->output);
-    TEST_ASSERT_EQUAL_UINT(2, stats->output->shape->numberOfDimensions);
-    TEST_ASSERT_EQUAL_UINT(1, stats->output->shape->dimensions[0]);
-    TEST_ASSERT_EQUAL_UINT(2, stats->output->shape->dimensions[1]);
+    /* CAPTURE before frees. */
+    bool capturedStatsNotNull = (stats != NULL);
+    bool capturedOutputNotNull = (stats && stats->output != NULL);
+    size_t capturedNumDims =
+        (stats && stats->output) ? stats->output->shape->numberOfDimensions : 0;
+    size_t capturedDim0 = (stats && stats->output) ? stats->output->shape->dimensions[0] : 0;
+    size_t capturedDim1 = (stats && stats->output) ? stats->output->shape->dimensions[1] : 0;
+
+    /* FREE in reverse-init order. */
+    freeTrainingStats(stats);
+    freeTensor(label);
+    freeTensor(input);
+    freeSoftmaxLayer(softmax);
+    freeLinearLayer(linear);
+    freeFlattenLayer(flatten);
+    freeParameter(b0);
+    freeParameter(w0);
+    freeQuantization(q);
+
+    /* ASSERT. */
+    TEST_ASSERT_TRUE(capturedStatsNotNull);
+    TEST_ASSERT_TRUE(capturedOutputNotNull);
+    TEST_ASSERT_EQUAL_UINT(2, capturedNumDims);
+    TEST_ASSERT_EQUAL_UINT(1, capturedDim0);
+    TEST_ASSERT_EQUAL_UINT(2, capturedDim1);
 }
 
 void testCalculateGradsSequential_FlattenRank1_DoesNotOOB(void) {
     // Regression: initLayerOutputs sized output-shape buffers by INPUT rank, but
     // flattenCalcOutputShape always writes 2 slots. For rank-1 input this is OOB.
-    size_t inputDims[] = {5};
-    float inputData[] = {1.f, 2.f, 3.f, 4.f, 5.f};
-    tensor_t *input = tensorInitFloat(inputData, inputDims, 1, NULL);
+    size_t *inputDims = reserveMemory(1 * sizeof(size_t));
+    inputDims[0] = 5;
+    size_t *inputOrder = reserveMemory(1 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(1, inputOrder);
+    shape_t *inputShape = reserveMemory(sizeof(shape_t));
+    setShape(inputShape, inputDims, 1, inputOrder);
+    tensor_t *input = initTensor(inputShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(input, (float[]){1.f, 2.f, 3.f, 4.f, 5.f}, 5);
 
-    size_t labelDims[] = {5, 1};
-    float labelData[] = {0.f, 0.f, 0.f, 0.f, 0.f};
-    tensor_t *label = tensorInitFloat(labelData, labelDims, 2, NULL);
+    size_t *labelDims = reserveMemory(2 * sizeof(size_t));
+    labelDims[0] = 5;
+    labelDims[1] = 1;
+    size_t *labelOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, labelOrder);
+    shape_t *labelShape = reserveMemory(sizeof(shape_t));
+    setShape(labelShape, labelDims, 2, labelOrder);
+    tensor_t *label = initTensor(labelShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(label, (float[]){0.f, 0.f, 0.f, 0.f, 0.f}, 5);
 
-    layer_t *model[1];
-    model[0] = flattenLayerInit();
+    layer_t *flatten = flattenLayerInit();
+    layer_t *model[1] = {flatten};
 
     trainingStats_t *stats = calculateGradsSequential(model, 1, MSE, input, label);
 
-    TEST_ASSERT_NOT_NULL(stats);
-    TEST_ASSERT_EQUAL_UINT(2, stats->output->shape->numberOfDimensions);
-    TEST_ASSERT_EQUAL_UINT(5, stats->output->shape->dimensions[0]);
-    TEST_ASSERT_EQUAL_UINT(1, stats->output->shape->dimensions[1]);
+    /* CAPTURE before frees. */
+    bool capturedStatsNotNull = (stats != NULL);
+    size_t capturedNumDims =
+        (stats && stats->output) ? stats->output->shape->numberOfDimensions : 0;
+    size_t capturedDim0 = (stats && stats->output) ? stats->output->shape->dimensions[0] : 0;
+    size_t capturedDim1 = (stats && stats->output) ? stats->output->shape->dimensions[1] : 0;
+
+    /* FREE in reverse-init order. */
+    freeTrainingStats(stats);
+    freeTensor(label);
+    freeTensor(input);
+    freeFlattenLayer(flatten);
+
+    /* ASSERT. */
+    TEST_ASSERT_TRUE(capturedStatsNotNull);
+    TEST_ASSERT_EQUAL_UINT(2, capturedNumDims);
+    TEST_ASSERT_EQUAL_UINT(5, capturedDim0);
+    TEST_ASSERT_EQUAL_UINT(1, capturedDim1);
 }
 
 void testCalculateGradsSequential_FlattenOnly_PreservesValues(void) {
     // FLATTEN is identity on values; stats->output must equal input, reshaped.
-    size_t inputDims[] = {1, 2, 3};
     float inputData[] = {1.f, 2.f, 3.f, 4.f, 5.f, 6.f};
-    tensor_t *input = tensorInitFloat(inputData, inputDims, 3, NULL);
 
-    size_t labelDims[] = {1, 6};
-    float labelData[] = {0.f, 0.f, 0.f, 0.f, 0.f, 0.f};
-    tensor_t *label = tensorInitFloat(labelData, labelDims, 2, NULL);
+    size_t *inputDims = reserveMemory(3 * sizeof(size_t));
+    inputDims[0] = 1;
+    inputDims[1] = 2;
+    inputDims[2] = 3;
+    size_t *inputOrder = reserveMemory(3 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(3, inputOrder);
+    shape_t *inputShape = reserveMemory(sizeof(shape_t));
+    setShape(inputShape, inputDims, 3, inputOrder);
+    tensor_t *input = initTensor(inputShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(input, inputData, 6);
 
-    layer_t *model[1];
-    model[0] = flattenLayerInit();
+    size_t *labelDims = reserveMemory(2 * sizeof(size_t));
+    labelDims[0] = 1;
+    labelDims[1] = 6;
+    size_t *labelOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, labelOrder);
+    shape_t *labelShape = reserveMemory(sizeof(shape_t));
+    setShape(labelShape, labelDims, 2, labelOrder);
+    tensor_t *label = initTensor(labelShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(label, (float[]){0.f, 0.f, 0.f, 0.f, 0.f, 0.f}, 6);
+
+    layer_t *flatten = flattenLayerInit();
+    layer_t *model[1] = {flatten};
 
     trainingStats_t *stats = calculateGradsSequential(model, 1, MSE, input, label);
 
-    TEST_ASSERT_NOT_NULL(stats);
-    TEST_ASSERT_EQUAL_UINT(2, stats->output->shape->numberOfDimensions);
-    TEST_ASSERT_EQUAL_UINT(1, stats->output->shape->dimensions[0]);
-    TEST_ASSERT_EQUAL_UINT(6, stats->output->shape->dimensions[1]);
+    /* CAPTURE before frees. */
+    bool capturedStatsNotNull = (stats != NULL);
+    size_t capturedNumDims =
+        (stats && stats->output) ? stats->output->shape->numberOfDimensions : 0;
+    size_t capturedDim0 = (stats && stats->output) ? stats->output->shape->dimensions[0] : 0;
+    size_t capturedDim1 = (stats && stats->output) ? stats->output->shape->dimensions[1] : 0;
+    float capturedValues[6] = {0};
+    if (stats && stats->output && stats->output->data) {
+        for (size_t i = 0; i < 6; i++) {
+            capturedValues[i] = ((float *)stats->output->data)[i];
+        }
+    }
 
-    float *actual = (float *)stats->output->data;
-    TEST_ASSERT_EQUAL_FLOAT_ARRAY(inputData, actual, 6);
+    /* FREE in reverse-init order. */
+    freeTrainingStats(stats);
+    freeTensor(label);
+    freeTensor(input);
+    freeFlattenLayer(flatten);
+
+    /* ASSERT. */
+    TEST_ASSERT_TRUE(capturedStatsNotNull);
+    TEST_ASSERT_EQUAL_UINT(2, capturedNumDims);
+    TEST_ASSERT_EQUAL_UINT(1, capturedDim0);
+    TEST_ASSERT_EQUAL_UINT(6, capturedDim1);
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(inputData, capturedValues, 6);
 }
 
 void setUp(void) {}

--- a/test/unit/userAPI/UnitTestInferenceApi.c
+++ b/test/unit/userAPI/UnitTestInferenceApi.c
@@ -1,140 +1,253 @@
-#include "Layer.h"
-#include "TensorApi.h"
 #include "InferenceApi.h"
-#include "unity.h"
+#include "Layer.h"
 #include "LinearApi.h"
-#include "ReluApi.h"
-#include "QuantizationApi.h"
-#include "TensorConversion.h"
 #include "LossFunction.h"
+#include "QuantizationApi.h"
+#include "ReluApi.h"
+#include "StorageApi.h"
+#include "TensorApi.h"
+#include "TensorConversion.h"
+#include "unity.h"
 
 void testInferenceLinearReluFloat() {
+    /* 1. Build heap-allocated quantization (shared across both layers). */
+    quantization_t *q = quantizationInitFloat();
 
-    float weightData[] = {-1.f, 2.f, -3.f, 4.f, 5.f, 6.f};
-    size_t weightDims[] = {2, 3};
-    size_t weightNumberOfDims = 2;
-
-    tensor_t *weightParam = tensorInitFloat(weightData, weightDims, weightNumberOfDims, NULL);
-
+    /* 2. Build weights tensor (shape 2x3) and its grad. */
+    size_t *weightDims = reserveMemory(2 * sizeof(size_t));
+    weightDims[0] = 2;
+    weightDims[1] = 3;
+    size_t *weightOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, weightOrder);
+    shape_t *weightShape = reserveMemory(sizeof(shape_t));
+    setShape(weightShape, weightDims, 2, weightOrder);
+    tensor_t *weightParam = initTensor(weightShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(weightParam, (float[]){-1.f, 2.f, -3.f, 4.f, 5.f, 6.f}, 6);
     tensor_t *weightGrad = gradInitFloat(weightParam, NULL);
     parameter_t *weights = parameterInit(weightParam, weightGrad);
 
-    float biasData[] = {-1.f, 3.f};
-    size_t biasDims[] = {1, 2};
-    size_t biasNumberOfDims = 2;
-
-    tensor_t *biasParam = tensorInitFloat(biasData, biasDims, biasNumberOfDims, NULL);
+    /* 3. Build bias tensor (shape 1x2) and its grad. */
+    size_t *biasDims = reserveMemory(2 * sizeof(size_t));
+    biasDims[0] = 1;
+    biasDims[1] = 2;
+    size_t *biasOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, biasOrder);
+    shape_t *biasShape = reserveMemory(sizeof(shape_t));
+    setShape(biasShape, biasDims, 2, biasOrder);
+    tensor_t *biasParam = initTensor(biasShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(biasParam, (float[]){-1.f, 3.f}, 2);
     tensor_t *biasGrad = gradInitFloat(biasParam, NULL);
     parameter_t *bias = parameterInit(biasParam, biasGrad);
 
-    float inputData[] = {0.f, 1.f, 2.f};
-    size_t inputDims[] = {1, 3};
-    size_t inputNumberOfDims = 2;
-    tensor_t *input = tensorInitFloat(inputData, inputDims, inputNumberOfDims, NULL);
+    /* 4. Build input tensor (shape 1x3). */
+    size_t *inputDims = reserveMemory(2 * sizeof(size_t));
+    inputDims[0] = 1;
+    inputDims[1] = 3;
+    size_t *inputOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, inputOrder);
+    shape_t *inputShape = reserveMemory(sizeof(shape_t));
+    setShape(inputShape, inputDims, 2, inputOrder);
+    tensor_t *input = initTensor(inputShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(input, (float[]){0.f, 1.f, 2.f}, 3);
 
-    quantization_t *test = quantizationInitFloat();
-
-    layer_t *linear = linearLayerInit(weights, bias, test, test, test, test);
-
-    layer_t *relu = reluLayerInit(test, test);
-
+    /* 5. Build layers; both layers share the same q (no ownership transfer). */
+    layer_t *linear = linearLayerInit(weights, bias, q, q, q, q);
+    layer_t *relu = reluLayerInit(q, q);
     layer_t *model[] = {linear, relu};
 
+    /* 6. Exercise the system. */
     tensor_t *output = inference(model, 2, input);
 
-    float expected[] = {0.f, 20.f};
+    /* 7. CAPTURE assertion values into stack locals BEFORE frees. */
+    float capturedOutput[2];
+    capturedOutput[0] = ((float *)output->data)[0];
+    capturedOutput[1] = ((float *)output->data)[1];
 
-    TEST_ASSERT_EQUAL_FLOAT_ARRAY(expected, output->data, 2);
+    /* 8. FREE in reverse-init order.
+     *    - inference() returns a heap tensor (via getTensorLike) — caller owns it.
+     *    - freeReluLayer / freeLinearLayer release config wrappers but NOT shared q
+     *      and NOT the parameters.
+     *    - freeParameter cascades to param + grad via freeTensor (TensorApi.c:389).
+     *    - The shared q is freed exactly once at the end. */
+    freeTensor(output);
+    freeReluLayer(relu);
+    freeLinearLayer(linear);
+    freeTensor(input);
+    freeParameter(bias);
+    freeParameter(weights);
+    freeQuantization(q);
+
+    /* 9. ASSERT on captured locals. */
+    float expected[] = {0.f, 20.f};
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(expected, capturedOutput, 2);
 }
 
 void testInferenceLinearReluSymInt32() {
     size_t numberOfOutputs = 2;
 
-    float weightDataFloat[] = {-1.f, 2.f, -3.f, 4.f, 5.f, 6.f};
-    size_t weightDims[] = {2, 3};
-    size_t weightNumberOfDims = 2;
-    tensor_t *weightsParam = tensorInitSymInt32(weightDataFloat, weightDims, weightNumberOfDims,
-                                                HTE, NULL);
+    /* Shared SymInt32 quantization for layers. */
+    quantization_t *q = quantizationInitSymInt32(HTE);
+
+    /* Weights (2x3). */
+    size_t *weightDims = reserveMemory(2 * sizeof(size_t));
+    weightDims[0] = 2;
+    weightDims[1] = 3;
+    size_t *weightOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, weightOrder);
+    shape_t *weightShape = reserveMemory(sizeof(shape_t));
+    setShape(weightShape, weightDims, 2, weightOrder);
+    tensor_t *weightsParam = initTensor(weightShape, quantizationInitSymInt32(HTE), NULL);
+    tensorFillFromFloatBuffer(weightsParam, (float[]){-1.f, 2.f, -3.f, 4.f, 5.f, 6.f}, 6);
     tensor_t *weightGrad = gradInitSymInt32(weightsParam, HTE, NULL);
     parameter_t *weights = parameterInit(weightsParam, weightGrad);
 
-    float biasData[] = {-1, 3};
-    size_t biasDims[] = {1, 2};
-    size_t biasNumberOfDims = 2;
-    tensor_t *biasParam = tensorInitSymInt32(biasData, biasDims, biasNumberOfDims, HTE, NULL);
+    /* Bias (1x2). */
+    size_t *biasDims = reserveMemory(2 * sizeof(size_t));
+    biasDims[0] = 1;
+    biasDims[1] = 2;
+    size_t *biasOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, biasOrder);
+    shape_t *biasShape = reserveMemory(sizeof(shape_t));
+    setShape(biasShape, biasDims, 2, biasOrder);
+    tensor_t *biasParam = initTensor(biasShape, quantizationInitSymInt32(HTE), NULL);
+    tensorFillFromFloatBuffer(biasParam, (float[]){-1.f, 3.f}, 2);
     tensor_t *biasGrad = gradInitSymInt32(biasParam, HTE, NULL);
     parameter_t *bias = parameterInit(biasParam, biasGrad);
 
-    float inputDataFloat[] = {0.f, 1.f, 2.f};
-    size_t inputDims[] = {1, 3};
-    size_t inputNumberOfDims = 2;
-    tensor_t *input = tensorInitSymInt32(inputDataFloat, inputDims, inputNumberOfDims, HTE, NULL);
+    /* Input (1x3). */
+    size_t *inputDims = reserveMemory(2 * sizeof(size_t));
+    inputDims[0] = 1;
+    inputDims[1] = 3;
+    size_t *inputOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, inputOrder);
+    shape_t *inputShape = reserveMemory(sizeof(shape_t));
+    setShape(inputShape, inputDims, 2, inputOrder);
+    tensor_t *input = initTensor(inputShape, quantizationInitSymInt32(HTE), NULL);
+    tensorFillFromFloatBuffer(input, (float[]){0.f, 1.f, 2.f}, 3);
 
-    quantization_t *test = quantizationInitSymInt32(HTE);
-    layer_t *linear = linearLayerInit(weights, bias, test, test, test, test);
-
-    layer_t *relu = reluLayerInit(test, test);
-
+    /* Layers. */
+    layer_t *linear = linearLayerInit(weights, bias, q, q, q, q);
+    layer_t *relu = reluLayerInit(q, q);
     layer_t *model[] = {linear, relu};
 
+    /* Run inference (returns a heap tensor in SymInt32 form). */
     tensor_t *outputSymInt32 = inference(model, 2, input);
 
-    float expected[] = {0.f, 20.f};
-    float outputData[numberOfOutputs];
-    tensor_t *outputFloat = tensorInitFloat(outputData, biasDims, biasNumberOfDims, NULL);
+    /* Convert SymInt32 → Float32 view for comparison. The output buffer is
+     * heap-allocated to keep us in the heap-tier idiom. */
+    size_t *outDims = reserveMemory(2 * sizeof(size_t));
+    outDims[0] = 1;
+    outDims[1] = numberOfOutputs;
+    size_t *outOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, outOrder);
+    shape_t *outShape = reserveMemory(sizeof(shape_t));
+    setShape(outShape, outDims, 2, outOrder);
+    tensor_t *outputFloat = initTensor(outShape, quantizationInitFloat(), NULL);
     convertTensor(outputSymInt32, outputFloat);
-    float *actual = (float *)outputFloat->data;
 
+    /* CAPTURE assertion values. */
+    float capturedActual[2];
+    capturedActual[0] = ((float *)outputFloat->data)[0];
+    capturedActual[1] = ((float *)outputFloat->data)[1];
+
+    /* FREE in reverse-init order. */
+    freeTensor(outputFloat);
+    freeTensor(outputSymInt32);
+    freeReluLayer(relu);
+    freeLinearLayer(linear);
+    freeTensor(input);
+    freeParameter(bias);
+    freeParameter(weights);
+    freeQuantization(q);
+
+    /* ASSERT on captured. */
+    float expected[] = {0.f, 20.f};
     for (size_t i = 0; i < numberOfOutputs; i++) {
-        TEST_ASSERT_FLOAT_WITHIN(0.1f, expected[i], actual[i]);
+        TEST_ASSERT_FLOAT_WITHIN(0.1f, expected[i], capturedActual[i]);
     }
 }
 
 void testInferenceWithLossLinearReluFloat() {
+    quantization_t *q = quantizationInitFloat();
 
-    float weightData[] = {-1.f, 2.f, -3.f, 4.f, 5.f, 6.f};
-    size_t weightDims[] = {2, 3};
-    size_t weightNumberOfDims = 2;
-
-    tensor_t *weightParam = tensorInitFloat(weightData, weightDims, weightNumberOfDims, NULL);
+    /* Weights (2x3). */
+    size_t *weightDims = reserveMemory(2 * sizeof(size_t));
+    weightDims[0] = 2;
+    weightDims[1] = 3;
+    size_t *weightOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, weightOrder);
+    shape_t *weightShape = reserveMemory(sizeof(shape_t));
+    setShape(weightShape, weightDims, 2, weightOrder);
+    tensor_t *weightParam = initTensor(weightShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(weightParam, (float[]){-1.f, 2.f, -3.f, 4.f, 5.f, 6.f}, 6);
     tensor_t *weightGrad = gradInitFloat(weightParam, NULL);
     parameter_t *weights = parameterInit(weightParam, weightGrad);
 
-    float biasData[] = {-1.f, 3.f};
-    size_t biasDims[] = {1, 2};
-    size_t biasNumberOfDims = 2;
-
-    tensor_t *biasParam = tensorInitFloat(biasData, biasDims, biasNumberOfDims, NULL);
+    /* Bias (1x2). */
+    size_t *biasDims = reserveMemory(2 * sizeof(size_t));
+    biasDims[0] = 1;
+    biasDims[1] = 2;
+    size_t *biasOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, biasOrder);
+    shape_t *biasShape = reserveMemory(sizeof(shape_t));
+    setShape(biasShape, biasDims, 2, biasOrder);
+    tensor_t *biasParam = initTensor(biasShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(biasParam, (float[]){-1.f, 3.f}, 2);
     tensor_t *biasGrad = gradInitFloat(biasParam, NULL);
     parameter_t *bias = parameterInit(biasParam, biasGrad);
 
-    float inputData[] = {0.f, 1.f, 2.f};
-    size_t inputDims[] = {1, 3};
-    size_t inputNumberOfDims = 2;
-    tensor_t *input = tensorInitFloat(inputData, inputDims, inputNumberOfDims, NULL);
+    /* Input (1x3). */
+    size_t *inputDims = reserveMemory(2 * sizeof(size_t));
+    inputDims[0] = 1;
+    inputDims[1] = 3;
+    size_t *inputOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, inputOrder);
+    shape_t *inputShape = reserveMemory(sizeof(shape_t));
+    setShape(inputShape, inputDims, 2, inputOrder);
+    tensor_t *input = initTensor(inputShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(input, (float[]){0.f, 1.f, 2.f}, 3);
 
-    quantization_t *test = quantizationInitFloat();
+    /* Label0 (1x2). */
+    size_t *label0Dims = reserveMemory(2 * sizeof(size_t));
+    label0Dims[0] = 1;
+    label0Dims[1] = 2;
+    size_t *label0Order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, label0Order);
+    shape_t *label0Shape = reserveMemory(sizeof(shape_t));
+    setShape(label0Shape, label0Dims, 2, label0Order);
+    tensor_t *label0 = initTensor(label0Shape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(label0, (float[]){59.f, -23.f}, 2);
 
-    layer_t *linear = linearLayerInit(weights, bias, test, test, test, test);
-
-    layer_t *relu = reluLayerInit(test, test);
-
+    /* Layers. */
+    layer_t *linear = linearLayerInit(weights, bias, q, q, q, q);
+    layer_t *relu = reluLayerInit(q, q);
     layer_t *model[] = {linear, relu};
 
-    float label0Data[] = {59.f, -23.f};
-    size_t label0Dims[] = {1, 2};
-    size_t label0NumberOfDims = 2;
-    tensor_t *label0 = tensorInitFloat(label0Data, label0Dims, label0NumberOfDims, NULL);
-
+    /* Run inferenceWithLoss. inferenceStats owns its `output` tensor; its
+     * matching free is freeInferenceStats. */
     inferenceStats_t *inferenceStats = inferenceWithLoss(model, 2, input, label0, MSE);
 
-    float expectedOutput[] = {0.f, 20.f};
-    float expectedLoss = 2665.f;
+    /* CAPTURE. */
+    float capturedLoss = inferenceStats->loss;
+    float capturedOutput[2];
+    capturedOutput[0] = ((float *)inferenceStats->output->data)[0];
+    capturedOutput[1] = ((float *)inferenceStats->output->data)[1];
 
-    TEST_ASSERT_EQUAL_FLOAT(expectedLoss, inferenceStats->loss);
-    TEST_ASSERT_EQUAL_FLOAT_ARRAY(expectedOutput, inferenceStats->output->data, 2);
-
+    /* FREE in reverse-init order. */
     freeInferenceStats(inferenceStats);
+    freeReluLayer(relu);
+    freeLinearLayer(linear);
+    freeTensor(label0);
+    freeTensor(input);
+    freeParameter(bias);
+    freeParameter(weights);
+    freeQuantization(q);
+
+    /* ASSERT on captured. */
+    float expectedLoss = 2665.f;
+    float expectedOutput[] = {0.f, 20.f};
+    TEST_ASSERT_EQUAL_FLOAT(expectedLoss, capturedLoss);
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(expectedOutput, capturedOutput, 2);
 }
 
 void setUp() {}

--- a/test/unit/userAPI/UnitTestMnistSmoke.c
+++ b/test/unit/userAPI/UnitTestMnistSmoke.c
@@ -4,25 +4,23 @@
 
 #include "unity.h"
 
-#include "Tensor.h"
-#include "TensorApi.h"
-#include "LinearApi.h"
-#include "ReluApi.h"
-#include "SoftmaxApi.h"
-#include "SgdApi.h"
-#include "QuantizationApi.h"
-#include "LossFunction.h"
-#include "InferenceApi.h"
+#include "CalculateGradsSequential.h"
 #include "DataLoaderApi.h"
 #include "Dataset.h"
+#include "InferenceApi.h"
+#include "LinearApi.h"
+#include "LossFunction.h"
+#include "QuantizationApi.h"
+#include "ReluApi.h"
+#include "SgdApi.h"
+#include "SoftmaxApi.h"
 #include "StorageApi.h"
+#include "Tensor.h"
+#include "TensorApi.h"
 #include "TrainingLoopApi.h"
-#include "CalculateGradsSequential.h"
-
 
 void setUp() {}
 void tearDown() {}
-
 
 #define INPUT_DIM 4
 #define HIDDEN_DIM 8
@@ -30,34 +28,51 @@ void tearDown() {}
 #define DATASET_SIZE 6
 #define MODEL_SIZE 4
 
-
-// Tiny trivially-learnable dataset: each input is a noisy one-hot prototype of its class.
+/* Tiny trivially-learnable dataset: each input is a noisy one-hot prototype of
+ * its class. The arrays are file-scope because the getSample callback (fired
+ * during trainingRun) must reach them; freeDataset releases them at end. */
 static tensor_t *items[DATASET_SIZE];
 static tensor_t *labels[DATASET_SIZE];
 
-static void initDataset() {
-    static float itemData[DATASET_SIZE][INPUT_DIM] = {
-        {1.0f, 0.0f, 0.0f, 0.0f},
-        {0.0f, 1.0f, 0.0f, 0.0f},
-        {0.0f, 0.0f, 1.0f, 0.0f},
-        {0.9f, 0.1f, 0.0f, 0.0f},
-        {0.1f, 0.9f, 0.0f, 0.0f},
-        {0.0f, 0.1f, 0.9f, 0.0f},
-    };
-    static float labelData[DATASET_SIZE][NUM_CLASSES] = {
-        {1.0f, 0.0f, 0.0f},
-        {0.0f, 1.0f, 0.0f},
-        {0.0f, 0.0f, 1.0f},
-        {1.0f, 0.0f, 0.0f},
-        {0.0f, 1.0f, 0.0f},
-        {0.0f, 0.0f, 1.0f},
-    };
-    static size_t itemDims[] = {1, INPUT_DIM};
-    static size_t labelDims[] = {1, NUM_CLASSES};
+static const float itemDataLiteral[DATASET_SIZE][INPUT_DIM] = {
+    {1.0f, 0.0f, 0.0f, 0.0f}, {0.0f, 1.0f, 0.0f, 0.0f}, {0.0f, 0.0f, 1.0f, 0.0f},
+    {0.9f, 0.1f, 0.0f, 0.0f}, {0.1f, 0.9f, 0.0f, 0.0f}, {0.0f, 0.1f, 0.9f, 0.0f},
+};
+static const float labelDataLiteral[DATASET_SIZE][NUM_CLASSES] = {
+    {1.0f, 0.0f, 0.0f}, {0.0f, 1.0f, 0.0f}, {0.0f, 0.0f, 1.0f},
+    {1.0f, 0.0f, 0.0f}, {0.0f, 1.0f, 0.0f}, {0.0f, 0.0f, 1.0f},
+};
 
+static void initDataset() {
     for (size_t i = 0; i < DATASET_SIZE; i++) {
-        items[i] = tensorInitFloat(itemData[i], itemDims, 2, NULL);
-        labels[i] = tensorInitFloat(labelData[i], labelDims, 2, NULL);
+        /* Item tensor (1, INPUT_DIM). */
+        size_t *itemDims = reserveMemory(2 * sizeof(size_t));
+        itemDims[0] = 1;
+        itemDims[1] = INPUT_DIM;
+        size_t *itemOrder = reserveMemory(2 * sizeof(size_t));
+        setOrderOfDimsForNewTensor(2, itemOrder);
+        shape_t *itemShape = reserveMemory(sizeof(shape_t));
+        setShape(itemShape, itemDims, 2, itemOrder);
+        items[i] = initTensor(itemShape, quantizationInitFloat(), NULL);
+        tensorFillFromFloatBuffer(items[i], itemDataLiteral[i], INPUT_DIM);
+
+        /* Label tensor (1, NUM_CLASSES). */
+        size_t *labelDims = reserveMemory(2 * sizeof(size_t));
+        labelDims[0] = 1;
+        labelDims[1] = NUM_CLASSES;
+        size_t *labelOrder = reserveMemory(2 * sizeof(size_t));
+        setOrderOfDimsForNewTensor(2, labelOrder);
+        shape_t *labelShape = reserveMemory(sizeof(shape_t));
+        setShape(labelShape, labelDims, 2, labelOrder);
+        labels[i] = initTensor(labelShape, quantizationInitFloat(), NULL);
+        tensorFillFromFloatBuffer(labels[i], labelDataLiteral[i], NUM_CLASSES);
+    }
+}
+
+static void freeDataset() {
+    for (size_t i = 0; i < DATASET_SIZE; i++) {
+        freeTensor(items[i]);
+        freeTensor(labels[i]);
     }
 }
 
@@ -72,48 +87,81 @@ static size_t getDatasetSize() {
     return DATASET_SIZE;
 }
 
-
-// Mirrors the buildModel pattern from experiments/MnistExperiment.c: model is
-// constructed inside a helper that returns to its caller before trainingRun()
-// runs. This exercises the stack-lifetime contract of setShape()/tensorInit*.
-static void buildModel(layer_t **model) {
+/* Builds a 4-layer Linear -> ReLU -> Linear -> Softmax model. The shared
+ * layer-level quantization q is exposed via q_out so the test can free it
+ * after the model layers are freed. Each parameter tensor takes its own
+ * fresh quantization (initTensor takes ownership), distinct from q. */
+static void buildModel(layer_t **model, quantization_t **q_out) {
     quantization_t *q = quantizationInitFloat();
+    *q_out = q;
 
-    static float w0Data[HIDDEN_DIM * INPUT_DIM] = {0};
-    static size_t w0Dims[] = {HIDDEN_DIM, INPUT_DIM};
-    tensor_t *w0Param = tensorInitWithDistribution(XAVIER_UNIFORM, w0Data, w0Dims, 2, q, NULL,
-                                                    INPUT_DIM, HIDDEN_DIM);
+    distribution_t xavier0 = {
+        .type = XAVIER_UNIFORM,
+        .params.xavier = {.gain = 1.0f, .fanIn = INPUT_DIM, .fanOut = HIDDEN_DIM}};
+    distribution_t zeros = {.type = ZEROS};
+
+    /* w0 (HIDDEN_DIM x INPUT_DIM, XAVIER_UNIFORM). */
+    size_t *w0Dims = reserveMemory(2 * sizeof(size_t));
+    w0Dims[0] = HIDDEN_DIM;
+    w0Dims[1] = INPUT_DIM;
+    size_t *w0Order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, w0Order);
+    shape_t *w0Shape = reserveMemory(sizeof(shape_t));
+    setShape(w0Shape, w0Dims, 2, w0Order);
+    tensor_t *w0Param = initTensor(w0Shape, quantizationInitFloat(), NULL);
+    initDistribution(w0Param, &xavier0);
     tensor_t *w0Grad = gradInitFloat(w0Param, NULL);
     parameter_t *w0 = parameterInit(w0Param, w0Grad);
 
-    static float b0Data[HIDDEN_DIM] = {0};
-    static size_t b0Dims[] = {1, HIDDEN_DIM};
-    tensor_t *b0Param = tensorInitWithDistribution(ZEROS, b0Data, b0Dims, 2, q, NULL, 1,
-                                                    HIDDEN_DIM);
+    /* b0 (1 x HIDDEN_DIM, ZEROS). */
+    size_t *b0Dims = reserveMemory(2 * sizeof(size_t));
+    b0Dims[0] = 1;
+    b0Dims[1] = HIDDEN_DIM;
+    size_t *b0Order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, b0Order);
+    shape_t *b0Shape = reserveMemory(sizeof(shape_t));
+    setShape(b0Shape, b0Dims, 2, b0Order);
+    tensor_t *b0Param = initTensor(b0Shape, quantizationInitFloat(), NULL);
+    initDistribution(b0Param, &zeros);
     tensor_t *b0Grad = gradInitFloat(b0Param, NULL);
     parameter_t *b0 = parameterInit(b0Param, b0Grad);
 
     model[0] = linearLayerInit(w0, b0, q, q, q, q);
     model[1] = reluLayerInit(q, q);
 
-    static float w1Data[NUM_CLASSES * HIDDEN_DIM] = {0};
-    static size_t w1Dims[] = {NUM_CLASSES, HIDDEN_DIM};
-    tensor_t *w1Param = tensorInitWithDistribution(XAVIER_UNIFORM, w1Data, w1Dims, 2, q, NULL,
-                                                    HIDDEN_DIM, NUM_CLASSES);
+    distribution_t xavier1 = {
+        .type = XAVIER_UNIFORM,
+        .params.xavier = {.gain = 1.0f, .fanIn = HIDDEN_DIM, .fanOut = NUM_CLASSES}};
+
+    /* w1 (NUM_CLASSES x HIDDEN_DIM, XAVIER_UNIFORM). */
+    size_t *w1Dims = reserveMemory(2 * sizeof(size_t));
+    w1Dims[0] = NUM_CLASSES;
+    w1Dims[1] = HIDDEN_DIM;
+    size_t *w1Order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, w1Order);
+    shape_t *w1Shape = reserveMemory(sizeof(shape_t));
+    setShape(w1Shape, w1Dims, 2, w1Order);
+    tensor_t *w1Param = initTensor(w1Shape, quantizationInitFloat(), NULL);
+    initDistribution(w1Param, &xavier1);
     tensor_t *w1Grad = gradInitFloat(w1Param, NULL);
     parameter_t *w1 = parameterInit(w1Param, w1Grad);
 
-    static float b1Data[NUM_CLASSES] = {0};
-    static size_t b1Dims[] = {1, NUM_CLASSES};
-    tensor_t *b1Param = tensorInitWithDistribution(ZEROS, b1Data, b1Dims, 2, q, NULL, 1,
-                                                    NUM_CLASSES);
+    /* b1 (1 x NUM_CLASSES, ZEROS). */
+    size_t *b1Dims = reserveMemory(2 * sizeof(size_t));
+    b1Dims[0] = 1;
+    b1Dims[1] = NUM_CLASSES;
+    size_t *b1Order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, b1Order);
+    shape_t *b1Shape = reserveMemory(sizeof(shape_t));
+    setShape(b1Shape, b1Dims, 2, b1Order);
+    tensor_t *b1Param = initTensor(b1Shape, quantizationInitFloat(), NULL);
+    initDistribution(b1Param, &zeros);
     tensor_t *b1Grad = gradInitFloat(b1Param, NULL);
     parameter_t *b1 = parameterInit(b1Param, b1Grad);
 
     model[2] = linearLayerInit(w1, b1, q, q, q, q);
     model[3] = softmaxLayerInit(q, q);
 }
-
 
 static size_t cbInvocations;
 static float firstTrainLoss;
@@ -129,7 +177,6 @@ static void captureEpoch(size_t epoch, float trainLoss, epochStats_t evalStats) 
     cbInvocations++;
 }
 
-
 /* End-to-end smoke test: runs the same pipeline as MnistExperiment at miniature
  * scale. Catches regressions in the Linear->ReLU->Linear->Softmax + CrossEntropy
  * path, trainingRun()'s epoch/batch orchestration, and the epochCallback
@@ -138,30 +185,49 @@ static void captureEpoch(size_t epoch, float trainLoss, epochStats_t evalStats) 
 void testMnistSmoke_FullTrainingPipelineReducesLoss() {
     initDataset();
 
-    dataLoader_t *trainDl = dataLoaderInit(getSample, getDatasetSize, 2,
-                                            NULL, NULL, false, 0, true);
-    dataLoader_t *evalDl = dataLoaderInit(getSample, getDatasetSize, 1,
-                                           NULL, NULL, false, 0, true);
+    dataLoader_t *trainDl =
+        dataLoaderInit(getSample, getDatasetSize, 2, NULL, NULL, false, 0, true);
+    dataLoader_t *evalDl = dataLoaderInit(getSample, getDatasetSize, 1, NULL, NULL, false, 0, true);
 
     layer_t *model[MODEL_SIZE];
-    buildModel(model);
+    quantization_t *q = NULL;
+    buildModel(model, &q);
 
     optimizer_t *sgd = sgdMCreateOptim(0.1f, 0.0f, 0.0f, model, MODEL_SIZE, FLOAT32);
 
     cbInvocations = 0;
     size_t numberOfEpochs = 20;
-    trainingRunResult_t result = trainingRun(model, MODEL_SIZE, CROSS_ENTROPY,
-                                              trainDl, evalDl, sgd, numberOfEpochs,
-                                              calculateGradsSequential, inferenceWithLoss,
-                                              captureEpoch);
+    trainingRunResult_t result =
+        trainingRun(model, MODEL_SIZE, CROSS_ENTROPY, trainDl, evalDl, sgd, numberOfEpochs,
+                    calculateGradsSequential, inferenceWithLoss, captureEpoch);
 
-    TEST_ASSERT_EQUAL_UINT(numberOfEpochs, cbInvocations);
-    TEST_ASSERT_TRUE(result.finalTrainLoss > 0.0f);
-    TEST_ASSERT_TRUE(result.finalEvalStats.accuracy >= 0.0f);
-    TEST_ASSERT_TRUE(result.finalEvalStats.accuracy <= 1.0f);
-    TEST_ASSERT_TRUE(lastTrainLoss < firstTrainLoss);
+    /* CAPTURE all assertion values into stack locals BEFORE any free. */
+    size_t capturedCbInvocations = cbInvocations;
+    float capturedFinalTrainLoss = result.finalTrainLoss;
+    float capturedAccuracy = result.finalEvalStats.accuracy;
+    float capturedFirstTrainLoss = firstTrainLoss;
+    float capturedLastTrainLoss = lastTrainLoss;
+
+    /* FREE in reverse-init order.
+     * NOTE: freeOptimSgdM cascades to all model parameters via freeParameter.
+     * Do NOT also call freeParameter on w0/b0/w1/b1 — would be a double-free. */
+    freeOptimSgdM(sgd);
+    freeSoftmaxLayer(model[3]);
+    freeLinearLayer(model[2]);
+    freeReluLayer(model[1]);
+    freeLinearLayer(model[0]);
+    freeDataLoader(evalDl);
+    freeDataLoader(trainDl);
+    freeQuantization(q);
+    freeDataset();
+
+    /* ASSERT on captured. */
+    TEST_ASSERT_EQUAL_UINT(numberOfEpochs, capturedCbInvocations);
+    TEST_ASSERT_TRUE(capturedFinalTrainLoss > 0.0f);
+    TEST_ASSERT_TRUE(capturedAccuracy >= 0.0f);
+    TEST_ASSERT_TRUE(capturedAccuracy <= 1.0f);
+    TEST_ASSERT_TRUE(capturedLastTrainLoss < capturedFirstTrainLoss);
 }
-
 
 int main() {
     UNITY_BEGIN();

--- a/test/unit/userAPI/UnitTestMnistSmoke.c
+++ b/test/unit/userAPI/UnitTestMnistSmoke.c
@@ -62,7 +62,7 @@ static void initDataset() {
 }
 
 static sample_t *getSample(size_t id) {
-    sample_t *sample = *reserveMemory(sizeof(sample_t));
+    sample_t *sample = reserveMemory(sizeof(sample_t));
     sample->item = items[id];
     sample->label = labels[id];
     return sample;

--- a/test/unit/userAPI/UnitTestMultiLayerTraining.c
+++ b/test/unit/userAPI/UnitTestMultiLayerTraining.c
@@ -2,59 +2,86 @@
 
 #include <stddef.h>
 
-#include "LossFunction.h"
-#include "TensorApi.h"
-#include "LinearApi.h"
-#include "ReluApi.h"
-#include "SoftmaxApi.h"
-#include "SgdApi.h"
-#include "unity.h"
-#include "TrainingLoopApi.h"
 #include "CalculateGradsSequential.h"
-#include "TrainingBatchDefault.h"
-#include "QuantizationApi.h"
-#include "Tensor.h"
-#include "StorageApi.h"
-#include "InferenceApi.h"
 #include "DataLoaderApi.h"
 #include "Dataset.h"
+#include "InferenceApi.h"
+#include "LinearApi.h"
+#include "LossFunction.h"
+#include "QuantizationApi.h"
+#include "ReluApi.h"
+#include "SgdApi.h"
+#include "SoftmaxApi.h"
+#include "StorageApi.h"
+#include "Tensor.h"
+#include "TensorApi.h"
+#include "TrainingBatchDefault.h"
+#include "TrainingLoopApi.h"
+#include "unity.h"
 
 void setUp() {}
 void tearDown() {}
 
 /*! Integration test: multi-layer model (Linear→ReLU→Linear→Softmax) with CrossEntropy.
  *  Reproduces the MnistExperiment structure at small scale (3→4→2).
- *  Uses tensorInitWithDistribution to init bias with ZEROS — exposes the += vs *= bug.
+ *  Uses initDistribution to init weights/biases with ZEROS — exposes the += vs *= bug.
  */
 void testMultiLayerBackward_WithCrossEntropy_DoesNotCrash() {
     quantization_t *q = quantizationInitFloat();
+    distribution_t zeros = {.type = ZEROS};
 
-    // Layer 0: Linear 3→4
-    float w0Data[4 * 3] = {0};
-    size_t w0Dims[] = {4, 3};
-    tensor_t *w0Param = tensorInitWithDistribution(ZEROS, w0Data, w0Dims, 2, q, NULL, 3, 4);
+    /* Layer 0 weights w0 (4x3, ZEROS). */
+    size_t *w0Dims = reserveMemory(2 * sizeof(size_t));
+    w0Dims[0] = 4;
+    w0Dims[1] = 3;
+    size_t *w0Order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, w0Order);
+    shape_t *w0Shape = reserveMemory(sizeof(shape_t));
+    setShape(w0Shape, w0Dims, 2, w0Order);
+    tensor_t *w0Param = initTensor(w0Shape, quantizationInitFloat(), NULL);
+    initDistribution(w0Param, &zeros);
     tensor_t *w0Grad = gradInitFloat(w0Param, NULL);
     parameter_t *w0 = parameterInit(w0Param, w0Grad);
 
-    float b0Data[4] = {0};
-    size_t b0Dims[] = {1, 4};
-    tensor_t *b0Param = tensorInitWithDistribution(ZEROS, b0Data, b0Dims, 2, q, NULL, 1, 4);
+    /* Layer 0 bias b0 (1x4, ZEROS). */
+    size_t *b0Dims = reserveMemory(2 * sizeof(size_t));
+    b0Dims[0] = 1;
+    b0Dims[1] = 4;
+    size_t *b0Order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, b0Order);
+    shape_t *b0Shape = reserveMemory(sizeof(shape_t));
+    setShape(b0Shape, b0Dims, 2, b0Order);
+    tensor_t *b0Param = initTensor(b0Shape, quantizationInitFloat(), NULL);
+    initDistribution(b0Param, &zeros);
     tensor_t *b0Grad = gradInitFloat(b0Param, NULL);
     parameter_t *b0 = parameterInit(b0Param, b0Grad);
 
     layer_t *linear0 = linearLayerInit(w0, b0, q, q, q, q);
     layer_t *relu = reluLayerInit(q, q);
 
-    // Layer 1: Linear 4→2
-    float w1Data[2 * 4] = {0};
-    size_t w1Dims[] = {2, 4};
-    tensor_t *w1Param = tensorInitWithDistribution(ZEROS, w1Data, w1Dims, 2, q, NULL, 4, 2);
+    /* Layer 1 weights w1 (2x4, ZEROS). */
+    size_t *w1Dims = reserveMemory(2 * sizeof(size_t));
+    w1Dims[0] = 2;
+    w1Dims[1] = 4;
+    size_t *w1Order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, w1Order);
+    shape_t *w1Shape = reserveMemory(sizeof(shape_t));
+    setShape(w1Shape, w1Dims, 2, w1Order);
+    tensor_t *w1Param = initTensor(w1Shape, quantizationInitFloat(), NULL);
+    initDistribution(w1Param, &zeros);
     tensor_t *w1Grad = gradInitFloat(w1Param, NULL);
     parameter_t *w1 = parameterInit(w1Param, w1Grad);
 
-    float b1Data[2] = {0};
-    size_t b1Dims[] = {1, 2};
-    tensor_t *b1Param = tensorInitWithDistribution(ZEROS, b1Data, b1Dims, 2, q, NULL, 1, 2);
+    /* Layer 1 bias b1 (1x2, ZEROS). */
+    size_t *b1Dims = reserveMemory(2 * sizeof(size_t));
+    b1Dims[0] = 1;
+    b1Dims[1] = 2;
+    size_t *b1Order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, b1Order);
+    shape_t *b1Shape = reserveMemory(sizeof(shape_t));
+    setShape(b1Shape, b1Dims, 2, b1Order);
+    tensor_t *b1Param = initTensor(b1Shape, quantizationInitFloat(), NULL);
+    initDistribution(b1Param, &zeros);
     tensor_t *b1Grad = gradInitFloat(b1Param, NULL);
     parameter_t *b1 = parameterInit(b1Param, b1Grad);
 
@@ -64,165 +91,308 @@ void testMultiLayerBackward_WithCrossEntropy_DoesNotCrash() {
     layer_t *model[] = {linear0, relu, linear1, softmax};
     size_t sizeModel = 4;
 
-    // Input: [1, 3], Label: [1, 2] (one-hot)
-    float inputData[] = {1.0f, 2.0f, 3.0f};
-    size_t inputDims[] = {1, 3};
-    tensor_t *input = tensorInitFloat(inputData, inputDims, 2, NULL);
+    /* Input (1x3). */
+    size_t *inputDims = reserveMemory(2 * sizeof(size_t));
+    inputDims[0] = 1;
+    inputDims[1] = 3;
+    size_t *inputOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, inputOrder);
+    shape_t *inputShape = reserveMemory(sizeof(shape_t));
+    setShape(inputShape, inputDims, 2, inputOrder);
+    tensor_t *input = initTensor(inputShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(input, (float[]){1.0f, 2.0f, 3.0f}, 3);
 
-    float labelData[] = {1.0f, 0.0f};
-    size_t labelDims[] = {1, 2};
-    tensor_t *label = tensorInitFloat(labelData, labelDims, 2, NULL);
+    /* Label (1x2 one-hot). */
+    size_t *labelDims = reserveMemory(2 * sizeof(size_t));
+    labelDims[0] = 1;
+    labelDims[1] = 2;
+    size_t *labelOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, labelOrder);
+    shape_t *labelShape = reserveMemory(sizeof(shape_t));
+    setShape(labelShape, labelDims, 2, labelOrder);
+    tensor_t *label = initTensor(labelShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(label, (float[]){1.0f, 0.0f}, 2);
 
-    // This is the call that crashes in the MnistExperiment
-    trainingStats_t *stats = calculateGradsSequential(model, sizeModel, CROSS_ENTROPY,
-                                                       input, label);
+    trainingStats_t *stats =
+        calculateGradsSequential(model, sizeModel, CROSS_ENTROPY, input, label);
 
-    TEST_ASSERT_NOT_NULL(stats);
-    // Loss should be finite and non-negative
-    TEST_ASSERT_TRUE(stats->loss >= 0.0f);
+    /* CAPTURE. */
+    bool capturedNotNull = (stats != NULL);
+    float capturedLoss = stats ? stats->loss : -1.0f;
 
+    /* FREE in reverse-init order. */
     freeTrainingStats(stats);
+    freeTensor(label);
+    freeTensor(input);
+    freeSoftmaxLayer(softmax);
+    freeLinearLayer(linear1);
+    freeParameter(b1);
+    freeParameter(w1);
+    freeReluLayer(relu);
+    freeLinearLayer(linear0);
+    freeParameter(b0);
+    freeParameter(w0);
+    freeQuantization(q);
+
+    /* ASSERT on captured. */
+    TEST_ASSERT_TRUE(capturedNotNull);
+    TEST_ASSERT_TRUE(capturedLoss >= 0.0f);
 }
 
-/*! Integration test: same as above but using tensorInitFloat (no distribution).
- *  This should always work — validates the backward pass logic itself is correct.
+/*! Integration test: same as above but with manually filled weights.
+ *  Validates the backward pass logic itself is correct.
  */
 void testMultiLayerBackward_WithManualInit_DoesNotCrash() {
-    quantization_t testQ;
-    initFloat32Quantization(&testQ);
+    quantization_t *q = quantizationInitFloat();
 
-    // Layer 0: Linear 3→4
-    float w0Data[] = {0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f,
-                      0.7f, 0.8f, 0.9f, 1.0f, 1.1f, 1.2f};
-    size_t w0Dims[] = {4, 3};
-    tensor_t *w0Param = tensorInitFloat(w0Data, w0Dims, 2, NULL);
-    float w0GradData[12] = {0};
-    tensor_t *w0Grad = tensorInitFloat(w0GradData, w0Dims, 2, NULL);
+    /* Layer 0 weights w0 (4x3, manual values). */
+    size_t *w0Dims = reserveMemory(2 * sizeof(size_t));
+    w0Dims[0] = 4;
+    w0Dims[1] = 3;
+    size_t *w0Order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, w0Order);
+    shape_t *w0Shape = reserveMemory(sizeof(shape_t));
+    setShape(w0Shape, w0Dims, 2, w0Order);
+    tensor_t *w0Param = initTensor(w0Shape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(
+        w0Param, (float[]){0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f, 0.7f, 0.8f, 0.9f, 1.0f, 1.1f, 1.2f},
+        12);
+    tensor_t *w0Grad = gradInitFloat(w0Param, NULL);
     parameter_t *w0 = parameterInit(w0Param, w0Grad);
 
-    float b0Data[] = {0.0f, 0.0f, 0.0f, 0.0f};
-    size_t b0Dims[] = {1, 4};
-    tensor_t *b0Param = tensorInitFloat(b0Data, b0Dims, 2, NULL);
-    float b0GradData[] = {0.0f, 0.0f, 0.0f, 0.0f};
-    tensor_t *b0Grad = tensorInitFloat(b0GradData, b0Dims, 2, NULL);
+    /* Layer 0 bias b0 (1x4, zeros). */
+    size_t *b0Dims = reserveMemory(2 * sizeof(size_t));
+    b0Dims[0] = 1;
+    b0Dims[1] = 4;
+    size_t *b0Order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, b0Order);
+    shape_t *b0Shape = reserveMemory(sizeof(shape_t));
+    setShape(b0Shape, b0Dims, 2, b0Order);
+    tensor_t *b0Param = initTensor(b0Shape, quantizationInitFloat(), NULL);
+    /* initTensor zero-initializes data per TensorApi.c:81-92, so no explicit fill. */
+    tensor_t *b0Grad = gradInitFloat(b0Param, NULL);
     parameter_t *b0 = parameterInit(b0Param, b0Grad);
 
-    layer_t *linear0 = linearLayerInit(w0, b0, &testQ, &testQ, &testQ, &testQ);
-    layer_t *relu = reluLayerInit(&testQ, &testQ);
+    layer_t *linear0 = linearLayerInit(w0, b0, q, q, q, q);
+    layer_t *relu = reluLayerInit(q, q);
 
-    // Layer 1: Linear 4→2
-    float w1Data[] = {0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f, 0.7f, 0.8f};
-    size_t w1Dims[] = {2, 4};
-    tensor_t *w1Param = tensorInitFloat(w1Data, w1Dims, 2, NULL);
-    float w1GradData[8] = {0};
-    tensor_t *w1Grad = tensorInitFloat(w1GradData, w1Dims, 2, NULL);
+    /* Layer 1 weights w1 (2x4, manual). */
+    size_t *w1Dims = reserveMemory(2 * sizeof(size_t));
+    w1Dims[0] = 2;
+    w1Dims[1] = 4;
+    size_t *w1Order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, w1Order);
+    shape_t *w1Shape = reserveMemory(sizeof(shape_t));
+    setShape(w1Shape, w1Dims, 2, w1Order);
+    tensor_t *w1Param = initTensor(w1Shape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(w1Param, (float[]){0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f, 0.7f, 0.8f},
+                              8);
+    tensor_t *w1Grad = gradInitFloat(w1Param, NULL);
     parameter_t *w1 = parameterInit(w1Param, w1Grad);
 
-    float b1Data[] = {0.0f, 0.0f};
-    size_t b1Dims[] = {1, 2};
-    tensor_t *b1Param = tensorInitFloat(b1Data, b1Dims, 2, NULL);
-    float b1GradData[] = {0.0f, 0.0f};
-    tensor_t *b1Grad = tensorInitFloat(b1GradData, b1Dims, 2, NULL);
+    /* Layer 1 bias b1 (1x2, zeros). */
+    size_t *b1Dims = reserveMemory(2 * sizeof(size_t));
+    b1Dims[0] = 1;
+    b1Dims[1] = 2;
+    size_t *b1Order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, b1Order);
+    shape_t *b1Shape = reserveMemory(sizeof(shape_t));
+    setShape(b1Shape, b1Dims, 2, b1Order);
+    tensor_t *b1Param = initTensor(b1Shape, quantizationInitFloat(), NULL);
+    tensor_t *b1Grad = gradInitFloat(b1Param, NULL);
     parameter_t *b1 = parameterInit(b1Param, b1Grad);
 
-    layer_t *linear1 = linearLayerInit(w1, b1, &testQ, &testQ, &testQ, &testQ);
-    layer_t *softmax = softmaxLayerInit(&testQ, &testQ);
+    layer_t *linear1 = linearLayerInit(w1, b1, q, q, q, q);
+    layer_t *softmax = softmaxLayerInit(q, q);
 
     layer_t *model[] = {linear0, relu, linear1, softmax};
     size_t sizeModel = 4;
 
-    float inputData[] = {1.0f, 2.0f, 3.0f};
-    size_t inputDims[] = {1, 3};
-    tensor_t *input = tensorInitFloat(inputData, inputDims, 2, NULL);
+    /* Input (1x3). */
+    size_t *inputDims = reserveMemory(2 * sizeof(size_t));
+    inputDims[0] = 1;
+    inputDims[1] = 3;
+    size_t *inputOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, inputOrder);
+    shape_t *inputShape = reserveMemory(sizeof(shape_t));
+    setShape(inputShape, inputDims, 2, inputOrder);
+    tensor_t *input = initTensor(inputShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(input, (float[]){1.0f, 2.0f, 3.0f}, 3);
 
-    float labelData[] = {1.0f, 0.0f};
-    size_t labelDims[] = {1, 2};
-    tensor_t *label = tensorInitFloat(labelData, labelDims, 2, NULL);
+    /* Label (1x2). */
+    size_t *labelDims = reserveMemory(2 * sizeof(size_t));
+    labelDims[0] = 1;
+    labelDims[1] = 2;
+    size_t *labelOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, labelOrder);
+    shape_t *labelShape = reserveMemory(sizeof(shape_t));
+    setShape(labelShape, labelDims, 2, labelOrder);
+    tensor_t *label = initTensor(labelShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(label, (float[]){1.0f, 0.0f}, 2);
 
-    trainingStats_t *stats = calculateGradsSequential(model, sizeModel, CROSS_ENTROPY,
-                                                       input, label);
+    trainingStats_t *stats =
+        calculateGradsSequential(model, sizeModel, CROSS_ENTROPY, input, label);
 
-    TEST_ASSERT_NOT_NULL(stats);
-    TEST_ASSERT_TRUE(stats->loss >= 0.0f);
-
-    // Verify bias grads were accumulated (not zero after backward)
-    float *b1GradValues = (float *)b1Grad->data;
-    bool anyNonZero = false;
-    for (size_t i = 0; i < 2; i++) {
-        if (b1GradValues[i] != 0.0f) {
-            anyNonZero = true;
-            break;
+    /* CAPTURE. The original test checks that b1Grad has at least one nonzero
+     * value AFTER the backward pass; we capture that boolean before frees so
+     * the post-free freeParameter(b1) doesn't zero or invalidate b1Grad. */
+    bool capturedNotNull = (stats != NULL);
+    float capturedLoss = stats ? stats->loss : -1.0f;
+    bool capturedAnyNonZero = false;
+    if (b1Grad && b1Grad->data) {
+        float *vals = (float *)b1Grad->data;
+        for (size_t i = 0; i < 2; i++) {
+            if (vals[i] != 0.0f) {
+                capturedAnyNonZero = true;
+                break;
+            }
         }
     }
-    TEST_ASSERT_TRUE(anyNonZero);
 
+    /* FREE in reverse-init order. */
     freeTrainingStats(stats);
+    freeTensor(label);
+    freeTensor(input);
+    freeSoftmaxLayer(softmax);
+    freeLinearLayer(linear1);
+    freeParameter(b1);
+    freeParameter(w1);
+    freeReluLayer(relu);
+    freeLinearLayer(linear0);
+    freeParameter(b0);
+    freeParameter(w0);
+    freeQuantization(q);
+
+    /* ASSERT on captured. */
+    TEST_ASSERT_TRUE(capturedNotNull);
+    TEST_ASSERT_TRUE(capturedLoss >= 0.0f);
+    TEST_ASSERT_TRUE(capturedAnyNonZero);
 }
 
 /*! Integration test: run multiple training steps to verify grad accumulation is stable. */
 void testMultiLayerTraining_MultipleSteps_GradsAccumulate() {
-    quantization_t testQ;
-    initFloat32Quantization(&testQ);
+    quantization_t *q = quantizationInitFloat();
 
-    float w0Data[] = {0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f,
-                      0.7f, 0.8f, 0.9f, 1.0f, 1.1f, 1.2f};
-    size_t w0Dims[] = {4, 3};
-    tensor_t *w0Param = tensorInitFloat(w0Data, w0Dims, 2, NULL);
-    float w0GradData[12] = {0};
-    tensor_t *w0Grad = tensorInitFloat(w0GradData, w0Dims, 2, NULL);
+    /* Layer 0 weights w0 (4x3). */
+    size_t *w0Dims = reserveMemory(2 * sizeof(size_t));
+    w0Dims[0] = 4;
+    w0Dims[1] = 3;
+    size_t *w0Order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, w0Order);
+    shape_t *w0Shape = reserveMemory(sizeof(shape_t));
+    setShape(w0Shape, w0Dims, 2, w0Order);
+    tensor_t *w0Param = initTensor(w0Shape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(
+        w0Param, (float[]){0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f, 0.7f, 0.8f, 0.9f, 1.0f, 1.1f, 1.2f},
+        12);
+    tensor_t *w0Grad = gradInitFloat(w0Param, NULL);
     parameter_t *w0 = parameterInit(w0Param, w0Grad);
 
-    float b0Data[] = {0.0f, 0.0f, 0.0f, 0.0f};
-    size_t b0Dims[] = {1, 4};
-    tensor_t *b0Param = tensorInitFloat(b0Data, b0Dims, 2, NULL);
-    float b0GradData[] = {0.0f, 0.0f, 0.0f, 0.0f};
-    tensor_t *b0Grad = tensorInitFloat(b0GradData, b0Dims, 2, NULL);
+    /* Layer 0 bias b0 (1x4, zeros). */
+    size_t *b0Dims = reserveMemory(2 * sizeof(size_t));
+    b0Dims[0] = 1;
+    b0Dims[1] = 4;
+    size_t *b0Order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, b0Order);
+    shape_t *b0Shape = reserveMemory(sizeof(shape_t));
+    setShape(b0Shape, b0Dims, 2, b0Order);
+    tensor_t *b0Param = initTensor(b0Shape, quantizationInitFloat(), NULL);
+    tensor_t *b0Grad = gradInitFloat(b0Param, NULL);
     parameter_t *b0 = parameterInit(b0Param, b0Grad);
 
-    layer_t *linear0 = linearLayerInit(w0, b0, &testQ, &testQ, &testQ, &testQ);
-    layer_t *relu = reluLayerInit(&testQ, &testQ);
+    layer_t *linear0 = linearLayerInit(w0, b0, q, q, q, q);
+    layer_t *relu = reluLayerInit(q, q);
 
-    float w1Data[] = {0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f, 0.7f, 0.8f};
-    size_t w1Dims[] = {2, 4};
-    tensor_t *w1Param = tensorInitFloat(w1Data, w1Dims, 2, NULL);
-    float w1GradData[8] = {0};
-    tensor_t *w1Grad = tensorInitFloat(w1GradData, w1Dims, 2, NULL);
+    /* Layer 1 weights w1 (2x4). */
+    size_t *w1Dims = reserveMemory(2 * sizeof(size_t));
+    w1Dims[0] = 2;
+    w1Dims[1] = 4;
+    size_t *w1Order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, w1Order);
+    shape_t *w1Shape = reserveMemory(sizeof(shape_t));
+    setShape(w1Shape, w1Dims, 2, w1Order);
+    tensor_t *w1Param = initTensor(w1Shape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(w1Param, (float[]){0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f, 0.7f, 0.8f},
+                              8);
+    tensor_t *w1Grad = gradInitFloat(w1Param, NULL);
     parameter_t *w1 = parameterInit(w1Param, w1Grad);
 
-    float b1Data[] = {0.0f, 0.0f};
-    size_t b1Dims[] = {1, 2};
-    tensor_t *b1Param = tensorInitFloat(b1Data, b1Dims, 2, NULL);
-    float b1GradData[] = {0.0f, 0.0f};
-    tensor_t *b1Grad = tensorInitFloat(b1GradData, b1Dims, 2, NULL);
+    /* Layer 1 bias b1 (1x2). */
+    size_t *b1Dims = reserveMemory(2 * sizeof(size_t));
+    b1Dims[0] = 1;
+    b1Dims[1] = 2;
+    size_t *b1Order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, b1Order);
+    shape_t *b1Shape = reserveMemory(sizeof(shape_t));
+    setShape(b1Shape, b1Dims, 2, b1Order);
+    tensor_t *b1Param = initTensor(b1Shape, quantizationInitFloat(), NULL);
+    tensor_t *b1Grad = gradInitFloat(b1Param, NULL);
     parameter_t *b1 = parameterInit(b1Param, b1Grad);
 
-    layer_t *linear1 = linearLayerInit(w1, b1, &testQ, &testQ, &testQ, &testQ);
-    layer_t *softmax = softmaxLayerInit(&testQ, &testQ);
+    layer_t *linear1 = linearLayerInit(w1, b1, q, q, q, q);
+    layer_t *softmax = softmaxLayerInit(q, q);
 
     layer_t *model[] = {linear0, relu, linear1, softmax};
     size_t sizeModel = 4;
 
+    /* Optimizer takes references to w0/b0/w1/b1 — its free will cascade. */
     optimizer_t *sgd = sgdMCreateOptim(0.01f, 0.f, 0.f, model, sizeModel, FLOAT32);
     optimizerFunctions_t sgdFns = optimizerFunctions[SGD_M];
 
-    float inputData[] = {1.0f, 2.0f, 3.0f};
-    size_t inputDims[] = {1, 3};
-    tensor_t *input = tensorInitFloat(inputData, inputDims, 2, NULL);
+    /* Input (1x3). */
+    size_t *inputDims = reserveMemory(2 * sizeof(size_t));
+    inputDims[0] = 1;
+    inputDims[1] = 3;
+    size_t *inputOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, inputOrder);
+    shape_t *inputShape = reserveMemory(sizeof(shape_t));
+    setShape(inputShape, inputDims, 2, inputOrder);
+    tensor_t *input = initTensor(inputShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(input, (float[]){1.0f, 2.0f, 3.0f}, 3);
 
-    float labelData[] = {1.0f, 0.0f};
-    size_t labelDims[] = {1, 2};
-    tensor_t *label = tensorInitFloat(labelData, labelDims, 2, NULL);
+    /* Label (1x2). */
+    size_t *labelDims = reserveMemory(2 * sizeof(size_t));
+    labelDims[0] = 1;
+    labelDims[1] = 2;
+    size_t *labelOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, labelOrder);
+    shape_t *labelShape = reserveMemory(sizeof(shape_t));
+    setShape(labelShape, labelDims, 2, labelOrder);
+    tensor_t *label = initTensor(labelShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(label, (float[]){1.0f, 0.0f}, 2);
 
-    // Run 3 training steps
+    /* Run 3 training steps. CAPTURE per-step assertions into a per-step
+     * tracking array; assert at end after all frees. */
+    bool capturedNotNull[3];
+    float capturedLoss[3];
     for (size_t step = 0; step < 3; step++) {
-        trainingStats_t *stats = calculateGradsSequential(model, sizeModel, CROSS_ENTROPY,
-                                                           input, label);
-        TEST_ASSERT_NOT_NULL(stats);
-        TEST_ASSERT_TRUE(stats->loss >= 0.0f);
+        trainingStats_t *stats =
+            calculateGradsSequential(model, sizeModel, CROSS_ENTROPY, input, label);
+        capturedNotNull[step] = (stats != NULL);
+        capturedLoss[step] = stats ? stats->loss : -1.0f;
         freeTrainingStats(stats);
 
         sgdFns.step(sgd);
         sgdFns.zero(sgd);
+    }
+
+    /* FREE in reverse-init order.
+     * NOTE: freeOptimSgdM cascades to w0, b0, w1, b1 via freeParameter (per
+     * SgdApi.c:85-93). Do NOT also call freeParameter(w0/b0/w1/b1) here — it
+     * would be a double-free. */
+    freeTensor(label);
+    freeTensor(input);
+    freeOptimSgdM(sgd);
+    freeSoftmaxLayer(softmax);
+    freeLinearLayer(linear1);
+    freeReluLayer(relu);
+    freeLinearLayer(linear0);
+    freeQuantization(q);
+
+    /* ASSERT on captured. */
+    for (size_t step = 0; step < 3; step++) {
+        TEST_ASSERT_TRUE(capturedNotNull[step]);
+        TEST_ASSERT_TRUE(capturedLoss[step] >= 0.0f);
     }
 }
 

--- a/test/unit/userAPI/UnitTestStorageApi.c
+++ b/test/unit/userAPI/UnitTestStorageApi.c
@@ -1,0 +1,55 @@
+#include <stddef.h>
+#include <stdint.h>
+
+#include "StorageApi.h"
+#include "unity.h"
+
+/* Compile-time contract: reserveMemory returns the allocated payload
+ * directly (void *), and freeReservedMemory accepts that same payload.
+ * The old void ** handle-indirection is removed; see issue #99 comment
+ * for the design rationale (a real handle-table allocator will reintroduce
+ * a typed opaque handle type later, not void **). */
+_Static_assert(_Generic((&reserveMemory), void *(*)(size_t): 1, default: 0),
+               "reserveMemory must return void * (payload), not void ** (handle)");
+_Static_assert(_Generic((&freeReservedMemory), void (*)(void *): 1, default: 0),
+               "freeReservedMemory must take void * (payload)");
+
+void testReserveMemoryReturnsZeroedWritablePayload(void) {
+    uint8_t *payload = reserveMemory(64);
+    TEST_ASSERT_NOT_NULL(payload);
+
+    for (size_t i = 0; i < 64; ++i) {
+        TEST_ASSERT_EQUAL_UINT8(0, payload[i]);
+    }
+    payload[0] = 0xAA;
+    payload[63] = 0x55;
+    TEST_ASSERT_EQUAL_UINT8(0xAA, payload[0]);
+    TEST_ASSERT_EQUAL_UINT8(0x55, payload[63]);
+
+    freeReservedMemory(payload);
+}
+
+void testReserveAndFreeRoundTrip(void) {
+    int *payload = reserveMemory(sizeof(int));
+    TEST_ASSERT_NOT_NULL(payload);
+
+    *payload = 42;
+    TEST_ASSERT_EQUAL_INT(42, *payload);
+
+    freeReservedMemory(payload);
+}
+
+void testFreeReservedMemoryIsNullSafe(void) {
+    freeReservedMemory(NULL);
+}
+
+void setUp() {}
+void tearDown() {}
+
+int main(void) {
+    UNITY_BEGIN();
+    RUN_TEST(testReserveMemoryReturnsZeroedWritablePayload);
+    RUN_TEST(testReserveAndFreeRoundTrip);
+    RUN_TEST(testFreeReservedMemoryIsNullSafe);
+    return UNITY_END();
+}

--- a/test/unit/userAPI/UnitTestTrainingLoopApi.c
+++ b/test/unit/userAPI/UnitTestTrainingLoopApi.c
@@ -13,6 +13,7 @@
 #include "ReluApi.h"
 #include "SgdApi.h"
 #include "StorageApi.h"
+#include "Tensor.h"
 #include "TensorApi.h"
 #include "TensorConversion.h"
 #include "TrainingBatchDefault.h"
@@ -20,33 +21,29 @@
 #include "TrainingLoopApi.h"
 #include "unity.h"
 
-void testCalculateGradsSequential_MatchesPyTorch() {
-    float weightData[] = {1.f, 1.f, 1.f, 1.f, 1.f, 1.f};
-    size_t weightDims[] = {2, 3};
-    tensor_t *weightsParam = tensorInitFloat(weightData, weightDims, 2, NULL);
+/* Build a fresh 2-D float tensor from a literal float buffer. Encapsulates the
+ * post-#106 chain so each test stays readable. */
+static tensor_t *buildFloatTensor2D(size_t d0, size_t d1, const float *src, size_t count) {
+    size_t *dims = reserveMemory(2 * sizeof(size_t));
+    dims[0] = d0;
+    dims[1] = d1;
+    size_t *order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, order);
+    shape_t *shape = reserveMemory(sizeof(shape_t));
+    setShape(shape, dims, 2, order);
+    tensor_t *t = initTensor(shape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(t, src, count);
+    return t;
+}
 
-    float weightGradData[] = {0.f, 0.f, 0.f, 0.f, 0.f, 0.f};
-    tensor_t *weightsGrad = tensorInitFloat(weightGradData, weightDims, 2, NULL);
+void testCalculateGradsSequential_MatchesPyTorch() {
+    tensor_t *weightsParam = buildFloatTensor2D(2, 3, (float[]){1.f, 1.f, 1.f, 1.f, 1.f, 1.f}, 6);
+    tensor_t *weightsGrad = gradInitFloat(weightsParam, NULL);
     parameter_t *weights = parameterInit(weightsParam, weightsGrad);
 
-    float biasData[] = {-1.f, 3.f};
-    size_t biasDims[] = {1, 2};
-    tensor_t *biasParam = tensorInitFloat(biasData, biasDims, 2, NULL);
-    float biasGradData[] = {0.f, 0.f};
-    tensor_t *biasGrad = tensorInitFloat(biasGradData, biasDims, 2, NULL);
+    tensor_t *biasParam = buildFloatTensor2D(1, 2, (float[]){-1.f, 3.f}, 2);
+    tensor_t *biasGrad = gradInitFloat(biasParam, NULL);
     parameter_t *bias = parameterInit(biasParam, biasGrad);
-
-    float input0Data[] = {-4.f, 1.f, 9.f};
-    size_t input0Dims[] = {1, 3};
-    tensor_t *input0 = tensorInitFloat(input0Data, input0Dims, 2, NULL);
-
-    float input1Data[] = {5.f, -1.f, 2.f};
-    size_t input1Dims[] = {1, 3};
-    tensor_t *input1 = tensorInitFloat(input1Data, input1Dims, 2, NULL);
-
-    float input2Data[] = {-7.f, -5.f, 6.f};
-    size_t input2Dims[] = {1, 3};
-    tensor_t *input2 = tensorInitFloat(input2Data, input2Dims, 2, NULL);
 
     quantization_t testQ;
     initFloat32Quantization(&testQ);
@@ -55,20 +52,20 @@ void testCalculateGradsSequential_MatchesPyTorch() {
     layer_t *model[] = {linear};
     size_t sizeModel = 1;
 
-    float label0Data[] = {59.f, -23.f};
-    size_t label0Dims[] = {1, 2};
-    tensor_t *label0 = tensorInitFloat(label0Data, label0Dims, 2, NULL);
+    tensor_t *input0 = buildFloatTensor2D(1, 3, (float[]){-4.f, 1.f, 9.f}, 3);
+    tensor_t *input1 = buildFloatTensor2D(1, 3, (float[]){5.f, -1.f, 2.f}, 3);
+    tensor_t *input2 = buildFloatTensor2D(1, 3, (float[]){-7.f, -5.f, 6.f}, 3);
 
-    float label1Data[] = {43.f, 249.f};
-    size_t label1Dims[] = {1, 2};
-    tensor_t *label1 = tensorInitFloat(label1Data, label1Dims, 2, NULL);
-
-    float label2Data[] = {23.f, 457.f};
-    size_t label2Dims[] = {1, 2};
-    tensor_t *label2 = tensorInitFloat(label2Data, label2Dims, 2, NULL);
+    tensor_t *label0 = buildFloatTensor2D(1, 2, (float[]){59.f, -23.f}, 2);
+    tensor_t *label1 = buildFloatTensor2D(1, 2, (float[]){43.f, 249.f}, 2);
+    tensor_t *label2 = buildFloatTensor2D(1, 2, (float[]){23.f, 457.f}, 2);
 
     optimizer_t *sgd = sgdMCreateOptim(0.01f, 0.f, 0.f, model, sizeModel, FLOAT32);
     optimizerFunctions_t sgdFns = optimizerFunctions[SGD_M];
+    /* Pre-existing test hack: only step weights, leaving bias unchanged across
+     * iterations. We restore sizeStates to 2 before the free below so
+     * freeOptimSgdM cascades to BOTH registered parameters and their state
+     * buffers (otherwise parameter[1]/states[1] would leak). */
     sgd->sizeStates = 1;
 
     for (size_t i = 0; i < 23; i++) {
@@ -84,31 +81,45 @@ void testCalculateGradsSequential_MatchesPyTorch() {
         freeTrainingStats(ts2);
     }
 
+    /* CAPTURE assertion values into stack locals BEFORE any free. */
     float expectedWeights[] = {5.f, -1.f, 9.f, 22.f, -100.f, 18.f};
     linearConfig_t *linearConfig = linear->config->linear;
-    float *actualWeights = (float *)linearConfig->weights->param->data;
+    float capturedActualWeights[6];
+    {
+        float *actualWeights = (float *)linearConfig->weights->param->data;
+        for (size_t i = 0; i < 6; i++) {
+            capturedActualWeights[i] = actualWeights[i];
+        }
+    }
 
+    /* FREE in reverse-init order. Restore sizeStates so freeOptimSgdM cascades
+     * to both weights and bias parameters + their state buffers. */
+    sgd->sizeStates = 2;
+    freeOptimSgdM(sgd);
+    freeTensor(label2);
+    freeTensor(label1);
+    freeTensor(label0);
+    freeTensor(input2);
+    freeTensor(input1);
+    freeTensor(input0);
+    freeLinearLayer(linear);
+
+    /* ASSERT on captured. */
     const float errorPercent = 0.03f;
     for (size_t i = 0; i < 6; i++) {
-        float currentThreshold = actualWeights[i] * errorPercent;
-        TEST_ASSERT_FLOAT_WITHIN(currentThreshold, expectedWeights[i], actualWeights[i]);
+        float currentThreshold = capturedActualWeights[i] * errorPercent;
+        TEST_ASSERT_FLOAT_WITHIN(currentThreshold, expectedWeights[i], capturedActualWeights[i]);
     }
 }
 
 void testEvaluationBatch_ReturnsAverageLoss() {
-    // Set up a simple linear model: weights=[1,1,1,1,1,1] shape=[2,3], bias=[-1,3]
-    float weightData[] = {1.f, 1.f, 1.f, 1.f, 1.f, 1.f};
-    size_t weightDims[] = {2, 3};
-    tensor_t *wParam = tensorInitFloat(weightData, weightDims, 2, NULL);
-    float wGradData[] = {0.f, 0.f, 0.f, 0.f, 0.f, 0.f};
-    tensor_t *wGrad = tensorInitFloat(wGradData, weightDims, 2, NULL);
+    /* Set up a simple linear model: weights=[1,1,1,1,1,1] shape=[2,3], bias=[-1,3] */
+    tensor_t *wParam = buildFloatTensor2D(2, 3, (float[]){1.f, 1.f, 1.f, 1.f, 1.f, 1.f}, 6);
+    tensor_t *wGrad = gradInitFloat(wParam, NULL);
     parameter_t *w = parameterInit(wParam, wGrad);
 
-    float biasData[] = {-1.f, 3.f};
-    size_t biasDims[] = {1, 2};
-    tensor_t *bParam = tensorInitFloat(biasData, biasDims, 2, NULL);
-    float bGradData[] = {0.f, 0.f};
-    tensor_t *bGrad = tensorInitFloat(bGradData, biasDims, 2, NULL);
+    tensor_t *bParam = buildFloatTensor2D(1, 2, (float[]){-1.f, 3.f}, 2);
+    tensor_t *bGrad = gradInitFloat(bParam, NULL);
     parameter_t *b = parameterInit(bParam, bGrad);
 
     quantization_t testQ;
@@ -116,28 +127,21 @@ void testEvaluationBatch_ReturnsAverageLoss() {
     layer_t *linear = linearLayerInit(w, b, &testQ, &testQ, &testQ, &testQ);
     layer_t *model[] = {linear};
 
-    // Create 2 samples manually
-    float input0Data[] = {0.f, 1.f, 2.f};
-    size_t inputDims[] = {1, 3};
-    tensor_t *input0 = tensorInitFloat(input0Data, inputDims, 2, NULL);
-    float label0Data[] = {10.f, 20.f};
-    size_t labelDims[] = {1, 2};
-    tensor_t *label0 = tensorInitFloat(label0Data, labelDims, 2, NULL);
+    /* Create 2 samples manually */
+    tensor_t *input0 = buildFloatTensor2D(1, 3, (float[]){0.f, 1.f, 2.f}, 3);
+    tensor_t *label0 = buildFloatTensor2D(1, 2, (float[]){10.f, 20.f}, 2);
+    tensor_t *input1 = buildFloatTensor2D(1, 3, (float[]){1.f, 0.f, 0.f}, 3);
+    tensor_t *label1 = buildFloatTensor2D(1, 2, (float[]){5.f, 5.f}, 2);
 
-    float input1Data[] = {1.f, 0.f, 0.f};
-    tensor_t *input1 = tensorInitFloat(input1Data, inputDims, 2, NULL);
-    float label1Data[] = {5.f, 5.f};
-    tensor_t *label1 = tensorInitFloat(label1Data, labelDims, 2, NULL);
-
-    // Compute expected losses via inferenceWithLoss directly
+    /* Compute expected losses via inferenceWithLoss directly */
     inferenceStats_t *stats0 = inferenceWithLoss(model, 1, input0, label0, MSE);
     inferenceStats_t *stats1 = inferenceWithLoss(model, 1, input1, label1, MSE);
     float expectedAvgLoss = (stats0->loss + stats1->loss) / 2.0f;
     freeInferenceStats(stats0);
     freeInferenceStats(stats1);
 
-    // Build a batch. Samples must be heap-allocated: evaluationBatch frees
-    // each via freeSample (the batch-consumer convention set by #119).
+    /* Build a batch. Samples must be heap-allocated: evaluationBatch frees
+     * each via freeSample (the batch-consumer convention set by #119). */
     sample_t *s0 = reserveMemory(sizeof(sample_t));
     s0->item = input0;
     s0->label = label0;
@@ -149,53 +153,79 @@ void testEvaluationBatch_ReturnsAverageLoss() {
 
     float actualAvgLoss = evaluationBatch(model, 1, MSE, &batch, inferenceWithLoss);
 
-    TEST_ASSERT_FLOAT_WITHIN(1e-5f, expectedAvgLoss, actualAvgLoss);
+    /* CAPTURE. */
+    float capturedExpected = expectedAvgLoss;
+    float capturedActual = actualAvgLoss;
+
+    /* FREE in reverse-init order. evaluationBatch consumed s0/s1 (freed via
+     * freeSample inside the production loop). The tensors they referenced
+     * (input0/label0/input1/label1) are still ours to free. */
+    freeTensor(label1);
+    freeTensor(input1);
+    freeTensor(label0);
+    freeTensor(input0);
+    freeLinearLayer(linear);
+    freeParameter(b);
+    freeParameter(w);
+
+    /* ASSERT on captured. */
+    TEST_ASSERT_FLOAT_WITHIN(1e-5f, capturedExpected, capturedActual);
 }
 
-// Test dataset for epoch-level tests: 4 samples, batchSize=2 → 2 batches
+/* Test dataset for epoch-level tests: 4 samples, batchSize=2 → 2 batches.
+ * File-scope so the dataLoader callback can reach it. Each test that calls
+ * initEpochDataset() must call freeEpochDataset() at end so the per-test
+ * teardown idiom holds (no shared lazy-init/never-free state).
+ *
+ * Mirrors the dataset pattern in UnitTestMnistSmoke.c (#120). */
 static tensor_t *epochItems[4];
 static tensor_t *epochLabels[4];
 static dataset_t epochDataset;
+static tensorArray_t epochItemsArr;
+static tensorArray_t epochLabelsArr;
 static bool epochDatasetInit = false;
+
+static const float epochItemDataLiteral[4][2] = {
+    {5.f, 1.f},
+    {1.f, 5.f},
+    {3.f, 1.f},
+    {1.f, 3.f},
+};
+static const float epochLabelDataLiteral[4][2] = {
+    {1.f, 0.f},
+    {0.f, 1.f},
+    {1.f, 0.f},
+    {0.f, 1.f},
+};
 
 static void initEpochDataset() {
     if (epochDatasetInit) {
         return;
     }
+    for (size_t i = 0; i < 4; i++) {
+        epochItems[i] = buildFloatTensor2D(1, 2, epochItemDataLiteral[i], 2);
+        epochLabels[i] = buildFloatTensor2D(1, 2, epochLabelDataLiteral[i], 2);
+    }
 
-    // 4 samples: input [1,2], label [1,0] or [0,1]
-    static float in0[] = {5.f, 1.f};
-    static float in1[] = {1.f, 5.f};
-    static float in2[] = {3.f, 1.f};
-    static float in3[] = {1.f, 3.f};
-    static float lb0[] = {1.f, 0.f};
-    static float lb1[] = {0.f, 1.f};
-    static float lb2[] = {1.f, 0.f};
-    static float lb3[] = {0.f, 1.f};
+    epochItemsArr.array = epochItems;
+    epochItemsArr.size = 4;
+    epochLabelsArr.array = epochLabels;
+    epochLabelsArr.size = 4;
 
-    static size_t inDims[] = {1, 2};
-    static size_t lbDims[] = {1, 2};
-
-    epochItems[0] = tensorInitFloat(in0, inDims, 2, NULL);
-    epochItems[1] = tensorInitFloat(in1, inDims, 2, NULL);
-    epochItems[2] = tensorInitFloat(in2, inDims, 2, NULL);
-    epochItems[3] = tensorInitFloat(in3, inDims, 2, NULL);
-
-    epochLabels[0] = tensorInitFloat(lb0, lbDims, 2, NULL);
-    epochLabels[1] = tensorInitFloat(lb1, lbDims, 2, NULL);
-    epochLabels[2] = tensorInitFloat(lb2, lbDims, 2, NULL);
-    epochLabels[3] = tensorInitFloat(lb3, lbDims, 2, NULL);
-
-    static tensorArray_t itemsArr;
-    itemsArr.array = epochItems;
-    itemsArr.size = 4;
-    static tensorArray_t labelsArr;
-    labelsArr.array = epochLabels;
-    labelsArr.size = 4;
-
-    epochDataset.items = &itemsArr;
-    epochDataset.labels = &labelsArr;
+    epochDataset.items = &epochItemsArr;
+    epochDataset.labels = &epochLabelsArr;
     epochDatasetInit = true;
+}
+
+static void freeEpochDataset() {
+    if (!epochDatasetInit) {
+        return;
+    }
+    for (size_t i = 0; i < 4; i++) {
+        freeTensor(epochItems[i]);
+        freeTensor(epochLabels[i]);
+    }
+    epochDatasetInit = false;
 }
 
 static sample_t *getEpochSample(size_t id) {
@@ -212,19 +242,13 @@ static size_t getEpochDatasetSize() {
 void testEvaluationEpoch_ReturnsAverageLossAcrossBatches() {
     initEpochDataset();
 
-    // Identity model
-    float wData[] = {1.f, 0.f, 0.f, 1.f};
-    size_t wDims[] = {2, 2};
-    tensor_t *wParam = tensorInitFloat(wData, wDims, 2, NULL);
-    float wgData[] = {0.f, 0.f, 0.f, 0.f};
-    tensor_t *wGrad = tensorInitFloat(wgData, wDims, 2, NULL);
+    /* Identity model */
+    tensor_t *wParam = buildFloatTensor2D(2, 2, (float[]){1.f, 0.f, 0.f, 1.f}, 4);
+    tensor_t *wGrad = gradInitFloat(wParam, NULL);
     parameter_t *w = parameterInit(wParam, wGrad);
 
-    float bData[] = {0.f, 0.f};
-    size_t bDims[] = {1, 2};
-    tensor_t *bParam = tensorInitFloat(bData, bDims, 2, NULL);
-    float bgData[] = {0.f, 0.f};
-    tensor_t *bGrad = tensorInitFloat(bgData, bDims, 2, NULL);
+    tensor_t *bParam = buildFloatTensor2D(1, 2, (float[]){0.f, 0.f}, 2);
+    tensor_t *bGrad = gradInitFloat(bParam, NULL);
     parameter_t *b = parameterInit(bParam, bGrad);
 
     quantization_t testQ;
@@ -237,31 +261,35 @@ void testEvaluationEpoch_ReturnsAverageLossAcrossBatches() {
 
     float totalAvg = evaluationEpoch(model, 1, MSE, dl, inferenceWithLoss);
 
-    // Identity model output = input, so loss = MSE(input, label)
-    // s0: MSE([5,1],[1,0]) = ((5-1)^2+(1-0)^2)/2 = 8.5
-    // s1: MSE([1,5],[0,1]) = ((1-0)^2+(5-1)^2)/2 = 8.5
-    // s2: MSE([3,1],[1,0]) = ((3-1)^2+(1-0)^2)/2 = 2.5
-    // s3: MSE([1,3],[0,1]) = ((1-0)^2+(3-1)^2)/2 = 2.5
-    // 4 batches of 1, avg of per-batch avg = (8.5+8.5+2.5+2.5)/4 = 5.5
-    TEST_ASSERT_FLOAT_WITHIN(0.01f, 5.5f, totalAvg);
+    /* CAPTURE. */
+    float capturedTotalAvg = totalAvg;
+
+    /* FREE. */
+    freeDataLoader(dl);
+    freeLinearLayer(linear);
+    freeParameter(b);
+    freeParameter(w);
+    freeEpochDataset();
+
+    /* Identity model output = input, so loss = MSE(input, label)
+     * s0: MSE([5,1],[1,0]) = ((5-1)^2+(1-0)^2)/2 = 8.5
+     * s1: MSE([1,5],[0,1]) = ((1-0)^2+(5-1)^2)/2 = 8.5
+     * s2: MSE([3,1],[1,0]) = ((3-1)^2+(1-0)^2)/2 = 2.5
+     * s3: MSE([1,3],[0,1]) = ((1-0)^2+(3-1)^2)/2 = 2.5
+     * 4 batches of 1, avg of per-batch avg = (8.5+8.5+2.5+2.5)/4 = 5.5 */
+    TEST_ASSERT_FLOAT_WITHIN(0.01f, 5.5f, capturedTotalAvg);
 }
 
 void testEvaluationEpoch_MinibatchMatchesMicrobatchAverage() {
     initEpochDataset();
 
-    // Identity model — output = input, so loss = MSE(input, label)
-    float wData[] = {1.f, 0.f, 0.f, 1.f};
-    size_t wDims[] = {2, 2};
-    tensor_t *wParam = tensorInitFloat(wData, wDims, 2, NULL);
-    float wgData[] = {0.f, 0.f, 0.f, 0.f};
-    tensor_t *wGrad = tensorInitFloat(wgData, wDims, 2, NULL);
+    /* Identity model — output = input, so loss = MSE(input, label) */
+    tensor_t *wParam = buildFloatTensor2D(2, 2, (float[]){1.f, 0.f, 0.f, 1.f}, 4);
+    tensor_t *wGrad = gradInitFloat(wParam, NULL);
     parameter_t *w = parameterInit(wParam, wGrad);
 
-    float bData[] = {0.f, 0.f};
-    size_t bDims[] = {1, 2};
-    tensor_t *bParam = tensorInitFloat(bData, bDims, 2, NULL);
-    float bgData[] = {0.f, 0.f};
-    tensor_t *bGrad = tensorInitFloat(bgData, bDims, 2, NULL);
+    tensor_t *bParam = buildFloatTensor2D(1, 2, (float[]){0.f, 0.f}, 2);
+    tensor_t *bGrad = gradInitFloat(bParam, NULL);
     parameter_t *b = parameterInit(bParam, bGrad);
 
     quantization_t testQ;
@@ -269,32 +297,37 @@ void testEvaluationEpoch_MinibatchMatchesMicrobatchAverage() {
     layer_t *linear = linearLayerInit(w, b, &testQ, &testQ, &testQ, &testQ);
     layer_t *model[] = {linear};
 
-    // batchSize=2 → 2 minibatches of 2 samples each
-    // Per-sample losses: 8.5, 8.5, 2.5, 2.5
-    // Batch 0 avg = (8.5+8.5)/2 = 8.5; Batch 1 avg = (2.5+2.5)/2 = 2.5
-    // Epoch avg = (8.5+2.5)/2 = 5.5 — identical to microbatch result
+    /* batchSize=2 → 2 minibatches of 2 samples each
+     * Per-sample losses: 8.5, 8.5, 2.5, 2.5
+     * Batch 0 avg = (8.5+8.5)/2 = 8.5; Batch 1 avg = (2.5+2.5)/2 = 2.5
+     * Epoch avg = (8.5+2.5)/2 = 5.5 — identical to microbatch result */
     dataLoader_t *dl =
         dataLoaderInit(getEpochSample, getEpochDatasetSize, 2, NULL, NULL, false, 0, true);
 
     float totalAvg = evaluationEpoch(model, 1, MSE, dl, inferenceWithLoss);
 
-    TEST_ASSERT_FLOAT_WITHIN(0.01f, 5.5f, totalAvg);
+    /* CAPTURE. */
+    float capturedTotalAvg = totalAvg;
+
+    /* FREE. */
+    freeDataLoader(dl);
+    freeLinearLayer(linear);
+    freeParameter(b);
+    freeParameter(w);
+    freeEpochDataset();
+
+    /* ASSERT. */
+    TEST_ASSERT_FLOAT_WITHIN(0.01f, 5.5f, capturedTotalAvg);
 }
 
 void testTrainingBatchDefault_ReturnsAverageLossAndAccumulatesGrads() {
-    // Single linear layer, 2 samples → avg loss should match manually computed value
-    float wData[] = {1.f, 1.f, 1.f, 1.f, 1.f, 1.f};
-    size_t wDims[] = {2, 3};
-    tensor_t *wParam = tensorInitFloat(wData, wDims, 2, NULL);
-    float wgData[] = {0.f, 0.f, 0.f, 0.f, 0.f, 0.f};
-    tensor_t *wGrad = tensorInitFloat(wgData, wDims, 2, NULL);
+    /* Single linear layer, 2 samples → avg loss should match manually computed value */
+    tensor_t *wParam = buildFloatTensor2D(2, 3, (float[]){1.f, 1.f, 1.f, 1.f, 1.f, 1.f}, 6);
+    tensor_t *wGrad = gradInitFloat(wParam, NULL);
     parameter_t *w = parameterInit(wParam, wGrad);
 
-    float bData[] = {-1.f, 3.f};
-    size_t bDims[] = {1, 2};
-    tensor_t *bParam = tensorInitFloat(bData, bDims, 2, NULL);
-    float bgData[] = {0.f, 0.f};
-    tensor_t *bGrad = tensorInitFloat(bgData, bDims, 2, NULL);
+    tensor_t *bParam = buildFloatTensor2D(1, 2, (float[]){-1.f, 3.f}, 2);
+    tensor_t *bGrad = gradInitFloat(bParam, NULL);
     parameter_t *b = parameterInit(bParam, bGrad);
 
     quantization_t testQ;
@@ -302,27 +335,20 @@ void testTrainingBatchDefault_ReturnsAverageLossAndAccumulatesGrads() {
     layer_t *linear = linearLayerInit(w, b, &testQ, &testQ, &testQ, &testQ);
     layer_t *model[] = {linear};
 
-    // Compute expected: run calculateGradsSequential manually per sample
-    float in0Data[] = {-4.f, 1.f, 9.f};
-    size_t inDims[] = {1, 3};
-    tensor_t *in0 = tensorInitFloat(in0Data, inDims, 2, NULL);
-    float lb0Data[] = {59.f, -23.f};
-    size_t lbDims[] = {1, 2};
-    tensor_t *lb0 = tensorInitFloat(lb0Data, lbDims, 2, NULL);
+    /* Compute expected: run calculateGradsSequential manually per sample */
+    tensor_t *in0 = buildFloatTensor2D(1, 3, (float[]){-4.f, 1.f, 9.f}, 3);
+    tensor_t *lb0 = buildFloatTensor2D(1, 2, (float[]){59.f, -23.f}, 2);
+    tensor_t *in1 = buildFloatTensor2D(1, 3, (float[]){5.f, -1.f, 2.f}, 3);
+    tensor_t *lb1 = buildFloatTensor2D(1, 2, (float[]){43.f, 249.f}, 2);
 
-    float in1Data[] = {5.f, -1.f, 2.f};
-    tensor_t *in1 = tensorInitFloat(in1Data, inDims, 2, NULL);
-    float lb1Data[] = {43.f, 249.f};
-    tensor_t *lb1 = tensorInitFloat(lb1Data, lbDims, 2, NULL);
-
-    // Get expected losses from individual calculateGrads calls
+    /* Get expected losses from individual calculateGrads calls */
     trainingStats_t *ts0 = calculateGradsSequential(model, 1, MSE, in0, lb0);
     trainingStats_t *ts1 = calculateGradsSequential(model, 1, MSE, in1, lb1);
     float expectedAvg = (ts0->loss + ts1->loss) / 2.0f;
     freeTrainingStats(ts0);
     freeTrainingStats(ts1);
 
-    // Reset grads to zero before testing trainingBatchDefault
+    /* Reset grads to zero before testing trainingBatchDefault */
     float *gArr = (float *)wGrad->data;
     for (size_t i = 0; i < 6; i++) {
         gArr[i] = 0.f;
@@ -331,8 +357,8 @@ void testTrainingBatchDefault_ReturnsAverageLossAndAccumulatesGrads() {
     bgArr[0] = 0.f;
     bgArr[1] = 0.f;
 
-    // Build batch. Samples must be heap-allocated: trainingBatchDefault frees
-    // each via freeSample (the batch-consumer convention set by #119).
+    /* Build batch. Samples must be heap-allocated: trainingBatchDefault frees
+     * each via freeSample (the batch-consumer convention set by #119). */
     sample_t *s0 = reserveMemory(sizeof(sample_t));
     s0->item = in0;
     s0->label = lb0;
@@ -344,24 +370,33 @@ void testTrainingBatchDefault_ReturnsAverageLossAndAccumulatesGrads() {
 
     float actualAvg = trainingBatchDefault(model, 1, MSE, &batch, calculateGradsSequential);
 
-    TEST_ASSERT_FLOAT_WITHIN(1e-5f, expectedAvg, actualAvg);
+    /* CAPTURE. */
+    float capturedExpected = expectedAvg;
+    float capturedActual = actualAvg;
+
+    /* FREE. */
+    freeTensor(lb1);
+    freeTensor(in1);
+    freeTensor(lb0);
+    freeTensor(in0);
+    freeLinearLayer(linear);
+    freeParameter(b);
+    freeParameter(w);
+
+    /* ASSERT. */
+    TEST_ASSERT_FLOAT_WITHIN(1e-5f, capturedExpected, capturedActual);
 }
 
 void testTrainingEpochDefault_DoesOptimizerStepPerBatch() {
-    // After one epoch with known data, weights should change
-    // Epoch dataset has 2 input features, 2 output classes
-    float wData[] = {1.f, 0.f, 0.f, 1.f};
-    size_t wDims[] = {2, 2};
-    tensor_t *wParam = tensorInitFloat(wData, wDims, 2, NULL);
-    float wgData[] = {0.f, 0.f, 0.f, 0.f};
-    tensor_t *wGrad = tensorInitFloat(wgData, wDims, 2, NULL);
+    /* After one epoch with known data, weights should change.
+     * Epoch dataset has 2 input features, 2 output classes. */
+    static const float wInitData[4] = {1.f, 0.f, 0.f, 1.f};
+    tensor_t *wParam = buildFloatTensor2D(2, 2, wInitData, 4);
+    tensor_t *wGrad = gradInitFloat(wParam, NULL);
     parameter_t *w = parameterInit(wParam, wGrad);
 
-    float bData[] = {0.f, 0.f};
-    size_t bDims[] = {1, 2};
-    tensor_t *bParam = tensorInitFloat(bData, bDims, 2, NULL);
-    float bgData[] = {0.f, 0.f};
-    tensor_t *bGrad = tensorInitFloat(bgData, bDims, 2, NULL);
+    tensor_t *bParam = buildFloatTensor2D(1, 2, (float[]){0.f, 0.f}, 2);
+    tensor_t *bGrad = gradInitFloat(bParam, NULL);
     parameter_t *b = parameterInit(bParam, bGrad);
 
     quantization_t testQ;
@@ -370,15 +405,15 @@ void testTrainingEpochDefault_DoesOptimizerStepPerBatch() {
     layer_t *model[] = {linear};
     size_t sizeModel = 1;
 
-    // Save initial weights
+    /* Save initial weights */
     float initWeights[4];
     for (size_t i = 0; i < 4; i++) {
-        initWeights[i] = wData[i];
+        initWeights[i] = wInitData[i];
     }
 
     optimizer_t *sgd = sgdMCreateOptim(0.01f, 0.f, 0.f, model, sizeModel, FLOAT32);
 
-    // Use epoch dataset (batchSize=1 → 4 batches)
+    /* Use epoch dataset (batchSize=1 → 4 batches) */
     initEpochDataset();
     dataLoader_t *dl =
         dataLoaderInit(getEpochSample, getEpochDatasetSize, 1, NULL, NULL, false, 0, true);
@@ -386,37 +421,44 @@ void testTrainingEpochDefault_DoesOptimizerStepPerBatch() {
     float epochLoss =
         trainingEpochDefault(model, sizeModel, MSE, dl, sgd, calculateGradsSequential);
 
-    // Weights should have changed
-    float *curWeights = (float *)wParam->data;
-    bool changed = false;
-    for (size_t i = 0; i < 4; i++) {
-        if (curWeights[i] != initWeights[i]) {
-            changed = true;
-            break;
+    /* CAPTURE assertion values BEFORE any free. */
+    bool capturedChanged = false;
+    {
+        float *curWeights = (float *)wParam->data;
+        for (size_t i = 0; i < 4; i++) {
+            if (curWeights[i] != initWeights[i]) {
+                capturedChanged = true;
+                break;
+            }
         }
     }
-    TEST_ASSERT_TRUE(changed);
-    TEST_ASSERT_TRUE(epochLoss > 0.0f);
+    float capturedEpochLoss = epochLoss;
+
+    /* FREE. freeOptimSgdM cascades to w and b parameters; do NOT also free
+     * those (would double-free). */
+    freeOptimSgdM(sgd);
+    freeDataLoader(dl);
+    freeLinearLayer(linear);
+    freeEpochDataset();
+
+    /* ASSERT. */
+    TEST_ASSERT_TRUE(capturedChanged);
+    TEST_ASSERT_TRUE(capturedEpochLoss > 0.0f);
 }
 
 void testTrainingEpochDefault_MinibatchStepsOncePerMinibatch() {
-    // Same model + dataset as microbatch training test, but batchSize=2
-    // means the optimizer steps twice (once per minibatch) instead of
-    // four times, with gradients accumulated across two samples per step.
-    // Weight trajectory differs from microbatch; only property tested
-    // here is that training runs end-to-end and updates the model.
-    float wData[] = {1.f, 0.f, 0.f, 1.f};
-    size_t wDims[] = {2, 2};
-    tensor_t *wParam = tensorInitFloat(wData, wDims, 2, NULL);
-    float wgData[] = {0.f, 0.f, 0.f, 0.f};
-    tensor_t *wGrad = tensorInitFloat(wgData, wDims, 2, NULL);
+    /* Same model + dataset as microbatch training test, but batchSize=2
+     * means the optimizer steps twice (once per minibatch) instead of
+     * four times, with gradients accumulated across two samples per step.
+     * Weight trajectory differs from microbatch; only property tested
+     * here is that training runs end-to-end and updates the model. */
+    static const float wInitData[4] = {1.f, 0.f, 0.f, 1.f};
+    tensor_t *wParam = buildFloatTensor2D(2, 2, wInitData, 4);
+    tensor_t *wGrad = gradInitFloat(wParam, NULL);
     parameter_t *w = parameterInit(wParam, wGrad);
 
-    float bData[] = {0.f, 0.f};
-    size_t bDims[] = {1, 2};
-    tensor_t *bParam = tensorInitFloat(bData, bDims, 2, NULL);
-    float bgData[] = {0.f, 0.f};
-    tensor_t *bGrad = tensorInitFloat(bgData, bDims, 2, NULL);
+    tensor_t *bParam = buildFloatTensor2D(1, 2, (float[]){0.f, 0.f}, 2);
+    tensor_t *bGrad = gradInitFloat(bParam, NULL);
     parameter_t *b = parameterInit(bParam, bGrad);
 
     quantization_t testQ;
@@ -427,7 +469,7 @@ void testTrainingEpochDefault_MinibatchStepsOncePerMinibatch() {
 
     float initWeights[4];
     for (size_t i = 0; i < 4; i++) {
-        initWeights[i] = wData[i];
+        initWeights[i] = wInitData[i];
     }
 
     optimizer_t *sgd = sgdMCreateOptim(0.01f, 0.f, 0.f, model, sizeModel, FLOAT32);
@@ -439,31 +481,37 @@ void testTrainingEpochDefault_MinibatchStepsOncePerMinibatch() {
     float epochLoss =
         trainingEpochDefault(model, sizeModel, MSE, dl, sgd, calculateGradsSequential);
 
-    float *curWeights = (float *)wParam->data;
-    bool changed = false;
-    for (size_t i = 0; i < 4; i++) {
-        if (curWeights[i] != initWeights[i]) {
-            changed = true;
-            break;
+    /* CAPTURE. */
+    bool capturedChanged = false;
+    {
+        float *curWeights = (float *)wParam->data;
+        for (size_t i = 0; i < 4; i++) {
+            if (curWeights[i] != initWeights[i]) {
+                capturedChanged = true;
+                break;
+            }
         }
     }
-    TEST_ASSERT_TRUE(changed);
-    TEST_ASSERT_TRUE(epochLoss > 0.0f);
+    float capturedEpochLoss = epochLoss;
+
+    /* FREE. */
+    freeOptimSgdM(sgd);
+    freeDataLoader(dl);
+    freeLinearLayer(linear);
+    freeEpochDataset();
+
+    /* ASSERT. */
+    TEST_ASSERT_TRUE(capturedChanged);
+    TEST_ASSERT_TRUE(capturedEpochLoss > 0.0f);
 }
 
 void testTrainingRun_ReturnsResult() {
-    float wData[] = {1.f, 0.f, 0.f, 1.f};
-    size_t wDims[] = {2, 2};
-    tensor_t *wParam = tensorInitFloat(wData, wDims, 2, NULL);
-    float wgData[] = {0.f, 0.f, 0.f, 0.f};
-    tensor_t *wGrad = tensorInitFloat(wgData, wDims, 2, NULL);
+    tensor_t *wParam = buildFloatTensor2D(2, 2, (float[]){1.f, 0.f, 0.f, 1.f}, 4);
+    tensor_t *wGrad = gradInitFloat(wParam, NULL);
     parameter_t *w = parameterInit(wParam, wGrad);
 
-    float bData[] = {0.f, 0.f};
-    size_t bDims[] = {1, 2};
-    tensor_t *bParam = tensorInitFloat(bData, bDims, 2, NULL);
-    float bgData[] = {0.f, 0.f};
-    tensor_t *bGrad = tensorInitFloat(bgData, bDims, 2, NULL);
+    tensor_t *bParam = buildFloatTensor2D(1, 2, (float[]){0.f, 0.f}, 2);
+    tensor_t *bGrad = gradInitFloat(bParam, NULL);
     parameter_t *b = parameterInit(bParam, bGrad);
 
     quantization_t testQ;
@@ -482,10 +530,23 @@ void testTrainingRun_ReturnsResult() {
     trainingRunResult_t result = trainingRun(model, 1, MSE, trainDl, evalDl, sgd, 2,
                                              calculateGradsSequential, inferenceWithLoss, NULL);
 
-    TEST_ASSERT_TRUE(result.finalTrainLoss > 0.0f);
-    TEST_ASSERT_TRUE(result.finalEvalStats.loss > 0.0f);
-    TEST_ASSERT_TRUE(result.finalEvalStats.accuracy >= 0.0f);
-    TEST_ASSERT_TRUE(result.finalEvalStats.accuracy <= 1.0f);
+    /* CAPTURE. */
+    float capturedFinalTrainLoss = result.finalTrainLoss;
+    float capturedEvalLoss = result.finalEvalStats.loss;
+    float capturedAccuracy = result.finalEvalStats.accuracy;
+
+    /* FREE. */
+    freeOptimSgdM(sgd);
+    freeDataLoader(evalDl);
+    freeDataLoader(trainDl);
+    freeLinearLayer(linear);
+    freeEpochDataset();
+
+    /* ASSERT. */
+    TEST_ASSERT_TRUE(capturedFinalTrainLoss > 0.0f);
+    TEST_ASSERT_TRUE(capturedEvalLoss > 0.0f);
+    TEST_ASSERT_TRUE(capturedAccuracy >= 0.0f);
+    TEST_ASSERT_TRUE(capturedAccuracy <= 1.0f);
 }
 
 static size_t cbCallCount;
@@ -506,18 +567,12 @@ void testTrainingRun_CallsCallbackEachEpochWithStats() {
     cbLastTrainLoss = 0.0f;
     cbLastStats = (epochStats_t){0};
 
-    float wData[] = {1.f, 0.f, 0.f, 1.f};
-    size_t wDims[] = {2, 2};
-    tensor_t *wParam = tensorInitFloat(wData, wDims, 2, NULL);
-    float wgData[] = {0.f, 0.f, 0.f, 0.f};
-    tensor_t *wGrad = tensorInitFloat(wgData, wDims, 2, NULL);
+    tensor_t *wParam = buildFloatTensor2D(2, 2, (float[]){1.f, 0.f, 0.f, 1.f}, 4);
+    tensor_t *wGrad = gradInitFloat(wParam, NULL);
     parameter_t *w = parameterInit(wParam, wGrad);
 
-    float bData[] = {0.f, 0.f};
-    size_t bDims[] = {1, 2};
-    tensor_t *bParam = tensorInitFloat(bData, bDims, 2, NULL);
-    float bgData[] = {0.f, 0.f};
-    tensor_t *bGrad = tensorInitFloat(bgData, bDims, 2, NULL);
+    tensor_t *bParam = buildFloatTensor2D(1, 2, (float[]){0.f, 0.f}, 2);
+    tensor_t *bGrad = gradInitFloat(bParam, NULL);
     parameter_t *b = parameterInit(bParam, bGrad);
 
     quantization_t testQ;
@@ -538,33 +593,44 @@ void testTrainingRun_CallsCallbackEachEpochWithStats() {
         trainingRun(model, 1, MSE, trainDl, evalDl, sgd, numberOfEpochs, calculateGradsSequential,
                     inferenceWithLoss, captureCallback);
 
-    // Callback was invoked once per epoch, in order
-    TEST_ASSERT_EQUAL_UINT(numberOfEpochs, cbCallCount);
-    TEST_ASSERT_EQUAL_UINT(numberOfEpochs - 1, cbLastEpoch); // 0-indexed
+    /* CAPTURE. */
+    size_t capturedCbCallCount = cbCallCount;
+    size_t capturedCbLastEpoch = cbLastEpoch;
+    float capturedCbLastTrainLoss = cbLastTrainLoss;
+    float capturedCbLastStatsLoss = cbLastStats.loss;
+    float capturedCbLastStatsAccuracy = cbLastStats.accuracy;
+    float capturedFinalTrainLoss = result.finalTrainLoss;
+    float capturedFinalEvalLoss = result.finalEvalStats.loss;
+    float capturedFinalEvalAccuracy = result.finalEvalStats.accuracy;
 
-    // Stats passed to callback are real (not zero-initialized) and match the final result
-    TEST_ASSERT_TRUE(cbLastTrainLoss > 0.0f);
-    TEST_ASSERT_TRUE(cbLastStats.loss > 0.0f);
-    TEST_ASSERT_EQUAL_FLOAT(result.finalTrainLoss, cbLastTrainLoss);
-    TEST_ASSERT_EQUAL_FLOAT(result.finalEvalStats.loss, cbLastStats.loss);
-    TEST_ASSERT_EQUAL_FLOAT(result.finalEvalStats.accuracy, cbLastStats.accuracy);
+    /* FREE. */
+    freeOptimSgdM(sgd);
+    freeDataLoader(evalDl);
+    freeDataLoader(trainDl);
+    freeLinearLayer(linear);
+    freeEpochDataset();
+
+    /* ASSERT. Callback was invoked once per epoch, in order. */
+    TEST_ASSERT_EQUAL_UINT(numberOfEpochs, capturedCbCallCount);
+    TEST_ASSERT_EQUAL_UINT(numberOfEpochs - 1, capturedCbLastEpoch); /* 0-indexed */
+
+    /* Stats passed to callback are real (not zero-initialized) and match the final result. */
+    TEST_ASSERT_TRUE(capturedCbLastTrainLoss > 0.0f);
+    TEST_ASSERT_TRUE(capturedCbLastStatsLoss > 0.0f);
+    TEST_ASSERT_EQUAL_FLOAT(capturedFinalTrainLoss, capturedCbLastTrainLoss);
+    TEST_ASSERT_EQUAL_FLOAT(capturedFinalEvalLoss, capturedCbLastStatsLoss);
+    TEST_ASSERT_EQUAL_FLOAT(capturedFinalEvalAccuracy, capturedCbLastStatsAccuracy);
 }
 
 void testEvaluationEpochWithMetrics_AllCorrect() {
     initEpochDataset();
 
-    float wData[] = {1.f, 0.f, 0.f, 1.f};
-    size_t wDims[] = {2, 2};
-    tensor_t *wParam = tensorInitFloat(wData, wDims, 2, NULL);
-    float wgData[] = {0.f, 0.f, 0.f, 0.f};
-    tensor_t *wGrad = tensorInitFloat(wgData, wDims, 2, NULL);
+    tensor_t *wParam = buildFloatTensor2D(2, 2, (float[]){1.f, 0.f, 0.f, 1.f}, 4);
+    tensor_t *wGrad = gradInitFloat(wParam, NULL);
     parameter_t *w = parameterInit(wParam, wGrad);
 
-    float bData[] = {0.f, 0.f};
-    size_t bDims[] = {1, 2};
-    tensor_t *bParam = tensorInitFloat(bData, bDims, 2, NULL);
-    float bgData[] = {0.f, 0.f};
-    tensor_t *bGrad = tensorInitFloat(bgData, bDims, 2, NULL);
+    tensor_t *bParam = buildFloatTensor2D(1, 2, (float[]){0.f, 0.f}, 2);
+    tensor_t *bGrad = gradInitFloat(bParam, NULL);
     parameter_t *b = parameterInit(bParam, bGrad);
 
     quantization_t testQ;
@@ -575,60 +641,80 @@ void testEvaluationEpochWithMetrics_AllCorrect() {
     dataLoader_t *dl =
         dataLoaderInit(getEpochSample, getEpochDatasetSize, 1, NULL, NULL, false, 0, true);
 
-    // Identity model: all 4 samples predict correctly (same as testEvaluationEpochAccuracy)
+    /* Identity model: all 4 samples predict correctly (same as testEvaluationEpochAccuracy) */
     epochStats_t stats = evaluationEpochWithMetrics(model, 1, MSE, dl, inferenceWithLoss);
 
-    TEST_ASSERT_FLOAT_WITHIN(0.01f, 5.5f, stats.loss); // same as testEvaluationEpoch
-    TEST_ASSERT_FLOAT_WITHIN(0.001f, 1.0f, stats.accuracy);
-    TEST_ASSERT_FLOAT_WITHIN(0.001f, 1.0f, stats.precision);
-    TEST_ASSERT_FLOAT_WITHIN(0.001f, 1.0f, stats.recall);
-    TEST_ASSERT_FLOAT_WITHIN(0.001f, 1.0f, stats.f1);
+    /* CAPTURE. */
+    float capturedLoss = stats.loss;
+    float capturedAccuracy = stats.accuracy;
+    float capturedPrecision = stats.precision;
+    float capturedRecall = stats.recall;
+    float capturedF1 = stats.f1;
+
+    /* FREE. */
+    freeDataLoader(dl);
+    freeLinearLayer(linear);
+    freeParameter(b);
+    freeParameter(w);
+    freeEpochDataset();
+
+    /* ASSERT. */
+    TEST_ASSERT_FLOAT_WITHIN(0.01f, 5.5f, capturedLoss); /* same as testEvaluationEpoch */
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 1.0f, capturedAccuracy);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 1.0f, capturedPrecision);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 1.0f, capturedRecall);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 1.0f, capturedF1);
 }
 
-// Partially-correct dataset: 4 samples, 3 correct, 1 wrong
+/* Partially-correct dataset: 4 samples, 3 correct, 1 wrong */
 static tensor_t *partialItems[4];
 static tensor_t *partialLabels[4];
 static dataset_t partialDataset;
+static tensorArray_t partialItemsArr;
+static tensorArray_t partialLabelsArr;
 static bool partialDatasetInit = false;
+
+static const float partialItemDataLiteral[4][2] = {
+    {5.f, 1.f}, /* pred=0 */
+    {3.f, 1.f}, /* pred=0 */
+    {4.f, 1.f}, /* pred=0 (wrong!) */
+    {1.f, 3.f}, /* pred=1 */
+};
+static const float partialLabelDataLiteral[4][2] = {
+    {1.f, 0.f}, /* true=0 */
+    {1.f, 0.f}, /* true=0 */
+    {0.f, 1.f}, /* true=1 */
+    {0.f, 1.f}, /* true=1 */
+};
 
 static void initPartialDataset() {
     if (partialDatasetInit) {
         return;
     }
+    for (size_t i = 0; i < 4; i++) {
+        partialItems[i] = buildFloatTensor2D(1, 2, partialItemDataLiteral[i], 2);
+        partialLabels[i] = buildFloatTensor2D(1, 2, partialLabelDataLiteral[i], 2);
+    }
 
-    static float in0[] = {5.f, 1.f}; // pred=0
-    static float in1[] = {3.f, 1.f}; // pred=0
-    static float in2[] = {4.f, 1.f}; // pred=0 (wrong!)
-    static float in3[] = {1.f, 3.f}; // pred=1
+    partialItemsArr.array = partialItems;
+    partialItemsArr.size = 4;
+    partialLabelsArr.array = partialLabels;
+    partialLabelsArr.size = 4;
 
-    static float lb0[] = {1.f, 0.f}; // true=0
-    static float lb1[] = {1.f, 0.f}; // true=0
-    static float lb2[] = {0.f, 1.f}; // true=1
-    static float lb3[] = {0.f, 1.f}; // true=1
-
-    static size_t inDims[] = {1, 2};
-    static size_t lbDims[] = {1, 2};
-
-    partialItems[0] = tensorInitFloat(in0, inDims, 2, NULL);
-    partialItems[1] = tensorInitFloat(in1, inDims, 2, NULL);
-    partialItems[2] = tensorInitFloat(in2, inDims, 2, NULL);
-    partialItems[3] = tensorInitFloat(in3, inDims, 2, NULL);
-
-    partialLabels[0] = tensorInitFloat(lb0, lbDims, 2, NULL);
-    partialLabels[1] = tensorInitFloat(lb1, lbDims, 2, NULL);
-    partialLabels[2] = tensorInitFloat(lb2, lbDims, 2, NULL);
-    partialLabels[3] = tensorInitFloat(lb3, lbDims, 2, NULL);
-
-    static tensorArray_t itemsArr;
-    itemsArr.array = partialItems;
-    itemsArr.size = 4;
-    static tensorArray_t labelsArr;
-    labelsArr.array = partialLabels;
-    labelsArr.size = 4;
-
-    partialDataset.items = &itemsArr;
-    partialDataset.labels = &labelsArr;
+    partialDataset.items = &partialItemsArr;
+    partialDataset.labels = &partialLabelsArr;
     partialDatasetInit = true;
+}
+
+static void freePartialDataset() {
+    if (!partialDatasetInit) {
+        return;
+    }
+    for (size_t i = 0; i < 4; i++) {
+        freeTensor(partialItems[i]);
+        freeTensor(partialLabels[i]);
+    }
+    partialDatasetInit = false;
 }
 
 static sample_t *getPartialSample(size_t id) {
@@ -645,18 +731,12 @@ static size_t getPartialDatasetSize() {
 void testEvaluationEpochWithMetrics_PartiallyCorrect() {
     initPartialDataset();
 
-    float wData[] = {1.f, 0.f, 0.f, 1.f};
-    size_t wDims[] = {2, 2};
-    tensor_t *wParam = tensorInitFloat(wData, wDims, 2, NULL);
-    float wgData[] = {0.f, 0.f, 0.f, 0.f};
-    tensor_t *wGrad = tensorInitFloat(wgData, wDims, 2, NULL);
+    tensor_t *wParam = buildFloatTensor2D(2, 2, (float[]){1.f, 0.f, 0.f, 1.f}, 4);
+    tensor_t *wGrad = gradInitFloat(wParam, NULL);
     parameter_t *w = parameterInit(wParam, wGrad);
 
-    float bData[] = {0.f, 0.f};
-    size_t bDims[] = {1, 2};
-    tensor_t *bParam = tensorInitFloat(bData, bDims, 2, NULL);
-    float bgData[] = {0.f, 0.f};
-    tensor_t *bGrad = tensorInitFloat(bgData, bDims, 2, NULL);
+    tensor_t *bParam = buildFloatTensor2D(1, 2, (float[]){0.f, 0.f}, 2);
+    tensor_t *bGrad = gradInitFloat(bParam, NULL);
     parameter_t *b = parameterInit(bParam, bGrad);
 
     quantization_t testQ;
@@ -669,58 +749,79 @@ void testEvaluationEpochWithMetrics_PartiallyCorrect() {
 
     epochStats_t stats = evaluationEpochWithMetrics(model, 1, MSE, dl, inferenceWithLoss);
 
-    // tp=[2,1], predCount=[3,1], actualCount=[2,2]
-    // accuracy = 3/4 = 0.75
-    TEST_ASSERT_FLOAT_WITHIN(0.001f, 0.75f, stats.accuracy);
-    // precision = mean(2/3, 1/1) = 5/6
-    TEST_ASSERT_FLOAT_WITHIN(0.001f, 5.0f / 6.0f, stats.precision);
-    // recall = mean(2/2, 1/2) = 0.75
-    TEST_ASSERT_FLOAT_WITHIN(0.001f, 0.75f, stats.recall);
-    // F1 = mean(2*(2/3)*1/(2/3+1), 2*1*0.5/(1+0.5)) = mean(4/5, 2/3) = 11/15
-    TEST_ASSERT_FLOAT_WITHIN(0.001f, 11.0f / 15.0f, stats.f1);
+    /* CAPTURE. */
+    float capturedAccuracy = stats.accuracy;
+    float capturedPrecision = stats.precision;
+    float capturedRecall = stats.recall;
+    float capturedF1 = stats.f1;
+
+    /* FREE. */
+    freeDataLoader(dl);
+    freeLinearLayer(linear);
+    freeParameter(b);
+    freeParameter(w);
+    freePartialDataset();
+
+    /* ASSERT.
+     * tp=[2,1], predCount=[3,1], actualCount=[2,2]
+     * accuracy = 3/4 = 0.75 */
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 0.75f, capturedAccuracy);
+    /* precision = mean(2/3, 1/1) = 5/6 */
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 5.0f / 6.0f, capturedPrecision);
+    /* recall = mean(2/2, 1/2) = 0.75 */
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 0.75f, capturedRecall);
+    /* F1 = mean(2*(2/3)*1/(2/3+1), 2*1*0.5/(1+0.5)) = mean(4/5, 2/3) = 11/15 */
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 11.0f / 15.0f, capturedF1);
 }
 
-// Zero-prediction dataset: model never predicts class 1.
-// 3 samples: 2 correct for class 0, 1 wrong (true class 1, predicted 0).
+/* Zero-prediction dataset: model never predicts class 1.
+ * 3 samples: 2 correct for class 0, 1 wrong (true class 1, predicted 0). */
 static tensor_t *zeroPredItems[3];
 static tensor_t *zeroPredLabels[3];
 static dataset_t zeroPredDataset;
+static tensorArray_t zeroPredItemsArr;
+static tensorArray_t zeroPredLabelsArr;
 static bool zeroPredDatasetInit = false;
+
+static const float zeroPredItemDataLiteral[3][2] = {
+    {5.f, 1.f}, /* pred=0 */
+    {3.f, 1.f}, /* pred=0 */
+    {4.f, 1.f}, /* pred=0 (wrong, true=1) */
+};
+static const float zeroPredLabelDataLiteral[3][2] = {
+    {1.f, 0.f}, /* true=0 */
+    {1.f, 0.f}, /* true=0 */
+    {0.f, 1.f}, /* true=1 */
+};
 
 static void initZeroPredDataset() {
     if (zeroPredDatasetInit) {
         return;
     }
+    for (size_t i = 0; i < 3; i++) {
+        zeroPredItems[i] = buildFloatTensor2D(1, 2, zeroPredItemDataLiteral[i], 2);
+        zeroPredLabels[i] = buildFloatTensor2D(1, 2, zeroPredLabelDataLiteral[i], 2);
+    }
 
-    static float in0[] = {5.f, 1.f}; // pred=0
-    static float in1[] = {3.f, 1.f}; // pred=0
-    static float in2[] = {4.f, 1.f}; // pred=0 (wrong, true=1)
+    zeroPredItemsArr.array = zeroPredItems;
+    zeroPredItemsArr.size = 3;
+    zeroPredLabelsArr.array = zeroPredLabels;
+    zeroPredLabelsArr.size = 3;
 
-    static float lb0[] = {1.f, 0.f}; // true=0
-    static float lb1[] = {1.f, 0.f}; // true=0
-    static float lb2[] = {0.f, 1.f}; // true=1
-
-    static size_t inDims[] = {1, 2};
-    static size_t lbDims[] = {1, 2};
-
-    zeroPredItems[0] = tensorInitFloat(in0, inDims, 2, NULL);
-    zeroPredItems[1] = tensorInitFloat(in1, inDims, 2, NULL);
-    zeroPredItems[2] = tensorInitFloat(in2, inDims, 2, NULL);
-
-    zeroPredLabels[0] = tensorInitFloat(lb0, lbDims, 2, NULL);
-    zeroPredLabels[1] = tensorInitFloat(lb1, lbDims, 2, NULL);
-    zeroPredLabels[2] = tensorInitFloat(lb2, lbDims, 2, NULL);
-
-    static tensorArray_t itemsArr;
-    itemsArr.array = zeroPredItems;
-    itemsArr.size = 3;
-    static tensorArray_t labelsArr;
-    labelsArr.array = zeroPredLabels;
-    labelsArr.size = 3;
-
-    zeroPredDataset.items = &itemsArr;
-    zeroPredDataset.labels = &labelsArr;
+    zeroPredDataset.items = &zeroPredItemsArr;
+    zeroPredDataset.labels = &zeroPredLabelsArr;
     zeroPredDatasetInit = true;
+}
+
+static void freeZeroPredDataset() {
+    if (!zeroPredDatasetInit) {
+        return;
+    }
+    for (size_t i = 0; i < 3; i++) {
+        freeTensor(zeroPredItems[i]);
+        freeTensor(zeroPredLabels[i]);
+    }
+    zeroPredDatasetInit = false;
 }
 
 static sample_t *getZeroPredSample(size_t id) {
@@ -737,18 +838,12 @@ static size_t getZeroPredDatasetSize() {
 void testEvaluationEpochWithMetrics_HandlesZeroPredictionClass() {
     initZeroPredDataset();
 
-    float wData[] = {1.f, 0.f, 0.f, 1.f};
-    size_t wDims[] = {2, 2};
-    tensor_t *wParam = tensorInitFloat(wData, wDims, 2, NULL);
-    float wgData[] = {0.f, 0.f, 0.f, 0.f};
-    tensor_t *wGrad = tensorInitFloat(wgData, wDims, 2, NULL);
+    tensor_t *wParam = buildFloatTensor2D(2, 2, (float[]){1.f, 0.f, 0.f, 1.f}, 4);
+    tensor_t *wGrad = gradInitFloat(wParam, NULL);
     parameter_t *w = parameterInit(wParam, wGrad);
 
-    float bData[] = {0.f, 0.f};
-    size_t bDims[] = {1, 2};
-    tensor_t *bParam = tensorInitFloat(bData, bDims, 2, NULL);
-    float bgData[] = {0.f, 0.f};
-    tensor_t *bGrad = tensorInitFloat(bgData, bDims, 2, NULL);
+    tensor_t *bParam = buildFloatTensor2D(1, 2, (float[]){0.f, 0.f}, 2);
+    tensor_t *bGrad = gradInitFloat(bParam, NULL);
     parameter_t *b = parameterInit(bParam, bGrad);
 
     quantization_t testQ;
@@ -761,40 +856,48 @@ void testEvaluationEpochWithMetrics_HandlesZeroPredictionClass() {
 
     epochStats_t stats = evaluationEpochWithMetrics(model, 1, MSE, dl, inferenceWithLoss);
 
-    // tp=[2,0], predCount=[3,0], actualCount=[2,1]
-    // Class 1 has no predictions -> precision guard skips it
-    // Class 1 has zero tp -> recall=0 for class 1
-    // Class 1 prec+rec=0 -> F1 guard skips it
-    // accuracy = 2/3
-    TEST_ASSERT_FLOAT_WITHIN(0.001f, 2.0f / 3.0f, stats.accuracy);
-    // precision = (2/3 + 0) / 2 = 1/3
-    TEST_ASSERT_FLOAT_WITHIN(0.001f, 1.0f / 3.0f, stats.precision);
-    // recall = (2/2 + 0/1) / 2 = 0.5
-    TEST_ASSERT_FLOAT_WITHIN(0.001f, 0.5f, stats.recall);
-    // F1 class 0: 2*(2/3)*1 / ((2/3)+1) = 4/5; class 1: 0. Mean = 2/5
-    TEST_ASSERT_FLOAT_WITHIN(0.001f, 2.0f / 5.0f, stats.f1);
+    /* CAPTURE. */
+    float capturedAccuracy = stats.accuracy;
+    float capturedPrecision = stats.precision;
+    float capturedRecall = stats.recall;
+    float capturedF1 = stats.f1;
 
-    // No NaN or Inf from division by zero
-    TEST_ASSERT_TRUE(stats.precision == stats.precision); // NaN check
-    TEST_ASSERT_TRUE(stats.recall == stats.recall);
-    TEST_ASSERT_TRUE(stats.f1 == stats.f1);
+    /* FREE. */
+    freeDataLoader(dl);
+    freeLinearLayer(linear);
+    freeParameter(b);
+    freeParameter(w);
+    freeZeroPredDataset();
+
+    /* ASSERT.
+     * tp=[2,0], predCount=[3,0], actualCount=[2,1]
+     * Class 1 has no predictions -> precision guard skips it
+     * Class 1 has zero tp -> recall=0 for class 1
+     * Class 1 prec+rec=0 -> F1 guard skips it
+     * accuracy = 2/3 */
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 2.0f / 3.0f, capturedAccuracy);
+    /* precision = (2/3 + 0) / 2 = 1/3 */
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 1.0f / 3.0f, capturedPrecision);
+    /* recall = (2/2 + 0/1) / 2 = 0.5 */
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 0.5f, capturedRecall);
+    /* F1 class 0: 2*(2/3)*1 / ((2/3)+1) = 4/5; class 1: 0. Mean = 2/5 */
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 2.0f / 5.0f, capturedF1);
+
+    /* No NaN or Inf from division by zero */
+    TEST_ASSERT_TRUE(capturedPrecision == capturedPrecision); /* NaN check */
+    TEST_ASSERT_TRUE(capturedRecall == capturedRecall);
+    TEST_ASSERT_TRUE(capturedF1 == capturedF1);
 }
 
 void testEvaluationEpochWithReport_ReturnsConfusionMatrix() {
     initPartialDataset();
 
-    float wData[] = {1.f, 0.f, 0.f, 1.f};
-    size_t wDims[] = {2, 2};
-    tensor_t *wParam = tensorInitFloat(wData, wDims, 2, NULL);
-    float wgData[] = {0.f, 0.f, 0.f, 0.f};
-    tensor_t *wGrad = tensorInitFloat(wgData, wDims, 2, NULL);
+    tensor_t *wParam = buildFloatTensor2D(2, 2, (float[]){1.f, 0.f, 0.f, 1.f}, 4);
+    tensor_t *wGrad = gradInitFloat(wParam, NULL);
     parameter_t *w = parameterInit(wParam, wGrad);
 
-    float bData[] = {0.f, 0.f};
-    size_t bDims[] = {1, 2};
-    tensor_t *bParam = tensorInitFloat(bData, bDims, 2, NULL);
-    float bgData[] = {0.f, 0.f};
-    tensor_t *bGrad = tensorInitFloat(bgData, bDims, 2, NULL);
+    tensor_t *bParam = buildFloatTensor2D(1, 2, (float[]){0.f, 0.f}, 2);
+    tensor_t *bGrad = gradInitFloat(bParam, NULL);
     parameter_t *b = parameterInit(bParam, bGrad);
 
     quantization_t testQ;
@@ -805,20 +908,36 @@ void testEvaluationEpochWithReport_ReturnsConfusionMatrix() {
     dataLoader_t *dl =
         dataLoaderInit(getPartialSample, getPartialDatasetSize, 1, NULL, NULL, false, 0, true);
 
-    // Pre-fill with non-zero to verify WithReport zeroes the caller's buffer before accumulating
+    /* Pre-fill with non-zero to verify WithReport zeroes the caller's buffer before accumulating */
     size_t cm[2 * 2] = {99, 99, 99, 99};
     classificationReport_t report =
         evaluationEpochWithReport(model, 1, MSE, dl, inferenceWithLoss, cm, 2);
 
-    // Expected CM[predicted][actual]: [[2,1],[0,1]]
-    // cm[0*2+0]=2, cm[0*2+1]=1, cm[1*2+0]=0, cm[1*2+1]=1
-    TEST_ASSERT_EQUAL_UINT(2, report.confusionMatrix[0]); // pred=0, actual=0
-    TEST_ASSERT_EQUAL_UINT(1, report.confusionMatrix[1]); // pred=0, actual=1
-    TEST_ASSERT_EQUAL_UINT(0, report.confusionMatrix[2]); // pred=1, actual=0
-    TEST_ASSERT_EQUAL_UINT(1, report.confusionMatrix[3]); // pred=1, actual=1
+    /* CAPTURE. */
+    size_t capturedCM[4];
+    for (size_t i = 0; i < 4; i++) {
+        capturedCM[i] = report.confusionMatrix[i];
+    }
+    size_t capturedNumClasses = report.numClasses;
+    float capturedAccuracy = report.stats.accuracy;
 
-    TEST_ASSERT_EQUAL_UINT(2, report.numClasses);
-    TEST_ASSERT_FLOAT_WITHIN(0.001f, 0.75f, report.stats.accuracy);
+    /* FREE. */
+    freeDataLoader(dl);
+    freeLinearLayer(linear);
+    freeParameter(b);
+    freeParameter(w);
+    freePartialDataset();
+
+    /* ASSERT.
+     * Expected CM[predicted][actual]: [[2,1],[0,1]]
+     * cm[0*2+0]=2, cm[0*2+1]=1, cm[1*2+0]=0, cm[1*2+1]=1 */
+    TEST_ASSERT_EQUAL_UINT(2, capturedCM[0]); /* pred=0, actual=0 */
+    TEST_ASSERT_EQUAL_UINT(1, capturedCM[1]); /* pred=0, actual=1 */
+    TEST_ASSERT_EQUAL_UINT(0, capturedCM[2]); /* pred=1, actual=0 */
+    TEST_ASSERT_EQUAL_UINT(1, capturedCM[3]); /* pred=1, actual=1 */
+
+    TEST_ASSERT_EQUAL_UINT(2, capturedNumClasses);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 0.75f, capturedAccuracy);
 }
 
 void setUp() {}

--- a/test/unit/userAPI/UnitTestTrainingLoopApi.c
+++ b/test/unit/userAPI/UnitTestTrainingLoopApi.c
@@ -2,23 +2,23 @@
 
 #include <stddef.h>
 
-#include "LossFunction.h"
-#include "TensorApi.h"
-#include "LinearApi.h"
-#include "SgdApi.h"
-#include "unity.h"
-#include "TrainingLoopApi.h"
 #include "CalculateGradsSequential.h"
+#include "DataLoaderApi.h"
+#include "Dataset.h"
+#include "InferenceApi.h"
+#include "Linear.h"
+#include "LinearApi.h"
+#include "LossFunction.h"
+#include "QuantizationApi.h"
+#include "ReluApi.h"
+#include "SgdApi.h"
+#include "StorageApi.h"
+#include "TensorApi.h"
+#include "TensorConversion.h"
 #include "TrainingBatchDefault.h"
 #include "TrainingEpochDefault.h"
-#include "TensorConversion.h"
-#include "QuantizationApi.h"
-#include "Linear.h"
-#include "ReluApi.h"
-#include "InferenceApi.h"
-#include "DataLoaderApi.h"
-#include "StorageApi.h"
-#include "Dataset.h"
+#include "TrainingLoopApi.h"
+#include "unity.h"
 
 void testCalculateGradsSequential_MatchesPyTorch() {
     float weightData[] = {1.f, 1.f, 1.f, 1.f, 1.f, 1.f};
@@ -136,10 +136,15 @@ void testEvaluationBatch_ReturnsAverageLoss() {
     freeInferenceStats(stats0);
     freeInferenceStats(stats1);
 
-    // Build a batch
-    sample_t s0 = {.item = input0, .label = label0};
-    sample_t s1 = {.item = input1, .label = label1};
-    sample_t *samples[] = {&s0, &s1};
+    // Build a batch. Samples must be heap-allocated: evaluationBatch frees
+    // each via freeSample (the batch-consumer convention set by #119).
+    sample_t *s0 = reserveMemory(sizeof(sample_t));
+    s0->item = input0;
+    s0->label = label0;
+    sample_t *s1 = reserveMemory(sizeof(sample_t));
+    s1->item = input1;
+    s1->label = label1;
+    sample_t *samples[] = {s0, s1};
     batch_t batch = {.samples = samples, .size = 2};
 
     float actualAvgLoss = evaluationBatch(model, 1, MSE, &batch, inferenceWithLoss);
@@ -154,13 +159,19 @@ static dataset_t epochDataset;
 static bool epochDatasetInit = false;
 
 static void initEpochDataset() {
-    if (epochDatasetInit) return;
+    if (epochDatasetInit) {
+        return;
+    }
 
     // 4 samples: input [1,2], label [1,0] or [0,1]
-    static float in0[] = {5.f, 1.f}; static float in1[] = {1.f, 5.f};
-    static float in2[] = {3.f, 1.f}; static float in3[] = {1.f, 3.f};
-    static float lb0[] = {1.f, 0.f}; static float lb1[] = {0.f, 1.f};
-    static float lb2[] = {1.f, 0.f}; static float lb3[] = {0.f, 1.f};
+    static float in0[] = {5.f, 1.f};
+    static float in1[] = {1.f, 5.f};
+    static float in2[] = {3.f, 1.f};
+    static float in3[] = {1.f, 3.f};
+    static float lb0[] = {1.f, 0.f};
+    static float lb1[] = {0.f, 1.f};
+    static float lb2[] = {1.f, 0.f};
+    static float lb3[] = {0.f, 1.f};
 
     static size_t inDims[] = {1, 2};
     static size_t lbDims[] = {1, 2};
@@ -221,8 +232,8 @@ void testEvaluationEpoch_ReturnsAverageLossAcrossBatches() {
     layer_t *linear = linearLayerInit(w, b, &testQ, &testQ, &testQ, &testQ);
     layer_t *model[] = {linear};
 
-    dataLoader_t *dl = dataLoaderInit(getEpochSample, getEpochDatasetSize, 1,
-                                       NULL, NULL, false, 0, true);
+    dataLoader_t *dl =
+        dataLoaderInit(getEpochSample, getEpochDatasetSize, 1, NULL, NULL, false, 0, true);
 
     float totalAvg = evaluationEpoch(model, 1, MSE, dl, inferenceWithLoss);
 
@@ -262,8 +273,8 @@ void testEvaluationEpoch_MinibatchMatchesMicrobatchAverage() {
     // Per-sample losses: 8.5, 8.5, 2.5, 2.5
     // Batch 0 avg = (8.5+8.5)/2 = 8.5; Batch 1 avg = (2.5+2.5)/2 = 2.5
     // Epoch avg = (8.5+2.5)/2 = 5.5 — identical to microbatch result
-    dataLoader_t *dl = dataLoaderInit(getEpochSample, getEpochDatasetSize, 2,
-                                       NULL, NULL, false, 0, true);
+    dataLoader_t *dl =
+        dataLoaderInit(getEpochSample, getEpochDatasetSize, 2, NULL, NULL, false, 0, true);
 
     float totalAvg = evaluationEpoch(model, 1, MSE, dl, inferenceWithLoss);
 
@@ -313,14 +324,22 @@ void testTrainingBatchDefault_ReturnsAverageLossAndAccumulatesGrads() {
 
     // Reset grads to zero before testing trainingBatchDefault
     float *gArr = (float *)wGrad->data;
-    for (size_t i = 0; i < 6; i++) gArr[i] = 0.f;
+    for (size_t i = 0; i < 6; i++) {
+        gArr[i] = 0.f;
+    }
     float *bgArr = (float *)bGrad->data;
-    bgArr[0] = 0.f; bgArr[1] = 0.f;
+    bgArr[0] = 0.f;
+    bgArr[1] = 0.f;
 
-    // Build batch
-    sample_t s0 = {.item = in0, .label = lb0};
-    sample_t s1 = {.item = in1, .label = lb1};
-    sample_t *samples[] = {&s0, &s1};
+    // Build batch. Samples must be heap-allocated: trainingBatchDefault frees
+    // each via freeSample (the batch-consumer convention set by #119).
+    sample_t *s0 = reserveMemory(sizeof(sample_t));
+    s0->item = in0;
+    s0->label = lb0;
+    sample_t *s1 = reserveMemory(sizeof(sample_t));
+    s1->item = in1;
+    s1->label = lb1;
+    sample_t *samples[] = {s0, s1};
     batch_t batch = {.samples = samples, .size = 2};
 
     float actualAvg = trainingBatchDefault(model, 1, MSE, &batch, calculateGradsSequential);
@@ -353,17 +372,19 @@ void testTrainingEpochDefault_DoesOptimizerStepPerBatch() {
 
     // Save initial weights
     float initWeights[4];
-    for (size_t i = 0; i < 4; i++) initWeights[i] = wData[i];
+    for (size_t i = 0; i < 4; i++) {
+        initWeights[i] = wData[i];
+    }
 
     optimizer_t *sgd = sgdMCreateOptim(0.01f, 0.f, 0.f, model, sizeModel, FLOAT32);
 
     // Use epoch dataset (batchSize=1 → 4 batches)
     initEpochDataset();
-    dataLoader_t *dl = dataLoaderInit(getEpochSample, getEpochDatasetSize, 1,
-                                       NULL, NULL, false, 0, true);
+    dataLoader_t *dl =
+        dataLoaderInit(getEpochSample, getEpochDatasetSize, 1, NULL, NULL, false, 0, true);
 
-    float epochLoss = trainingEpochDefault(model, sizeModel, MSE, dl, sgd,
-                                            calculateGradsSequential);
+    float epochLoss =
+        trainingEpochDefault(model, sizeModel, MSE, dl, sgd, calculateGradsSequential);
 
     // Weights should have changed
     float *curWeights = (float *)wParam->data;
@@ -405,16 +426,18 @@ void testTrainingEpochDefault_MinibatchStepsOncePerMinibatch() {
     size_t sizeModel = 1;
 
     float initWeights[4];
-    for (size_t i = 0; i < 4; i++) initWeights[i] = wData[i];
+    for (size_t i = 0; i < 4; i++) {
+        initWeights[i] = wData[i];
+    }
 
     optimizer_t *sgd = sgdMCreateOptim(0.01f, 0.f, 0.f, model, sizeModel, FLOAT32);
 
     initEpochDataset();
-    dataLoader_t *dl = dataLoaderInit(getEpochSample, getEpochDatasetSize, 2,
-                                       NULL, NULL, false, 0, true);
+    dataLoader_t *dl =
+        dataLoaderInit(getEpochSample, getEpochDatasetSize, 2, NULL, NULL, false, 0, true);
 
-    float epochLoss = trainingEpochDefault(model, sizeModel, MSE, dl, sgd,
-                                            calculateGradsSequential);
+    float epochLoss =
+        trainingEpochDefault(model, sizeModel, MSE, dl, sgd, calculateGradsSequential);
 
     float *curWeights = (float *)wParam->data;
     bool changed = false;
@@ -451,10 +474,10 @@ void testTrainingRun_ReturnsResult() {
     optimizer_t *sgd = sgdMCreateOptim(0.01f, 0.f, 0.f, model, 1, FLOAT32);
 
     initEpochDataset();
-    dataLoader_t *trainDl = dataLoaderInit(getEpochSample, getEpochDatasetSize, 1,
-                                            NULL, NULL, false, 0, true);
-    dataLoader_t *evalDl = dataLoaderInit(getEpochSample, getEpochDatasetSize, 1,
-                                           NULL, NULL, false, 0, true);
+    dataLoader_t *trainDl =
+        dataLoaderInit(getEpochSample, getEpochDatasetSize, 1, NULL, NULL, false, 0, true);
+    dataLoader_t *evalDl =
+        dataLoaderInit(getEpochSample, getEpochDatasetSize, 1, NULL, NULL, false, 0, true);
 
     trainingRunResult_t result = trainingRun(model, 1, MSE, trainDl, evalDl, sgd, 2,
                                              calculateGradsSequential, inferenceWithLoss, NULL);
@@ -505,15 +528,15 @@ void testTrainingRun_CallsCallbackEachEpochWithStats() {
     optimizer_t *sgd = sgdMCreateOptim(0.01f, 0.f, 0.f, model, 1, FLOAT32);
 
     initEpochDataset();
-    dataLoader_t *trainDl = dataLoaderInit(getEpochSample, getEpochDatasetSize, 1,
-                                            NULL, NULL, false, 0, true);
-    dataLoader_t *evalDl = dataLoaderInit(getEpochSample, getEpochDatasetSize, 1,
-                                           NULL, NULL, false, 0, true);
+    dataLoader_t *trainDl =
+        dataLoaderInit(getEpochSample, getEpochDatasetSize, 1, NULL, NULL, false, 0, true);
+    dataLoader_t *evalDl =
+        dataLoaderInit(getEpochSample, getEpochDatasetSize, 1, NULL, NULL, false, 0, true);
 
     size_t numberOfEpochs = 3;
-    trainingRunResult_t result = trainingRun(model, 1, MSE, trainDl, evalDl, sgd, numberOfEpochs,
-                                              calculateGradsSequential, inferenceWithLoss,
-                                              captureCallback);
+    trainingRunResult_t result =
+        trainingRun(model, 1, MSE, trainDl, evalDl, sgd, numberOfEpochs, calculateGradsSequential,
+                    inferenceWithLoss, captureCallback);
 
     // Callback was invoked once per epoch, in order
     TEST_ASSERT_EQUAL_UINT(numberOfEpochs, cbCallCount);
@@ -549,13 +572,13 @@ void testEvaluationEpochWithMetrics_AllCorrect() {
     layer_t *linear = linearLayerInit(w, b, &testQ, &testQ, &testQ, &testQ);
     layer_t *model[] = {linear};
 
-    dataLoader_t *dl = dataLoaderInit(getEpochSample, getEpochDatasetSize, 1,
-                                       NULL, NULL, false, 0, true);
+    dataLoader_t *dl =
+        dataLoaderInit(getEpochSample, getEpochDatasetSize, 1, NULL, NULL, false, 0, true);
 
     // Identity model: all 4 samples predict correctly (same as testEvaluationEpochAccuracy)
     epochStats_t stats = evaluationEpochWithMetrics(model, 1, MSE, dl, inferenceWithLoss);
 
-    TEST_ASSERT_FLOAT_WITHIN(0.01f, 5.5f, stats.loss);  // same as testEvaluationEpoch
+    TEST_ASSERT_FLOAT_WITHIN(0.01f, 5.5f, stats.loss); // same as testEvaluationEpoch
     TEST_ASSERT_FLOAT_WITHIN(0.001f, 1.0f, stats.accuracy);
     TEST_ASSERT_FLOAT_WITHIN(0.001f, 1.0f, stats.precision);
     TEST_ASSERT_FLOAT_WITHIN(0.001f, 1.0f, stats.recall);
@@ -569,7 +592,9 @@ static dataset_t partialDataset;
 static bool partialDatasetInit = false;
 
 static void initPartialDataset() {
-    if (partialDatasetInit) return;
+    if (partialDatasetInit) {
+        return;
+    }
 
     static float in0[] = {5.f, 1.f}; // pred=0
     static float in1[] = {3.f, 1.f}; // pred=0
@@ -639,8 +664,8 @@ void testEvaluationEpochWithMetrics_PartiallyCorrect() {
     layer_t *linear = linearLayerInit(w, b, &testQ, &testQ, &testQ, &testQ);
     layer_t *model[] = {linear};
 
-    dataLoader_t *dl = dataLoaderInit(getPartialSample, getPartialDatasetSize, 1,
-                                       NULL, NULL, false, 0, true);
+    dataLoader_t *dl =
+        dataLoaderInit(getPartialSample, getPartialDatasetSize, 1, NULL, NULL, false, 0, true);
 
     epochStats_t stats = evaluationEpochWithMetrics(model, 1, MSE, dl, inferenceWithLoss);
 
@@ -663,7 +688,9 @@ static dataset_t zeroPredDataset;
 static bool zeroPredDatasetInit = false;
 
 static void initZeroPredDataset() {
-    if (zeroPredDatasetInit) return;
+    if (zeroPredDatasetInit) {
+        return;
+    }
 
     static float in0[] = {5.f, 1.f}; // pred=0
     static float in1[] = {3.f, 1.f}; // pred=0
@@ -729,8 +756,8 @@ void testEvaluationEpochWithMetrics_HandlesZeroPredictionClass() {
     layer_t *linear = linearLayerInit(w, b, &testQ, &testQ, &testQ, &testQ);
     layer_t *model[] = {linear};
 
-    dataLoader_t *dl = dataLoaderInit(getZeroPredSample, getZeroPredDatasetSize, 1,
-                                       NULL, NULL, false, 0, true);
+    dataLoader_t *dl =
+        dataLoaderInit(getZeroPredSample, getZeroPredDatasetSize, 1, NULL, NULL, false, 0, true);
 
     epochStats_t stats = evaluationEpochWithMetrics(model, 1, MSE, dl, inferenceWithLoss);
 
@@ -775,13 +802,13 @@ void testEvaluationEpochWithReport_ReturnsConfusionMatrix() {
     layer_t *linear = linearLayerInit(w, b, &testQ, &testQ, &testQ, &testQ);
     layer_t *model[] = {linear};
 
-    dataLoader_t *dl = dataLoaderInit(getPartialSample, getPartialDatasetSize, 1,
-                                       NULL, NULL, false, 0, true);
+    dataLoader_t *dl =
+        dataLoaderInit(getPartialSample, getPartialDatasetSize, 1, NULL, NULL, false, 0, true);
 
     // Pre-fill with non-zero to verify WithReport zeroes the caller's buffer before accumulating
     size_t cm[2 * 2] = {99, 99, 99, 99};
-    classificationReport_t report = evaluationEpochWithReport(model, 1, MSE, dl,
-                                                               inferenceWithLoss, cm, 2);
+    classificationReport_t report =
+        evaluationEpochWithReport(model, 1, MSE, dl, inferenceWithLoss, cm, 2);
 
     // Expected CM[predicted][actual]: [[2,1],[0,1]]
     // cm[0*2+0]=2, cm[0*2+1]=1, cm[1*2+0]=0, cm[1*2+1]=1

--- a/test/unit/userAPI/UnitTestTrainingLoopApi.c
+++ b/test/unit/userAPI/UnitTestTrainingLoopApi.c
@@ -188,7 +188,7 @@ static void initEpochDataset() {
 }
 
 static sample_t *getEpochSample(size_t id) {
-    sample_t *s = *reserveMemory(sizeof(sample_t));
+    sample_t *s = reserveMemory(sizeof(sample_t));
     s->item = epochDataset.items->array[id];
     s->label = epochDataset.labels->array[id];
     return s;
@@ -607,7 +607,7 @@ static void initPartialDataset() {
 }
 
 static sample_t *getPartialSample(size_t id) {
-    sample_t *s = *reserveMemory(sizeof(sample_t));
+    sample_t *s = reserveMemory(sizeof(sample_t));
     s->item = partialDataset.items->array[id];
     s->label = partialDataset.labels->array[id];
     return s;
@@ -697,7 +697,7 @@ static void initZeroPredDataset() {
 }
 
 static sample_t *getZeroPredSample(size_t id) {
-    sample_t *s = *reserveMemory(sizeof(sample_t));
+    sample_t *s = reserveMemory(sizeof(sample_t));
     s->item = zeroPredDataset.items->array[id];
     s->label = zeroPredDataset.labels->array[id];
     return s;


### PR DESCRIPTION
## Summary

Aggregates the in-flight `develop` integration branch into `main`. 46 commits across the following workstreams, all with passing local CI (33 ctest + 3 pytest):

### Workstreams included

- **#76 Flatten layer** (Stage 1) — non-in-place FLATTEN op, wired into `initLayerOutputs`, model[0] usage, `Data Shape Convention` doc.
- **#81 ASan + UBSan preset** — `unit_test_asan` CMake preset; SymInt32 uninit + NPY OOB header + VLA memcpy fixes that the sanitizer surfaced.
- **#99 StorageApi flat alloc** — drops the `void**` handle indirection; lost-bytes −73% (per memory `project_issue99_outcome`).
- **#100 initTensor refactor** — 11-commit stack adding `initTensor`, `initDistribution`, `tensorFillFromBuffer`, `tensorFillFromFloatBuffer`; deprecates the `tensorInit*` family; closes H1/H2/H3 leak hazards.
- **#101 free-API gaps** — three free-API gaps surfaced by Phase 1 LSan recon.
- **#102 CI alloc-locality** — grep-check rejecting `malloc/calloc/realloc/free` outside `src/userApi/`.
- **#82 LSan Phase 2 — explicit-free + assert-last** — wave batches 1–7b across 12 unit-test files; `docs/CONVENTIONS.md` tier-table for cleanup-cascade rules; container-leak fixes in `freeOptimSgdM` / `freeState` / `inferenceWithLoss`.
- **boyscout** — two latent bugs in optimizer + tensor-conversion paths, surfaced during the wave migrations.

### Stack still in flight against develop (not in this PR)

- **#125 (#96)** — `rngSetSeed(0)` no longer aliases to `rngSetSeed(1)`. Stacked on develop.
- **#126 (#92)** — `PRINT_ERROR` fires by default — `DEBUG_MODE_ERROR` unconditional in `Common__hdrs`. Stacked on #125.
- **#127 (#90)** — `lossConfig_t` with `REDUCTION_MEAN`/`REDUCTION_SUM` — fixes the silent batchSize-× CE/MSE gradient distortion. Stacked on #126.

These will land on develop separately, then a follow-up develop → main PR will pick them up.

## Test plan

- [x] `ctest --preset unit_test` — 33/33 cases pass locally
- [x] `uv run pytest` — 3/3 Python smoke pass
- [ ] Branch-protected CI (c-build-and-test, alloc-locality, python-test) green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)