### PR TITLE
fix(#86, #94): guard byteConversion against OOB read/write

### DIFF
--- a/src/tensor/Tensor.c
+++ b/src/tensor/Tensor.c
@@ -167,9 +167,17 @@ void byteConversion(uint8_t *dataIn, size_t dataInBits, uint8_t *dataOut, size_t
         printf("\n");
         printf("Value %i\n", i);*/
         while ((dataInStartbit < dataInEndbit) | (dataOutStartbit < dataOutEndbit)) {
-            uint8_t data = readByte(dataIn[dataInIndex], dataInStartbit, dataInEndbit);
-            dataOut[dataOutIndex] =
-                writeByte(dataOut[dataOutIndex], data, dataOutStartbit, dataOutEndbit);
+            /* Guard each side: input may exhaust before output (widening) or
+             * output may fill before input (narrowing); skipping the out-of-range
+             * access avoids OOB while preserving zero-fill semantics. */
+            uint8_t data = 0;
+            if (dataInStartbit < dataInEndbit) {
+                data = readByte(dataIn[dataInIndex], dataInStartbit, dataInEndbit);
+            }
+            if (dataOutStartbit < dataOutEndbit) {
+                dataOut[dataOutIndex] =
+                    writeByte(dataOut[dataOutIndex], data, dataOutStartbit, dataOutEndbit);
+            }
 
             /*
             printf("dataInStartbit %d\n", dataInStartbit);

--- a/test/unit/tensor/UnitTestTensor.c
+++ b/test/unit/tensor/UnitTestTensor.c
@@ -144,6 +144,59 @@ void testByteFlattening5() {
     TEST_ASSERT_EQUAL_UINT8_ARRAY(expectedBytes, dataOut, numBytesDataOut);
 }
 
+/* Regression for an ASan-detected heap-buffer-overflow surfaced by
+ * testLinearBackwardFloatWithMismatchedQuantizations on the float32 -> asym8
+ * conversion path. byteConversion's inner while-loop keeps iterating after
+ * the output for a value is full to consume remaining input bits, accessing
+ * dataOut[dataOutIndex] one byte past the end of the buffer. The OOB write
+ * is a no-op on the value (writeByte with startbit==endbit), so the bug is
+ * invisible to value assertions and only fires under ASan. */
+void testByteConversion_NarrowingInt32ToByte_DoesNotOverreadOutputBuffer() {
+    /* Two int32 values, little-endian: 0xAABBCCDD, 0xEEFF1122. */
+    uint8_t dataIn[8] = {0xDD, 0xCC, 0xBB, 0xAA, 0x22, 0x11, 0xFF, 0xEE};
+    size_t dataInBits = 32;
+    size_t dataOutBits = 8;
+    size_t numValues = 2;
+    size_t numBytesDataOut = (numValues * dataOutBits - 1) / 8 + 1; /* = 2 */
+
+    uint8_t *dataOut = reserveMemory(numBytesDataOut);
+    byteConversion(dataIn, dataInBits, dataOut, dataOutBits, numValues);
+
+    uint8_t captured[numBytesDataOut];
+    memcpy(captured, dataOut, numBytesDataOut);
+    freeReservedMemory(dataOut);
+
+    uint8_t expectedBytes[2] = {0xDD, 0x22};
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(expectedBytes, captured, numBytesDataOut);
+}
+
+/* Companion to the narrowing test above, exercising the sub-byte path of #86.
+ * 32-bit input -> 4-bit output, 4 values packed into 2 bytes. The same
+ * loop-control bug shows up: after the last value's bits are written, the
+ * inner while-loop continues consuming input bits and accesses
+ * dataOut[dataOutIndex] one byte past the end of the buffer. */
+void testByteConversion_NarrowingInt32ToSubByte_DoesNotOverreadOutputBuffer() {
+    /* Four int32 values, low 4 bits matter: 0xA, 0xB, 0xC, 0xD. */
+    uint8_t dataIn[16] = {
+        0x0A, 0, 0, 0, 0x0B, 0, 0, 0, 0x0C, 0, 0, 0, 0x0D, 0, 0, 0,
+    };
+    size_t dataInBits = 32;
+    size_t dataOutBits = 4;
+    size_t numValues = 4;
+    size_t numBytesDataOut = (numValues * dataOutBits - 1) / 8 + 1; /* = 2 */
+
+    uint8_t *dataOut = reserveMemory(numBytesDataOut);
+    byteConversion(dataIn, dataInBits, dataOut, dataOutBits, numValues);
+
+    uint8_t captured[numBytesDataOut];
+    memcpy(captured, dataOut, numBytesDataOut);
+    freeReservedMemory(dataOut);
+
+    /* byte 0 = (0xB << 4) | 0xA = 0xBA; byte 1 = (0xD << 4) | 0xC = 0xDC. */
+    uint8_t expectedBytes[2] = {0xBA, 0xDC};
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(expectedBytes, captured, numBytesDataOut);
+}
+
 void testCopyTensor() {
     size_t numberOfValues = 3;
     tensor_t src;
@@ -191,6 +244,8 @@ int main(void) {
     RUN_TEST(testByteFlattening3);
     RUN_TEST(testByteFlattening4);
     RUN_TEST(testByteFlattening5);
+    RUN_TEST(testByteConversion_NarrowingInt32ToSubByte_DoesNotOverreadOutputBuffer);
+    RUN_TEST(testByteConversion_NarrowingInt32ToByte_DoesNotOverreadOutputBuffer);
 
     RUN_TEST(testGetBitmask);
     RUN_TEST(testGetBitmask2);

--- a/test/unit/userAPI/UnitTestMnistSmoke.c
+++ b/test/unit/userAPI/UnitTestMnistSmoke.c
@@ -1,6 +1,8 @@
 #define SOURCE_FILE "UNIT_TEST_MNIST_SMOKE"
 
 #include <stddef.h>
+#include <stdio.h>
+#include <time.h>
 
 #include "unity.h"
 
@@ -230,8 +232,66 @@ void testMnistSmoke_FullTrainingPipelineReducesLoss() {
     TEST_ASSERT_TRUE(capturedLastTrainLoss < capturedFirstTrainLoss);
 }
 
+/* Regression test for #94. The original audit observed a silent exit(1) on
+ * macOS when an snprintf or gmtime_r call sat between init() and trainingRun()
+ * in the base project; #94 hypothesised an uninitialized-read or sized-buffer
+ * overrun in a static-init path whose visible symptom was gated on stack/dyld
+ * layout. This test mirrors the reproducer pattern (full FLOAT32 setup,
+ * gmtime_r + snprintf, then trainingRun) on the in-tree smoke pipeline. If the
+ * underlying memory bug is still present, trainingRun terminates with exit(1)
+ * before reaching any assertion; reaching the final TEST_ASSERT_TRUE proves
+ * the run completed normally. */
+void testMnistSmoke_SnprintfGmtimeRBetweenSetupAndTrainingRun_NoSilentExit() {
+    initDataset();
+
+    dataLoader_t *trainDl =
+        dataLoaderInit(getSample, getDatasetSize, 2, NULL, NULL, false, 0, true);
+    dataLoader_t *evalDl = dataLoaderInit(getSample, getDatasetSize, 1, NULL, NULL, false, 0, true);
+
+    layer_t *model[MODEL_SIZE];
+    quantization_t *q = NULL;
+    buildModel(model, &q);
+
+    optimizer_t *sgd = sgdMCreateOptim(0.1f, 0.0f, 0.0f, model, MODEL_SIZE, FLOAT32);
+
+    /* The poison block from #94's reproducer: gmtime_r + snprintf wedged
+     * between setup and trainingRun. Pre-fix this triggered silent exit(1). */
+    char buf[64];
+    time_t t = time(NULL);
+    struct tm tmStruct;
+    gmtime_r(&t, &tmStruct);
+    snprintf(buf, sizeof(buf), "%04d-%02d-%02d", tmStruct.tm_year + 1900, tmStruct.tm_mon + 1,
+             tmStruct.tm_mday);
+
+    cbInvocations = 0;
+    trainingRunResult_t result = trainingRun(
+        model, MODEL_SIZE, (lossConfig_t){.funcType = CROSS_ENTROPY, .reduction = REDUCTION_MEAN},
+        trainDl, evalDl, sgd, 1, calculateGradsSequential, inferenceWithLoss, captureEpoch);
+
+    /* CAPTURE before free. */
+    size_t capturedCbInvocations = cbInvocations;
+    float capturedFinalTrainLoss = result.finalTrainLoss;
+    char capturedFirstChar = buf[0];
+
+    freeOptimSgdM(sgd);
+    freeSoftmaxLayer(model[3]);
+    freeLinearLayer(model[2]);
+    freeReluLayer(model[1]);
+    freeLinearLayer(model[0]);
+    freeDataLoader(evalDl);
+    freeDataLoader(trainDl);
+    freeQuantization(q);
+    freeDataset();
+
+    /* Reaching these at all proves trainingRun did not silent-exit. */
+    TEST_ASSERT_EQUAL_UINT(1, capturedCbInvocations);
+    TEST_ASSERT_TRUE(capturedFinalTrainLoss > 0.0f);
+    TEST_ASSERT_NOT_EQUAL('\0', capturedFirstChar);
+}
+
 int main() {
     UNITY_BEGIN();
     RUN_TEST(testMnistSmoke_FullTrainingPipelineReducesLoss);
+    RUN_TEST(testMnistSmoke_SnprintfGmtimeRBetweenSetupAndTrainingRun_NoSilentExit);
     return UNITY_END();
 }


### PR DESCRIPTION
## Summary

ASan-detected heap-buffer-overflow in `byteConversion` (`src/tensor/Tensor.c`) when the inner while-loop accessed `dataOut[dataOutIndex]` past the end of the output buffer in narrowing conversions (e.g. `float32 -> asym8`) and `dataIn[dataInIndex]` past the input buffer in widening conversions (e.g. `asym8 -> float32`). Both surfaced under `unit_test_asan` via `testLinearBackwardFloatWithMismatchedQuantizations`.

**Fix:** guard each access independently with `if (start < end)`. Read-side falls back to `data = 0`, preserving the existing zero-fill semantics on widening.

## Tests (TDD: RED → GREEN)

- `UnitTestTensor.c` — two regression tests covering narrowing `32->8` (`#86` heap-OOB) and narrowing `32->sub-byte` (`#86` sub-byte path); both fire under ASan pre-fix, green post-fix.
- `UnitTestMnistSmoke.c` — targeted `#94` reproducer: full FLOAT32 setup + `snprintf` + `gmtime_r` between setup and `trainingRun`. `#94` was closed nebenbei by `#99`/`#100`/`#101` refactors on `develop`; this test guards against re-emergence.

## Verification

- `ctest --preset unit_test_asan` — 33/33 green
- `ctest --preset unit_test` — 33/33 green
- `uv run pytest` — 3/3 green
- `alloc-locality` grep — clean

## Closes

Closes #86
Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)