### PR TITLE
build(#81): add c-asan-build-and-test CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,24 @@ jobs:
       - name: Test
         run: ctest --preset unit_test
 
+  c-asan-build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y cmake ninja-build clang
+
+      - name: Configure
+        run: CC=clang cmake --preset unit_test_asan
+
+      - name: Build
+        run: cmake --build --preset unit_test_asan
+
+      - name: Test
+        run: ctest --preset unit_test_asan
+
   python-test:
     runs-on: ubuntu-latest
 

--- a/devenv.nix
+++ b/devenv.nix
@@ -60,16 +60,29 @@ in
 			package = pkgs.bash;
 			description = "Run all Unity unit tests and print their result";
 		};
+		run_asan_tests = {
+			exec = ''
+				set -e
+				cmake --preset unit_test_asan
+				cmake --build --preset unit_test_asan
+				ctest --preset unit_test_asan
+			'';
+			package = pkgs.bash;
+			description = "Run the unit-test suite under AddressSanitizer + UBSan";
+		};
 		ci = {
 			exec = ''
 				set -e
 				cmake --preset unit_test
 				cmake --build --preset unit_test
 				ctest --preset unit_test
+				cmake --preset unit_test_asan
+				cmake --build --preset unit_test_asan
+				ctest --preset unit_test_asan
 				uv run pytest
 			'';
 			package = pkgs.bash;
-			description = "Run the full CI pipeline locally (C + Python tests)";
+			description = "Run the full CI pipeline locally (C + ASan/UBSan + Python tests)";
 		};
 
 };

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -14,6 +14,61 @@ the dataset. This:
 
 For flatten-to-2D, use `flattenLayerInit()` from `FlattenApi.h`.
 
+## Sanitizer-driven memory bug detection
+
+The C unit-test suite is run twice in CI: once normally (`c-build-and-test`),
+and once under AddressSanitizer + UndefinedBehaviorSanitizer
+(`c-asan-build-and-test`). The sanitizer job is a hard gate — any heap-OOB,
+use-after-free, double-free, or UB diagnoses fails the PR. LeakSanitizer is
+deliberately **off** (`detect_leaks=0`) in CI; see the opt-in recipe below.
+
+### Local reproduction
+
+The `unit_test_asan` preset is the source of truth. Same flags, same runtime
+options as CI:
+
+```bash
+cmake --preset unit_test_asan
+cmake --build --preset unit_test_asan
+ctest --preset unit_test_asan
+```
+
+Or, in the devenv shell, the composite script:
+
+```bash
+run_asan_tests
+```
+
+Sanitizer flags (`-fsanitize=address,undefined -fno-sanitize=function
+-fno-omit-frame-pointer -fno-sanitize-recover=all -g -O1`) propagate to every
+target in the link graph via the configure preset — there is no opt-in per
+target.
+
+Runtime options the test preset sets:
+
+- `ASAN_OPTIONS=detect_leaks=0:abort_on_error=1:halt_on_error=1:strict_string_checks=1:check_initialization_order=1`
+- `UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1`
+
+`halt_on_error=1` plus `-fno-sanitize-recover=all` means the **first** finding
+aborts the test binary — earlier tests must run cleanly to surface later ones.
+When triaging multiple unrelated failures, isolate by running individual test
+binaries from `build/unit_test_asan/test/unit/...` directly.
+
+### Opt-in LeakSanitizer recipe
+
+LSan is staged separately because it requires a cleanup convention every test
+honours; see #82 for the umbrella. To run a single test or directory under LSan
+during incremental cleanup work, override `detect_leaks` at the call site:
+
+```bash
+ASAN_OPTIONS="detect_leaks=1:abort_on_error=1:halt_on_error=1" \
+  build/unit_test_asan/test/unit/<module>/UnitTest<Name>
+```
+
+For broader recon (e.g. surveying which tests currently leak), prefer the
+valgrind-based recipe in `docs/superpowers/tools/lsan-recon/` — it produces
+reproducible, fully-attributed per-test reports.
+
 ## Allocation Locality
 
 Only `src/userApi/` may call `malloc`, `calloc`, `realloc`, or `free` directly. All other code (sub-layers under `src/`, tests under `test/`) must route allocations through `reserveMemory` and `freeReservedMemory` in `src/userApi/StorageApi.{c,h}`.


### PR DESCRIPTION
## Summary

Adds a parallel CI job `c-asan-build-and-test` that builds and runs the C unit-test suite under AddressSanitizer + UndefinedBehaviorSanitizer on every push and PR. This is a hard gate — any heap-OOB, use-after-free, double-free, or UB diagnoses fails the PR.

The `unit_test_asan` preset itself was already present (introduced during the #86 recon work). This PR only wires it into CI, devenv, and docs.

## Changes

- **`.github/workflows/ci.yml`** — new `c-asan-build-and-test` job, parallel to `c-build-and-test`. Uses Clang on `ubuntu-latest`. No `continue-on-error`.
- **`devenv.nix`** — new `run_asan_tests` script invoking the ASan preset; the `ci` composite script now runs both default and ASan suites before pytest.
- **`docs/CONVENTIONS.md`** — new "Sanitizer-driven memory bug detection" section with local-reproduction commands, runtime-options reference, and an opt-in LSan recipe for incremental cleanup work.

## Why now

#86 (heap-OOB in `byteConversion`) was the only known failure under ASan; closed by #131 in this same review batch. With develop now ASan-clean (33/33 green, verified locally), turning on the CI gate prevents regression.

## Out of scope (separate follow-ups)

- LeakSanitizer enablement in CI — needs the cleanup convention from `docs/CONVENTIONS.md`'s "Test memory discipline" section to be honoured everywhere; tracked under `#82`.
- Adding `c-asan-build-and-test` as a Required Check on `main` and `develop` branch protection rules — done out-of-band via `gh api` after this PR merges, same pattern as `alloc-locality`.

## Verification

- `ctest --preset unit_test_asan` — 33/33 green
- `ctest --preset unit_test` — 33/33 green
- `uv run pytest` — 3/3 green
- `alloc-locality` grep — clean
- `run_asan_tests` devenv script — executes end-to-end clean
- `ci` composite devenv script — executes end-to-end clean

## Closes

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)