### PR TITLE
ci: run pipeline on develop branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
   pull_request:
-    branches: [main]
+    branches: [main, develop]
 
 jobs:
   alloc-locality:


### PR DESCRIPTION
## Summary
- Extends GitHub Actions triggers (`push` + `pull_request`) so the pipeline also runs on `develop`, not just `main`.

## Notes
- Branch protection on `develop` mirrors `main`: required checks `c-build-and-test`, `python-test`, `alloc-locality` (set out-of-band via `gh api`).
- No workflow logic changes — only the `on:` trigger list.

## Test plan
- [ ] Verify this PR's CI runs to completion (push + pull_request events targeting `develop`).
- [ ] After merge, push a no-op commit to `develop` and confirm the post-merge `push` trigger fires.