### PR TITLE
fix(#108): close ASYM byte-count under-allocation

### DIFF
--- a/src/tensor/Tensor.c
+++ b/src/tensor/Tensor.c
@@ -85,7 +85,7 @@ size_t calcNumberOfBytesForData(quantization_t *q, size_t numberOfElements) {
         return numberOfElements * sizeof(int32_t);
     case ASYM:
         size_t bitsPerElement = calcBitsPerElement(q);
-        return ceilf((float)(bitsPerElement * numberOfElements / 8));
+        return (bitsPerElement * numberOfElements + 7) / 8;
     default:
         PRINT_ERROR("Unknown QType!");
         exit(1);

--- a/src/userApi/tensor/TensorApi.c
+++ b/src/userApi/tensor/TensorApi.c
@@ -323,7 +323,7 @@ uint8_t *getDataLike(quantization_t *quantization, size_t numberOfValues) {
     case ASYM:
         asymQConfig_t *asymQC = quantization->qConfig;
         size_t totalBits = numberOfValues * asymQC->qBits;
-        size_t totalBytes = ceilf(totalBits / 8);
+        size_t totalBytes = (totalBits + 7) / 8;
         return reserveMemory(totalBytes);
     default:
         PRINT_ERROR("Unknown QType");

--- a/test/unit/tensor/UnitTestTensorApi.c
+++ b/test/unit/tensor/UnitTestTensorApi.c
@@ -456,6 +456,34 @@ void testGradInitAsym_DoesNotAliasParentShape(void) {
     freeTensor(param);
 }
 
+/* Regression for #108. calcNumberOfBytesForData on the ASYM arm did
+ * (bitsPerElement * numberOfElements / 8) with integer arithmetic, then ceilf
+ * on the already-truncated result — under-allocating by one byte whenever the
+ * total bit count was not a multiple of 8. */
+void testCalcNumberOfBytesForData_AsymSubByte_RoundsUpInsteadOfTruncating(void) {
+    quantization_t *q = quantizationInitAsym(3, HTE);
+    /* 10 elements * 3 bits = 30 bits => ceil(30/8) = 4 bytes. */
+    size_t bytes = calcNumberOfBytesForData(q, 10);
+    freeQuantization(q);
+    TEST_ASSERT_EQUAL_UINT(4, bytes);
+}
+
+/* Companion to the test above for #108: getDataLike has the same
+ * integer-div-before-ceilf shape and under-allocates the data buffer.
+ * Under ASan, writing the full 4 expected bytes into a 3-byte allocation
+ * trips heap-buffer-overflow; the value-assertion test above catches the
+ * arithmetic itself. */
+void testGetDataLike_AsymSubByte_AllocatesCeilingOfBits(void) {
+    quantization_t *q = quantizationInitAsym(3, HTE);
+    uint8_t *data = getDataLike(q, 10);
+    /* 30 bits => 4 bytes; pre-fix only 3 are allocated. */
+    for (size_t i = 0; i < 4; ++i) {
+        data[i] = 0xFF;
+    }
+    freeReservedMemory(data);
+    freeQuantization(q);
+}
+
 void testInitTensor_Int32_AllocatesFourBytesPerElement(void) {
     /* Closes the calcNumberOfBytesForData gap surfaced by code-review on Task A:
      * the INT32 arm was missing, which would have made gradInitInt32 (Task D)
@@ -520,6 +548,8 @@ int main(void) {
     RUN_TEST(testTensorInitWithDistribution_ShapeIsCorrect);
     RUN_TEST(testInitTensor_AllocatesOwnZeroDataBuffer_FreeTensorIsSafe);
     RUN_TEST(testInitTensor_Int32_AllocatesFourBytesPerElement);
+    RUN_TEST(testCalcNumberOfBytesForData_AsymSubByte_RoundsUpInsteadOfTruncating);
+    RUN_TEST(testGetDataLike_AsymSubByte_AllocatesCeilingOfBits);
     RUN_TEST(testTensorFillFromFloatBuffer_CopiesValues_SourceCanGoOutOfScope);
     RUN_TEST(testFreeParameter_NullGrad_DoesNotSegfault);
     RUN_TEST(testGradInitFloat_DoesNotAliasParentShape);


### PR DESCRIPTION
## Summary

`calcNumberOfBytesForData` (`src/tensor/Tensor.c:88`) and `getDataLike` (`src/userApi/tensor/TensorApi.c:326`) both computed `(bits * N / 8)` with integer arithmetic and then applied `ceilf` to the already-truncated result. For sub-byte ASYM \`qBits\` with non-multiple-of-8 total bit counts the buffer was under-allocated by one byte.

**Concrete example:** ASYM \`qBits=3\`, \`N=10\` elements → 30 bits → expected \`ceil(30/8) = 4\` bytes; pre-fix returned \`3\`. Manifests as heap-buffer-overflow under ASan whenever \`byteConversion\` or any other ASYM consumer writes the full packed payload.

## Fix

Replace \`ceilf\`-of-int with integer ceiling \`(a + b - 1) / b\`. No \`math.h\` dependency, no float pipeline, no precision loss for large tensors (relevant on MCU targets).

## Tests (TDD: RED → GREEN)

- \`testCalcNumberOfBytesForData_AsymSubByte_RoundsUpInsteadOfTruncating\` — asserts the returned value (4) directly; pre-fix returned 3.
- \`testGetDataLike_AsymSubByte_AllocatesCeilingOfBits\` — writes the full packed payload (4 bytes) into the returned buffer; pre-fix the third byte was OOB and tripped ASan.

## Verification

- \`ctest --preset unit_test_asan\` — 33/33 green
- \`ctest --preset unit_test\` — 33/33 green
- \`uv run pytest\` — 3/3 green
- alloc-locality grep — clean

## Closes

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)