### PR TITLE
feat(loss): unify forward/backward reduction semantics across loss / …

### DIFF
--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -179,3 +179,58 @@ A test file is considered idiom-compliant when, run under valgrind in the
 categories report 0 bytes in 0 blocks (or valgrind emits "All heap blocks
 were freed -- no leaks are possible"). The reproducible recipe and
 container Dockerfile live in `docs/superpowers/tools/lsan-recon/`.
+
+## Loss API: microbatch contracts
+
+Each loss function in `src/loss_functions/` exposes:
+
+- `forward(modelOutput, label, reduction) → float`
+- `backward(modelOutput, label, result) → void`
+- `computeMeanScale(totalSamples, modelOutput) → float`
+
+### Reduction split
+
+`lossConfig_t.backwardReduction` is the user's training-strategy choice — it
+drives whether `scaleOptimizerGradients` runs between `trainingBatchDefault`
+and `optimFns.step`. It is a config field.
+
+`forwardReduction` is a per-call parameter on every aggregator
+(`trainingBatchDefault`, `evaluationBatch`, `evaluationEpoch`, `inferenceWithLoss`,
+`calculateGradsFn_t`). It controls how the per-microbatch loss value is
+reported. `trainingRun` is the only function that hardcodes it
+(to `REDUCTION_MEAN`) so train and eval losses are comparable; lower-level
+callers pick freely.
+
+### Microbatch shape
+
+`modelOutput->shape->dimensions[0]` is the microbatch dimension `B`. For
+`B=1` today, output shape is `[F]` (the leading 1 is implicit). For `B>=1`
+in the future, output shape is `[B, F]` and `numFeaturesPerSample = numElements / B`.
+
+**Uniform-B assumption** (DataLoader contract): all microbatches in one
+macro batch have equal `B`. The MEAN aggregator divides by total samples
+(`Σ batch->size`) rather than by `(numberOfBatches × B)`, so non-uniform B
+would skew the mean. ODT's DataLoader currently always produces uniform
+batches via `dropLast=true`; non-uniform B is out of contract.
+
+### Backward macro-scaling
+
+Backward writes raw per-element gradients (`2(o-l)` for MSE, `(p-y)` for CE).
+The macro-batch divisor lives at the optimizer:
+
+- `lossFunctions[lossConfig.funcType].computeMeanScale(N, modelOutput)`
+  returns the PyTorch-parity divisor (`1/(N*F)` for MSE, `1/N` for CE).
+- `scaleOptimizerGradients(optimizer, factor)` multiplies every parameter's
+  `grad` field by the factor in place.
+- `trainingEpochDefault` calls these between accumulation and `step`,
+  but only when `backwardReduction == REDUCTION_MEAN`.
+
+For SUM (or future per-sample weighted variants — see #150), the backward
+gradient flows through unscaled.
+
+### Shape assertion (deferred)
+
+Runtime assertion of the `dimensions[0] >= 1` contract is deferred to the
+microbatch-B>1 umbrella (#152) — specifically #153. Today (B=1 only) the
+assertion would be effectively a no-op; the protective value materialises
+when B>1 becomes a real feature target.

--- a/example/MnistExperiment.c
+++ b/example/MnistExperiment.c
@@ -176,10 +176,11 @@ int main(void) {
 
     clock_t start = clock();
 
-    trainingRunResult_t result = trainingRun(
-        model, MODEL_SIZE, (lossConfig_t){.funcType = CROSS_ENTROPY, .reduction = REDUCTION_MEAN},
-        trainDataloader, testDataloader, sgd, numberOfEpochs, calculateGradsSequential,
-        inferenceWithLoss, epochCallback);
+    trainingRunResult_t result =
+        trainingRun(model, MODEL_SIZE,
+                    (lossConfig_t){.funcType = CROSS_ENTROPY, .backwardReduction = REDUCTION_MEAN},
+                    trainDataloader, testDataloader, sgd, numberOfEpochs, calculateGradsSequential,
+                    inferenceWithLoss, epochCallback);
 
     clock_t end = clock();
 

--- a/src/loss_functions/CrossEntropy.c
+++ b/src/loss_functions/CrossEntropy.c
@@ -9,7 +9,8 @@
 
 #include <math.h>
 
-float crossEntropyForwardFloat(tensor_t *softmaxOutput, tensor_t *distribution) {
+float crossEntropyForwardFloat(tensor_t *softmaxOutput, tensor_t *distribution,
+                               reduction_t reduction) {
     size_t n = calcNumberOfElementsByTensor(softmaxOutput);
     float *p = (float *)softmaxOutput->data;
     float *y = (float *)distribution->data;
@@ -26,6 +27,11 @@ float crossEntropyForwardFloat(tensor_t *softmaxOutput, tensor_t *distribution) 
 
         pi = fmaxf(pi, 1e-7f);
         loss += y[i] * -logf(pi);
+    }
+
+    if (reduction == REDUCTION_MEAN && softmaxOutput->shape->numberOfDimensions >= 2) {
+        size_t microbatch = softmaxOutput->shape->dimensions[0];
+        return loss / (float)microbatch;
     }
     return loss;
 }
@@ -53,24 +59,20 @@ float crossEntropyForwardFloat(tensor_t *softmaxOutput, tensor_t *distribution) 
 }*/
 
 static void crossEntropySoftmaxBackwardFloat(tensor_t *softmaxOutput, tensor_t *distribution,
-                                             tensor_t *loss, size_t batchSize,
-                                             reduction_t reduction) {
+                                             tensor_t *loss) {
     size_t totalInputSize = calcNumberOfElementsByTensor(softmaxOutput);
 
     float *softmaxOutputFloat = (float *)softmaxOutput->data;
     float *distributionFloat = (float *)distribution->data;
     float *lossFloat = (float *)loss->data;
 
-    float divisor = (reduction == REDUCTION_MEAN) ? (float)batchSize : 1.0f;
-
     for (size_t i = 0; i < totalInputSize; i++) {
-        lossFloat[i] = (softmaxOutputFloat[i] - distributionFloat[i]) / divisor;
+        lossFloat[i] = softmaxOutputFloat[i] - distributionFloat[i];
     }
 }
 
 static void crossEntropySoftmaxBackwardAsym(tensor_t *softmaxOutput, tensor_t *distribution,
-                                            tensor_t *loss, size_t batchSize,
-                                            reduction_t reduction) {
+                                            tensor_t *loss) {
     size_t inputSize = calcNumberOfElementsByTensor(softmaxOutput);
 
     tensor_t softmaxOutputFloat;
@@ -100,27 +102,29 @@ static void crossEntropySoftmaxBackwardAsym(tensor_t *softmaxOutput, tensor_t *d
     float *distributionFloatArr = (float *)distributionFloat.data;
     float *lossFloatArr = (float *)lossFloat.data;
 
-    float divisor = (reduction == REDUCTION_MEAN) ? (float)batchSize : 1.0f;
-
     for (size_t i = 0; i < inputSize; i++) {
-        lossFloatArr[i] = (softmaxOutputFloatArr[i] - distributionFloatArr[i]) / divisor;
+        lossFloatArr[i] = softmaxOutputFloatArr[i] - distributionFloatArr[i];
     }
 
     convertTensor(&lossFloat, loss);
 }
 
 // IMPORTANT: This implementation already takes the softmax backward into account
-void crossEntropySoftmaxBackward(tensor_t *softmaxOutput, tensor_t *distribution, tensor_t *loss,
-                                 size_t batchSize, reduction_t reduction) {
+void crossEntropySoftmaxBackward(tensor_t *softmaxOutput, tensor_t *distribution, tensor_t *loss) {
     switch (softmaxOutput->quantization->type) {
     case FLOAT32:
-        crossEntropySoftmaxBackwardFloat(softmaxOutput, distribution, loss, batchSize, reduction);
+        crossEntropySoftmaxBackwardFloat(softmaxOutput, distribution, loss);
         break;
     case ASYM:
-        crossEntropySoftmaxBackwardAsym(softmaxOutput, distribution, loss, batchSize, reduction);
+        crossEntropySoftmaxBackwardAsym(softmaxOutput, distribution, loss);
         break;
     default:
         PRINT_ERROR("Unknown QType!");
         exit(1);
     }
+}
+
+float computeMeanScaleCE(size_t totalSamples, tensor_t *modelOutput) {
+    (void)modelOutput;
+    return 1.0f / (float)totalSamples;
 }

--- a/src/loss_functions/LossFunction.c
+++ b/src/loss_functions/LossFunction.c
@@ -5,5 +5,14 @@
 #include "MSE.h"
 
 lossFunctions_t lossFunctions[] = {
-    [MSE] = {mseLossForward, mseLossBackward},
-    [CROSS_ENTROPY] = {crossEntropyForwardFloat, crossEntropySoftmaxBackward}};
+    [MSE] = {mseLossForward, mseLossBackward, computeMeanScaleMSE},
+    [CROSS_ENTROPY] = {crossEntropyForwardFloat, crossEntropySoftmaxBackward, computeMeanScaleCE},
+};
+
+lossConfig_t defaultLossConfig(lossFuncType_t funcType) {
+    lossConfig_t cfg;
+    cfg.funcType = funcType;
+    cfg.backwardReduction = REDUCTION_MEAN;
+    cfg.classWeights = NULL;
+    return cfg;
+}

--- a/src/loss_functions/MSE.c
+++ b/src/loss_functions/MSE.c
@@ -10,23 +10,25 @@
 #include "Tensor.h"
 #include "TensorConversion.h"
 
-float mseLossForwardFloat(tensor_t *output, tensor_t *label) {
+float mseLossForwardFloat(tensor_t *output, tensor_t *label, reduction_t reduction) {
     size_t size = calcNumberOfElementsByTensor(output);
 
     float *outputFloat = (float *)output->data;
     float *labelFloat = (float *)label->data;
 
     float sum = 0.0f;
-
     for (size_t i = 0; i < size; ++i) {
         float delta = outputFloat[i] - labelFloat[i];
         sum += delta * delta;
     }
 
-    return sum / (float)size;
+    if (reduction == REDUCTION_MEAN) {
+        return sum / (float)size;
+    }
+    return sum;
 }
 
-float mseLossForwardSymInt32(tensor_t *output, tensor_t *label) {
+float mseLossForwardSymInt32(tensor_t *output, tensor_t *label, reduction_t reduction) {
     size_t size = calcNumberOfElementsByTensor(output);
 
     tensor_t outputFloat;
@@ -53,40 +55,36 @@ float mseLossForwardSymInt32(tensor_t *output, tensor_t *label) {
         sum += delta * delta;
     }
 
-    return sum / (float)size;
+    if (reduction == REDUCTION_MEAN) {
+        return sum / (float)size;
+    }
+    return sum;
 }
 
-float mseLossForward(tensor_t *output, tensor_t *label) {
+float mseLossForward(tensor_t *output, tensor_t *label, reduction_t reduction) {
     switch (output->quantization->type) {
     case FLOAT32:
-        return mseLossForwardFloat(output, label);
+        return mseLossForwardFloat(output, label, reduction);
     case SYM_INT32:
-        return mseLossForwardSymInt32(output, label);
+        return mseLossForwardSymInt32(output, label, reduction);
     default:
         PRINT_ERROR("Unknown QType!");
         exit(1);
     }
 }
 
-void mseLossBackwardFloat(tensor_t *modelOutput, tensor_t *label, tensor_t *result,
-                          size_t batchSize, reduction_t reduction) {
+void mseLossBackwardFloat(tensor_t *modelOutput, tensor_t *label, tensor_t *result) {
     size_t numberOfElements = calcNumberOfElementsByTensor(modelOutput);
-
-    float perSampleMean = 2.f / (float)numberOfElements;
-    float batchDivisor = (reduction == REDUCTION_MEAN) ? (float)batchSize : 1.0f;
-    float mean = perSampleMean / batchDivisor;
-
     float *modelOutputArray = (float *)modelOutput->data;
     float *labelArray = (float *)label->data;
     float *resultArray = (float *)result->data;
 
     for (size_t i = 0; i < numberOfElements; i++) {
-        resultArray[i] = mulFloat32s(mean, subFloat32s(modelOutputArray[i], labelArray[i]));
+        resultArray[i] = 2.0f * (modelOutputArray[i] - labelArray[i]);
     }
 }
 
-void mseLossBackwardSymInt32(tensor_t *modelOutput, tensor_t *label, tensor_t *result,
-                             size_t batchSize, reduction_t reduction) {
+void mseLossBackwardSymInt32(tensor_t *modelOutput, tensor_t *label, tensor_t *result) {
     size_t numberOfElements = calcNumberOfElementsByTensor(modelOutput);
 
     tensor_t modelOutputFloat;
@@ -115,30 +113,31 @@ void mseLossBackwardSymInt32(tensor_t *modelOutput, tensor_t *label, tensor_t *r
     float *labelArray = (float *)labelFloat.data;
     float *resultArray = (float *)resultFloat.data;
 
-    float perSampleMean = 2.f / (float)numberOfElements;
-    float batchDivisor = (reduction == REDUCTION_MEAN) ? (float)batchSize : 1.0f;
-    float mean = perSampleMean / batchDivisor;
-
     for (size_t i = 0; i < numberOfElements; i++) {
-        resultArray[i] = mulFloat32s(mean, subFloat32s(modelOutputArray[i], labelArray[i]));
+        resultArray[i] = 2.0f * (modelOutputArray[i] - labelArray[i]);
     }
 
     convertTensor(&resultFloat, result);
 }
 
-void mseLossBackward(tensor_t *modelOutput, tensor_t *label, tensor_t *result, size_t batchSize,
-                     reduction_t reduction) {
+void mseLossBackward(tensor_t *modelOutput, tensor_t *label, tensor_t *result) {
     qtype_t modelOutputQType = modelOutput->quantization->type;
 
     switch (modelOutputQType) {
     case FLOAT32:
-        mseLossBackwardFloat(modelOutput, label, result, batchSize, reduction);
+        mseLossBackwardFloat(modelOutput, label, result);
         break;
     case SYM_INT32:
-        mseLossBackwardSymInt32(modelOutput, label, result, batchSize, reduction);
+        mseLossBackwardSymInt32(modelOutput, label, result);
         break;
     default:
         PRINT_ERROR("Unknown QType!");
         exit(1);
     }
+}
+
+float computeMeanScaleMSE(size_t totalSamples, tensor_t *modelOutput) {
+    size_t microbatch = modelOutput->shape->dimensions[0];
+    size_t numFeaturesPerSample = calcNumberOfElementsByTensor(modelOutput) / microbatch;
+    return 1.0f / (float)(totalSamples * numFeaturesPerSample);
 }

--- a/src/loss_functions/include/CrossEntropy.h
+++ b/src/loss_functions/include/CrossEntropy.h
@@ -4,9 +4,18 @@
 #include "LossFunction.h"
 #include "Tensor.h"
 
-float crossEntropyForwardFloat(tensor_t *softmaxOutput, tensor_t *distribution);
+float crossEntropyForwardFloat(tensor_t *softmaxOutput, tensor_t *distribution,
+                               reduction_t reduction);
 
-void crossEntropySoftmaxBackward(tensor_t *softmaxOutput, tensor_t *distribution, tensor_t *loss,
-                                 size_t batchSize, reduction_t reduction);
+void crossEntropySoftmaxBackward(tensor_t *softmaxOutput, tensor_t *distribution, tensor_t *loss);
+
+/* Per-loss MEAN-reduction scale factor (PyTorch parity).
+ *
+ * Returns 1 / totalSamples for CE. The modelOutput tensor is accepted for
+ * vtable-uniformity with MSE but is ignored: the class axis is internal
+ * aggregation in CE, not an independent loss-term axis.
+ *
+ * Caller must check backwardReduction == REDUCTION_MEAN before invoking. */
+float computeMeanScaleCE(size_t totalSamples, tensor_t *modelOutput);
 
 #endif // CROSSENTROPY_H

--- a/src/loss_functions/include/LossFunction.h
+++ b/src/loss_functions/include/LossFunction.h
@@ -9,16 +9,56 @@ typedef enum reduction { REDUCTION_SUM, REDUCTION_MEAN } reduction_t;
 
 typedef struct lossConfig {
     lossFuncType_t funcType;
-    reduction_t reduction;
+    reduction_t backwardReduction;
+    tensor_t *classWeights;
 } lossConfig_t;
 
-typedef float (*lossFwdFn_t)(tensor_t *modelOutput, tensor_t *label);
-typedef void (*lossBwdFn_t)(tensor_t *modelOutput, tensor_t *label, tensor_t *result,
-                            size_t batchSize, reduction_t reduction);
+/* Convenience initializer. Returns {funcType, REDUCTION_MEAN, REDUCTION_MEAN, NULL}.
+ * forwardReduction is intentionally NOT a config field — it is a per-call parameter
+ * on aggregators. trainingRun hardcodes REDUCTION_MEAN to keep train/eval comparability. */
+lossConfig_t defaultLossConfig(lossFuncType_t funcType);
+
+/*! Per-microbatch forward.
+ *
+ * Reduction-aware; PyTorch-parity for both MEAN and SUM.
+ *
+ * \param modelOutput  Tensor of shape [B, F] (B microbatch dim, F feature dim).
+ *                     For B=1 today the [B, ...] dim may be implicit.
+ * \param label        Same shape as modelOutput.
+ * \param reduction    REDUCTION_MEAN ⇒ per-microbatch mean over own elements;
+ *                     REDUCTION_SUM  ⇒ per-microbatch raw sum.
+ * \return Per-microbatch scalar loss value.
+ *
+ * Contract: `modelOutput->shape->dimensions[0] >= 1`. All microbatches in one
+ * macro batch must have equal B (uniform microbatch size assumption — see
+ * docs/CONVENTIONS.md §"Loss API: microbatch contracts"). */
+typedef float (*lossFwdFn_t)(tensor_t *modelOutput, tensor_t *label, reduction_t reduction);
+
+/*! Per-microbatch backward.
+ *
+ * Writes raw per-element gradient (no batchSize/reduction divisor).
+ * Macro-batch scaling is applied at the optimizer step via
+ * scaleOptimizerGradients(optimizer, computeMeanScale(...)) in
+ * trainingEpochDefault when backwardReduction == REDUCTION_MEAN.
+ *
+ * \param modelOutput  Same shape contract as forward.
+ * \param label        Same shape as modelOutput.
+ * \param result       Output buffer (same shape) for the raw per-element grad. */
+typedef void (*lossBwdFn_t)(tensor_t *modelOutput, tensor_t *label, tensor_t *result);
+
+/* Per-loss MEAN-reduction scale factor (PyTorch parity).
+ * Only called when backwardReduction == REDUCTION_MEAN.
+ * Each loss family derives numFeaturesPerSample from the model output
+ * shape itself (B = dimensions[0], F = numElements / B), so the caller
+ * does not need to know about microbatch-vs-feature dimensions:
+ *   MSE: 1 / (totalSamples × F)
+ *   CE:  1 / totalSamples (modelOutput unused) */
+typedef float (*computeMeanScaleFn_t)(size_t totalSamples, tensor_t *modelOutput);
 
 typedef struct lossFunctions {
     lossFwdFn_t forward;
     lossBwdFn_t backward;
+    computeMeanScaleFn_t computeMeanScale;
 } lossFunctions_t;
 
 extern lossFunctions_t lossFunctions[];

--- a/src/loss_functions/include/MSE.h
+++ b/src/loss_functions/include/MSE.h
@@ -4,15 +4,20 @@
 #include "LossFunction.h"
 #include "Tensor.h"
 
-float mseLossForward(tensor_t *output, tensor_t *label);
+float mseLossForward(tensor_t *output, tensor_t *label, reduction_t reduction);
 
-void mseLossBackwardFloat(tensor_t *modelOutput, tensor_t *label, tensor_t *result,
-                          size_t batchSize, reduction_t reduction);
+void mseLossBackwardFloat(tensor_t *modelOutput, tensor_t *label, tensor_t *result);
 
-void mseLossBackwardAsym(tensor_t *modelOutput, tensor_t *label, tensor_t *result, size_t batchSize,
-                         reduction_t reduction);
+void mseLossBackward(tensor_t *modelOutput, tensor_t *label, tensor_t *result);
 
-void mseLossBackward(tensor_t *modelOutput, tensor_t *label, tensor_t *result, size_t batchSize,
-                     reduction_t reduction);
+/* Per-loss MEAN-reduction scale factor (PyTorch parity).
+ *
+ * Returns 1 / (totalSamples * numFeaturesPerSample) for MSE, where
+ * numFeaturesPerSample is derived from the model output's shape:
+ * numElements(modelOutput) / dimensions[0]. The microbatch dimension
+ * (B = dimensions[0]) is treated as 1 if shape is degenerate (B=0).
+ *
+ * Caller must check backwardReduction == REDUCTION_MEAN before invoking. */
+float computeMeanScaleMSE(size_t totalSamples, tensor_t *modelOutput);
 
 #endif // MSE_H

--- a/src/userApi/InferenceApi.c
+++ b/src/userApi/InferenceApi.c
@@ -175,7 +175,8 @@ void freeInferenceStats(inferenceStats_t *inferenceStats) {
 }
 
 inferenceStats_t *inferenceWithLoss(layer_t **model, size_t numberOfLayers, tensor_t *input,
-                                    tensor_t *label, lossFuncType_t funcType) {
+                                    tensor_t *label, lossFuncType_t funcType,
+                                    reduction_t forwardReduction) {
     tensor_t outputNext;
     initBufferInput(input, &outputNext);
 
@@ -196,7 +197,7 @@ inferenceStats_t *inferenceWithLoss(layer_t **model, size_t numberOfLayers, tens
     copyTensor(inferenceStats->output, &outputNext);
 
     lossFunctions_t lossFns = lossFunctions[funcType];
-    float loss = lossFns.forward(&outputNext, label);
+    float loss = lossFns.forward(&outputNext, label, forwardReduction);
     inferenceStats->loss = loss;
 
     deInitBuffer(&outputNext);

--- a/src/userApi/include/InferenceApi.h
+++ b/src/userApi/include/InferenceApi.h
@@ -18,6 +18,7 @@ tensor_t *inference(layer_t **model, size_t numberOfLayers, tensor_t *input);
 tensor_t **inferenceBatched(layer_t **model, size_t numberOfLayers, batch_t *batch);
 
 inferenceStats_t *inferenceWithLoss(layer_t **model, size_t numberOfLayers, tensor_t *input,
-                                    tensor_t *label, lossFuncType_t funcType);
+                                    tensor_t *label, lossFuncType_t funcType,
+                                    reduction_t forwardReduction);
 
 #endif // INFERENCE_H

--- a/src/userApi/optimizer/OptimizerApi.c
+++ b/src/userApi/optimizer/OptimizerApi.c
@@ -1,3 +1,45 @@
 #define SOURCE_FILE "OPTIMIZER_API"
 
+#include <math.h>
+#include <stdlib.h>
+
+#include "Common.h"
 #include "OptimizerApi.h"
+#include "Quantization.h"
+#include "Tensor.h"
+
+void scaleOptimizerGradients(optimizer_t *optimizer, float factor) {
+    /* Validation: warn (currently via PRINT_ERROR — see #151 for unified
+     * warn/assert macros) on non-positive or non-finite factor. */
+    if (!(factor > 0.0f && isfinite(factor))) {
+        PRINT_ERROR("scaleOptimizerGradients: suspicious factor %f "
+                    "(expected positive, finite)",
+                    (double)factor);
+    }
+
+    for (size_t i = 0; i < optimizer->sizeStates; i++) {
+        parameter_t *param = optimizer->parameter[i];
+
+        switch (param->grad->quantization->type) {
+        case FLOAT32: {
+            size_t numberOfValues = calcNumberOfElementsByParameter(param);
+            float *gradArr = (float *)param->grad->data;
+            for (size_t j = 0; j < numberOfValues; j++) {
+                gradArr[j] *= factor;
+            }
+            break;
+        }
+        case SYM_INT32: {
+            /* float_value = int32_value * scale ⇒ multiplicative scaling can
+             * be absorbed into the per-tensor scale, leaving the int32 storage
+             * untouched. O(1) and avoids quantization round-trip loss. */
+            symInt32QConfig_t *gradQ = param->grad->quantization->qConfig;
+            gradQ->scale *= factor;
+            break;
+        }
+        default:
+            PRINT_ERROR("scaleOptimizerGradients: unsupported gradient qtype");
+            exit(1);
+        }
+    }
+}

--- a/src/userApi/optimizer/include/OptimizerApi.h
+++ b/src/userApi/optimizer/include/OptimizerApi.h
@@ -5,4 +5,16 @@
 
 optimizer_t *optimizerInit(optimizerType_t type, void *optimizerConfig);
 
+/* Scales every gradient field of every parameter tracked by the optimizer
+ * by the given factor in-place.
+ *
+ * Iterates the same parameter list that sgdZeroGrad uses
+ * (optimizer->parameter[0..sizeStates-1]).
+ *
+ * Caller is responsible for not calling with factor == 1.0 (no-op);
+ * factor must be positive and finite — non-positive or non-finite values
+ * are logged via PRINT_ERROR (the closest existing tool; #151 will replace
+ * this with a proper PRINT_WARN). */
+void scaleOptimizerGradients(optimizer_t *optimizer, float factor);
+
 #endif // OPTIMIZER_API_H

--- a/src/userApi/training_loop/TrainingLoopApi.c
+++ b/src/userApi/training_loop/TrainingLoopApi.c
@@ -17,18 +17,19 @@ void freeTrainingStats(trainingStats_t *trainingStats) {
 }
 
 float evaluationBatch(layer_t **model, size_t modelSize, lossFuncType_t funcType, batch_t *batch,
-                      inferenceWithLossFn_t inferenceFn) {
+                      inferenceWithLossFn_t inferenceFn, reduction_t forwardReduction) {
     float totalLoss = 0.0f;
 
     for (size_t i = 0; i < batch->size; i++) {
         inferenceStats_t *stats = inferenceFn(model, modelSize, batch->samples[i]->item,
-                                              batch->samples[i]->label, funcType);
+                                              batch->samples[i]->label, funcType, forwardReduction);
         totalLoss += stats->loss;
         freeInferenceStats(stats);
         freeSample(batch->samples[i]);
     }
 
-    return totalLoss / (float)batch->size;
+    /* Pure sum — no division. Caller (evaluationEpoch) handles macro reduction. */
+    return totalLoss;
 }
 
 static size_t argmax(const float *data, size_t n) {
@@ -45,29 +46,36 @@ static size_t argmax(const float *data, size_t n) {
 }
 
 float evaluationEpoch(layer_t **model, size_t modelSize, lossFuncType_t funcType,
-                      dataLoader_t *dataLoader, inferenceWithLossFn_t inferenceFn) {
+                      dataLoader_t *dataLoader, inferenceWithLossFn_t inferenceFn,
+                      reduction_t forwardReduction) {
     size_t datasetSize = dataLoader->getDatasetSize();
     size_t numberOfBatches = datasetSize / dataLoader->batchSize;
     float totalLoss = 0.0f;
+    size_t totalSamples = 0;
 
     for (size_t i = 0; i < numberOfBatches; i++) {
         batch_t *batch = dataLoader->getBatch(dataLoader, i);
-        totalLoss += evaluationBatch(model, modelSize, funcType, batch, inferenceFn);
+        totalLoss +=
+            evaluationBatch(model, modelSize, funcType, batch, inferenceFn, forwardReduction);
+        totalSamples += batch->size;
         freeBatch(batch);
     }
 
-    return totalLoss / (float)numberOfBatches;
+    if (forwardReduction == REDUCTION_MEAN) {
+        return totalLoss / (float)totalSamples;
+    }
+    return totalLoss;
 }
 
 static float evaluateBatchInternal(layer_t **model, size_t modelSize, lossFuncType_t funcType,
                                    batch_t *batch, inferenceWithLossFn_t inferenceFn, size_t *tp,
                                    size_t *predCount, size_t *actualCount, size_t *confusionMatrix,
-                                   size_t numClasses) {
+                                   size_t numClasses, reduction_t forwardReduction) {
     float totalLoss = 0.0f;
 
     for (size_t i = 0; i < batch->size; i++) {
         inferenceStats_t *stats = inferenceFn(model, modelSize, batch->samples[i]->item,
-                                              batch->samples[i]->label, funcType);
+                                              batch->samples[i]->label, funcType, forwardReduction);
         totalLoss += stats->loss;
 
         float *outputData = (float *)stats->output->data;
@@ -89,7 +97,8 @@ static float evaluateBatchInternal(layer_t **model, size_t modelSize, lossFuncTy
         freeSample(batch->samples[i]);
     }
 
-    return totalLoss / (float)batch->size;
+    /* Pure sum — caller divides by totalSamples for MEAN. */
+    return totalLoss;
 }
 
 static float computeAccuracy(const size_t *tp, size_t numClasses, size_t totalSamples) {
@@ -136,7 +145,8 @@ static float computeMacroF1(const size_t *tp, const size_t *predCount, const siz
 static epochStats_t evaluateEpochInternal(layer_t **model, size_t modelSize,
                                           lossFuncType_t funcType, dataLoader_t *dataLoader,
                                           inferenceWithLossFn_t inferenceFn,
-                                          size_t *confusionMatrix, size_t numClasses) {
+                                          size_t *confusionMatrix, size_t numClasses,
+                                          reduction_t forwardReduction) {
     size_t datasetSize = dataLoader->getDatasetSize();
     size_t numberOfBatches = datasetSize / dataLoader->batchSize;
 
@@ -155,14 +165,19 @@ static epochStats_t evaluateEpochInternal(layer_t **model, size_t modelSize,
 
     for (size_t i = 0; i < numberOfBatches; i++) {
         batch_t *batch = dataLoader->getBatch(dataLoader, i);
-        totalLoss += evaluateBatchInternal(model, modelSize, funcType, batch, inferenceFn, tp,
-                                           predCount, actualCount, confusionMatrix, numClasses);
+        totalLoss +=
+            evaluateBatchInternal(model, modelSize, funcType, batch, inferenceFn, tp, predCount,
+                                  actualCount, confusionMatrix, numClasses, forwardReduction);
         totalSamples += batch->size;
         freeBatch(batch);
     }
 
     epochStats_t stats;
-    stats.loss = totalLoss / (float)numberOfBatches;
+    if (forwardReduction == REDUCTION_MEAN) {
+        stats.loss = totalLoss / (float)totalSamples;
+    } else {
+        stats.loss = totalLoss;
+    }
     stats.accuracy = computeAccuracy(tp, numClasses, totalSamples);
     stats.precision = computeMacroPrecision(tp, predCount, numClasses);
     stats.recall = computeMacroRecall(tp, actualCount, numClasses);
@@ -176,8 +191,8 @@ static epochStats_t evaluateEpochInternal(layer_t **model, size_t modelSize,
 }
 
 epochStats_t evaluationEpochWithMetrics(layer_t **model, size_t modelSize, lossFuncType_t funcType,
-                                        dataLoader_t *dataLoader,
-                                        inferenceWithLossFn_t inferenceFn) {
+                                        dataLoader_t *dataLoader, inferenceWithLossFn_t inferenceFn,
+                                        reduction_t forwardReduction) {
     // Peek at first sample to derive numClasses from label shape
     batch_t *firstBatch = dataLoader->getBatch(dataLoader, 0);
     size_t numClasses = calcNumberOfElementsByTensor(firstBatch->samples[0]->label);
@@ -187,13 +202,14 @@ epochStats_t evaluationEpochWithMetrics(layer_t **model, size_t modelSize, lossF
     freeBatch(firstBatch);
 
     return evaluateEpochInternal(model, modelSize, funcType, dataLoader, inferenceFn, NULL,
-                                 numClasses);
+                                 numClasses, forwardReduction);
 }
 
 classificationReport_t evaluationEpochWithReport(layer_t **model, size_t modelSize,
                                                  lossFuncType_t funcType, dataLoader_t *dataLoader,
                                                  inferenceWithLossFn_t inferenceFn,
-                                                 size_t *cmBuffer, size_t numClasses) {
+                                                 size_t *cmBuffer, size_t numClasses,
+                                                 reduction_t forwardReduction) {
     // Zero the caller's CM buffer
     for (size_t i = 0; i < numClasses * numClasses; i++) {
         cmBuffer[i] = 0;
@@ -201,7 +217,7 @@ classificationReport_t evaluationEpochWithReport(layer_t **model, size_t modelSi
 
     classificationReport_t report;
     report.stats = evaluateEpochInternal(model, modelSize, funcType, dataLoader, inferenceFn,
-                                         cmBuffer, numClasses);
+                                         cmBuffer, numClasses, forwardReduction);
     report.confusionMatrix = cmBuffer;
     report.numClasses = numClasses;
     return report;
@@ -214,7 +230,6 @@ trainingRunResult_t trainingRun(layer_t **model, size_t modelSize, lossConfig_t 
                                 inferenceWithLossFn_t inferenceFn, epochCallbackFn_t callback) {
     trainingRunResult_t result = {0};
 
-    // Derive numClasses from eval dataset labels
     batch_t *firstBatch = evalDataLoader->getBatch(evalDataLoader, 0);
     size_t numClasses = calcNumberOfElementsByTensor(firstBatch->samples[0]->label);
     for (size_t i = 0; i < firstBatch->size; i++) {
@@ -222,11 +237,18 @@ trainingRunResult_t trainingRun(layer_t **model, size_t modelSize, lossConfig_t 
     }
     freeBatch(firstBatch);
 
+    /* Policy: trainingRun is the SOLE place that hardcodes forwardReduction.
+     * Both train and eval use MEAN to keep the two reported losses comparable
+     * (per-sample mean, same units). Direct callers of trainingEpochDefault /
+     * evaluationEpoch can pick either reduction freely. */
+    const reduction_t forwardReduction = REDUCTION_MEAN;
+
     for (size_t epoch = 0; epoch < numberOfEpochs; epoch++) {
         float trainLoss = trainingEpochDefault(model, modelSize, lossConfig, trainDataLoader,
-                                               optimizer, calculateGradsFn);
-        epochStats_t evalStats = evaluateEpochInternal(
-            model, modelSize, lossConfig.funcType, evalDataLoader, inferenceFn, NULL, numClasses);
+                                               optimizer, calculateGradsFn, forwardReduction);
+        epochStats_t evalStats =
+            evaluateEpochInternal(model, modelSize, lossConfig.funcType, evalDataLoader,
+                                  inferenceFn, NULL, numClasses, forwardReduction);
 
         if (callback != NULL) {
             callback(epoch, trainLoss, evalStats);

--- a/src/userApi/training_loop/calculate_grads/CalculateGradsSequential.c
+++ b/src/userApi/training_loop/calculate_grads/CalculateGradsSequential.c
@@ -17,7 +17,7 @@
 #include "TrainingLoopApiInternal.h"
 
 trainingStats_t *calculateGradsSequential(layer_t **model, size_t modelSize,
-                                          lossConfig_t lossConfig, size_t batchSize,
+                                          lossConfig_t lossConfig, reduction_t forwardReduction,
                                           tensor_t *input, tensor_t *label) {
 
     tensor_t *layerOutputs[modelSize + 1];
@@ -38,7 +38,7 @@ trainingStats_t *calculateGradsSequential(layer_t **model, size_t modelSize,
     // LOSS
 
     lossFunctions_t lossFns = lossFunctions[lossConfig.funcType];
-    float loss = lossFns.forward(layerOutputs[modelSize], label);
+    float loss = lossFns.forward(layerOutputs[modelSize], label, forwardReduction);
     trainingStats->loss = loss;
 
     // Backward pass
@@ -49,7 +49,7 @@ trainingStats_t *calculateGradsSequential(layer_t **model, size_t modelSize,
 
     tensor_t gradNext;
     initGradTensor(&gradNext, layerOutputs[modelSize]);
-    lossFns.backward(layerOutputs[modelSize], label, &gradNext, batchSize, lossConfig.reduction);
+    lossFns.backward(layerOutputs[modelSize], label, &gradNext);
 
     for (int i = (int)backwardIndex; i >= 0; i--) {
         tensor_t gradCurr;

--- a/src/userApi/training_loop/calculate_grads/include/CalculateGradsSequential.h
+++ b/src/userApi/training_loop/calculate_grads/include/CalculateGradsSequential.h
@@ -4,7 +4,7 @@
 #include "TrainingLoopApi.h"
 
 trainingStats_t *calculateGradsSequential(layer_t **model, size_t modelSize,
-                                          lossConfig_t lossConfig, size_t batchSize,
+                                          lossConfig_t lossConfig, reduction_t forwardReduction,
                                           tensor_t *input, tensor_t *label);
 
 #endif // CALCULATE_GRADS_SEQUENTIAL_H

--- a/src/userApi/training_loop/include/TrainingLoopApi.h
+++ b/src/userApi/training_loop/include/TrainingLoopApi.h
@@ -64,12 +64,14 @@ typedef struct trainingRunResult {
 } trainingRunResult_t;
 
 typedef trainingStats_t *(*calculateGradsFn_t)(layer_t **model, size_t modelSize,
-                                               lossConfig_t lossConfig, size_t batchSize,
-                                               tensor_t *input, tensor_t *label);
+                                               lossConfig_t lossConfig,
+                                               reduction_t forwardReduction, tensor_t *input,
+                                               tensor_t *label);
 
 typedef inferenceStats_t *(*inferenceWithLossFn_t)(layer_t **model, size_t numberOfLayers,
                                                    tensor_t *input, tensor_t *label,
-                                                   lossFuncType_t funcType);
+                                                   lossFuncType_t funcType,
+                                                   reduction_t forwardReduction);
 
 /*! Callback invoked once per training epoch, after evaluation completes. */
 typedef void (*epochCallbackFn_t)(size_t epoch, float trainLoss, epochStats_t evalStats);
@@ -77,19 +79,21 @@ typedef void (*epochCallbackFn_t)(size_t epoch, float trainLoss, epochStats_t ev
 void freeTrainingStats(trainingStats_t *trainingStats);
 
 float evaluationBatch(layer_t **model, size_t modelSize, lossFuncType_t funcType, batch_t *batch,
-                      inferenceWithLossFn_t inferenceFn);
+                      inferenceWithLossFn_t inferenceFn, reduction_t forwardReduction);
 
 float evaluationEpoch(layer_t **model, size_t modelSize, lossFuncType_t funcType,
-                      dataLoader_t *dataLoader, inferenceWithLossFn_t inferenceFn);
+                      dataLoader_t *dataLoader, inferenceWithLossFn_t inferenceFn,
+                      reduction_t forwardReduction);
 
 epochStats_t evaluationEpochWithMetrics(layer_t **model, size_t modelSize, lossFuncType_t funcType,
-                                        dataLoader_t *dataLoader,
-                                        inferenceWithLossFn_t inferenceFn);
+                                        dataLoader_t *dataLoader, inferenceWithLossFn_t inferenceFn,
+                                        reduction_t forwardReduction);
 
 classificationReport_t evaluationEpochWithReport(layer_t **model, size_t modelSize,
                                                  lossFuncType_t funcType, dataLoader_t *dataLoader,
                                                  inferenceWithLossFn_t inferenceFn,
-                                                 size_t *cmBuffer, size_t numClasses);
+                                                 size_t *cmBuffer, size_t numClasses,
+                                                 reduction_t forwardReduction);
 
 trainingRunResult_t trainingRun(layer_t **model, size_t modelSize, lossConfig_t lossConfig,
                                 dataLoader_t *trainDataLoader, dataLoader_t *evalDataLoader,

--- a/src/userApi/training_loop/training_batch/TrainingBatchDefault.c
+++ b/src/userApi/training_loop/training_batch/TrainingBatchDefault.c
@@ -5,17 +5,21 @@
 #include "DataLoaderApi.h"
 
 float trainingBatchDefault(layer_t **model, size_t modelSize, lossConfig_t lossConfig,
-                           batch_t *batch, calculateGradsFn_t calculateGradsFn) {
+                           batch_t *batch, calculateGradsFn_t calculateGradsFn,
+                           reduction_t forwardReduction) {
     float totalLoss = 0.0f;
 
     for (size_t i = 0; i < batch->size; i++) {
         trainingStats_t *stats =
-            calculateGradsFn(model, modelSize, lossConfig, batch->size, batch->samples[i]->item,
-                             batch->samples[i]->label);
+            calculateGradsFn(model, modelSize, lossConfig, forwardReduction,
+                             batch->samples[i]->item, batch->samples[i]->label);
         totalLoss += stats->loss;
         freeTrainingStats(stats);
         freeSample(batch->samples[i]);
     }
 
-    return totalLoss / (float)batch->size;
+    if (forwardReduction == REDUCTION_MEAN) {
+        return totalLoss / (float)batch->size;
+    }
+    return totalLoss;
 }

--- a/src/userApi/training_loop/training_batch/include/TrainingBatchDefault.h
+++ b/src/userApi/training_loop/training_batch/include/TrainingBatchDefault.h
@@ -4,6 +4,7 @@
 #include "TrainingLoopApi.h"
 
 float trainingBatchDefault(layer_t **model, size_t modelSize, lossConfig_t lossConfig,
-                           batch_t *batch, calculateGradsFn_t calculateGradsFn);
+                           batch_t *batch, calculateGradsFn_t calculateGradsFn,
+                           reduction_t forwardReduction);
 
 #endif // TRAINING_BATCH_DEFAULT_H

--- a/src/userApi/training_loop/training_epoch/CMakeLists.txt
+++ b/src/userApi/training_loop/training_epoch/CMakeLists.txt
@@ -7,6 +7,7 @@ target_link_libraries(TrainingEpochDefault PRIVATE
         Rounding
         Layer
         Optimizer
+        OptimizerApi
         LossFunction
         InferenceApi
         DataLoader

--- a/src/userApi/training_loop/training_epoch/TrainingEpochDefault.c
+++ b/src/userApi/training_loop/training_epoch/TrainingEpochDefault.c
@@ -3,12 +3,15 @@
 #include "TrainingEpochDefault.h"
 #include "Common.h"
 #include "DataLoaderApi.h"
+#include "LossFunction.h"
 #include "Optimizer.h"
+#include "OptimizerApi.h"
+#include "Tensor.h"
 #include "TrainingBatchDefault.h"
 
 float trainingEpochDefault(layer_t **model, size_t modelSize, lossConfig_t lossConfig,
                            dataLoader_t *dataLoader, optimizer_t *optimizer,
-                           calculateGradsFn_t calculateGradsFn) {
+                           calculateGradsFn_t calculateGradsFn, reduction_t forwardReduction) {
     size_t datasetSize = dataLoader->getDatasetSize();
     size_t numberOfBatches = datasetSize / dataLoader->batchSize;
     optimizerFunctions_t optimFns = optimizerFunctions[optimizer->type];
@@ -16,7 +19,24 @@ float trainingEpochDefault(layer_t **model, size_t modelSize, lossConfig_t lossC
 
     for (size_t i = 0; i < numberOfBatches; i++) {
         batch_t *batch = dataLoader->getBatch(dataLoader, i);
-        totalLoss += trainingBatchDefault(model, modelSize, lossConfig, batch, calculateGradsFn);
+
+        /* Capture a reference to the first sample's label BEFORE
+         * trainingBatchDefault consumes the samples. freeSample only
+         * releases the sample_t struct; the underlying label tensor is
+         * owned by the dataset and remains alive throughout the macro
+         * batch, so labelRef stays valid for computeMeanScale below. */
+        tensor_t *labelRef = batch->samples[0]->label;
+
+        totalLoss += trainingBatchDefault(model, modelSize, lossConfig, batch, calculateGradsFn,
+                                          forwardReduction);
+
+        if (lossConfig.backwardReduction == REDUCTION_MEAN) {
+            /* Each loss family derives F from labelRef's shape itself. */
+            float meanScale =
+                lossFunctions[lossConfig.funcType].computeMeanScale(batch->size, labelRef);
+            scaleOptimizerGradients(optimizer, meanScale);
+        }
+
         optimFns.step(optimizer);
         optimFns.zero(optimizer);
         freeBatch(batch);

--- a/src/userApi/training_loop/training_epoch/include/TrainingEpochDefault.h
+++ b/src/userApi/training_loop/training_epoch/include/TrainingEpochDefault.h
@@ -5,6 +5,6 @@
 
 float trainingEpochDefault(layer_t **model, size_t modelSize, lossConfig_t lossConfig,
                            dataLoader_t *dataLoader, optimizer_t *optimizer,
-                           calculateGradsFn_t calculateGradsFn);
+                           calculateGradsFn_t calculateGradsFn, reduction_t forwardReduction);
 
 #endif // TRAINING_EPOCH_DEFAULT_H

--- a/test/unit/loss_functions/CMakeLists.txt
+++ b/test/unit/loss_functions/CMakeLists.txt
@@ -18,3 +18,15 @@ add_elastic_ai_unit_test(
         StorageApi
         QuantizationApi
 )
+
+add_elastic_ai_unit_test(
+        LIB_UNDER_TEST
+        LossFunction
+        MORE_LIBS
+        CommonLayerLibs
+        MSE
+        CrossEntropy
+        TensorApi
+        QuantizationApi
+        StorageApi
+)

--- a/test/unit/loss_functions/UnitTestCrossEntropy.c
+++ b/test/unit/loss_functions/UnitTestCrossEntropy.c
@@ -4,59 +4,7 @@
 #include "SoftmaxApi.h"
 #include "TensorApi.h"
 #include "unity.h"
-
-void unitTestCrossEntropyForward() {
-    tensor_t logits;
-    float logitData[] = {2.f, 1.f, 0.1f};
-    size_t logitDims[] = {1, 3};
-    size_t logitNumberOfDims = 2;
-    size_t logitOrder[] = {0, 1};
-    shape_t logitShape;
-    setShape(&logitShape, logitDims, logitNumberOfDims, logitOrder);
-    quantization_t logitQ;
-    initFloat32Quantization(&logitQ);
-    setTensorValues(&logits, (uint8_t *)logitData, &logitShape, &logitQ, NULL);
-
-    tensor_t softmaxOutput;
-    float outputData[3];
-    size_t outputDims[] = {1, 3};
-    size_t outputNumberOfDims = 2;
-    size_t outputOrder[] = {0, 1};
-    shape_t outputShape;
-    setShape(&outputShape, outputDims, outputNumberOfDims, outputOrder);
-    quantization_t outputQ;
-    initFloat32Quantization(&outputQ);
-    setTensorValues(&softmaxOutput, (uint8_t *)outputData, &outputShape, &outputQ, NULL);
-
-    quantization_t *floatQ = quantizationInitFloat();
-    layer_t *softmaxLayer = softmaxLayerInit(floatQ, floatQ);
-    layerFunctions_t softmaxFns = layerFunctions[SOFTMAX];
-    softmaxFns.forward(softmaxLayer, &logits, &softmaxOutput);
-
-    tensor_t distribution;
-    float distData[] = {0.9f, 0.1f, 0.0f};
-    size_t distDims[] = {1, 3};
-    size_t distNumberOfDims = 2;
-    size_t distOrderOfDims[] = {0, 1};
-    shape_t distShape;
-    setShape(&distShape, distDims, distNumberOfDims, distOrderOfDims);
-    quantization_t distQ;
-    initFloat32Quantization(&distQ);
-    setTensorValues(&distribution, (uint8_t *)distData, &distShape, &distQ, NULL);
-
-    /* CAPTURE. */
-    float capturedActual = crossEntropyForwardFloat(&softmaxOutput, &distribution);
-
-    /* FREE. freeSoftmaxLayer releases the layer config wrapper only; it does
-     * NOT touch the stored forwardQ/backwardQ pointer (which is floatQ). So
-     * floatQ is safe to free after. */
-    freeSoftmaxLayer(softmaxLayer);
-    freeQuantization(floatQ);
-
-    /* ASSERT. */
-    float expected = 0.5170299410820007f;
-    TEST_ASSERT_EQUAL_FLOAT(expected, capturedActual);
-}
+#include <math.h>
 
 void unitTestCrossEntropySoftmaxBackward() {
     size_t inputSize = 3;
@@ -111,8 +59,7 @@ void unitTestCrossEntropySoftmaxBackward() {
     initFloat32Quantization(&propLossQ);
     setTensorValues(&propLoss, (uint8_t *)propLossData, &propLossShape, &propLossQ, NULL);
 
-    crossEntropySoftmaxBackward(&softmaxOutput, &distribution, &propLoss, /* batchSize */ 1,
-                                REDUCTION_SUM);
+    crossEntropySoftmaxBackward(&softmaxOutput, &distribution, &propLoss);
 
     /* CAPTURE. propLoss.data is stack memory (propLossData[]); copy into a
      * dedicated capture array so the assertions read from a buffer that
@@ -126,14 +73,14 @@ void unitTestCrossEntropySoftmaxBackward() {
     freeSoftmaxLayer(softmaxLayer);
     freeQuantization(floatQ);
 
-    /* ASSERT. */
+    /* ASSERT: raw per-element gradient (p-y), no batch divisor. */
     float expected[] = {-0.2410f, 0.1424f, 0.0986f};
     for (size_t i = 0; i < inputSize; i++) {
         TEST_ASSERT_FLOAT_WITHIN(0.0001f, expected[i], capturedActual[i]);
     }
 }
 
-void testCrossEntropyBackward_MeanDividesByBatchSize(void) {
+void testCrossEntropyBackward_WritesRawPerElementGrad(void) {
     size_t inputSize = 3;
 
     tensor_t softmaxOutput;
@@ -158,24 +105,107 @@ void testCrossEntropyBackward_MeanDividesByBatchSize(void) {
     initFloat32Quantization(&lossGradQ);
     setTensorValues(&lossGrad, (uint8_t *)lossGradData, &shape, &lossGradQ, NULL);
 
-    crossEntropySoftmaxBackward(&softmaxOutput, &distribution, &lossGrad,
-                                /* batchSize */ 4, REDUCTION_MEAN);
+    /* Raw per-element gradient: (p-y). No batch divisor — scaleOptimizerGradients
+     * applies macro-scale at the optimizer step. */
+    crossEntropySoftmaxBackward(&softmaxOutput, &distribution, &lossGrad);
 
-    float expected[3] = {(0.7f - 1.f) / 4.f, (0.2f - 0.f) / 4.f, (0.1f - 0.f) / 4.f};
+    /* Expected = p - y = [0.7-1, 0.2-0, 0.1-0] = [-0.3, 0.2, 0.1] */
+    float expected[3] = {0.7f - 1.f, 0.2f - 0.f, 0.1f - 0.f};
     for (size_t i = 0; i < inputSize; i++) {
         TEST_ASSERT_FLOAT_WITHIN(1e-5f, expected[i], ((float *)lossGrad.data)[i]);
     }
 }
 
-void testCrossEntropyBackward_SumPreservesMagnitude(void) {
-    size_t inputSize = 3;
+void testCrossEntropyForward_SumReturnsRawSum() {
+    tensor_t logits;
+    float logitData[] = {2.f, 1.f, 0.1f};
+    size_t logitDims[] = {1, 3};
+    size_t logitOrder[] = {0, 1};
+    shape_t logitShape;
+    setShape(&logitShape, logitDims, 2, logitOrder);
+    quantization_t logitQ;
+    initFloat32Quantization(&logitQ);
+    setTensorValues(&logits, (uint8_t *)logitData, &logitShape, &logitQ, NULL);
 
     tensor_t softmaxOutput;
-    float softmaxData[] = {0.7f, 0.2f, 0.1f};
-    size_t dims[] = {1, inputSize};
+    float outputData[3];
+    size_t outputDims[] = {1, 3};
+    size_t outputOrder[] = {0, 1};
+    shape_t outputShape;
+    setShape(&outputShape, outputDims, 2, outputOrder);
+    quantization_t outputQ;
+    initFloat32Quantization(&outputQ);
+    setTensorValues(&softmaxOutput, (uint8_t *)outputData, &outputShape, &outputQ, NULL);
+
+    quantization_t *floatQ = quantizationInitFloat();
+    layer_t *softmaxLayer = softmaxLayerInit(floatQ, floatQ);
+    layerFunctions_t softmaxFns = layerFunctions[SOFTMAX];
+    softmaxFns.forward(softmaxLayer, &logits, &softmaxOutput);
+
+    tensor_t distribution;
+    float distData[] = {0.9f, 0.1f, 0.0f};
+    size_t distDims[] = {1, 3};
+    size_t distOrder[] = {0, 1};
+    shape_t distShape;
+    setShape(&distShape, distDims, 2, distOrder);
+    quantization_t distQ;
+    initFloat32Quantization(&distQ);
+    setTensorValues(&distribution, (uint8_t *)distData, &distShape, &distQ, NULL);
+
+    float capturedActual = crossEntropyForwardFloat(&softmaxOutput, &distribution, REDUCTION_SUM);
+
+    freeSoftmaxLayer(softmaxLayer);
+    freeQuantization(floatQ);
+
+    /* SUM: same as the pre-existing forward value (raw -log probability sum). */
+    float expected = 0.5170299410820007f;
+    TEST_ASSERT_EQUAL_FLOAT(expected, capturedActual);
+}
+
+void testCrossEntropyForward_MeanDividesByMicrobatch() {
+    /* Synthetic distribution with B=2 (dimensions[0] = 2). The B=2 case
+     * forces MEAN and SUM to diverge numerically — without B>1, MEAN and
+     * SUM would coincide and a missing branch in the impl would pass
+     * the test accidentally. */
+    tensor_t softmaxOutput;
+    float softmaxData[] = {0.6f, 0.4f, 0.7f, 0.3f};
+    size_t dims[] = {2, 2};
     size_t order[] = {0, 1};
     shape_t shape;
     setShape(&shape, dims, 2, order);
+    quantization_t softmaxQ;
+    initFloat32Quantization(&softmaxQ);
+    setTensorValues(&softmaxOutput, (uint8_t *)softmaxData, &shape, &softmaxQ, NULL);
+
+    tensor_t distribution;
+    float distData[] = {1.f, 0.f, 1.f, 0.f};
+    quantization_t distQ;
+    initFloat32Quantization(&distQ);
+    setTensorValues(&distribution, (uint8_t *)distData, &shape, &distQ, NULL);
+
+    /* SUM = -log(0.6) + -log(0.7); MEAN = SUM / 2 (microbatch dim B=2). */
+    float capturedSum = crossEntropyForwardFloat(&softmaxOutput, &distribution, REDUCTION_SUM);
+    float capturedMean = crossEntropyForwardFloat(&softmaxOutput, &distribution, REDUCTION_MEAN);
+
+    float expectedSum = -logf(0.6f) + -logf(0.7f);
+    float expectedMean = expectedSum / 2.0f;
+
+    TEST_ASSERT_FLOAT_WITHIN(1e-5f, expectedSum, capturedSum);
+    TEST_ASSERT_FLOAT_WITHIN(1e-5f, expectedMean, capturedMean);
+}
+
+void testCrossEntropyForward_Mean1DTensorReturnsSum() {
+    /* 1D tensor (numberOfDimensions=1) carries no microbatch dim — MEAN
+     * passes through as the raw -log probability sum (PyTorch parity:
+     * a 1D logit vector is treated as a single-sample batch with no
+     * divisor). Without the numberOfDimensions>=2 guard the impl would
+     * divide by dimensions[0]=3 and yield -log(0.6)/3, breaking parity. */
+    tensor_t softmaxOutput;
+    float softmaxData[] = {0.6f, 0.3f, 0.1f};
+    size_t dims[] = {3};
+    size_t order[] = {0};
+    shape_t shape;
+    setShape(&shape, dims, 1, order);
     quantization_t softmaxQ;
     initFloat32Quantization(&softmaxQ);
     setTensorValues(&softmaxOutput, (uint8_t *)softmaxData, &shape, &softmaxQ, NULL);
@@ -186,19 +216,11 @@ void testCrossEntropyBackward_SumPreservesMagnitude(void) {
     initFloat32Quantization(&distQ);
     setTensorValues(&distribution, (uint8_t *)distData, &shape, &distQ, NULL);
 
-    tensor_t lossGrad;
-    float lossGradData[3] = {0};
-    quantization_t lossGradQ;
-    initFloat32Quantization(&lossGradQ);
-    setTensorValues(&lossGrad, (uint8_t *)lossGradData, &shape, &lossGradQ, NULL);
+    float capturedSum = crossEntropyForwardFloat(&softmaxOutput, &distribution, REDUCTION_SUM);
+    float capturedMean = crossEntropyForwardFloat(&softmaxOutput, &distribution, REDUCTION_MEAN);
 
-    crossEntropySoftmaxBackward(&softmaxOutput, &distribution, &lossGrad,
-                                /* batchSize */ 4, REDUCTION_SUM);
-
-    float expected[3] = {0.7f - 1.f, 0.2f - 0.f, 0.1f - 0.f};
-    for (size_t i = 0; i < inputSize; i++) {
-        TEST_ASSERT_FLOAT_WITHIN(1e-5f, expected[i], ((float *)lossGrad.data)[i]);
-    }
+    TEST_ASSERT_FLOAT_WITHIN(1e-5f, -logf(0.6f), capturedSum);
+    TEST_ASSERT_FLOAT_WITHIN(1e-5f, capturedSum, capturedMean);
 }
 
 void setUp() {}
@@ -206,9 +228,10 @@ void tearDown() {}
 
 int main() {
     UNITY_BEGIN();
-    RUN_TEST(unitTestCrossEntropyForward);
     RUN_TEST(unitTestCrossEntropySoftmaxBackward);
-    RUN_TEST(testCrossEntropyBackward_MeanDividesByBatchSize);
-    RUN_TEST(testCrossEntropyBackward_SumPreservesMagnitude);
+    RUN_TEST(testCrossEntropyBackward_WritesRawPerElementGrad);
+    RUN_TEST(testCrossEntropyForward_SumReturnsRawSum);
+    RUN_TEST(testCrossEntropyForward_MeanDividesByMicrobatch);
+    RUN_TEST(testCrossEntropyForward_Mean1DTensorReturnsSum);
     return UNITY_END();
 }

--- a/test/unit/loss_functions/UnitTestLossFunction.c
+++ b/test/unit/loss_functions/UnitTestLossFunction.c
@@ -1,0 +1,102 @@
+#include "CrossEntropy.h"
+#include "LossFunction.h"
+#include "MSE.h"
+#include "QuantizationApi.h"
+#include "StorageApi.h"
+#include "Tensor.h"
+#include "TensorApi.h"
+#include "unity.h"
+
+void setUp() {}
+void tearDown() {}
+
+/* Build a model-output tensor with the requested shape so computeMeanScale*
+ * can derive numFeaturesPerSample = numElements / dimensions[0] itself. The
+ * tensor's data is uninitialized — only the shape is read. */
+static tensor_t *buildOutputShapeTensor2D(size_t d0, size_t d1) {
+    size_t *dims = reserveMemory(2 * sizeof(size_t));
+    dims[0] = d0;
+    dims[1] = d1;
+    size_t *order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, order);
+    shape_t *shape = reserveMemory(sizeof(shape_t));
+    setShape(shape, dims, 2, order);
+    return initTensor(shape, quantizationInitFloat(), NULL);
+}
+
+void testComputeMeanScaleMSE_ScaleIsOneOverNTimesF() {
+    /* B=1, F=10 → scale = 1 / (N * F) = 1 / (2 * 10). */
+    tensor_t *output = buildOutputShapeTensor2D(1, 10);
+    float scale = computeMeanScaleMSE(/* N */ 2, output);
+    freeTensor(output);
+    TEST_ASSERT_FLOAT_WITHIN(1e-7f, 1.0f / 20.0f, scale);
+}
+
+void testComputeMeanScaleMSE_LargerInputsScaleDenominatorAccordingly() {
+    /* B=1, F=784 (MNIST flattened) → scale = 1 / (32 * 784). */
+    tensor_t *output = buildOutputShapeTensor2D(1, 784);
+    float scale = computeMeanScaleMSE(/* N */ 32, output);
+    freeTensor(output);
+    TEST_ASSERT_FLOAT_WITHIN(1e-7f, 1.0f / (32.0f * 784.0f), scale);
+}
+
+void testComputeMeanScaleCE_ScaleIsOneOverN() {
+    /* CE convention: 1 / totalSamples (class-axis is internal — F is unused). */
+    tensor_t *output = buildOutputShapeTensor2D(1, 10);
+    float scale = computeMeanScaleCE(/* N */ 2, output);
+    freeTensor(output);
+    TEST_ASSERT_FLOAT_WITHIN(1e-7f, 1.0f / 2.0f, scale);
+}
+
+void testComputeMeanScaleCE_FeatureCountDoesNotAffectScale() {
+    /* F variation must NOT change CE's mean scale. */
+    tensor_t *outputA = buildOutputShapeTensor2D(1, 10);
+    tensor_t *outputB = buildOutputShapeTensor2D(1, 1000);
+    float scaleA = computeMeanScaleCE(8, outputA);
+    float scaleB = computeMeanScaleCE(8, outputB);
+    freeTensor(outputA);
+    freeTensor(outputB);
+    TEST_ASSERT_EQUAL_FLOAT(scaleA, scaleB);
+}
+
+void testLossFunctionsVtable_ComputeMeanScaleDispatchesToFamilyImpl() {
+    /* B=1, F=10. MSE expects 1/(2*10)=0.05; CE expects 1/2=0.5. */
+    tensor_t *output = buildOutputShapeTensor2D(1, 10);
+
+    float mseScale = lossFunctions[MSE].computeMeanScale(2, output);
+    float ceScale = lossFunctions[CROSS_ENTROPY].computeMeanScale(2, output);
+
+    freeTensor(output);
+
+    /* Distinct values prove both slots wired with the right family-specific impl. */
+    TEST_ASSERT_FLOAT_WITHIN(1e-7f, 0.05f, mseScale);
+    TEST_ASSERT_FLOAT_WITHIN(1e-7f, 0.5f, ceScale);
+}
+
+/* === defaultLossConfig === */
+
+void testDefaultLossConfig_MSE() {
+    lossConfig_t cfg = defaultLossConfig(MSE);
+    TEST_ASSERT_EQUAL_INT(MSE, cfg.funcType);
+    TEST_ASSERT_EQUAL_INT(REDUCTION_MEAN, cfg.backwardReduction);
+    TEST_ASSERT_NULL(cfg.classWeights);
+}
+
+void testDefaultLossConfig_CrossEntropy() {
+    lossConfig_t cfg = defaultLossConfig(CROSS_ENTROPY);
+    TEST_ASSERT_EQUAL_INT(CROSS_ENTROPY, cfg.funcType);
+    TEST_ASSERT_EQUAL_INT(REDUCTION_MEAN, cfg.backwardReduction);
+    TEST_ASSERT_NULL(cfg.classWeights);
+}
+
+int main(void) {
+    UNITY_BEGIN();
+    RUN_TEST(testComputeMeanScaleMSE_ScaleIsOneOverNTimesF);
+    RUN_TEST(testComputeMeanScaleMSE_LargerInputsScaleDenominatorAccordingly);
+    RUN_TEST(testComputeMeanScaleCE_ScaleIsOneOverN);
+    RUN_TEST(testComputeMeanScaleCE_FeatureCountDoesNotAffectScale);
+    RUN_TEST(testLossFunctionsVtable_ComputeMeanScaleDispatchesToFamilyImpl);
+    RUN_TEST(testDefaultLossConfig_MSE);
+    RUN_TEST(testDefaultLossConfig_CrossEntropy);
+    return UNITY_END();
+}

--- a/test/unit/loss_functions/UnitTestMSE.c
+++ b/test/unit/loss_functions/UnitTestMSE.c
@@ -7,8 +7,8 @@
 #include "TensorConversion.h"
 #include "unity.h"
 
-void testMSEForward() {
-    /* Output (1D, 3 elements). */
+void testMSEForward_MeanReturnsPerSampleMean() {
+    /* Output (1D, 3 elements). Today B=1, so numFeaturesPerSample = 3. */
     size_t *outputDims = reserveMemory(1 * sizeof(size_t));
     outputDims[0] = 3;
     size_t *outputOrder = reserveMemory(1 * sizeof(size_t));
@@ -18,7 +18,6 @@ void testMSEForward() {
     tensor_t *output = initTensor(outputShape, quantizationInitFloat(), NULL);
     tensorFillFromFloatBuffer(output, (float[]){1.f, 2.f, 3.f}, 3);
 
-    /* Label (1D, 3 elements). */
     size_t *labelDims = reserveMemory(1 * sizeof(size_t));
     labelDims[0] = 3;
     size_t *labelOrder = reserveMemory(1 * sizeof(size_t));
@@ -28,26 +27,48 @@ void testMSEForward() {
     tensor_t *label = initTensor(labelShape, quantizationInitFloat(), NULL);
     tensorFillFromFloatBuffer(label, (float[]){2.f, 4.f, 6.f}, 3);
 
-    /* CAPTURE. */
-    float capturedLoss = mseLossForward(output, label);
+    float capturedLoss = mseLossForward(output, label, REDUCTION_MEAN);
 
-    /* FREE. */
     freeTensor(label);
     freeTensor(output);
 
-    /* ASSERT. */
-    float expected = 4.67f;
-    TEST_ASSERT_FLOAT_WITHIN(0.01f, expected, capturedLoss);
+    /* MEAN: ((1-2)² + (2-4)² + (3-6)²) / 3 = (1+4+9)/3 = 14/3 ≈ 4.667 */
+    TEST_ASSERT_FLOAT_WITHIN(0.01f, 14.0f / 3.0f, capturedLoss);
 }
 
-void testMSELossBackwardFloat() {
+void testMSEForward_SumReturnsRawSum() {
+    size_t *outputDims = reserveMemory(1 * sizeof(size_t));
+    outputDims[0] = 3;
+    size_t *outputOrder = reserveMemory(1 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(1, outputOrder);
+    shape_t *outputShape = reserveMemory(sizeof(shape_t));
+    setShape(outputShape, outputDims, 1, outputOrder);
+    tensor_t *output = initTensor(outputShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(output, (float[]){1.f, 2.f, 3.f}, 3);
 
+    size_t *labelDims = reserveMemory(1 * sizeof(size_t));
+    labelDims[0] = 3;
+    size_t *labelOrder = reserveMemory(1 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(1, labelOrder);
+    shape_t *labelShape = reserveMemory(sizeof(shape_t));
+    setShape(labelShape, labelDims, 1, labelOrder);
+    tensor_t *label = initTensor(labelShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(label, (float[]){2.f, 4.f, 6.f}, 3);
+
+    float capturedLoss = mseLossForward(output, label, REDUCTION_SUM);
+
+    freeTensor(label);
+    freeTensor(output);
+
+    /* SUM: 1 + 4 + 9 = 14 (no division). */
+    TEST_ASSERT_FLOAT_WITHIN(0.01f, 14.0f, capturedLoss);
+}
+
+void testMSELossBackward_FloatWritesRawPerElementGrad() {
     size_t numberOfElements = 3;
     size_t dims[] = {numberOfElements};
-    size_t numberOfDims = 1;
     size_t orderOfDims[] = {0};
-    shape_t shape = {
-        .dimensions = dims, .orderOfDimensions = orderOfDims, .numberOfDimensions = numberOfDims};
+    shape_t shape = {.dimensions = dims, .orderOfDimensions = orderOfDims, .numberOfDimensions = 1};
 
     tensor_t modelOutput;
     quantization_t modelOutputQ;
@@ -64,28 +85,26 @@ void testMSELossBackwardFloat() {
     tensor_t result;
     quantization_t resultQ;
     initFloat32Quantization(&resultQ);
-    float resultData[numberOfElements];
+    float resultData[3];
     setTensorValues(&result, (uint8_t *)resultData, &shape, &resultQ, NULL);
 
-    mseLossBackwardFloat(&modelOutput, &label, &result, /* batchSize */ 1, REDUCTION_MEAN);
+    /* Raw per-element gradient: 2*(o-l). No /F division — that lives in
+     * computeMeanScaleMSE applied at the optimizer step. */
+    mseLossBackwardFloat(&modelOutput, &label, &result);
 
-    float expected[] = {4.f, 4.f, -3.3333f};
-
+    /* delta = [6, 6, -5]; raw grad = 2*delta = [12, 12, -10] */
+    float expected[] = {12.f, 12.f, -10.f};
     float *actual = (float *)result.data;
-
     for (size_t i = 0; i < 3; i++) {
-        TEST_ASSERT_FLOAT_WITHIN(0.0001f, expected[i], actual[i]);
+        TEST_ASSERT_FLOAT_WITHIN(1e-4f, expected[i], actual[i]);
     }
 }
 
-void testMSELossBackwardSymInt32() {
+void testMSELossBackward_SymInt32WritesRawPerElementGrad() {
     size_t numberOfElements = 3;
-
     size_t dims[] = {numberOfElements};
-    size_t numberOfDims = 1;
     size_t orderOfDims[] = {0};
-    shape_t shape = {
-        .dimensions = dims, .orderOfDimensions = orderOfDims, .numberOfDimensions = numberOfDims};
+    shape_t shape = {.dimensions = dims, .orderOfDimensions = orderOfDims, .numberOfDimensions = 1};
 
     tensor_t modelOutput;
     quantization_t modelOutputQ;
@@ -133,87 +152,14 @@ void testMSELossBackwardSymInt32() {
     setTensorValuesForConversion(resultSymInt32Data, &resultSymInt32Q, &result, &resultSymInt32);
     convertTensor(&result, &resultSymInt32);
 
-    mseLossBackward(&modelOutputSymInt32, &labelSymInt32, &resultSymInt32, /* batchSize */ 1,
-                    REDUCTION_MEAN);
-
+    mseLossBackward(&modelOutputSymInt32, &labelSymInt32, &resultSymInt32);
     convertTensor(&resultSymInt32, &result);
 
-    float expected[] = {4.f, 4.f, -3.f};
-
+    /* Raw per-element gradient: same shape as float test, allow wider tolerance for fixed-point. */
+    float expected[] = {12.f, 12.f, -10.f};
     float *actual = (float *)result.data;
-
     for (size_t i = 0; i < numberOfElements; i++) {
         TEST_ASSERT_FLOAT_WITHIN(0.5f, expected[i], actual[i]);
-    }
-}
-
-void testMSELossBackward_MeanDividesByBatchSize(void) {
-    size_t numberOfElements = 3;
-    size_t dims[] = {numberOfElements};
-    size_t order[] = {0};
-    shape_t shape = {.dimensions = dims, .orderOfDimensions = order, .numberOfDimensions = 1};
-
-    tensor_t modelOutput;
-    quantization_t modelOutputQ;
-    initFloat32Quantization(&modelOutputQ);
-    float modelOutputData[] = {1.f, 2.f, -3.f};
-    setTensorValues(&modelOutput, (uint8_t *)modelOutputData, &shape, &modelOutputQ, NULL);
-
-    tensor_t label;
-    quantization_t labelQ;
-    initFloat32Quantization(&labelQ);
-    float labelData[] = {-5.f, -4.f, 2.f};
-    setTensorValues(&label, (uint8_t *)labelData, &shape, &labelQ, NULL);
-
-    tensor_t result;
-    quantization_t resultQ;
-    initFloat32Quantization(&resultQ);
-    float resultData[3];
-    setTensorValues(&result, (uint8_t *)resultData, &shape, &resultQ, NULL);
-
-    /* batchSize=2 with MEAN: per-sample-mean (2/3) divided by 2. */
-    mseLossBackwardFloat(&modelOutput, &label, &result, /* batchSize */ 2, REDUCTION_MEAN);
-
-    /* Expected = ((2/3) / 2) * (model - label) = (1/3) * [6, 6, -5] = [2, 2, -1.667] */
-    float expected[] = {2.f, 2.f, -5.f / 3.f};
-    float *actual = (float *)result.data;
-    for (size_t i = 0; i < 3; i++) {
-        TEST_ASSERT_FLOAT_WITHIN(1e-4f, expected[i], actual[i]);
-    }
-}
-
-void testMSELossBackward_SumPreservesPerSampleMean(void) {
-    size_t numberOfElements = 3;
-    size_t dims[] = {numberOfElements};
-    size_t order[] = {0};
-    shape_t shape = {.dimensions = dims, .orderOfDimensions = order, .numberOfDimensions = 1};
-
-    tensor_t modelOutput;
-    quantization_t modelOutputQ;
-    initFloat32Quantization(&modelOutputQ);
-    float modelOutputData[] = {1.f, 2.f, -3.f};
-    setTensorValues(&modelOutput, (uint8_t *)modelOutputData, &shape, &modelOutputQ, NULL);
-
-    tensor_t label;
-    quantization_t labelQ;
-    initFloat32Quantization(&labelQ);
-    float labelData[] = {-5.f, -4.f, 2.f};
-    setTensorValues(&label, (uint8_t *)labelData, &shape, &labelQ, NULL);
-
-    tensor_t result;
-    quantization_t resultQ;
-    initFloat32Quantization(&resultQ);
-    float resultData[3];
-    setTensorValues(&result, (uint8_t *)resultData, &shape, &resultQ, NULL);
-
-    /* batchSize=2 with SUM: per-sample-mean (2/3) only — no batch divisor. */
-    mseLossBackwardFloat(&modelOutput, &label, &result, /* batchSize */ 2, REDUCTION_SUM);
-
-    /* Expected = (2/3) * (model - label) = (2/3) * [6, 6, -5] = [4, 4, -10/3] */
-    float expected[] = {4.f, 4.f, -10.f / 3.f};
-    float *actual = (float *)result.data;
-    for (size_t i = 0; i < 3; i++) {
-        TEST_ASSERT_FLOAT_WITHIN(1e-4f, expected[i], actual[i]);
     }
 }
 
@@ -223,13 +169,11 @@ void tearDown() {}
 int main(void) {
     UNITY_BEGIN();
 
-    RUN_TEST(testMSEForward);
+    RUN_TEST(testMSEForward_MeanReturnsPerSampleMean);
+    RUN_TEST(testMSEForward_SumReturnsRawSum);
 
-    RUN_TEST(testMSELossBackwardFloat);
-    RUN_TEST(testMSELossBackwardSymInt32);
-
-    RUN_TEST(testMSELossBackward_MeanDividesByBatchSize);
-    RUN_TEST(testMSELossBackward_SumPreservesPerSampleMean);
+    RUN_TEST(testMSELossBackward_FloatWritesRawPerElementGrad);
+    RUN_TEST(testMSELossBackward_SymInt32WritesRawPerElementGrad);
 
     return UNITY_END();
 }

--- a/test/unit/userAPI/CMakeLists.txt
+++ b/test/unit/userAPI/CMakeLists.txt
@@ -100,3 +100,18 @@ target_link_libraries(UnitTestFlattenIntegration PRIVATE
         StorageApi
 )
 __register_target_as_unit_test(UnitTestFlattenIntegration)
+
+add_executable(UnitTestOptimizerScaling UnitTestOptimizerScaling.c)
+target_link_libraries(UnitTestOptimizerScaling PRIVATE
+        unity
+        OptimizerApi
+        SgdApi
+        Sgd
+        Optimizer
+        LinearApi
+        CommonLayerLibs
+        TensorApi
+        QuantizationApi
+        StorageApi
+)
+__register_target_as_unit_test(UnitTestOptimizerScaling)

--- a/test/unit/userAPI/UnitTestFlattenIntegration.c
+++ b/test/unit/userAPI/UnitTestFlattenIntegration.c
@@ -78,7 +78,8 @@ void testCalculateGradsSequential_WithFlattenFirst_DoesNotCrash(void) {
     tensorFillFromFloatBuffer(label, (float[]){1.0f, 0.0f}, 2);
 
     trainingStats_t *stats = calculateGradsSequential(
-        model, 3, (lossConfig_t){.funcType = MSE, .reduction = REDUCTION_SUM}, 1, input, label);
+        model, 3, (lossConfig_t){.funcType = MSE, .backwardReduction = REDUCTION_SUM},
+        REDUCTION_SUM, input, label);
 
     /* CAPTURE before frees. */
     bool capturedStatsNotNull = (stats != NULL);
@@ -133,7 +134,8 @@ void testCalculateGradsSequential_FlattenRank1_DoesNotOOB(void) {
     layer_t *model[1] = {flatten};
 
     trainingStats_t *stats = calculateGradsSequential(
-        model, 1, (lossConfig_t){.funcType = MSE, .reduction = REDUCTION_SUM}, 1, input, label);
+        model, 1, (lossConfig_t){.funcType = MSE, .backwardReduction = REDUCTION_SUM},
+        REDUCTION_SUM, input, label);
 
     /* CAPTURE before frees. */
     bool capturedStatsNotNull = (stats != NULL);
@@ -184,7 +186,8 @@ void testCalculateGradsSequential_FlattenOnly_PreservesValues(void) {
     layer_t *model[1] = {flatten};
 
     trainingStats_t *stats = calculateGradsSequential(
-        model, 1, (lossConfig_t){.funcType = MSE, .reduction = REDUCTION_SUM}, 1, input, label);
+        model, 1, (lossConfig_t){.funcType = MSE, .backwardReduction = REDUCTION_SUM},
+        REDUCTION_SUM, input, label);
 
     /* CAPTURE before frees. */
     bool capturedStatsNotNull = (stats != NULL);

--- a/test/unit/userAPI/UnitTestInferenceApi.c
+++ b/test/unit/userAPI/UnitTestInferenceApi.c
@@ -225,7 +225,8 @@ void testInferenceWithLossLinearReluFloat() {
 
     /* Run inferenceWithLoss. inferenceStats owns its `output` tensor; its
      * matching free is freeInferenceStats. */
-    inferenceStats_t *inferenceStats = inferenceWithLoss(model, 2, input, label0, MSE);
+    inferenceStats_t *inferenceStats =
+        inferenceWithLoss(model, 2, input, label0, MSE, REDUCTION_MEAN);
 
     /* CAPTURE. */
     float capturedLoss = inferenceStats->loss;

--- a/test/unit/userAPI/UnitTestMnistSmoke.c
+++ b/test/unit/userAPI/UnitTestMnistSmoke.c
@@ -200,9 +200,9 @@ void testMnistSmoke_FullTrainingPipelineReducesLoss() {
     cbInvocations = 0;
     size_t numberOfEpochs = 20;
     trainingRunResult_t result = trainingRun(
-        model, MODEL_SIZE, (lossConfig_t){.funcType = CROSS_ENTROPY, .reduction = REDUCTION_MEAN},
-        trainDl, evalDl, sgd, numberOfEpochs, calculateGradsSequential, inferenceWithLoss,
-        captureEpoch);
+        model, MODEL_SIZE,
+        (lossConfig_t){.funcType = CROSS_ENTROPY, .backwardReduction = REDUCTION_MEAN}, trainDl,
+        evalDl, sgd, numberOfEpochs, calculateGradsSequential, inferenceWithLoss, captureEpoch);
 
     /* CAPTURE all assertion values into stack locals BEFORE any free. */
     size_t capturedCbInvocations = cbInvocations;
@@ -265,8 +265,9 @@ void testMnistSmoke_SnprintfGmtimeRBetweenSetupAndTrainingRun_NoSilentExit() {
 
     cbInvocations = 0;
     trainingRunResult_t result = trainingRun(
-        model, MODEL_SIZE, (lossConfig_t){.funcType = CROSS_ENTROPY, .reduction = REDUCTION_MEAN},
-        trainDl, evalDl, sgd, 1, calculateGradsSequential, inferenceWithLoss, captureEpoch);
+        model, MODEL_SIZE,
+        (lossConfig_t){.funcType = CROSS_ENTROPY, .backwardReduction = REDUCTION_MEAN}, trainDl,
+        evalDl, sgd, 1, calculateGradsSequential, inferenceWithLoss, captureEpoch);
 
     /* CAPTURE before free. */
     size_t capturedCbInvocations = cbInvocations;

--- a/test/unit/userAPI/UnitTestMultiLayerTraining.c
+++ b/test/unit/userAPI/UnitTestMultiLayerTraining.c
@@ -114,8 +114,9 @@ void testMultiLayerBackward_WithCrossEntropy_DoesNotCrash() {
     tensorFillFromFloatBuffer(label, (float[]){1.0f, 0.0f}, 2);
 
     trainingStats_t *stats = calculateGradsSequential(
-        model, sizeModel, (lossConfig_t){.funcType = CROSS_ENTROPY, .reduction = REDUCTION_SUM},
-        /* batchSize */ 1, input, label);
+        model, sizeModel,
+        (lossConfig_t){.funcType = CROSS_ENTROPY, .backwardReduction = REDUCTION_SUM},
+        REDUCTION_SUM, input, label);
 
     /* CAPTURE. */
     bool capturedNotNull = (stats != NULL);
@@ -232,8 +233,9 @@ void testMultiLayerBackward_WithManualInit_DoesNotCrash() {
     tensorFillFromFloatBuffer(label, (float[]){1.0f, 0.0f}, 2);
 
     trainingStats_t *stats = calculateGradsSequential(
-        model, sizeModel, (lossConfig_t){.funcType = CROSS_ENTROPY, .reduction = REDUCTION_SUM},
-        /* batchSize */ 1, input, label);
+        model, sizeModel,
+        (lossConfig_t){.funcType = CROSS_ENTROPY, .backwardReduction = REDUCTION_SUM},
+        REDUCTION_SUM, input, label);
 
     /* CAPTURE. The original test checks that b1Grad has at least one nonzero
      * value AFTER the backward pass; we capture that boolean before frees so
@@ -369,8 +371,9 @@ void testMultiLayerTraining_MultipleSteps_GradsAccumulate() {
     float capturedLoss[3];
     for (size_t step = 0; step < 3; step++) {
         trainingStats_t *stats = calculateGradsSequential(
-            model, sizeModel, (lossConfig_t){.funcType = CROSS_ENTROPY, .reduction = REDUCTION_SUM},
-            /* batchSize */ 1, input, label);
+            model, sizeModel,
+            (lossConfig_t){.funcType = CROSS_ENTROPY, .backwardReduction = REDUCTION_SUM},
+            REDUCTION_SUM, input, label);
         capturedNotNull[step] = (stats != NULL);
         capturedLoss[step] = stats ? stats->loss : -1.0f;
         freeTrainingStats(stats);

--- a/test/unit/userAPI/UnitTestOptimizerScaling.c
+++ b/test/unit/userAPI/UnitTestOptimizerScaling.c
@@ -1,0 +1,393 @@
+#define SOURCE_FILE "UNIT_TEST_OPTIMIZER_SCALING"
+
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "Layer.h"
+#include "Linear.h"
+#include "LinearApi.h"
+#include "Optimizer.h"
+#include "OptimizerApi.h"
+#include "Quantization.h"
+#include "QuantizationApi.h"
+#include "Rounding.h"
+#include "SgdApi.h"
+#include "StorageApi.h"
+#include "Tensor.h"
+#include "TensorApi.h"
+#include "unity.h"
+
+void setUp() {}
+void tearDown() {}
+
+/* Build a one-layer Linear model with grads pre-filled to known values, so
+ * scaleOptimizerGradients's effect on the optimizer's parameter list is
+ * directly observable. */
+static optimizer_t *buildOneLayerOptimWithGrads(layer_t **modelOut, parameter_t **wOut,
+                                                parameter_t **bOut, float *initialWGrad,
+                                                float *initialBGrad) {
+    tensor_t *wParam;
+    {
+        size_t *dims = reserveMemory(2 * sizeof(size_t));
+        dims[0] = 2;
+        dims[1] = 3;
+        size_t *order = reserveMemory(2 * sizeof(size_t));
+        setOrderOfDimsForNewTensor(2, order);
+        shape_t *shape = reserveMemory(sizeof(shape_t));
+        setShape(shape, dims, 2, order);
+        wParam = initTensor(shape, quantizationInitFloat(), NULL);
+        tensorFillFromFloatBuffer(wParam, (float[]){1.f, 1.f, 1.f, 1.f, 1.f, 1.f}, 6);
+    }
+    tensor_t *wGrad = gradInitFloat(wParam, NULL);
+    tensorFillFromFloatBuffer(wGrad, initialWGrad, 6);
+    parameter_t *w = parameterInit(wParam, wGrad);
+
+    tensor_t *bParam;
+    {
+        size_t *dims = reserveMemory(2 * sizeof(size_t));
+        dims[0] = 1;
+        dims[1] = 2;
+        size_t *order = reserveMemory(2 * sizeof(size_t));
+        setOrderOfDimsForNewTensor(2, order);
+        shape_t *shape = reserveMemory(sizeof(shape_t));
+        setShape(shape, dims, 2, order);
+        bParam = initTensor(shape, quantizationInitFloat(), NULL);
+        tensorFillFromFloatBuffer(bParam, (float[]){0.f, 0.f}, 2);
+    }
+    tensor_t *bGrad = gradInitFloat(bParam, NULL);
+    tensorFillFromFloatBuffer(bGrad, initialBGrad, 2);
+    parameter_t *b = parameterInit(bParam, bGrad);
+
+    quantization_t testQ;
+    initFloat32Quantization(&testQ);
+    layer_t *linear = linearLayerInit(w, b, &testQ, &testQ, &testQ, &testQ);
+    modelOut[0] = linear;
+    *wOut = w;
+    *bOut = b;
+
+    /* SGD optimizer wraps both parameters via the standard helper. */
+    return sgdMCreateOptim(0.01f, 0.f, 0.f, modelOut, 1, FLOAT32);
+}
+
+void testScaleOptimizerGradients_DoublesGradients() {
+    layer_t *model[1];
+    parameter_t *w;
+    parameter_t *b;
+    float wInit[6] = {1.f, 2.f, 3.f, 4.f, 5.f, 6.f};
+    float bInit[2] = {7.f, 8.f};
+
+    optimizer_t *sgd = buildOneLayerOptimWithGrads(model, &w, &b, wInit, bInit);
+
+    scaleOptimizerGradients(sgd, 2.0f);
+
+    /* CAPTURE before any free. */
+    float capturedWGrad[6];
+    {
+        float *g = (float *)w->grad->data;
+        for (size_t i = 0; i < 6; i++) {
+            capturedWGrad[i] = g[i];
+        }
+    }
+    float capturedBGrad[2];
+    {
+        float *g = (float *)b->grad->data;
+        capturedBGrad[0] = g[0];
+        capturedBGrad[1] = g[1];
+    }
+
+    /* FREE. freeOptimSgdM cascades to both parameters. */
+    freeOptimSgdM(sgd);
+    freeLinearLayer(model[0]);
+
+    /* ASSERT — every grad doubled. */
+    for (size_t i = 0; i < 6; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(1e-5f, wInit[i] * 2.0f, capturedWGrad[i]);
+    }
+    TEST_ASSERT_FLOAT_WITHIN(1e-5f, bInit[0] * 2.0f, capturedBGrad[0]);
+    TEST_ASSERT_FLOAT_WITHIN(1e-5f, bInit[1] * 2.0f, capturedBGrad[1]);
+}
+
+/* These tests verify that the validation branch is reached without aborting
+ * the process. PRINT_ERROR writes to stderr but does not exit; if the impl
+ * regressed to abort()/exit(), all three tests would never reach their
+ * assertions. Captured grads are unchanged because the loop still runs with
+ * the bad factor — the spec accepts that the warning is informational only. */
+void testScaleOptimizerGradients_FactorZero_DoesNotAbort() {
+    layer_t *model[1];
+    parameter_t *w;
+    parameter_t *b;
+    float wInit[6] = {1.f, 2.f, 3.f, 4.f, 5.f, 6.f};
+    float bInit[2] = {7.f, 8.f};
+
+    optimizer_t *sgd = buildOneLayerOptimWithGrads(model, &w, &b, wInit, bInit);
+
+    /* Must not abort — validation is a warning. */
+    scaleOptimizerGradients(sgd, 0.0f);
+
+    /* CAPTURE that grads are now zero (factor 0 multiplied through). */
+    float capturedFirst = ((float *)w->grad->data)[0];
+
+    freeOptimSgdM(sgd);
+    freeLinearLayer(model[0]);
+
+    TEST_ASSERT_EQUAL_FLOAT(0.0f, capturedFirst);
+}
+
+void testScaleOptimizerGradients_FactorNaN_DoesNotAbort() {
+    layer_t *model[1];
+    parameter_t *w;
+    parameter_t *b;
+    float wInit[6] = {1.f, 2.f, 3.f, 4.f, 5.f, 6.f};
+    float bInit[2] = {7.f, 8.f};
+
+    optimizer_t *sgd = buildOneLayerOptimWithGrads(model, &w, &b, wInit, bInit);
+
+    /* NaN propagates through; we just want to prove the function returns. */
+    float nanFactor = 0.0f / 0.0f;
+    scaleOptimizerGradients(sgd, nanFactor);
+
+    float captured = ((float *)w->grad->data)[0];
+
+    freeOptimSgdM(sgd);
+    freeLinearLayer(model[0]);
+
+    /* NaN != NaN by IEEE 754. */
+    TEST_ASSERT_TRUE(captured != captured);
+}
+
+/* SYM_INT32 builder mirrors buildOneLayerOptimWithGrads but pins both param and
+ * grad tensors to SYM_INT32 quantization. The grad tensor's int32 storage and
+ * scale are written directly (NOT via tensorFillFromFloatBuffer, which would
+ * route through convertTensor and recompute scale from the float source).
+ * The param data stays at default-zero, which matches the scale=1.0 default
+ * from initSymInt32QConfig — sgdStepSymInt32 round-trips it through float and
+ * back, but for the scaling assertions below the param values are irrelevant. */
+static optimizer_t *buildSymInt32OneLayerOptim(layer_t **modelOut, parameter_t **wOut,
+                                               parameter_t **bOut, float wInitialScale,
+                                               const int32_t *wInitialGradInt32,
+                                               float bInitialScale,
+                                               const int32_t *bInitialGradInt32, float lr,
+                                               float momentum) {
+    /* Weight param: SYM_INT32, dims [2, 3] (6 elements). */
+    tensor_t *wParam;
+    {
+        size_t *dims = reserveMemory(2 * sizeof(size_t));
+        dims[0] = 2;
+        dims[1] = 3;
+        size_t *order = reserveMemory(2 * sizeof(size_t));
+        setOrderOfDimsForNewTensor(2, order);
+        shape_t *shape = reserveMemory(sizeof(shape_t));
+        setShape(shape, dims, 2, order);
+        wParam = initTensor(shape, quantizationInitSymInt32(HTE), NULL);
+    }
+    tensor_t *wGrad = gradInitSymInt32(wParam, HTE, NULL);
+    {
+        int32_t *gradData = (int32_t *)wGrad->data;
+        memcpy(gradData, wInitialGradInt32, 6 * sizeof(int32_t));
+        symInt32QConfig_t *gradQ = wGrad->quantization->qConfig;
+        gradQ->scale = wInitialScale;
+    }
+    parameter_t *w = parameterInit(wParam, wGrad);
+
+    /* Bias param: SYM_INT32, dims [1, 2] (2 elements). */
+    tensor_t *bParam;
+    {
+        size_t *dims = reserveMemory(2 * sizeof(size_t));
+        dims[0] = 1;
+        dims[1] = 2;
+        size_t *order = reserveMemory(2 * sizeof(size_t));
+        setOrderOfDimsForNewTensor(2, order);
+        shape_t *shape = reserveMemory(sizeof(shape_t));
+        setShape(shape, dims, 2, order);
+        bParam = initTensor(shape, quantizationInitSymInt32(HTE), NULL);
+    }
+    tensor_t *bGrad = gradInitSymInt32(bParam, HTE, NULL);
+    {
+        int32_t *gradData = (int32_t *)bGrad->data;
+        memcpy(gradData, bInitialGradInt32, 2 * sizeof(int32_t));
+        symInt32QConfig_t *gradQ = bGrad->quantization->qConfig;
+        gradQ->scale = bInitialScale;
+    }
+    parameter_t *b = parameterInit(bParam, bGrad);
+
+    quantization_t *layerQ = quantizationInitSymInt32(HTE);
+    layer_t *linear = linearLayerInit(w, b, layerQ, layerQ, layerQ, layerQ);
+    modelOut[0] = linear;
+    *wOut = w;
+    *bOut = b;
+
+    return sgdMCreateOptim(lr, momentum, 0.f, modelOut, 1, SYM_INT32);
+}
+
+void testScaleOptimizerGradients_SymInt32_ScalesScaleOnly() {
+    layer_t *model[1];
+    parameter_t *w;
+    parameter_t *b;
+    int32_t wGradInt[6] = {10, 20, 30, -40, 50, -60};
+    int32_t bGradInt[2] = {100, -200};
+    float wScale0 = 0.5f;
+    float bScale0 = 0.25f;
+    float factor = 0.25f;
+
+    optimizer_t *sgd =
+        buildSymInt32OneLayerOptim(model, &w, &b, wScale0, wGradInt, bScale0, bGradInt, 0.01f, 0.f);
+
+    scaleOptimizerGradients(sgd, factor);
+
+    /* CAPTURE before frees. */
+    int32_t capturedWInt[6];
+    memcpy(capturedWInt, w->grad->data, 6 * sizeof(int32_t));
+    int32_t capturedBInt[2];
+    memcpy(capturedBInt, b->grad->data, 2 * sizeof(int32_t));
+    float capturedWScale = ((symInt32QConfig_t *)w->grad->quantization->qConfig)->scale;
+    float capturedBScale = ((symInt32QConfig_t *)b->grad->quantization->qConfig)->scale;
+
+    freeOptimSgdM(sgd);
+    freeLinearLayer(model[0]);
+
+    /* int32 storage is byte-for-byte unchanged. */
+    for (size_t i = 0; i < 6; i++) {
+        TEST_ASSERT_EQUAL_INT32(wGradInt[i], capturedWInt[i]);
+    }
+    for (size_t i = 0; i < 2; i++) {
+        TEST_ASSERT_EQUAL_INT32(bGradInt[i], capturedBInt[i]);
+    }
+    /* scale absorbed the multiplicative factor. */
+    TEST_ASSERT_FLOAT_WITHIN(1e-7f, wScale0 * factor, capturedWScale);
+    TEST_ASSERT_FLOAT_WITHIN(1e-7f, bScale0 * factor, capturedBScale);
+}
+
+void testScaleOptimizerGradients_SymInt32_DequantEquivalence() {
+    layer_t *model[1];
+    parameter_t *w;
+    parameter_t *b;
+    int32_t wGradInt[6] = {7, -14, 21, -28, 35, -42};
+    int32_t bGradInt[2] = {3, -3};
+    float wScale0 = 0.125f;
+    float bScale0 = 1.0f;
+    float factor = 0.5f;
+
+    /* Pre-compute dequantized grads (float_value = int32_value * scale) before
+     * scaling, then multiply by factor — this is the mathematical identity the
+     * scale-only path must satisfy. */
+    float wDequantBeforeTimesFactor[6];
+    for (size_t i = 0; i < 6; i++) {
+        wDequantBeforeTimesFactor[i] = (float)wGradInt[i] * wScale0 * factor;
+    }
+    float bDequantBeforeTimesFactor[2];
+    for (size_t i = 0; i < 2; i++) {
+        bDequantBeforeTimesFactor[i] = (float)bGradInt[i] * bScale0 * factor;
+    }
+
+    optimizer_t *sgd =
+        buildSymInt32OneLayerOptim(model, &w, &b, wScale0, wGradInt, bScale0, bGradInt, 0.01f, 0.f);
+
+    scaleOptimizerGradients(sgd, factor);
+
+    /* CAPTURE dequantized values after scaling, using post-scale int32 + scale. */
+    float wDequantAfter[6];
+    {
+        int32_t *gradInt = (int32_t *)w->grad->data;
+        float postScale = ((symInt32QConfig_t *)w->grad->quantization->qConfig)->scale;
+        for (size_t i = 0; i < 6; i++) {
+            wDequantAfter[i] = (float)gradInt[i] * postScale;
+        }
+    }
+    float bDequantAfter[2];
+    {
+        int32_t *gradInt = (int32_t *)b->grad->data;
+        float postScale = ((symInt32QConfig_t *)b->grad->quantization->qConfig)->scale;
+        for (size_t i = 0; i < 2; i++) {
+            bDequantAfter[i] = (float)gradInt[i] * postScale;
+        }
+    }
+
+    freeOptimSgdM(sgd);
+    freeLinearLayer(model[0]);
+
+    for (size_t i = 0; i < 6; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(1e-6f, wDequantBeforeTimesFactor[i], wDequantAfter[i]);
+    }
+    for (size_t i = 0; i < 2; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(1e-6f, bDequantBeforeTimesFactor[i], bDequantAfter[i]);
+    }
+}
+
+void testScaleOptimizerGradients_SymInt32_MomentumSgdAppliesScaledGradient() {
+    /* End-to-end: scaleOptimizerGradients into sgdStep with momentum > 0.
+     * The dequantized grad (int32 * scale) MUST equal int32_initial * scale_initial * factor
+     * once scaling is applied, and momentum-SGD's parameter update (with
+     * momentum=0 in the very first step) becomes -lr * scaled_grad. We assert
+     * that the post-step parameter equals the expected dequantized update,
+     * proving scaleOptimizerGradients fed sgdStep correctly. */
+    layer_t *model[1];
+    parameter_t *w;
+    parameter_t *b;
+    int32_t wGradInt[6] = {4, 8, 12, 16, 20, 24};
+    int32_t bGradInt[2] = {2, -2};
+    float wScale0 = 0.5f;
+    float bScale0 = 0.5f;
+    float factor = 0.25f;
+    float lr = 0.1f;
+
+    /* Expected param-after-step: param_before (zero from calloc) - lr * (int32 * scale_initial *
+     * factor). With param_before == 0: param_after == -lr * dequant_grad_scaled. */
+    float wExpectedParam[6];
+    for (size_t i = 0; i < 6; i++) {
+        wExpectedParam[i] = -lr * (float)wGradInt[i] * wScale0 * factor;
+    }
+    float bExpectedParam[2];
+    for (size_t i = 0; i < 2; i++) {
+        bExpectedParam[i] = -lr * (float)bGradInt[i] * bScale0 * factor;
+    }
+
+    optimizer_t *sgd = buildSymInt32OneLayerOptim(model, &w, &b, wScale0, wGradInt, bScale0,
+                                                  bGradInt, lr, 0.f /* momentum=0 first step */);
+
+    scaleOptimizerGradients(sgd, factor);
+    optimizerFunctions[sgd->type].step(sgd);
+
+    /* CAPTURE param-after-step as dequantized floats. */
+    float wParamAfter[6];
+    {
+        int32_t *paramInt = (int32_t *)w->param->data;
+        float pScale = ((symInt32QConfig_t *)w->param->quantization->qConfig)->scale;
+        for (size_t i = 0; i < 6; i++) {
+            wParamAfter[i] = (float)paramInt[i] * pScale;
+        }
+    }
+    float bParamAfter[2];
+    {
+        int32_t *paramInt = (int32_t *)b->param->data;
+        float pScale = ((symInt32QConfig_t *)b->param->quantization->qConfig)->scale;
+        for (size_t i = 0; i < 2; i++) {
+            bParamAfter[i] = (float)paramInt[i] * pScale;
+        }
+    }
+
+    freeOptimSgdM(sgd);
+    freeLinearLayer(model[0]);
+
+    /* Tolerance accounts for the int32 round-trip in sgdStepSymInt32 — the
+     * intermediate float value gets requantized through wScale0 (post-step
+     * scale unchanged on param tensor in this iteration). 1e-3f is generous
+     * enough for the small magnitudes here. */
+    for (size_t i = 0; i < 6; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(1e-3f, wExpectedParam[i], wParamAfter[i]);
+    }
+    for (size_t i = 0; i < 2; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(1e-3f, bExpectedParam[i], bParamAfter[i]);
+    }
+}
+
+int main(void) {
+    UNITY_BEGIN();
+    RUN_TEST(testScaleOptimizerGradients_DoublesGradients);
+    RUN_TEST(testScaleOptimizerGradients_FactorZero_DoesNotAbort);
+    RUN_TEST(testScaleOptimizerGradients_FactorNaN_DoesNotAbort);
+    RUN_TEST(testScaleOptimizerGradients_SymInt32_ScalesScaleOnly);
+    RUN_TEST(testScaleOptimizerGradients_SymInt32_DequantEquivalence);
+    RUN_TEST(testScaleOptimizerGradients_SymInt32_MomentumSgdAppliesScaledGradient);
+    return UNITY_END();
+}

--- a/test/unit/userAPI/UnitTestTrainingLoopApi.c
+++ b/test/unit/userAPI/UnitTestTrainingLoopApi.c
@@ -9,6 +9,7 @@
 #include "Linear.h"
 #include "LinearApi.h"
 #include "LossFunction.h"
+#include "OptimizerApi.h"
 #include "QuantizationApi.h"
 #include "ReluApi.h"
 #include "SgdApi.h"
@@ -70,14 +71,21 @@ void testCalculateGradsSequential_MatchesPyTorch() {
 
     for (size_t i = 0; i < 23; i++) {
         trainingStats_t *ts0 = calculateGradsSequential(
-            model, sizeModel, (lossConfig_t){.funcType = MSE, .reduction = REDUCTION_SUM}, 1,
-            input0, label0);
+            model, sizeModel, (lossConfig_t){.funcType = MSE, .backwardReduction = REDUCTION_SUM},
+            REDUCTION_SUM, input0, label0);
         trainingStats_t *ts1 = calculateGradsSequential(
-            model, sizeModel, (lossConfig_t){.funcType = MSE, .reduction = REDUCTION_SUM}, 1,
-            input1, label1);
+            model, sizeModel, (lossConfig_t){.funcType = MSE, .backwardReduction = REDUCTION_SUM},
+            REDUCTION_SUM, input1, label1);
         trainingStats_t *ts2 = calculateGradsSequential(
-            model, sizeModel, (lossConfig_t){.funcType = MSE, .reduction = REDUCTION_SUM}, 1,
-            input2, label2);
+            model, sizeModel, (lossConfig_t){.funcType = MSE, .backwardReduction = REDUCTION_SUM},
+            REDUCTION_SUM, input2, label2);
+
+        /* PyTorch reference is MSE-mean-of-features (`2/F * (o-l)` per element). Post-#135
+         * backward writes raw `2*(o-l)`; recover the reference trajectory via explicit
+         * 1/F = 1/2 scaling here. trainingEpochDefault does this implicitly when
+         * backwardReduction == REDUCTION_MEAN; this test exercises calculateGradsSequential
+         * directly, so the scaling must be manual. */
+        scaleOptimizerGradients(sgd, 1.0f / 2.0f);
 
         sgdFns.step(sgd);
         sgdFns.zero(sgd);
@@ -139,10 +147,12 @@ void testEvaluationBatch_ReturnsAverageLoss() {
     tensor_t *input1 = buildFloatTensor2D(1, 3, (float[]){1.f, 0.f, 0.f}, 3);
     tensor_t *label1 = buildFloatTensor2D(1, 2, (float[]){5.f, 5.f}, 2);
 
-    /* Compute expected losses via inferenceWithLoss directly */
-    inferenceStats_t *stats0 = inferenceWithLoss(model, 1, input0, label0, MSE);
-    inferenceStats_t *stats1 = inferenceWithLoss(model, 1, input1, label1, MSE);
-    float expectedAvgLoss = (stats0->loss + stats1->loss) / 2.0f;
+    /* Compute expected losses via inferenceWithLoss directly.
+     * evaluationBatch now returns a pure sum (no division); expected = sum of
+     * per-sample MEAN losses. */
+    inferenceStats_t *stats0 = inferenceWithLoss(model, 1, input0, label0, MSE, REDUCTION_MEAN);
+    inferenceStats_t *stats1 = inferenceWithLoss(model, 1, input1, label1, MSE, REDUCTION_MEAN);
+    float expectedSumLoss = stats0->loss + stats1->loss;
     freeInferenceStats(stats0);
     freeInferenceStats(stats1);
 
@@ -157,11 +167,11 @@ void testEvaluationBatch_ReturnsAverageLoss() {
     sample_t *samples[] = {s0, s1};
     batch_t batch = {.samples = samples, .size = 2};
 
-    float actualAvgLoss = evaluationBatch(model, 1, MSE, &batch, inferenceWithLoss);
+    float actualSumLoss = evaluationBatch(model, 1, MSE, &batch, inferenceWithLoss, REDUCTION_MEAN);
 
     /* CAPTURE. */
-    float capturedExpected = expectedAvgLoss;
-    float capturedActual = actualAvgLoss;
+    float capturedExpected = expectedSumLoss;
+    float capturedActual = actualSumLoss;
 
     /* FREE in reverse-init order. evaluationBatch consumed s0/s1 (freed via
      * freeSample inside the production loop). The tensors they referenced
@@ -265,7 +275,7 @@ void testEvaluationEpoch_ReturnsAverageLossAcrossBatches() {
     dataLoader_t *dl =
         dataLoaderInit(getEpochSample, getEpochDatasetSize, 1, NULL, NULL, false, 0, true);
 
-    float totalAvg = evaluationEpoch(model, 1, MSE, dl, inferenceWithLoss);
+    float totalAvg = evaluationEpoch(model, 1, MSE, dl, inferenceWithLoss, REDUCTION_MEAN);
 
     /* CAPTURE. */
     float capturedTotalAvg = totalAvg;
@@ -282,7 +292,7 @@ void testEvaluationEpoch_ReturnsAverageLossAcrossBatches() {
      * s1: MSE([1,5],[0,1]) = ((1-0)^2+(5-1)^2)/2 = 8.5
      * s2: MSE([3,1],[1,0]) = ((3-1)^2+(1-0)^2)/2 = 2.5
      * s3: MSE([1,3],[0,1]) = ((1-0)^2+(3-1)^2)/2 = 2.5
-     * 4 batches of 1, avg of per-batch avg = (8.5+8.5+2.5+2.5)/4 = 5.5 */
+     * flat aggregator: totalLoss=22, totalSamples=4, mean=22/4=5.5 */
     TEST_ASSERT_FLOAT_WITHIN(0.01f, 5.5f, capturedTotalAvg);
 }
 
@@ -305,12 +315,11 @@ void testEvaluationEpoch_MinibatchMatchesMicrobatchAverage() {
 
     /* batchSize=2 → 2 minibatches of 2 samples each
      * Per-sample losses: 8.5, 8.5, 2.5, 2.5
-     * Batch 0 avg = (8.5+8.5)/2 = 8.5; Batch 1 avg = (2.5+2.5)/2 = 2.5
-     * Epoch avg = (8.5+2.5)/2 = 5.5 — identical to microbatch result */
+     * flat aggregator: totalLoss=22, totalSamples=4, mean=22/4=5.5 */
     dataLoader_t *dl =
         dataLoaderInit(getEpochSample, getEpochDatasetSize, 2, NULL, NULL, false, 0, true);
 
-    float totalAvg = evaluationEpoch(model, 1, MSE, dl, inferenceWithLoss);
+    float totalAvg = evaluationEpoch(model, 1, MSE, dl, inferenceWithLoss, REDUCTION_MEAN);
 
     /* CAPTURE. */
     float capturedTotalAvg = totalAvg;
@@ -347,11 +356,15 @@ void testTrainingBatchDefault_ReturnsAverageLossAndAccumulatesGrads() {
     tensor_t *in1 = buildFloatTensor2D(1, 3, (float[]){5.f, -1.f, 2.f}, 3);
     tensor_t *lb1 = buildFloatTensor2D(1, 2, (float[]){43.f, 249.f}, 2);
 
-    /* Get expected losses from individual calculateGrads calls */
+    /* Get expected losses from individual calculateGrads calls.
+     * Use REDUCTION_MEAN + batchSize=2 to match what trainingBatchDefault threads
+     * through when called with forwardReduction=REDUCTION_MEAN. */
     trainingStats_t *ts0 = calculateGradsSequential(
-        model, 1, (lossConfig_t){.funcType = MSE, .reduction = REDUCTION_SUM}, 1, in0, lb0);
+        model, 1, (lossConfig_t){.funcType = MSE, .backwardReduction = REDUCTION_SUM},
+        REDUCTION_MEAN, in0, lb0);
     trainingStats_t *ts1 = calculateGradsSequential(
-        model, 1, (lossConfig_t){.funcType = MSE, .reduction = REDUCTION_SUM}, 1, in1, lb1);
+        model, 1, (lossConfig_t){.funcType = MSE, .backwardReduction = REDUCTION_SUM},
+        REDUCTION_MEAN, in1, lb1);
     float expectedAvg = (ts0->loss + ts1->loss) / 2.0f;
     freeTrainingStats(ts0);
     freeTrainingStats(ts1);
@@ -376,9 +389,9 @@ void testTrainingBatchDefault_ReturnsAverageLossAndAccumulatesGrads() {
     sample_t *samples[] = {s0, s1};
     batch_t batch = {.samples = samples, .size = 2};
 
-    float actualAvg =
-        trainingBatchDefault(model, 1, (lossConfig_t){.funcType = MSE, .reduction = REDUCTION_SUM},
-                             &batch, calculateGradsSequential);
+    float actualAvg = trainingBatchDefault(
+        model, 1, (lossConfig_t){.funcType = MSE, .backwardReduction = REDUCTION_SUM}, &batch,
+        calculateGradsSequential, REDUCTION_MEAN);
 
     /* CAPTURE. */
     float capturedExpected = expectedAvg;
@@ -395,6 +408,72 @@ void testTrainingBatchDefault_ReturnsAverageLossAndAccumulatesGrads() {
 
     /* ASSERT. */
     TEST_ASSERT_FLOAT_WITHIN(1e-5f, capturedExpected, capturedActual);
+}
+
+void testTrainingBatchDefault_SumAggregatesWithoutDivision() {
+    tensor_t *wParam = buildFloatTensor2D(2, 3, (float[]){1.f, 1.f, 1.f, 1.f, 1.f, 1.f}, 6);
+    tensor_t *wGrad = gradInitFloat(wParam, NULL);
+    parameter_t *w = parameterInit(wParam, wGrad);
+
+    tensor_t *bParam = buildFloatTensor2D(1, 2, (float[]){-1.f, 3.f}, 2);
+    tensor_t *bGrad = gradInitFloat(bParam, NULL);
+    parameter_t *b = parameterInit(bParam, bGrad);
+
+    quantization_t testQ;
+    initFloat32Quantization(&testQ);
+    layer_t *linear = linearLayerInit(w, b, &testQ, &testQ, &testQ, &testQ);
+    layer_t *model[] = {linear};
+
+    tensor_t *in0 = buildFloatTensor2D(1, 3, (float[]){-4.f, 1.f, 9.f}, 3);
+    tensor_t *lb0 = buildFloatTensor2D(1, 2, (float[]){59.f, -23.f}, 2);
+    tensor_t *in1 = buildFloatTensor2D(1, 3, (float[]){5.f, -1.f, 2.f}, 3);
+    tensor_t *lb1 = buildFloatTensor2D(1, 2, (float[]){43.f, 249.f}, 2);
+
+    trainingStats_t *ts0 = calculateGradsSequential(
+        model, 1, (lossConfig_t){.funcType = MSE, .backwardReduction = REDUCTION_SUM},
+        REDUCTION_SUM, in0, lb0);
+    trainingStats_t *ts1 = calculateGradsSequential(
+        model, 1, (lossConfig_t){.funcType = MSE, .backwardReduction = REDUCTION_SUM},
+        REDUCTION_SUM, in1, lb1);
+    float expectedSum = ts0->loss + ts1->loss;
+    freeTrainingStats(ts0);
+    freeTrainingStats(ts1);
+
+    /* Reset grads. */
+    float *gArr = (float *)wGrad->data;
+    for (size_t i = 0; i < 6; i++) {
+        gArr[i] = 0.f;
+    }
+    float *bgArr = (float *)bGrad->data;
+    bgArr[0] = 0.f;
+    bgArr[1] = 0.f;
+
+    sample_t *s0 = reserveMemory(sizeof(sample_t));
+    s0->item = in0;
+    s0->label = lb0;
+    sample_t *s1 = reserveMemory(sizeof(sample_t));
+    s1->item = in1;
+    s1->label = lb1;
+    sample_t *samples[] = {s0, s1};
+    batch_t batch = {.samples = samples, .size = 2};
+
+    /* SUM forwardReduction: aggregator returns Σ stats->loss, NOT divided by batch->size. */
+    float actualSum = trainingBatchDefault(
+        model, 1, (lossConfig_t){.funcType = MSE, .backwardReduction = REDUCTION_SUM}, &batch,
+        calculateGradsSequential, REDUCTION_SUM);
+
+    float capturedExpected = expectedSum;
+    float capturedActual = actualSum;
+
+    freeTensor(lb1);
+    freeTensor(in1);
+    freeTensor(lb0);
+    freeTensor(in0);
+    freeLinearLayer(linear);
+    freeParameter(b);
+    freeParameter(w);
+
+    TEST_ASSERT_FLOAT_WITHIN(1e-3f, capturedExpected, capturedActual);
 }
 
 void testTrainingEpochDefault_DoesOptimizerStepPerBatch() {
@@ -429,8 +508,8 @@ void testTrainingEpochDefault_DoesOptimizerStepPerBatch() {
         dataLoaderInit(getEpochSample, getEpochDatasetSize, 1, NULL, NULL, false, 0, true);
 
     float epochLoss = trainingEpochDefault(
-        model, sizeModel, (lossConfig_t){.funcType = MSE, .reduction = REDUCTION_SUM}, dl, sgd,
-        calculateGradsSequential);
+        model, sizeModel, (lossConfig_t){.funcType = MSE, .backwardReduction = REDUCTION_SUM}, dl,
+        sgd, calculateGradsSequential, REDUCTION_SUM);
 
     /* CAPTURE assertion values BEFORE any free. */
     bool capturedChanged = false;
@@ -490,8 +569,8 @@ void testTrainingEpochDefault_MinibatchStepsOncePerMinibatch() {
         dataLoaderInit(getEpochSample, getEpochDatasetSize, 2, NULL, NULL, false, 0, true);
 
     float epochLoss = trainingEpochDefault(
-        model, sizeModel, (lossConfig_t){.funcType = MSE, .reduction = REDUCTION_SUM}, dl, sgd,
-        calculateGradsSequential);
+        model, sizeModel, (lossConfig_t){.funcType = MSE, .backwardReduction = REDUCTION_SUM}, dl,
+        sgd, calculateGradsSequential, REDUCTION_SUM);
 
     /* CAPTURE. */
     bool capturedChanged = false;
@@ -540,8 +619,8 @@ void testTrainingRun_ReturnsResult() {
         dataLoaderInit(getEpochSample, getEpochDatasetSize, 1, NULL, NULL, false, 0, true);
 
     trainingRunResult_t result =
-        trainingRun(model, 1, (lossConfig_t){.funcType = MSE, .reduction = REDUCTION_SUM}, trainDl,
-                    evalDl, sgd, 2, calculateGradsSequential, inferenceWithLoss, NULL);
+        trainingRun(model, 1, (lossConfig_t){.funcType = MSE, .backwardReduction = REDUCTION_SUM},
+                    trainDl, evalDl, sgd, 2, calculateGradsSequential, inferenceWithLoss, NULL);
 
     /* CAPTURE. */
     float capturedFinalTrainLoss = result.finalTrainLoss;
@@ -603,8 +682,8 @@ void testTrainingRun_CallsCallbackEachEpochWithStats() {
 
     size_t numberOfEpochs = 3;
     trainingRunResult_t result = trainingRun(
-        model, 1, (lossConfig_t){.funcType = MSE, .reduction = REDUCTION_SUM}, trainDl, evalDl, sgd,
-        numberOfEpochs, calculateGradsSequential, inferenceWithLoss, captureCallback);
+        model, 1, (lossConfig_t){.funcType = MSE, .backwardReduction = REDUCTION_SUM}, trainDl,
+        evalDl, sgd, numberOfEpochs, calculateGradsSequential, inferenceWithLoss, captureCallback);
 
     /* CAPTURE. */
     size_t capturedCbCallCount = cbCallCount;
@@ -655,7 +734,8 @@ void testEvaluationEpochWithMetrics_AllCorrect() {
         dataLoaderInit(getEpochSample, getEpochDatasetSize, 1, NULL, NULL, false, 0, true);
 
     /* Identity model: all 4 samples predict correctly (same as testEvaluationEpochAccuracy) */
-    epochStats_t stats = evaluationEpochWithMetrics(model, 1, MSE, dl, inferenceWithLoss);
+    epochStats_t stats =
+        evaluationEpochWithMetrics(model, 1, MSE, dl, inferenceWithLoss, REDUCTION_MEAN);
 
     /* CAPTURE. */
     float capturedLoss = stats.loss;
@@ -677,6 +757,112 @@ void testEvaluationEpochWithMetrics_AllCorrect() {
     TEST_ASSERT_FLOAT_WITHIN(0.001f, 1.0f, capturedPrecision);
     TEST_ASSERT_FLOAT_WITHIN(0.001f, 1.0f, capturedRecall);
     TEST_ASSERT_FLOAT_WITHIN(0.001f, 1.0f, capturedF1);
+}
+
+/* Single-sample dataset for fine-grained gradient-magnitude tests. The
+ * mirror-image of epochDataset but with exactly one sample, F=4, so
+ * computeMeanScaleMSE returns 1/(N*F) = 1/4 — non-trivial scaling that
+ * the optimizer-scaling mutation breaks measurably. */
+static tensor_t *singleSampleItem;
+static tensor_t *singleSampleLabel;
+static dataset_t singleSampleDataset;
+static tensorArray_t singleSampleItemsArr;
+static tensorArray_t singleSampleLabelsArr;
+static bool singleSampleDatasetInit = false;
+
+static void initSingleSampleDataset() {
+    if (singleSampleDatasetInit) {
+        return;
+    }
+    singleSampleItem = buildFloatTensor2D(1, 4, (float[]){1.f, 1.f, 1.f, 1.f}, 4);
+    singleSampleLabel = buildFloatTensor2D(1, 4, (float[]){0.f, 0.f, 0.f, 0.f}, 4);
+    singleSampleItemsArr.array = &singleSampleItem;
+    singleSampleItemsArr.size = 1;
+    singleSampleLabelsArr.array = &singleSampleLabel;
+    singleSampleLabelsArr.size = 1;
+    singleSampleDataset.items = &singleSampleItemsArr;
+    singleSampleDataset.labels = &singleSampleLabelsArr;
+    singleSampleDatasetInit = true;
+}
+
+static void freeSingleSampleDataset() {
+    if (!singleSampleDatasetInit) {
+        return;
+    }
+    freeTensor(singleSampleItem);
+    freeTensor(singleSampleLabel);
+    singleSampleDatasetInit = false;
+}
+
+static sample_t *getSingleSample(size_t id) {
+    sample_t *s = reserveMemory(sizeof(sample_t));
+    s->item = singleSampleDataset.items->array[id];
+    s->label = singleSampleDataset.labels->array[id];
+    return s;
+}
+
+static size_t getSingleSampleDatasetSize() {
+    return 1;
+}
+
+void testTrainingEpochDefault_MeanScalesGradByOneOverNF() {
+    /* 4×4 identity-weight linear layer, single sample with input=[1,1,1,1]
+     * and label=[0,0,0,0], lr=0.01, momentum=0. F=4 (4 output features),
+     * N=1, B=1.
+     *
+     * Forward: output = W * input + b = [1, 1, 1, 1] (identity passes input).
+     * MSE backward raw: 2*(o - l) = [2, 2, 2, 2].
+     * Linear backward dL/dW[i,j] = dL/dout[i] * input[j] = 2 * 1 = 2 in
+     * every position.
+     * scaleOptimizerGradients factor = 1/(N*F) = 1/4.
+     * Scaled dL/dW = 0.5 in every position.
+     * Step with lr=0.01: each weight changes by 0.01 * 0.5 = 0.005.
+     *   Diagonal:  W[i,i] = 1.0 - 0.005 = 0.995.
+     *   Off-diag:  W[i,j] = 0.0 - 0.005 = -0.005.
+     *
+     * Mutation (no scaleOptimizerGradients call): each weight changes by
+     * 0.01 * 2.0 = 0.02 instead. W[0,0] = 0.98, W[0,1] = -0.02.
+     * Tolerance 1e-4 distinguishes 0.995 from 0.98 cleanly. */
+
+    static const float wInitData[16] = {
+        1.f, 0.f, 0.f, 0.f, 0.f, 1.f, 0.f, 0.f, 0.f, 0.f, 1.f, 0.f, 0.f, 0.f, 0.f, 1.f,
+    };
+    tensor_t *wParam = buildFloatTensor2D(4, 4, wInitData, 16);
+    tensor_t *wGrad = gradInitFloat(wParam, NULL);
+    parameter_t *w = parameterInit(wParam, wGrad);
+
+    tensor_t *bParam = buildFloatTensor2D(1, 4, (float[]){0.f, 0.f, 0.f, 0.f}, 4);
+    tensor_t *bGrad = gradInitFloat(bParam, NULL);
+    parameter_t *b = parameterInit(bParam, bGrad);
+
+    quantization_t testQ;
+    initFloat32Quantization(&testQ);
+    layer_t *linear = linearLayerInit(w, b, &testQ, &testQ, &testQ, &testQ);
+    layer_t *model[] = {linear};
+
+    /* momentumFactor=0 makes SGD_M behave like plain SGD. */
+    optimizer_t *sgd = sgdMCreateOptim(0.01f, 0.f, 0.f, model, 1, FLOAT32);
+
+    initSingleSampleDataset();
+    dataLoader_t *dl =
+        dataLoaderInit(getSingleSample, getSingleSampleDatasetSize, 1, NULL, NULL, false, 0, true);
+
+    /* defaultLossConfig: backwardReduction = REDUCTION_MEAN. */
+    lossConfig_t cfg = defaultLossConfig(MSE);
+
+    trainingEpochDefault(model, 1, cfg, dl, sgd, calculateGradsSequential, REDUCTION_MEAN);
+
+    /* CAPTURE before any free. */
+    float capturedW00 = ((float *)wParam->data)[0];
+    float capturedW01 = ((float *)wParam->data)[1];
+
+    freeOptimSgdM(sgd);
+    freeDataLoader(dl);
+    freeLinearLayer(linear);
+    freeSingleSampleDataset();
+
+    TEST_ASSERT_FLOAT_WITHIN(1e-4f, 0.995f, capturedW00);
+    TEST_ASSERT_FLOAT_WITHIN(1e-4f, -0.005f, capturedW01);
 }
 
 /* Partially-correct dataset: 4 samples, 3 correct, 1 wrong */
@@ -760,7 +946,8 @@ void testEvaluationEpochWithMetrics_PartiallyCorrect() {
     dataLoader_t *dl =
         dataLoaderInit(getPartialSample, getPartialDatasetSize, 1, NULL, NULL, false, 0, true);
 
-    epochStats_t stats = evaluationEpochWithMetrics(model, 1, MSE, dl, inferenceWithLoss);
+    epochStats_t stats =
+        evaluationEpochWithMetrics(model, 1, MSE, dl, inferenceWithLoss, REDUCTION_MEAN);
 
     /* CAPTURE. */
     float capturedAccuracy = stats.accuracy;
@@ -867,7 +1054,8 @@ void testEvaluationEpochWithMetrics_HandlesZeroPredictionClass() {
     dataLoader_t *dl =
         dataLoaderInit(getZeroPredSample, getZeroPredDatasetSize, 1, NULL, NULL, false, 0, true);
 
-    epochStats_t stats = evaluationEpochWithMetrics(model, 1, MSE, dl, inferenceWithLoss);
+    epochStats_t stats =
+        evaluationEpochWithMetrics(model, 1, MSE, dl, inferenceWithLoss, REDUCTION_MEAN);
 
     /* CAPTURE. */
     float capturedAccuracy = stats.accuracy;
@@ -924,7 +1112,7 @@ void testEvaluationEpochWithReport_ReturnsConfusionMatrix() {
     /* Pre-fill with non-zero to verify WithReport zeroes the caller's buffer before accumulating */
     size_t cm[2 * 2] = {99, 99, 99, 99};
     classificationReport_t report =
-        evaluationEpochWithReport(model, 1, MSE, dl, inferenceWithLoss, cm, 2);
+        evaluationEpochWithReport(model, 1, MSE, dl, inferenceWithLoss, cm, 2, REDUCTION_MEAN);
 
     /* CAPTURE. */
     size_t capturedCM[4];
@@ -953,6 +1141,281 @@ void testEvaluationEpochWithReport_ReturnsConfusionMatrix() {
     TEST_ASSERT_FLOAT_WITHIN(0.001f, 0.75f, capturedAccuracy);
 }
 
+void testInferenceWithLoss_PropagatesForwardReductionSum() {
+    /* Identity model: output = input. Allows the loss value to be computed
+     * independently of the forward chain — only the reduction parameter
+     * threading is exercised here. */
+    tensor_t *wParam = buildFloatTensor2D(2, 2, (float[]){1.f, 0.f, 0.f, 1.f}, 4);
+    tensor_t *wGrad = gradInitFloat(wParam, NULL);
+    parameter_t *w = parameterInit(wParam, wGrad);
+
+    tensor_t *bParam = buildFloatTensor2D(1, 2, (float[]){0.f, 0.f}, 2);
+    tensor_t *bGrad = gradInitFloat(bParam, NULL);
+    parameter_t *b = parameterInit(bParam, bGrad);
+
+    quantization_t testQ;
+    initFloat32Quantization(&testQ);
+    layer_t *linear = linearLayerInit(w, b, &testQ, &testQ, &testQ, &testQ);
+    layer_t *model[] = {linear};
+
+    tensor_t *input = buildFloatTensor2D(1, 2, (float[]){5.f, 1.f}, 2);
+    tensor_t *label = buildFloatTensor2D(1, 2, (float[]){1.f, 0.f}, 2);
+
+    /* SUM: (5-1)² + (1-0)² = 17. MEAN: 17 / 2 = 8.5. Different by construction. */
+    inferenceStats_t *sumStats = inferenceWithLoss(model, 1, input, label, MSE, REDUCTION_SUM);
+    inferenceStats_t *meanStats = inferenceWithLoss(model, 1, input, label, MSE, REDUCTION_MEAN);
+
+    float capturedSum = sumStats->loss;
+    float capturedMean = meanStats->loss;
+
+    freeInferenceStats(sumStats);
+    freeInferenceStats(meanStats);
+    freeTensor(label);
+    freeTensor(input);
+    freeLinearLayer(linear);
+    freeParameter(b);
+    freeParameter(w);
+
+    TEST_ASSERT_FLOAT_WITHIN(1e-4f, 17.0f, capturedSum);
+    TEST_ASSERT_FLOAT_WITHIN(1e-4f, 8.5f, capturedMean);
+}
+
+void testTrainingEpochDefault_SumBackwardSkipsOptimizerScaling() {
+    /* With backwardReduction = SUM, gradients should land at the optimizer
+     * unscaled — multiple steps with SUM should produce a different weight
+     * trajectory than MEAN over the same data. */
+    static const float wInitData[4] = {1.f, 0.f, 0.f, 1.f};
+    static const float bInitData[2] = {0.f, 0.f};
+
+    tensor_t *wParam = buildFloatTensor2D(2, 2, wInitData, 4);
+    tensor_t *wGrad = gradInitFloat(wParam, NULL);
+    parameter_t *w = parameterInit(wParam, wGrad);
+    tensor_t *bParam = buildFloatTensor2D(1, 2, bInitData, 2);
+    tensor_t *bGrad = gradInitFloat(bParam, NULL);
+    parameter_t *b = parameterInit(bParam, bGrad);
+
+    quantization_t testQ;
+    initFloat32Quantization(&testQ);
+    layer_t *linear = linearLayerInit(w, b, &testQ, &testQ, &testQ, &testQ);
+    layer_t *model[] = {linear};
+
+    /* Use a very small learning rate so SUM doesn't NaN — SUM gradients are
+     * larger by N*F than MEAN gradients on the same data. */
+    optimizer_t *sgd = sgdMCreateOptim(0.001f, 0.f, 0.f, model, 1, FLOAT32);
+
+    initEpochDataset();
+    dataLoader_t *dl =
+        dataLoaderInit(getEpochSample, getEpochDatasetSize, 1, NULL, NULL, false, 0, true);
+
+    /* SUM backwardReduction skips scaleOptimizerGradients. */
+    lossConfig_t cfg = defaultLossConfig(MSE);
+    cfg.backwardReduction = REDUCTION_SUM;
+
+    float epochLoss =
+        trainingEpochDefault(model, 1, cfg, dl, sgd, calculateGradsSequential, REDUCTION_SUM);
+
+    bool capturedChanged = false;
+    {
+        float *curWeights = (float *)wParam->data;
+        for (size_t i = 0; i < 4; i++) {
+            if (curWeights[i] != wInitData[i]) {
+                capturedChanged = true;
+                break;
+            }
+        }
+    }
+    bool capturedFinite = (epochLoss == epochLoss) && (epochLoss != 1.0f / 0.0f);
+    float capturedEpochLoss = epochLoss;
+
+    freeOptimSgdM(sgd);
+    freeDataLoader(dl);
+    freeLinearLayer(linear);
+    freeEpochDataset();
+
+    TEST_ASSERT_TRUE(capturedChanged);
+    TEST_ASSERT_TRUE(capturedFinite);
+    TEST_ASSERT_TRUE(capturedEpochLoss > 0.0f);
+}
+
+void testTrainingEpochDefault_MeanForwardSumBackward_MixedCombination() {
+    /* Leo's stated use case: report per-sample MEAN losses (comparable
+     * across runs), but step the optimizer with raw SUM gradients (no
+     * scaleOptimizerGradients call). */
+    static const float wInitData[4] = {1.f, 0.f, 0.f, 1.f};
+    static const float bInitData[2] = {0.f, 0.f};
+
+    tensor_t *wParam = buildFloatTensor2D(2, 2, wInitData, 4);
+    tensor_t *wGrad = gradInitFloat(wParam, NULL);
+    parameter_t *w = parameterInit(wParam, wGrad);
+    tensor_t *bParam = buildFloatTensor2D(1, 2, bInitData, 2);
+    tensor_t *bGrad = gradInitFloat(bParam, NULL);
+    parameter_t *b = parameterInit(bParam, bGrad);
+
+    quantization_t testQ;
+    initFloat32Quantization(&testQ);
+    layer_t *linear = linearLayerInit(w, b, &testQ, &testQ, &testQ, &testQ);
+    layer_t *model[] = {linear};
+
+    optimizer_t *sgd = sgdMCreateOptim(0.001f, 0.f, 0.f, model, 1, FLOAT32);
+
+    initEpochDataset();
+    dataLoader_t *dl =
+        dataLoaderInit(getEpochSample, getEpochDatasetSize, 1, NULL, NULL, false, 0, true);
+
+    lossConfig_t cfg = defaultLossConfig(MSE);
+    cfg.backwardReduction = REDUCTION_SUM; /* SUM gradients, no optimizer scaling */
+
+    /* forwardReduction = MEAN: stats->loss is per-sample mean, comparable. */
+    float epochLoss =
+        trainingEpochDefault(model, 1, cfg, dl, sgd, calculateGradsSequential, REDUCTION_MEAN);
+
+    bool capturedChanged = false;
+    {
+        float *curWeights = (float *)wParam->data;
+        for (size_t i = 0; i < 4; i++) {
+            if (curWeights[i] != wInitData[i]) {
+                capturedChanged = true;
+                break;
+            }
+        }
+    }
+    bool capturedFinite = (epochLoss == epochLoss) && (epochLoss != 1.0f / 0.0f);
+    float capturedEpochLoss = epochLoss;
+
+    freeOptimSgdM(sgd);
+    freeDataLoader(dl);
+    freeLinearLayer(linear);
+    freeEpochDataset();
+
+    TEST_ASSERT_TRUE(capturedChanged);
+    TEST_ASSERT_TRUE(capturedFinite);
+    TEST_ASSERT_TRUE(capturedEpochLoss > 0.0f);
+    /* MEAN-reported loss should be per-sample-scale (small), not raw-SUM-scale (large). */
+    TEST_ASSERT_TRUE(capturedEpochLoss < 100.0f);
+}
+
+void testEvaluationEpoch_FlatAggregator_DivisionByTotalSamples() {
+    initEpochDataset();
+
+    tensor_t *wParam = buildFloatTensor2D(2, 2, (float[]){1.f, 0.f, 0.f, 1.f}, 4);
+    tensor_t *wGrad = gradInitFloat(wParam, NULL);
+    parameter_t *w = parameterInit(wParam, wGrad);
+    tensor_t *bParam = buildFloatTensor2D(1, 2, (float[]){0.f, 0.f}, 2);
+    tensor_t *bGrad = gradInitFloat(bParam, NULL);
+    parameter_t *b = parameterInit(bParam, bGrad);
+
+    quantization_t testQ;
+    initFloat32Quantization(&testQ);
+    layer_t *linear = linearLayerInit(w, b, &testQ, &testQ, &testQ, &testQ);
+    layer_t *model[] = {linear};
+
+    /* batchSize=2 → 2 batches of 2 samples; per-sample MSE losses are
+     * 8.5, 8.5, 2.5, 2.5 (computed by hand, as in
+     * testEvaluationEpoch_MinibatchMatchesMicrobatchAverage).
+     * Flat aggregator: totalLoss = 8.5+8.5+2.5+2.5 = 22; totalSamples = 4;
+     * mean = 22/4 = 5.5. */
+    dataLoader_t *dl =
+        dataLoaderInit(getEpochSample, getEpochDatasetSize, 2, NULL, NULL, false, 0, true);
+
+    /* MEAN: divides by totalSamples. */
+    float meanLoss = evaluationEpoch(model, 1, MSE, dl, inferenceWithLoss, REDUCTION_MEAN);
+
+    float capturedMean = meanLoss;
+
+    freeDataLoader(dl);
+    freeLinearLayer(linear);
+    freeParameter(b);
+    freeParameter(w);
+    freeEpochDataset();
+
+    TEST_ASSERT_FLOAT_WITHIN(0.01f, 5.5f, capturedMean);
+}
+
+void testEvaluationEpoch_SumPath_ReturnsRawTotal() {
+    initEpochDataset();
+
+    tensor_t *wParam = buildFloatTensor2D(2, 2, (float[]){1.f, 0.f, 0.f, 1.f}, 4);
+    tensor_t *wGrad = gradInitFloat(wParam, NULL);
+    parameter_t *w = parameterInit(wParam, wGrad);
+    tensor_t *bParam = buildFloatTensor2D(1, 2, (float[]){0.f, 0.f}, 2);
+    tensor_t *bGrad = gradInitFloat(bParam, NULL);
+    parameter_t *b = parameterInit(bParam, bGrad);
+
+    quantization_t testQ;
+    initFloat32Quantization(&testQ);
+    layer_t *linear = linearLayerInit(w, b, &testQ, &testQ, &testQ, &testQ);
+    layer_t *model[] = {linear};
+
+    dataLoader_t *dl =
+        dataLoaderInit(getEpochSample, getEpochDatasetSize, 1, NULL, NULL, false, 0, true);
+
+    /* SUM forwardReduction: returns raw totalLoss = sum of per-sample
+     * SUM losses. Per-sample SUM: 17, 17, 5, 5 (= per-sample MEAN * F=2). */
+    float sumLoss = evaluationEpoch(model, 1, MSE, dl, inferenceWithLoss, REDUCTION_SUM);
+
+    float capturedSum = sumLoss;
+
+    freeDataLoader(dl);
+    freeLinearLayer(linear);
+    freeParameter(b);
+    freeParameter(w);
+    freeEpochDataset();
+
+    TEST_ASSERT_FLOAT_WITHIN(0.01f, 17.f + 17.f + 5.f + 5.f, capturedSum);
+}
+
+void testTrainingRun_HardcodesForwardReductionMean() {
+    /* trainingRun should produce comparable train and eval losses (both
+     * per-sample MEAN) regardless of lossConfig's other fields. With
+     * backwardReduction = MEAN and a near-trivial learnable dataset,
+     * train and eval losses should both be small finite floats — and in
+     * the same ballpark, since both are MEAN-reduced over the same data
+     * shape. */
+    tensor_t *wParam = buildFloatTensor2D(2, 2, (float[]){1.f, 0.f, 0.f, 1.f}, 4);
+    tensor_t *wGrad = gradInitFloat(wParam, NULL);
+    parameter_t *w = parameterInit(wParam, wGrad);
+    tensor_t *bParam = buildFloatTensor2D(1, 2, (float[]){0.f, 0.f}, 2);
+    tensor_t *bGrad = gradInitFloat(bParam, NULL);
+    parameter_t *b = parameterInit(bParam, bGrad);
+
+    quantization_t testQ;
+    initFloat32Quantization(&testQ);
+    layer_t *linear = linearLayerInit(w, b, &testQ, &testQ, &testQ, &testQ);
+    layer_t *model[] = {linear};
+
+    optimizer_t *sgd = sgdMCreateOptim(0.01f, 0.f, 0.f, model, 1, FLOAT32);
+
+    initEpochDataset();
+    dataLoader_t *trainDl =
+        dataLoaderInit(getEpochSample, getEpochDatasetSize, 1, NULL, NULL, false, 0, true);
+    dataLoader_t *evalDl =
+        dataLoaderInit(getEpochSample, getEpochDatasetSize, 1, NULL, NULL, false, 0, true);
+
+    /* trainingRun hardcodes forwardReduction = MEAN for train/eval comparability.
+     * This test uses defaultLossConfig (backwardReduction = MEAN) to act as a
+     * regression barrier: if forwardReduction were inadvertently set to SUM,
+     * eval loss would be F× larger than train loss, failing the assertion below. */
+    lossConfig_t cfg = defaultLossConfig(MSE);
+
+    trainingRunResult_t result = trainingRun(model, 1, cfg, trainDl, evalDl, sgd, 2,
+                                             calculateGradsSequential, inferenceWithLoss, NULL);
+
+    float capturedTrain = result.finalTrainLoss;
+    float capturedEval = result.finalEvalStats.loss;
+
+    freeOptimSgdM(sgd);
+    freeDataLoader(evalDl);
+    freeDataLoader(trainDl);
+    freeLinearLayer(linear);
+    freeEpochDataset();
+
+    TEST_ASSERT_TRUE(capturedTrain > 0.0f && capturedTrain < 100.0f);
+    TEST_ASSERT_TRUE(capturedEval > 0.0f && capturedEval < 100.0f);
+    /* MEAN-vs-MEAN comparability: ratio within an order of magnitude. */
+    TEST_ASSERT_TRUE(capturedEval / capturedTrain < 10.0f);
+    TEST_ASSERT_TRUE(capturedTrain / capturedEval < 10.0f);
+}
+
 void setUp() {}
 void tearDown() {}
 
@@ -963,13 +1426,21 @@ int main(void) {
     RUN_TEST(testEvaluationEpoch_ReturnsAverageLossAcrossBatches);
     RUN_TEST(testEvaluationEpoch_MinibatchMatchesMicrobatchAverage);
     RUN_TEST(testTrainingBatchDefault_ReturnsAverageLossAndAccumulatesGrads);
+    RUN_TEST(testTrainingBatchDefault_SumAggregatesWithoutDivision);
     RUN_TEST(testTrainingEpochDefault_DoesOptimizerStepPerBatch);
     RUN_TEST(testTrainingEpochDefault_MinibatchStepsOncePerMinibatch);
+    RUN_TEST(testTrainingEpochDefault_MeanScalesGradByOneOverNF);
+    RUN_TEST(testTrainingEpochDefault_SumBackwardSkipsOptimizerScaling);
+    RUN_TEST(testTrainingEpochDefault_MeanForwardSumBackward_MixedCombination);
     RUN_TEST(testTrainingRun_ReturnsResult);
     RUN_TEST(testEvaluationEpochWithMetrics_AllCorrect);
     RUN_TEST(testEvaluationEpochWithMetrics_PartiallyCorrect);
     RUN_TEST(testEvaluationEpochWithMetrics_HandlesZeroPredictionClass);
     RUN_TEST(testEvaluationEpochWithReport_ReturnsConfusionMatrix);
     RUN_TEST(testTrainingRun_CallsCallbackEachEpochWithStats);
+    RUN_TEST(testInferenceWithLoss_PropagatesForwardReductionSum);
+    RUN_TEST(testEvaluationEpoch_FlatAggregator_DivisionByTotalSamples);
+    RUN_TEST(testEvaluationEpoch_SumPath_ReturnsRawTotal);
+    RUN_TEST(testTrainingRun_HardcodesForwardReductionMean);
     return UNITY_END();
 }


### PR DESCRIPTION
…optimizer / aggregators for #135

Single coherent microbatch contract from sample → batch → epoch, so microbatching with B ≥ 1 will not silently break and reduction = SUM works end-to-end.

Loss functions become macro-blind:
- forward(output, label, reduction) → float
- backward(output, label, result) → void; writes RAW per-element gradients (2(o-l) for MSE, (p-y) for CE). No batchSize / reduction parameters.

Macro-batch scaling moves to the optimizer:
- New free function scaleOptimizerGradients(optimizer, factor), called by trainingEpochDefault between accumulation and step, only when lossConfig.backwardReduction == REDUCTION_MEAN.
- The factor comes from a new vtable column lossFunctions[type].computeMeanScale(N, modelOutput) — PyTorch parity: 1/(N*F) for MSE, 1/N for CE.
- scaleOptimizerGradients dispatches on the gradient qtype:
  - FLOAT32: scales each element.
  - SYM_INT32: absorbs the factor into gradQ->scale. Mathematically identical to scaling each int32 (float_value = int32 * scale) while leaving int32 storage untouched — O(1), no convertTensor round-trip loss. The naive cast-to-float* loop would have silently corrupted gradient bits on a SYM_INT32 training path.
  - default: PRINT_ERROR + exit(1), matching sgdStep.

Aggregators (trainingBatchDefault, evaluationEpoch, evaluationBatch, inferenceWithLoss) take a forwardReduction per-call parameter; trainingRun is the SOLE policy enforcer (hardcodes REDUCTION_MEAN for train/eval comparability).

evaluationEpoch flat aggregator: the 3-stage divide cascade collapses into a flat totalLoss / totalSamples (correct under non-uniform B; the old cascade was not).

lossConfig_t gains backwardReduction and a NULL-placeholder classWeights; the transitional .reduction field is removed.

Forward MEAN guards on numberOfDimensions >= 2: a 1D [F]-shape tensor passes through as the raw sum (PyTorch parity: 1D logits = single- sample batch, no divisor). The earlier microbatch == 0 fallbacks in crossEntropyForwardFloat and computeMeanScaleMSE are removed — defensive masking of an unreachable bug case is anti-pattern; division-by-zero is the louder, more debuggable failure mode.

Doxygen + docs/CONVENTIONS.md chapter cover the new microbatch contract (incl. the deferred B > 1 runtime assert tracked in #152 / #153).

Tests:
- UnitTestLossFunction: vtable contract + computeMeanScale columns.
- UnitTestCrossEntropy / UnitTestMSE: raw per-element backward, forward MEAN/SUM split, 1D mean-passthrough.
- UnitTestOptimizerScaling: FLOAT32 doubles, validation warning paths, SYM_INT32 scale-only invariance, dequant equivalence, end-to-end through sgdStepM with momentum.
- UnitTestTrainingLoopApi: forwardReduction threading, trainingRun policy lock, SUM backward keeps gradients unscaled.
- Integration: UnitTestMnistSmoke, UnitTestMultiLayerTraining, UnitTestFlattenIntegration re-greened on the post-#135 trajectory.

Mutation-verified: scale=factor (vs. *=) and SYM_INT32 no-op both fail the new SYM_INT32 tests; the SUM-backward test catches a dropped scale-skip in trainingEpochDefault.

Out-of-scope, tracked elsewhere:
- #150 (weighted loss) — classWeights stays a NULL placeholder.
- #151 (PRINT_WARN / unified asserts) — scaleOptimizerGradients uses PRINT_ERROR with a // see #151 comment.
- #152 / #153 (microbatch B > 1) — runtime dimensions[0] >= 1 assert deferred; doc-side contract lands here in docs/CONVENTIONS.md.

Closes #135