### PR TITLE
ci(devenv): align local `ci` with .github/workflows/ci.yml

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -9,8 +9,9 @@ in
   in
     [
       pkgs.git
-      pkgs.clang-tools
+      u.llvmPackages_21.clang-tools
       pkgs.gcc
+      pkgs.clang
       pkgs.cmake
       pkgs.ninja
       u.gcc-arm-embedded-13
@@ -34,7 +35,7 @@ in
   scripts = {
     setup_cmake = {
       exec = ''
-        cmake --preset unit_test
+        CC=gcc cmake --preset unit_test
       '';
       package = pkgs.bash;
       description = "setup cmake";
@@ -63,7 +64,7 @@ in
 		run_asan_tests = {
 			exec = ''
 				set -e
-				cmake --preset unit_test_asan
+				CC=clang cmake --preset unit_test_asan
 				cmake --build --preset unit_test_asan
 				ctest --preset unit_test_asan
 			'';
@@ -73,12 +74,28 @@ in
 		ci = {
 			exec = ''
 				set -e
+				# git grep exits 1 on no matches; suspend abort-on-error for this block only
+				set +e
+				matches=$(git grep -nP '\b(malloc|calloc|realloc|free)\s*\(' \
+					-- 'src/' 'test/' \
+					':!src/userApi/' \
+					':!*.md' \
+					| grep -vE '^[^:]+:[0-9]+:[[:space:]]*(//|\*)')
+				set -e
+				if [ -n "$matches" ]; then
+					echo "Allocation-locality violation: malloc/calloc/realloc/free are only allowed in src/userApi/."
+					echo "All other code must route through reserveMemory/freeReservedMemory in src/userApi/StorageApi.{c,h}."
+					echo
+					echo "Offending lines:"
+					echo "$matches"
+					exit 1
+				fi
 				find src test example \( -name '*.c' -o -name '*.h' \) -print0 \
 					| xargs -0 clang-format --dry-run -Werror
-				cmake --preset unit_test
+				CC=gcc cmake --preset unit_test
 				cmake --build --preset unit_test
 				ctest --preset unit_test
-				cmake --preset unit_test_asan
+				CC=clang cmake --preset unit_test_asan
 				cmake --build --preset unit_test_asan
 				ctest --preset unit_test_asan
 				uv run pytest


### PR DESCRIPTION
Mirror the alloc-locality, format-check, and ASan-compiler aspects of .github/workflows/ci.yml so a green local run predicts a green PR (with `-P` not `-E` for the grep — macOS git silently ignores `\b` in POSIX-ERE — and both cmake configures explicit `CC=` because `pkgs.clang` + `languages.c.enable` would otherwise flip the shell to clang globally). Helper scripts (`setup_cmake`, `run_asan_tests`) get the same explicit-prefix discipline.