### PR TITLE
feat(layer): MaxPool1d + AvgPool1d (PR 3/3)

### DIFF
--- a/src/layer/AvgPool1d.c
+++ b/src/layer/AvgPool1d.c
@@ -1,0 +1,139 @@
+#define SOURCE_FILE "ODT_AVG_POOL_1D"
+
+#include "AvgPool1d.h"
+
+#include "Common.h"
+#include "Layer.h"
+#include "SlidingWindow1d.h"
+#include "Tensor.h"
+
+void initAvgPool1dConfig(avgPool1dConfig_t *cfg, kernel_t *kernel, quantization_t *forwardQ,
+                         quantization_t *propLossQ) {
+    if (kernel->size == 0) {
+        PRINT_ERROR("AvgPool1d: kernel size must be >= 1");
+        exit(1);
+    }
+    cfg->kernel = kernel;
+    cfg->forwardQ = forwardQ;
+    cfg->propLossQ = propLossQ;
+}
+
+void avgPool1dForwardFloat(layer_t *layer, tensor_t *input, tensor_t *output) {
+    avgPool1dConfig_t *cfg = layer->config->avgPool1d;
+
+    size_t batch = input->shape->dimensions[0];
+    size_t channels = input->shape->dimensions[1];
+    size_t inputLength = input->shape->dimensions[2];
+
+    windowGeometry1d_t geom = windowGeometry1dCalc(inputLength, cfg->kernel);
+    size_t outputLength = geom.outputLength;
+
+    if (output->shape->dimensions[2] != outputLength) {
+        PRINT_ERROR("AvgPool1d forward: output length (%zu) does not match "
+                    "geometry-derived (%zu)",
+                    output->shape->dimensions[2], outputLength);
+        exit(1);
+    }
+
+    float const *xArr = (float const *)input->data;
+    float *yArr = (float *)output->data;
+    float divisor = (float)cfg->kernel->size; // count_include_pad=true: divisor = K always
+
+    for (size_t b = 0; b < batch; b++) {
+        for (size_t c = 0; c < channels; c++) {
+            for (size_t outPos = 0; outPos < outputLength; outPos++) {
+                windowSlice1d_t slice = windowSlice1dAt(&geom, outPos);
+
+                float sum = 0.0f;
+                for (size_t i = 0; i < slice.validCount; i++) {
+                    size_t inputIdx = slice.firstValidInputIdx + i * geom.dilation;
+                    sum += xArr[(b * channels + c) * inputLength + inputIdx];
+                }
+
+                size_t outIdx = (b * channels + c) * outputLength + outPos;
+                yArr[outIdx] = sum / divisor;
+            }
+        }
+    }
+}
+
+void avgPool1dForward(layer_t *layer, tensor_t *input, tensor_t *output) {
+    avgPool1dConfig_t *cfg = layer->config->avgPool1d;
+    switch (cfg->forwardQ->type) {
+    case FLOAT32:
+        avgPool1dForwardFloat(layer, input, output);
+        break;
+    default:
+        PRINT_ERROR("AvgPool1d forward: quantization type not implemented");
+        exit(1);
+    }
+}
+
+void avgPool1dBackwardFloat(layer_t *layer, tensor_t *forwardInput, tensor_t *lossGrad,
+                            tensor_t *propLoss) {
+    avgPool1dConfig_t *cfg = layer->config->avgPool1d;
+    (void)forwardInput; // not needed: window geometry is determined by kernel + input shape
+
+    size_t batch = lossGrad->shape->dimensions[0];
+    size_t channels = lossGrad->shape->dimensions[1];
+    size_t outputLength = lossGrad->shape->dimensions[2];
+    size_t inputLength = propLoss->shape->dimensions[2];
+
+    windowGeometry1d_t geom = windowGeometry1dCalc(inputLength, cfg->kernel);
+    if (geom.outputLength != outputLength) {
+        PRINT_ERROR("AvgPool1d backward: lossGrad outputLength (%zu) does not match "
+                    "geometry-derived (%zu)",
+                    outputLength, geom.outputLength);
+        exit(1);
+    }
+
+    float const *gyArr = (float const *)lossGrad->data;
+    float *gxArr = (float *)propLoss->data;
+    float divisor = (float)cfg->kernel->size;
+
+    for (size_t b = 0; b < batch; b++) {
+        for (size_t c = 0; c < channels; c++) {
+            for (size_t outPos = 0; outPos < outputLength; outPos++) {
+                windowSlice1d_t slice = windowSlice1dAt(&geom, outPos);
+                size_t outIdx = (b * channels + c) * outputLength + outPos;
+                float contribution = gyArr[outIdx] / divisor;
+
+                for (size_t i = 0; i < slice.validCount; i++) {
+                    size_t inputIdx = slice.firstValidInputIdx + i * geom.dilation;
+                    gxArr[(b * channels + c) * inputLength + inputIdx] += contribution;
+                }
+            }
+        }
+    }
+}
+
+void avgPool1dBackward(layer_t *layer, tensor_t *forwardInput, tensor_t *lossGrad,
+                       tensor_t *propLoss) {
+    avgPool1dConfig_t *cfg = layer->config->avgPool1d;
+    switch (cfg->propLossQ->type) {
+    case FLOAT32:
+        avgPool1dBackwardFloat(layer, forwardInput, lossGrad, propLoss);
+        break;
+    default:
+        PRINT_ERROR("AvgPool1d backward: quantization type not implemented");
+        exit(1);
+    }
+}
+
+void avgPool1dCalcOutputShape(layer_t *layer, shape_t *inputShape, shape_t *outputShape) {
+    if (inputShape->numberOfDimensions != 3) {
+        PRINT_ERROR("AvgPool1d expects 3D input [batch, channel, length], got %luD",
+                    inputShape->numberOfDimensions);
+        exit(1);
+    }
+
+    avgPool1dConfig_t *cfg = layer->config->avgPool1d;
+    size_t inputLength = inputShape->dimensions[2];
+    windowGeometry1d_t geom = windowGeometry1dCalc(inputLength, cfg->kernel);
+
+    outputShape->numberOfDimensions = 3;
+    outputShape->dimensions[0] = inputShape->dimensions[0]; // B
+    outputShape->dimensions[1] = inputShape->dimensions[1]; // C
+    outputShape->dimensions[2] = geom.outputLength;
+    setOrderOfDimsForNewTensor(inputShape->numberOfDimensions, outputShape->orderOfDimensions);
+}

--- a/src/layer/CMakeLists.txt
+++ b/src/layer/CMakeLists.txt
@@ -24,6 +24,28 @@ target_link_libraries(Conv1dTransposed PRIVATE
         ConvTranspose1dKernel
 )
 
+add_library(MaxPool1d MaxPool1d.c)
+target_include_directories(MaxPool1d PUBLIC include)
+target_link_libraries(MaxPool1d PRIVATE
+        DTypes
+        Tensor
+        Arithmetic
+        Common
+        Kernel
+        SlidingWindow1d
+)
+
+add_library(AvgPool1d AvgPool1d.c)
+target_include_directories(AvgPool1d PUBLIC include)
+target_link_libraries(AvgPool1d PRIVATE
+        DTypes
+        Tensor
+        Arithmetic
+        Common
+        Kernel
+        SlidingWindow1d
+)
+
 add_library(Layer Layer.c)
 target_include_directories(Layer PUBLIC include)
 target_link_libraries(Layer PRIVATE
@@ -34,6 +56,8 @@ target_link_libraries(Layer PRIVATE
         Relu
         Conv1d
         Conv1dTransposed
+        MaxPool1d
+        AvgPool1d
         Softmax
         Flatten
 )
@@ -96,6 +120,8 @@ target_link_libraries(CommonLayerLibs INTERFACE
         Relu
         Conv1d
         Conv1dTransposed
+        MaxPool1d
+        AvgPool1d
         Softmax
         Flatten
         Rounding

--- a/src/layer/Layer.c
+++ b/src/layer/Layer.c
@@ -1,10 +1,12 @@
 #define SOURCE_FILE "LAYER"
 
 #include "Layer.h"
+#include "AvgPool1d.h"
 #include "Conv1d.h"
 #include "Conv1dTransposed.h"
 #include "Flatten.h"
 #include "Linear.h"
+#include "MaxPool1d.h"
 #include "Relu.h"
 #include "Softmax.h"
 
@@ -14,6 +16,8 @@ layerFunctions_t layerFunctions[] = {
     [CONV1D] = {conv1dForward, conv1dBackward, conv1dCalcOutputShape},
     [CONV1D_TRANSPOSED] = {conv1dTransposedForward, conv1dTransposedBackward,
                            conv1dTransposedCalcOutputShape},
+    [MAXPOOL1D] = {maxPool1dForward, maxPool1dBackward, maxPool1dCalcOutputShape},
+    [AVGPOOL1D] = {avgPool1dForward, avgPool1dBackward, avgPool1dCalcOutputShape},
     [SOFTMAX] = {softmaxForward, softmaxBackward, softmaxCalcOutputShape},
     [FLATTEN] = {flattenForward, flattenBackward, flattenCalcOutputShape}};
 

--- a/src/layer/MaxPool1d.c
+++ b/src/layer/MaxPool1d.c
@@ -1,0 +1,161 @@
+#define SOURCE_FILE "ODT_MAX_POOL_1D"
+
+#include <math.h>
+
+#include "MaxPool1d.h"
+
+#include "Common.h"
+#include "Layer.h"
+#include "SlidingWindow1d.h"
+#include "Tensor.h"
+
+void initMaxPool1dConfig(maxPool1dConfig_t *cfg, kernel_t *kernel, tensor_t *argmaxIndices,
+                         quantization_t *forwardQ, quantization_t *propLossQ) {
+    if (argmaxIndices == NULL) {
+        PRINT_ERROR("MaxPool1d: argmaxIndices must not be NULL — caller must pre-allocate");
+        exit(1);
+    }
+    cfg->kernel = kernel;
+    cfg->argmaxIndices = argmaxIndices;
+    cfg->forwardQ = forwardQ;
+    cfg->propLossQ = propLossQ;
+}
+
+void maxPool1dForwardFloat(layer_t *layer, tensor_t *input, tensor_t *output) {
+    maxPool1dConfig_t *cfg = layer->config->maxPool1d;
+
+    size_t batch = input->shape->dimensions[0];
+    size_t channels = input->shape->dimensions[1];
+    size_t inputLength = input->shape->dimensions[2];
+
+    windowGeometry1d_t geom = windowGeometry1dCalc(inputLength, cfg->kernel);
+    size_t outputLength = geom.outputLength;
+
+    if (output->shape->dimensions[2] != outputLength) {
+        PRINT_ERROR("MaxPool1d forward: output length (%zu) does not match "
+                    "geometry-derived (%zu)",
+                    output->shape->dimensions[2], outputLength);
+        exit(1);
+    }
+    if (cfg->argmaxIndices->shape->dimensions[2] != outputLength) {
+        PRINT_ERROR("MaxPool1d forward: argmaxIndices length (%zu) does not match "
+                    "geometry-derived (%zu)",
+                    cfg->argmaxIndices->shape->dimensions[2], outputLength);
+        exit(1);
+    }
+
+    float const *xArr = (float const *)input->data;
+    float *yArr = (float *)output->data;
+    int32_t *argmaxArr = (int32_t *)cfg->argmaxIndices->data;
+
+    for (size_t b = 0; b < batch; b++) {
+        for (size_t c = 0; c < channels; c++) {
+            for (size_t outPos = 0; outPos < outputLength; outPos++) {
+                windowSlice1d_t slice = windowSlice1dAt(&geom, outPos);
+
+                float bestVal = -INFINITY;
+                int32_t bestInputIdx = -1;
+                for (size_t i = 0; i < slice.validCount; i++) {
+                    size_t inputIdx = slice.firstValidInputIdx + i * geom.dilation;
+                    float v = xArr[(b * channels + c) * inputLength + inputIdx];
+                    if (v > bestVal) {
+                        bestVal = v;
+                        bestInputIdx = (int32_t)inputIdx;
+                    }
+                }
+
+                size_t outIdx = (b * channels + c) * outputLength + outPos;
+                if (slice.validCount > 0) {
+                    yArr[outIdx] = bestVal;
+                    argmaxArr[outIdx] = bestInputIdx;
+                } else {
+                    // spec §6.3: empty window is theoretically possible but in
+                    // practice unreachable; log + sentinel-encode rather than exit
+                    yArr[outIdx] = 0.0f;
+                    argmaxArr[outIdx] = -1;
+                    PRINT_ERROR("MaxPool1d: empty window at outPos=%zu — likely user misconfig",
+                                outPos);
+                }
+            }
+        }
+    }
+}
+
+void maxPool1dForward(layer_t *layer, tensor_t *input, tensor_t *output) {
+    maxPool1dConfig_t *cfg = layer->config->maxPool1d;
+    switch (cfg->forwardQ->type) {
+    case FLOAT32:
+        maxPool1dForwardFloat(layer, input, output);
+        break;
+    default:
+        PRINT_ERROR("MaxPool1d forward: quantization type not implemented");
+        exit(1);
+    }
+}
+
+void maxPool1dBackwardFloat(layer_t *layer, tensor_t *forwardInput, tensor_t *lossGrad,
+                            tensor_t *propLoss) {
+    maxPool1dConfig_t *cfg = layer->config->maxPool1d;
+    (void)forwardInput; // not needed: argmax already encodes which input position to update.
+
+    size_t batch = lossGrad->shape->dimensions[0];
+    size_t channels = lossGrad->shape->dimensions[1];
+    size_t outputLength = lossGrad->shape->dimensions[2];
+    size_t inputLength = propLoss->shape->dimensions[2];
+
+    // Defensive: argmax shape must match lossGrad shape.
+    if (cfg->argmaxIndices->shape->dimensions[2] != outputLength) {
+        PRINT_ERROR("MaxPool1d backward: argmaxIndices length (%zu) does not match "
+                    "lossGrad outputLength (%zu)",
+                    cfg->argmaxIndices->shape->dimensions[2], outputLength);
+        exit(1);
+    }
+
+    float const *gyArr = (float const *)lossGrad->data;
+    int32_t const *argmaxArr = (int32_t const *)cfg->argmaxIndices->data;
+    float *gxArr = (float *)propLoss->data;
+
+    for (size_t b = 0; b < batch; b++) {
+        for (size_t c = 0; c < channels; c++) {
+            for (size_t outPos = 0; outPos < outputLength; outPos++) {
+                size_t outIdx = (b * channels + c) * outputLength + outPos;
+                int32_t inputIdx = argmaxArr[outIdx];
+                if (inputIdx < 0) {
+                    continue; // sentinel: empty window, no gradient flows
+                }
+                gxArr[(b * channels + c) * inputLength + (size_t)inputIdx] += gyArr[outIdx];
+            }
+        }
+    }
+}
+
+void maxPool1dBackward(layer_t *layer, tensor_t *forwardInput, tensor_t *lossGrad,
+                       tensor_t *propLoss) {
+    maxPool1dConfig_t *cfg = layer->config->maxPool1d;
+    switch (cfg->propLossQ->type) {
+    case FLOAT32:
+        maxPool1dBackwardFloat(layer, forwardInput, lossGrad, propLoss);
+        break;
+    default:
+        PRINT_ERROR("MaxPool1d backward: quantization type not implemented");
+        exit(1);
+    }
+}
+
+void maxPool1dCalcOutputShape(layer_t *layer, shape_t *inputShape, shape_t *outputShape) {
+    if (inputShape->numberOfDimensions != 3) {
+        PRINT_ERROR("MaxPool1d expects 3D input [batch, channel, length], got %luD",
+                    inputShape->numberOfDimensions);
+        exit(1);
+    }
+
+    maxPool1dConfig_t *cfg = layer->config->maxPool1d;
+    size_t inputLength = inputShape->dimensions[2];
+    windowGeometry1d_t geom = windowGeometry1dCalc(inputLength, cfg->kernel);
+
+    outputShape->numberOfDimensions = 3;
+    outputShape->dimensions[0] = inputShape->dimensions[0]; // B
+    outputShape->dimensions[1] = inputShape->dimensions[1]; // C
+    outputShape->dimensions[2] = geom.outputLength;
+    setOrderOfDimsForNewTensor(inputShape->numberOfDimensions, outputShape->orderOfDimensions);
+}

--- a/src/layer/include/AvgPool1d.h
+++ b/src/layer/include/AvgPool1d.h
@@ -1,0 +1,29 @@
+#ifndef ODT_AVG_POOL_1D_H
+#define ODT_AVG_POOL_1D_H
+
+#include <stdlib.h>
+
+#include "Kernel.h"
+#include "Layer.h"
+#include "Tensor.h"
+
+typedef struct avgPool1dConfig {
+    kernel_t *kernel;
+    quantization_t *forwardQ;
+    quantization_t *propLossQ;
+} avgPool1dConfig_t;
+
+void initAvgPool1dConfig(avgPool1dConfig_t *cfg, kernel_t *kernel, quantization_t *forwardQ,
+                         quantization_t *propLossQ);
+
+void avgPool1dForward(layer_t *layer, tensor_t *input, tensor_t *output);
+void avgPool1dForwardFloat(layer_t *layer, tensor_t *input, tensor_t *output);
+
+void avgPool1dBackward(layer_t *layer, tensor_t *forwardInput, tensor_t *lossGrad,
+                       tensor_t *propLoss);
+void avgPool1dBackwardFloat(layer_t *layer, tensor_t *forwardInput, tensor_t *lossGrad,
+                            tensor_t *propLoss);
+
+void avgPool1dCalcOutputShape(layer_t *layer, shape_t *inputShape, shape_t *outputShape);
+
+#endif // ODT_AVG_POOL_1D_H

--- a/src/layer/include/Layer.h
+++ b/src/layer/include/Layer.h
@@ -8,12 +8,16 @@ typedef struct reluConfig reluConfig_t;
 typedef struct softmaxConfig softmaxConfig_t;
 typedef struct conv1dConfig conv1dConfig_t;
 typedef struct conv1dTransposedConfig conv1dTransposedConfig_t;
+typedef struct maxPool1dConfig maxPool1dConfig_t;
+typedef struct avgPool1dConfig avgPool1dConfig_t;
 
 typedef enum layerType {
     LINEAR,
     RELU,
     CONV1D,
     CONV1D_TRANSPOSED,
+    MAXPOOL1D,
+    AVGPOOL1D,
     SOFTMAX,
     FLATTEN,
     QUANTIZATION
@@ -27,6 +31,8 @@ typedef union layerConfig {
     softmaxConfig_t *softmax;
     conv1dConfig_t *conv1d;
     conv1dTransposedConfig_t *conv1dTransposed;
+    maxPool1dConfig_t *maxPool1d;
+    avgPool1dConfig_t *avgPool1d;
 } layerConfig_t;
 
 typedef struct layer {

--- a/src/layer/include/MaxPool1d.h
+++ b/src/layer/include/MaxPool1d.h
@@ -1,0 +1,30 @@
+#ifndef ODT_MAX_POOL_1D_H
+#define ODT_MAX_POOL_1D_H
+
+#include <stdlib.h>
+
+#include "Kernel.h"
+#include "Layer.h"
+#include "Tensor.h"
+
+typedef struct maxPool1dConfig {
+    kernel_t *kernel;
+    tensor_t *argmaxIndices; // INT32, shape == output shape; pre-allocated by caller
+    quantization_t *forwardQ;
+    quantization_t *propLossQ;
+} maxPool1dConfig_t;
+
+void initMaxPool1dConfig(maxPool1dConfig_t *cfg, kernel_t *kernel, tensor_t *argmaxIndices,
+                         quantization_t *forwardQ, quantization_t *propLossQ);
+
+void maxPool1dForward(layer_t *layer, tensor_t *input, tensor_t *output);
+void maxPool1dForwardFloat(layer_t *layer, tensor_t *input, tensor_t *output);
+
+void maxPool1dBackward(layer_t *layer, tensor_t *forwardInput, tensor_t *lossGrad,
+                       tensor_t *propLoss);
+void maxPool1dBackwardFloat(layer_t *layer, tensor_t *forwardInput, tensor_t *lossGrad,
+                            tensor_t *propLoss);
+
+void maxPool1dCalcOutputShape(layer_t *layer, shape_t *inputShape, shape_t *outputShape);
+
+#endif // ODT_MAX_POOL_1D_H

--- a/src/optimizer/Optimizer.c
+++ b/src/optimizer/Optimizer.c
@@ -16,6 +16,8 @@ static size_t calcNumberOfStatesByLayerType(const layerType_t type) {
     case RELU:
     case SOFTMAX:
     case FLATTEN:
+    case MAXPOOL1D:
+    case AVGPOOL1D:
         return 0;
     case CONV1D:
         return 2;

--- a/test/unit/layer/CMakeLists.txt
+++ b/test/unit/layer/CMakeLists.txt
@@ -24,6 +24,30 @@ add_custom_command(
 add_custom_target(generate_expected_conv1d_transposed
         DEPENDS ${GEN_CONV1D_TRANSPOSED_HEADER})
 
+set(GEN_MAX_POOL_1D_HEADER ${CMAKE_CURRENT_BINARY_DIR}/expected_max_pool_1d.h)
+add_custom_command(
+        OUTPUT ${GEN_MAX_POOL_1D_HEADER}
+        COMMAND uv run ${CMAKE_CURRENT_SOURCE_DIR}/generate_expected_max_pool_1d.py
+                --out ${GEN_MAX_POOL_1D_HEADER}
+        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/generate_expected_max_pool_1d.py
+        COMMENT "Generating expected_max_pool_1d.h via PyTorch"
+        VERBATIM
+)
+add_custom_target(generate_expected_max_pool_1d
+        DEPENDS ${GEN_MAX_POOL_1D_HEADER})
+
+set(GEN_AVG_POOL_1D_HEADER ${CMAKE_CURRENT_BINARY_DIR}/expected_avg_pool_1d.h)
+add_custom_command(
+        OUTPUT ${GEN_AVG_POOL_1D_HEADER}
+        COMMAND uv run ${CMAKE_CURRENT_SOURCE_DIR}/generate_expected_avg_pool_1d.py
+                --out ${GEN_AVG_POOL_1D_HEADER}
+        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/generate_expected_avg_pool_1d.py
+        COMMENT "Generating expected_avg_pool_1d.h via PyTorch"
+        VERBATIM
+)
+add_custom_target(generate_expected_avg_pool_1d
+        DEPENDS ${GEN_AVG_POOL_1D_HEADER})
+
 add_elastic_ai_unit_test(
         LIB_UNDER_TEST
         Conv1d
@@ -95,3 +119,27 @@ add_elastic_ai_unit_test(
 )
 add_dependencies(UnitTestConv1dTransposed generate_expected_conv1d_transposed)
 target_include_directories(UnitTestConv1dTransposed PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+
+add_elastic_ai_unit_test(
+        LIB_UNDER_TEST
+        MaxPool1d
+        MORE_LIBS
+        CommonLayerLibs
+        TensorApi
+        QuantizationApi
+        StorageApi
+)
+add_dependencies(UnitTestMaxPool1d generate_expected_max_pool_1d)
+target_include_directories(UnitTestMaxPool1d PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+
+add_elastic_ai_unit_test(
+        LIB_UNDER_TEST
+        AvgPool1d
+        MORE_LIBS
+        CommonLayerLibs
+        TensorApi
+        QuantizationApi
+        StorageApi
+)
+add_dependencies(UnitTestAvgPool1d generate_expected_avg_pool_1d)
+target_include_directories(UnitTestAvgPool1d PRIVATE ${CMAKE_CURRENT_BINARY_DIR})

--- a/test/unit/layer/UnitTestAvgPool1d.c
+++ b/test/unit/layer/UnitTestAvgPool1d.c
@@ -1,0 +1,246 @@
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "AvgPool1d.h"
+#include "Layer.h"
+#include "QuantizationApi.h"
+#include "TensorApi.h"
+#include "expected_avg_pool_1d.h"
+#include "unity.h"
+
+typedef struct avgPool1dRunResult {
+    layer_t *layer;
+    tensor_t *input;
+    tensor_t *output;
+    quantization_t *q;
+} avgPool1dRunResult_t;
+
+static avgPool1dRunResult_t avgPool1dBuild(float const *inputData, size_t const *inputDims,
+                                           size_t kSize, paddingType_t padding, size_t dilation,
+                                           size_t stride, float *outputBuf,
+                                           size_t const *outputDims) {
+    static kernel_t kernelStore;
+    static avgPool1dConfig_t cfgStore;
+    static layer_t layerStore;
+    static layerConfig_t lcStore;
+
+    initKernel(&kernelStore, kSize, padding, dilation, stride);
+
+    quantization_t *q = quantizationInitFloat();
+    initAvgPool1dConfig(&cfgStore, &kernelStore, q, q);
+
+    layerStore.type = AVGPOOL1D;
+    lcStore.avgPool1d = &cfgStore;
+    layerStore.config = &lcStore;
+
+    avgPool1dRunResult_t r = {0};
+    r.layer = &layerStore;
+    r.input = tensorInitFloat((float *)inputData, (size_t *)inputDims, 3, NULL);
+    r.output = tensorInitFloat(outputBuf, (size_t *)outputDims, 3, NULL);
+    r.q = q;
+    return r;
+}
+
+void testAvgPool1dForwardBasic(void) {
+    size_t inputDims[] = {1, 1, 4};
+    size_t outputDims[] = {1, 1, 3};
+    float outputData[1 * 1 * 3] = {0};
+
+    avgPool1dRunResult_t r =
+        avgPool1dBuild(input_avgPool1d_basic, inputDims, 2, VALID, 1, 1, outputData, outputDims);
+
+    avgPool1dForward(r.layer, r.input, r.output);
+
+    for (size_t i = 0; i < expectedForward_avgPool1d_basic_len; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(1e-5f, expectedForward_avgPool1d_basic[i],
+                                 ((float *)r.output->data)[i]);
+    }
+}
+
+void testAvgPool1dBackwardBasic(void) {
+    size_t inputDims[] = {1, 1, 4};
+    size_t outputDims[] = {1, 1, 3};
+    float outputData[1 * 1 * 3] = {0};
+
+    avgPool1dRunResult_t r =
+        avgPool1dBuild(input_avgPool1d_basic, inputDims, 2, VALID, 1, 1, outputData, outputDims);
+
+    avgPool1dForward(r.layer, r.input, r.output);
+
+    float lossGradData[1 * 1 * 3];
+    for (size_t i = 0; i < 3; i++) {
+        lossGradData[i] = 1.0f;
+    }
+    tensor_t *lossGrad = tensorInitFloat(lossGradData, (size_t *)outputDims, 3, NULL);
+
+    float propLossData[1 * 1 * 4] = {0};
+    tensor_t *propLoss = tensorInitFloat(propLossData, (size_t *)inputDims, 3, NULL);
+
+    avgPool1dBackward(r.layer, r.input, lossGrad, propLoss);
+
+    for (size_t i = 0; i < expectedPropLoss_avgPool1d_basic_len; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(1e-5f, expectedPropLoss_avgPool1d_basic[i],
+                                 ((float *)propLoss->data)[i]);
+    }
+}
+
+void testAvgPool1dMultiChannel(void) {
+    size_t inputDims[] = {1, 3, 5};
+    size_t outputDims[] = {1, 3, 4};
+    float outputData[1 * 3 * 4] = {0};
+
+    avgPool1dRunResult_t r = avgPool1dBuild(input_avgPool1d_multiChannel, inputDims, 2, VALID, 1, 1,
+                                            outputData, outputDims);
+
+    avgPool1dForward(r.layer, r.input, r.output);
+    for (size_t i = 0; i < expectedForward_avgPool1d_multiChannel_len; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(1e-5f, expectedForward_avgPool1d_multiChannel[i],
+                                 ((float *)r.output->data)[i]);
+    }
+
+    float lossGradData[1 * 3 * 4];
+    for (size_t i = 0; i < 12; i++) {
+        lossGradData[i] = 1.0f;
+    }
+    tensor_t *lossGrad = tensorInitFloat(lossGradData, (size_t *)outputDims, 3, NULL);
+
+    float propLossData[1 * 3 * 5] = {0};
+    tensor_t *propLoss = tensorInitFloat(propLossData, (size_t *)inputDims, 3, NULL);
+
+    avgPool1dBackward(r.layer, r.input, lossGrad, propLoss);
+    for (size_t i = 0; i < expectedPropLoss_avgPool1d_multiChannel_len; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(1e-5f, expectedPropLoss_avgPool1d_multiChannel[i],
+                                 ((float *)propLoss->data)[i]);
+    }
+}
+
+void testAvgPool1dMultiBatch(void) {
+    size_t inputDims[] = {4, 2, 4};
+    size_t outputDims[] = {4, 2, 3};
+    float outputData[4 * 2 * 3] = {0};
+
+    avgPool1dRunResult_t r = avgPool1dBuild(input_avgPool1d_multiBatch, inputDims, 2, VALID, 1, 1,
+                                            outputData, outputDims);
+
+    avgPool1dForward(r.layer, r.input, r.output);
+    for (size_t i = 0; i < expectedForward_avgPool1d_multiBatch_len; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(1e-5f, expectedForward_avgPool1d_multiBatch[i],
+                                 ((float *)r.output->data)[i]);
+    }
+
+    float lossGradData[4 * 2 * 3];
+    for (size_t i = 0; i < 24; i++) {
+        lossGradData[i] = 1.0f;
+    }
+    tensor_t *lossGrad = tensorInitFloat(lossGradData, (size_t *)outputDims, 3, NULL);
+
+    float propLossData[4 * 2 * 4] = {0};
+    tensor_t *propLoss = tensorInitFloat(propLossData, (size_t *)inputDims, 3, NULL);
+
+    avgPool1dBackward(r.layer, r.input, lossGrad, propLoss);
+    for (size_t i = 0; i < expectedPropLoss_avgPool1d_multiBatch_len; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(1e-5f, expectedPropLoss_avgPool1d_multiBatch[i],
+                                 ((float *)propLoss->data)[i]);
+    }
+}
+
+void testAvgPool1dWithStrideAndDilation(void) {
+    size_t inputDims[] = {1, 1, 9};
+    size_t outputDims[] = {1, 1, 3};
+    float outputData[1 * 1 * 3] = {0};
+
+    avgPool1dRunResult_t r = avgPool1dBuild(input_avgPool1d_withStrideAndDilation, inputDims, 2,
+                                            VALID, 2, 3, outputData, outputDims);
+
+    avgPool1dForward(r.layer, r.input, r.output);
+    for (size_t i = 0; i < expectedForward_avgPool1d_withStrideAndDilation_len; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(1e-5f, expectedForward_avgPool1d_withStrideAndDilation[i],
+                                 ((float *)r.output->data)[i]);
+    }
+
+    tensor_t *lossGrad = tensorInitFloat((float *)lossGrad_avgPool1d_withStrideAndDilation,
+                                         (size_t *)outputDims, 3, NULL);
+
+    float propLossData[1 * 1 * 9] = {0};
+    tensor_t *propLoss = tensorInitFloat(propLossData, (size_t *)inputDims, 3, NULL);
+
+    avgPool1dBackward(r.layer, r.input, lossGrad, propLoss);
+    for (size_t i = 0; i < expectedPropLoss_avgPool1d_withStrideAndDilation_len; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(1e-5f, expectedPropLoss_avgPool1d_withStrideAndDilation[i],
+                                 ((float *)propLoss->data)[i]);
+    }
+}
+
+void testAvgPool1dWithSamePadding(void) {
+    size_t inputDims[] = {1, 1, 5};
+    size_t outputDims[] = {1, 1, 5}; // SAME -> outLen = inLen
+    float outputData[1 * 1 * 5] = {0};
+
+    avgPool1dRunResult_t r = avgPool1dBuild(input_avgPool1d_withSamePadding, inputDims, 3, SAME, 1,
+                                            1, outputData, outputDims);
+
+    avgPool1dForward(r.layer, r.input, r.output);
+    for (size_t i = 0; i < expectedForward_avgPool1d_withSamePadding_len; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(1e-5f, expectedForward_avgPool1d_withSamePadding[i],
+                                 ((float *)r.output->data)[i]);
+    }
+
+    float lossGradData[1 * 1 * 5];
+    for (size_t i = 0; i < 5; i++) {
+        lossGradData[i] = 1.0f;
+    }
+    tensor_t *lossGrad = tensorInitFloat(lossGradData, (size_t *)outputDims, 3, NULL);
+
+    float propLossData[1 * 1 * 5] = {0};
+    tensor_t *propLoss = tensorInitFloat(propLossData, (size_t *)inputDims, 3, NULL);
+
+    avgPool1dBackward(r.layer, r.input, lossGrad, propLoss);
+    for (size_t i = 0; i < expectedPropLoss_avgPool1d_withSamePadding_len; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(1e-5f, expectedPropLoss_avgPool1d_withSamePadding[i],
+                                 ((float *)propLoss->data)[i]);
+    }
+}
+
+void testAvgPool1dEdgeCases(void) {
+    size_t inputDims[] = {1, 1, 4};
+    size_t outputDims[] = {1, 1, 1}; // K=L=4, stride=1, VALID -> outLen = 4-4+1 = 1
+    float outputData[1] = {0};
+
+    avgPool1dRunResult_t r = avgPool1dBuild(input_avgPool1d_edgeCases, inputDims, 4, VALID, 1, 1,
+                                            outputData, outputDims);
+
+    avgPool1dForward(r.layer, r.input, r.output);
+    // input [1,2,3,4] mean = 2.5
+    for (size_t i = 0; i < expectedForward_avgPool1d_edgeCases_len; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(1e-5f, expectedForward_avgPool1d_edgeCases[i],
+                                 ((float *)r.output->data)[i]);
+    }
+
+    float lossGradData[1] = {1.0f};
+    tensor_t *lossGrad = tensorInitFloat(lossGradData, (size_t *)outputDims, 3, NULL);
+
+    float propLossData[1 * 1 * 4] = {0};
+    tensor_t *propLoss = tensorInitFloat(propLossData, (size_t *)inputDims, 3, NULL);
+
+    avgPool1dBackward(r.layer, r.input, lossGrad, propLoss);
+    // 1/K = 0.25 contribution to each of 4 input positions.
+    for (size_t i = 0; i < expectedPropLoss_avgPool1d_edgeCases_len; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(1e-5f, expectedPropLoss_avgPool1d_edgeCases[i],
+                                 ((float *)propLoss->data)[i]);
+    }
+}
+
+void setUp(void) {}
+void tearDown(void) {}
+
+int main(void) {
+    UNITY_BEGIN();
+    RUN_TEST(testAvgPool1dForwardBasic);
+    RUN_TEST(testAvgPool1dBackwardBasic);
+    RUN_TEST(testAvgPool1dMultiChannel);
+    RUN_TEST(testAvgPool1dMultiBatch);
+    RUN_TEST(testAvgPool1dWithStrideAndDilation);
+    RUN_TEST(testAvgPool1dWithSamePadding);
+    RUN_TEST(testAvgPool1dEdgeCases);
+    return UNITY_END();
+}

--- a/test/unit/layer/UnitTestMaxPool1d.c
+++ b/test/unit/layer/UnitTestMaxPool1d.c
@@ -1,0 +1,378 @@
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "Layer.h"
+#include "MaxPool1d.h"
+#include "QuantizationApi.h"
+#include "TensorApi.h"
+#include "expected_max_pool_1d.h"
+#include "unity.h"
+
+// Helper: build a MaxPool1d layer manually (no UserAPI in Phase 1).
+// Uses function-local statics for kernel/cfg/layer storage so addresses
+// survive the return-by-value (per PR-2 plan-bug helper-pattern dangling pointers).
+typedef struct maxPool1dRunResult {
+    layer_t *layer;
+    tensor_t *input;
+    tensor_t *output;
+    tensor_t *argmax;
+    quantization_t *q;
+} maxPool1dRunResult_t;
+
+static maxPool1dRunResult_t maxPool1dBuild(float const *inputData, size_t const *inputDims,
+                                           size_t kSize, paddingType_t padding, size_t dilation,
+                                           size_t stride, float *outputBuf, int32_t *argmaxBuf,
+                                           size_t const *outputDims) {
+    static kernel_t kernelStore;
+    static maxPool1dConfig_t cfgStore;
+    static layer_t layerStore;
+    static layerConfig_t lcStore;
+
+    initKernel(&kernelStore, kSize, padding, dilation, stride);
+
+    quantization_t *q = quantizationInitFloat();
+
+    tensor_t *argmax = tensorInitInt32(argmaxBuf, (size_t *)outputDims, 3, NULL);
+    initMaxPool1dConfig(&cfgStore, &kernelStore, argmax, q, q);
+
+    layerStore.type = MAXPOOL1D;
+    lcStore.maxPool1d = &cfgStore;
+    layerStore.config = &lcStore;
+
+    maxPool1dRunResult_t r = {0};
+    r.layer = &layerStore;
+    r.input = tensorInitFloat((float *)inputData, (size_t *)inputDims, 3, NULL);
+    r.output = tensorInitFloat(outputBuf, (size_t *)outputDims, 3, NULL);
+    r.argmax = argmax;
+    r.q = q;
+    return r;
+}
+
+void testMaxPool1dForwardBasic(void) {
+    size_t inputDims[] = {1, 1, 4};
+    size_t outputDims[] = {1, 1, 3};
+    float outputData[1 * 1 * 3] = {0};
+    int32_t argmaxData[1 * 1 * 3] = {0};
+
+    maxPool1dRunResult_t r = maxPool1dBuild(input_maxPool1d_basic, inputDims, 2, VALID, 1, 1,
+                                            outputData, argmaxData, outputDims);
+
+    maxPool1dForward(r.layer, r.input, r.output);
+
+    for (size_t i = 0; i < expectedForward_maxPool1d_basic_len; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(1e-5f, expectedForward_maxPool1d_basic[i],
+                                 ((float *)r.output->data)[i]);
+    }
+}
+
+void testMaxPool1dCalcOutputShapeValidAndSame(void) {
+    quantization_t *q = quantizationInitFloat();
+
+    // VALID: K=3, stride=1, dilation=1 -> outLen = inLen - K + 1 = 5
+    {
+        kernel_t kernel;
+        initKernel(&kernel, 3, VALID, 1, 1);
+        maxPool1dConfig_t cfg = {0};
+        // argmax tensor not used by calcOutputShape — pass a dummy via minimal init.
+        size_t dummyDims[] = {1, 1, 1};
+        int32_t dummyData[1] = {0};
+        tensor_t *dummyArgmax = tensorInitInt32(dummyData, dummyDims, 3, NULL);
+        initMaxPool1dConfig(&cfg, &kernel, dummyArgmax, q, q);
+
+        layer_t layer;
+        layerConfig_t lc;
+        layer.type = MAXPOOL1D;
+        lc.maxPool1d = &cfg;
+        layer.config = &lc;
+
+        // shape_t uses pointer fields — must point to valid stack arrays.
+        size_t inDimsBacking[] = {2, 4, 7};
+        size_t inOrderBacking[] = {0, 1, 2};
+        size_t outDimsBacking[] = {0, 0, 0};
+        size_t outOrderBacking[] = {0, 0, 0};
+        shape_t inShape = {.dimensions = inDimsBacking,
+                           .orderOfDimensions = inOrderBacking,
+                           .numberOfDimensions = 3};
+        shape_t outShape = {.dimensions = outDimsBacking,
+                            .orderOfDimensions = outOrderBacking,
+                            .numberOfDimensions = 0};
+
+        maxPool1dCalcOutputShape(&layer, &inShape, &outShape);
+
+        TEST_ASSERT_EQUAL_size_t(3, outShape.numberOfDimensions);
+        TEST_ASSERT_EQUAL_size_t(2, outShape.dimensions[0]);
+        TEST_ASSERT_EQUAL_size_t(4, outShape.dimensions[1]);
+        TEST_ASSERT_EQUAL_size_t(5, outShape.dimensions[2]);
+    }
+
+    // SAME: K=3, stride=1, dilation=1 -> outLen = inLen
+    {
+        kernel_t kernel;
+        initKernel(&kernel, 3, SAME, 1, 1);
+        maxPool1dConfig_t cfg = {0};
+        size_t dummyDims[] = {1, 1, 1};
+        int32_t dummyData[1] = {0};
+        tensor_t *dummyArgmax = tensorInitInt32(dummyData, dummyDims, 3, NULL);
+        initMaxPool1dConfig(&cfg, &kernel, dummyArgmax, q, q);
+
+        layer_t layer;
+        layerConfig_t lc;
+        layer.type = MAXPOOL1D;
+        lc.maxPool1d = &cfg;
+        layer.config = &lc;
+
+        size_t inDimsBacking[] = {1, 1, 7};
+        size_t inOrderBacking[] = {0, 1, 2};
+        size_t outDimsBacking[] = {0, 0, 0};
+        size_t outOrderBacking[] = {0, 0, 0};
+        shape_t inShape = {.dimensions = inDimsBacking,
+                           .orderOfDimensions = inOrderBacking,
+                           .numberOfDimensions = 3};
+        shape_t outShape = {.dimensions = outDimsBacking,
+                            .orderOfDimensions = outOrderBacking,
+                            .numberOfDimensions = 0};
+
+        maxPool1dCalcOutputShape(&layer, &inShape, &outShape);
+
+        TEST_ASSERT_EQUAL_size_t(7, outShape.dimensions[2]);
+    }
+}
+
+void testMaxPool1dBackwardBasic(void) {
+    size_t inputDims[] = {1, 1, 4};
+    size_t outputDims[] = {1, 1, 3};
+    float outputData[1 * 1 * 3] = {0};
+    int32_t argmaxData[1 * 1 * 3] = {0};
+
+    maxPool1dRunResult_t r = maxPool1dBuild(input_maxPool1d_basic, inputDims, 2, VALID, 1, 1,
+                                            outputData, argmaxData, outputDims);
+
+    // Forward populates argmax — required precondition for backward.
+    maxPool1dForward(r.layer, r.input, r.output);
+
+    // lossGrad = ones (matches what the generator used for autograd on `basic`).
+    float lossGradData[1 * 1 * 3];
+    for (size_t i = 0; i < 3; i++) {
+        lossGradData[i] = 1.0f;
+    }
+    tensor_t *lossGrad = tensorInitFloat(lossGradData, (size_t *)outputDims, 3, NULL);
+
+    float propLossData[1 * 1 * 4] = {0};
+    tensor_t *propLoss = tensorInitFloat(propLossData, (size_t *)inputDims, 3, NULL);
+
+    maxPool1dBackward(r.layer, r.input, lossGrad, propLoss);
+
+    // (Mutation: sentinel-skip removal is vacuous in basic fixture; no empty-window
+    //  fixture is in this PR's test set per spec §6.3 / Q3.)
+    for (size_t i = 0; i < expectedPropLoss_maxPool1d_basic_len; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(1e-5f, expectedPropLoss_maxPool1d_basic[i],
+                                 ((float *)propLoss->data)[i]);
+    }
+}
+
+void testMaxPool1dArgmaxIndicesContent(void) {
+    size_t inputDims[] = {1, 1, 4};
+    size_t outputDims[] = {1, 1, 3};
+    float outputData[1 * 1 * 3] = {0};
+    int32_t argmaxData[1 * 1 * 3] = {0};
+
+    maxPool1dRunResult_t r = maxPool1dBuild(input_maxPool1d_basic, inputDims, 2, VALID, 1, 1,
+                                            outputData, argmaxData, outputDims);
+
+    maxPool1dForward(r.layer, r.input, r.output);
+
+    // Compare argmax tensor content against generator-emitted gold values.
+    int32_t const *actual = (int32_t const *)r.argmax->data;
+    for (size_t i = 0; i < expectedArgmax_maxPool1d_basic_len; i++) {
+        TEST_ASSERT_EQUAL_INT32(expectedArgmax_maxPool1d_basic[i], actual[i]);
+    }
+}
+
+void testMaxPool1dMultiChannel(void) {
+    size_t inputDims[] = {1, 3, 5};  // B=1, C=3, L=5
+    size_t outputDims[] = {1, 3, 4}; // outLen = (5-2)/1 + 1 = 4
+    float outputData[1 * 3 * 4] = {0};
+    int32_t argmaxData[1 * 3 * 4] = {0};
+
+    maxPool1dRunResult_t r = maxPool1dBuild(input_maxPool1d_multiChannel, inputDims, 2, VALID, 1, 1,
+                                            outputData, argmaxData, outputDims);
+
+    maxPool1dForward(r.layer, r.input, r.output);
+    for (size_t i = 0; i < expectedForward_maxPool1d_multiChannel_len; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(1e-5f, expectedForward_maxPool1d_multiChannel[i],
+                                 ((float *)r.output->data)[i]);
+    }
+
+    int32_t const *argmaxActual = (int32_t const *)r.argmax->data;
+    for (size_t i = 0; i < expectedArgmax_maxPool1d_multiChannel_len; i++) {
+        TEST_ASSERT_EQUAL_INT32(expectedArgmax_maxPool1d_multiChannel[i], argmaxActual[i]);
+    }
+
+    float lossGradData[1 * 3 * 4];
+    for (size_t i = 0; i < 12; i++) {
+        lossGradData[i] = 1.0f;
+    }
+    tensor_t *lossGrad = tensorInitFloat(lossGradData, (size_t *)outputDims, 3, NULL);
+
+    float propLossData[1 * 3 * 5] = {0};
+    tensor_t *propLoss = tensorInitFloat(propLossData, (size_t *)inputDims, 3, NULL);
+
+    maxPool1dBackward(r.layer, r.input, lossGrad, propLoss);
+    for (size_t i = 0; i < expectedPropLoss_maxPool1d_multiChannel_len; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(1e-5f, expectedPropLoss_maxPool1d_multiChannel[i],
+                                 ((float *)propLoss->data)[i]);
+    }
+}
+
+void testMaxPool1dMultiBatch(void) {
+    size_t inputDims[] = {4, 2, 4};  // B=4, C=2, L=4
+    size_t outputDims[] = {4, 2, 3}; // outLen = (4-2)/1 + 1 = 3
+    float outputData[4 * 2 * 3] = {0};
+    int32_t argmaxData[4 * 2 * 3] = {0};
+
+    maxPool1dRunResult_t r = maxPool1dBuild(input_maxPool1d_multiBatch, inputDims, 2, VALID, 1, 1,
+                                            outputData, argmaxData, outputDims);
+
+    maxPool1dForward(r.layer, r.input, r.output);
+    for (size_t i = 0; i < expectedForward_maxPool1d_multiBatch_len; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(1e-5f, expectedForward_maxPool1d_multiBatch[i],
+                                 ((float *)r.output->data)[i]);
+    }
+
+    float lossGradData[4 * 2 * 3];
+    for (size_t i = 0; i < 24; i++) {
+        lossGradData[i] = 1.0f;
+    }
+    tensor_t *lossGrad = tensorInitFloat(lossGradData, (size_t *)outputDims, 3, NULL);
+
+    float propLossData[4 * 2 * 4] = {0};
+    tensor_t *propLoss = tensorInitFloat(propLossData, (size_t *)inputDims, 3, NULL);
+
+    maxPool1dBackward(r.layer, r.input, lossGrad, propLoss);
+    for (size_t i = 0; i < expectedPropLoss_maxPool1d_multiBatch_len; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(1e-5f, expectedPropLoss_maxPool1d_multiBatch[i],
+                                 ((float *)propLoss->data)[i]);
+    }
+}
+
+void testMaxPool1dWithStrideAndDilation(void) {
+    size_t inputDims[] = {1, 1, 9}; // B=1, C=1, L=9
+    // K=2, stride=3, dilation=2 -> effective_K = (2-1)*2+1 = 3, outLen = (9-3)/3+1 = 3
+    size_t outputDims[] = {1, 1, 3};
+    float outputData[1 * 1 * 3] = {0};
+    int32_t argmaxData[1 * 1 * 3] = {0};
+
+    maxPool1dRunResult_t r = maxPool1dBuild(input_maxPool1d_withStrideAndDilation, inputDims, 2,
+                                            VALID, 2, 3, outputData, argmaxData, outputDims);
+
+    maxPool1dForward(r.layer, r.input, r.output);
+    for (size_t i = 0; i < expectedForward_maxPool1d_withStrideAndDilation_len; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(1e-5f, expectedForward_maxPool1d_withStrideAndDilation[i],
+                                 ((float *)r.output->data)[i]);
+    }
+
+    // Use the gold-emitted random lossGrad (NOT ones), so positional mutations
+    // on the backward path are non-vacuous (codebase_uniform_lossgrad_mutation_vacuity).
+    tensor_t *lossGrad = tensorInitFloat((float *)lossGrad_maxPool1d_withStrideAndDilation,
+                                         (size_t *)outputDims, 3, NULL);
+
+    float propLossData[1 * 1 * 9] = {0};
+    tensor_t *propLoss = tensorInitFloat(propLossData, (size_t *)inputDims, 3, NULL);
+
+    maxPool1dBackward(r.layer, r.input, lossGrad, propLoss);
+    for (size_t i = 0; i < expectedPropLoss_maxPool1d_withStrideAndDilation_len; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(1e-5f, expectedPropLoss_maxPool1d_withStrideAndDilation[i],
+                                 ((float *)propLoss->data)[i]);
+    }
+}
+
+void testMaxPool1dWithSamePadding(void) {
+    size_t inputDims[] = {1, 1, 5};
+    size_t outputDims[] = {1, 1, 5}; // SAME -> outLen = inLen
+    float outputData[1 * 1 * 5] = {0};
+    int32_t argmaxData[1 * 1 * 5] = {0};
+
+    maxPool1dRunResult_t r = maxPool1dBuild(input_maxPool1d_withSamePadding, inputDims, 3, SAME, 1,
+                                            1, outputData, argmaxData, outputDims);
+
+    maxPool1dForward(r.layer, r.input, r.output);
+    for (size_t i = 0; i < expectedForward_maxPool1d_withSamePadding_len; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(1e-5f, expectedForward_maxPool1d_withSamePadding[i],
+                                 ((float *)r.output->data)[i]);
+    }
+
+    // Verify argmax content for both edge windows (outPos=0 and outPos=4).
+    int32_t const *argmaxActual = (int32_t const *)r.argmax->data;
+    for (size_t i = 0; i < expectedArgmax_maxPool1d_withSamePadding_len; i++) {
+        TEST_ASSERT_EQUAL_INT32(expectedArgmax_maxPool1d_withSamePadding[i], argmaxActual[i]);
+    }
+
+    float lossGradData[1 * 1 * 5];
+    for (size_t i = 0; i < 5; i++) {
+        lossGradData[i] = 1.0f;
+    }
+    tensor_t *lossGrad = tensorInitFloat(lossGradData, (size_t *)outputDims, 3, NULL);
+
+    float propLossData[1 * 1 * 5] = {0};
+    tensor_t *propLoss = tensorInitFloat(propLossData, (size_t *)inputDims, 3, NULL);
+
+    maxPool1dBackward(r.layer, r.input, lossGrad, propLoss);
+    for (size_t i = 0; i < expectedPropLoss_maxPool1d_withSamePadding_len; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(1e-5f, expectedPropLoss_maxPool1d_withSamePadding[i],
+                                 ((float *)propLoss->data)[i]);
+    }
+}
+
+void testMaxPool1dEdgeCases(void) {
+    size_t inputDims[] = {1, 1, 4};
+    size_t outputDims[] = {1, 1, 4}; // K=1 stride=1 -> outLen = inLen
+    float outputData[1 * 1 * 4] = {0};
+    int32_t argmaxData[1 * 1 * 4] = {0};
+
+    maxPool1dRunResult_t r = maxPool1dBuild(input_maxPool1d_edgeCases, inputDims, 1, VALID, 1, 1,
+                                            outputData, argmaxData, outputDims);
+
+    maxPool1dForward(r.layer, r.input, r.output);
+    for (size_t i = 0; i < expectedForward_maxPool1d_edgeCases_len; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(1e-5f, expectedForward_maxPool1d_edgeCases[i],
+                                 ((float *)r.output->data)[i]);
+    }
+
+    // K=1 -> argmax[i] == i for every output position.
+    int32_t const *argmaxActual = (int32_t const *)r.argmax->data;
+    for (size_t i = 0; i < expectedArgmax_maxPool1d_edgeCases_len; i++) {
+        TEST_ASSERT_EQUAL_INT32(expectedArgmax_maxPool1d_edgeCases[i], argmaxActual[i]);
+    }
+
+    float lossGradData[1 * 1 * 4];
+    for (size_t i = 0; i < 4; i++) {
+        lossGradData[i] = 1.0f;
+    }
+    tensor_t *lossGrad = tensorInitFloat(lossGradData, (size_t *)outputDims, 3, NULL);
+
+    float propLossData[1 * 1 * 4] = {0};
+    tensor_t *propLoss = tensorInitFloat(propLossData, (size_t *)inputDims, 3, NULL);
+
+    maxPool1dBackward(r.layer, r.input, lossGrad, propLoss);
+    for (size_t i = 0; i < expectedPropLoss_maxPool1d_edgeCases_len; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(1e-5f, expectedPropLoss_maxPool1d_edgeCases[i],
+                                 ((float *)propLoss->data)[i]);
+    }
+}
+
+void setUp(void) {}
+void tearDown(void) {}
+
+int main(void) {
+    UNITY_BEGIN();
+    RUN_TEST(testMaxPool1dForwardBasic);
+    RUN_TEST(testMaxPool1dCalcOutputShapeValidAndSame);
+    RUN_TEST(testMaxPool1dBackwardBasic);
+    RUN_TEST(testMaxPool1dArgmaxIndicesContent);
+    RUN_TEST(testMaxPool1dMultiChannel);
+    RUN_TEST(testMaxPool1dMultiBatch);
+    RUN_TEST(testMaxPool1dWithStrideAndDilation);
+    RUN_TEST(testMaxPool1dWithSamePadding);
+    RUN_TEST(testMaxPool1dEdgeCases);
+    return UNITY_END();
+}

--- a/test/unit/layer/generate_expected_avg_pool_1d.py
+++ b/test/unit/layer/generate_expected_avg_pool_1d.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""Generate expected_avg_pool_1d.h for UnitTestAvgPool1d (Layer-3 tests).
+
+Produces a C header with PyTorch-derived ground-truth values for each
+fixture: forward output, propLoss (dL/dx). For most fixtures
+lossGrad = torch.ones_like(y); withStrideAndDilation uses
+torch.randn_like(y) (and emits the lossGrad as a gold array) so that
+positional mutations on the stride/dilation backward path are
+non-vacuous (per codebase_uniform_lossgrad_mutation_vacuity).
+
+Divisor is `count_include_pad=True` (PyTorch default — A1 semantics
+per spec §6.4 / §11). The hand-derived self-check uses kernel_size
+as divisor for ALL output positions, including SAME edges where
+validCount < kernel_size — same convention as the C impl.
+
+Run via `uv run` (CMake wires this automatically).
+"""
+import argparse
+import sys
+from pathlib import Path
+
+import torch
+import torch.nn.functional as F
+
+
+def _format_float_literal(v: float) -> str:
+    s = repr(v)
+    if s in ("inf", "-inf", "nan"):
+        raise ValueError(f"non-finite gold value: {v!r}")
+    return s + "f"
+
+
+def emit_float_array(name: str, tensor: torch.Tensor) -> str:
+    flat = tensor.detach().flatten().tolist()
+    body = ", ".join(_format_float_literal(v) for v in flat)
+    return (
+        f"static const float {name}[] = {{ {body} }};\n"
+        f"static const size_t {name}_len = {len(flat)};\n"
+    )
+
+
+def _hand_check_avg_forward(x, kernel_size, stride, padding, dilation):
+    """count_include_pad=True semantics: divisor = kernel_size always.
+    Padded positions are treated as zero and INCLUDED in the divisor count."""
+    B, C, L = x.shape
+    in_padded_L = L + 2 * padding
+    eff_k = (kernel_size - 1) * dilation + 1
+    out_L = (in_padded_L - eff_k) // stride + 1
+    out = torch.zeros((B, C, out_L))
+    for b in range(B):
+        for c in range(C):
+            for o in range(out_L):
+                start = o * stride - padding
+                accum = 0.0
+                for k in range(kernel_size):
+                    idx = start + k * dilation
+                    if 0 <= idx < L:
+                        accum += x[b, c, idx].item()
+                    # else: padded position contributes 0, INCLUDED in divisor
+                out[b, c, o] = accum / kernel_size
+    return out
+
+
+def _run_avg_fixture(name, x, *, kernel_size, stride, padding, dilation,
+                     loss_grad_kind="ones"):
+    x_in = x.clone().detach().requires_grad_(True)
+
+    # PyTorch's F.avg_pool1d defaults to count_include_pad=True.
+    # Note: F.avg_pool1d does NOT support `dilation` — for the
+    # withStrideAndDilation fixture we manually pad+stride+dilate via a
+    # hand-built reference (verified internally below).
+    if dilation == 1:
+        y = F.avg_pool1d(x_in, kernel_size=kernel_size, stride=stride,
+                         padding=padding, count_include_pad=True)
+    else:
+        # F.avg_pool1d has no dilation arg; build the reference manually,
+        # using count_include_pad=True semantics, then verify against numpy.
+        y = _hand_check_avg_forward(x_in.detach(), kernel_size, stride,
+                                     padding, dilation).clone()
+        # Re-attach to autograd by recomputing in a way that keeps the
+        # graph: use a manual gather + mean-by-divisor.
+        y = _autograd_avg_with_dilation(x_in, kernel_size, stride, padding, dilation)
+
+    expected_y = _hand_check_avg_forward(
+        x_in.detach(), kernel_size, stride, padding, dilation,
+    )
+    assert torch.allclose(y.detach(), expected_y, atol=1e-5), (
+        f"{name}: avg_pool1d forward disagrees with hand-derived (count_include_pad=True)"
+    )
+
+    if loss_grad_kind == "ones":
+        gy = torch.ones_like(y)
+    elif loss_grad_kind == "randn":
+        torch.manual_seed(hash(name) & 0xFFFF)
+        gy = torch.randn_like(y)
+    else:
+        raise ValueError(loss_grad_kind)
+
+    y.backward(gy)
+
+    return {
+        "name": name,
+        "x": x_in.detach(),
+        "y": y.detach(),
+        "dx": x_in.grad.detach(),
+        "gy": gy.detach(),
+        "loss_grad_kind": loss_grad_kind,
+    }
+
+
+def _autograd_avg_with_dilation(x_in, kernel_size, stride, padding, dilation):
+    """Recompute avg pool with dilation via index_select chain so autograd
+    can track gradients. count_include_pad=True semantics: divisor = kernel_size.
+
+    Uses torch.zeros for padding (which keeps the autograd graph since
+    out-of-range positions get 0 directly without indexing past x_in's bounds).
+    """
+    B, C, L = x_in.shape
+    in_padded_L = L + 2 * padding
+    eff_k = (kernel_size - 1) * dilation + 1
+    out_L = (in_padded_L - eff_k) // stride + 1
+
+    # Pad x_in with zeros on left/right.
+    x_pad = F.pad(x_in, (padding, padding))  # shape: [B, C, L + 2*padding]
+
+    # Build output by gathering windows.
+    outputs = []
+    for o in range(out_L):
+        start = o * stride
+        # Gather kernel_size positions, each at start + k*dilation in x_pad.
+        col = torch.zeros((B, C), dtype=x_in.dtype)
+        for k in range(kernel_size):
+            idx = start + k * dilation
+            col = col + x_pad[:, :, idx]
+        outputs.append(col / kernel_size)
+    y = torch.stack(outputs, dim=2)
+    return y
+
+
+def fixture_basic():
+    x = torch.tensor([[[1.0, 4.0, 2.0, 3.0]]])
+    return _run_avg_fixture("basic", x, kernel_size=2, stride=1, padding=0, dilation=1)
+
+
+def fixture_multi_channel():
+    torch.manual_seed(201)
+    x = torch.randn(1, 3, 5)
+    return _run_avg_fixture("multiChannel", x, kernel_size=2, stride=1,
+                            padding=0, dilation=1)
+
+
+def fixture_multi_batch():
+    torch.manual_seed(202)
+    x = torch.randn(4, 2, 4)
+    return _run_avg_fixture("multiBatch", x, kernel_size=2, stride=1,
+                            padding=0, dilation=1)
+
+
+def fixture_with_stride_and_dilation():
+    # Random lossGrad — Errata 3: stride/dilation backward needs non-uniform gy.
+    torch.manual_seed(203)
+    x = torch.randn(1, 1, 9)
+    return _run_avg_fixture("withStrideAndDilation", x,
+                            kernel_size=2, stride=3, padding=0, dilation=2,
+                            loss_grad_kind="randn")
+
+
+def fixture_with_same_padding():
+    # K=3, S=1, D=1, padLeft=padRight=1 -> outLen = inLen = 5.
+    # Edge windows: outPos=0 (validCount=2, padded left counts in divisor=3),
+    # outPos=4 (validCount=2, padded right counts in divisor=3).
+    x = torch.tensor([[[2.0, 4.0, 6.0, 8.0, 10.0]]])
+    return _run_avg_fixture("withSamePadding", x, kernel_size=3, stride=1,
+                            padding=1, dilation=1)
+
+
+def fixture_edge_cases():
+    # K=L=4, full-input window. outLen=1; output is x.mean() per channel.
+    # validCount == kernel_size == 4. Tests the divisor == kernel_size path
+    # with no truncation.
+    x = torch.tensor([[[1.0, 2.0, 3.0, 4.0]]])
+    return _run_avg_fixture("edgeCases", x, kernel_size=4, stride=1,
+                            padding=0, dilation=1)
+
+
+def emit_fixture(parts, fx):
+    pre = f"avgPool1d_{fx['name']}"
+    parts.append(emit_float_array(f"input_{pre}", fx["x"]))
+    parts.append(emit_float_array(f"expectedForward_{pre}", fx["y"]))
+    parts.append(emit_float_array(f"expectedPropLoss_{pre}", fx["dx"]))
+    if fx["loss_grad_kind"] != "ones":
+        parts.append(emit_float_array(f"lossGrad_{pre}", fx["gy"]))
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out", required=True, type=Path)
+    args = ap.parse_args()
+
+    parts = [
+        "// AUTOGENERATED by generate_expected_avg_pool_1d.py — DO NOT EDIT\n",
+        "#ifndef ODT_EXPECTED_AVG_POOL_1D_H\n",
+        "#define ODT_EXPECTED_AVG_POOL_1D_H\n",
+        "#include <stdlib.h>\n\n",
+    ]
+
+    fixtures = [
+        fixture_basic(),
+        fixture_multi_channel(),
+        fixture_multi_batch(),
+        fixture_with_stride_and_dilation(),
+        fixture_with_same_padding(),
+        fixture_edge_cases(),
+    ]
+    for fx in fixtures:
+        emit_fixture(parts, fx)
+
+    parts.append("\n#endif // ODT_EXPECTED_AVG_POOL_1D_H\n")
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text("".join(parts))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/unit/layer/generate_expected_max_pool_1d.py
+++ b/test/unit/layer/generate_expected_max_pool_1d.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""Generate expected_max_pool_1d.h for UnitTestMaxPool1d (Layer-3 tests).
+
+Produces a C header with PyTorch-derived ground-truth values for each
+test fixture: forward output, expected argmax indices (int32_t),
+propLoss (dL/dx). For most fixtures lossGrad = torch.ones_like(y);
+the `withStrideAndDilation` fixture uses torch.randn_like(y) (and
+emits the lossGrad as a gold array) so that index-permuting mutations
+on the stride/dilation backward path are non-vacuous (per
+codebase_uniform_lossgrad_mutation_vacuity).
+
+Run via `uv run` (CMake wires this automatically).
+"""
+import argparse
+import sys
+from pathlib import Path
+
+import torch
+import torch.nn.functional as F
+
+
+def _format_float_literal(v: float) -> str:
+    """Format a Python float as a valid C float literal.
+
+    Python's f"{v:.9g}" strips the trailing ".0" from whole-number
+    floats (10.0 -> "10"), which combined with the f suffix produces
+    invalid C (10f is rejected by gcc as an integer suffix). repr
+    always contains "." or "e" for finite floats, both legal in C
+    with the f suffix.
+    """
+    s = repr(v)
+    if s in ("inf", "-inf", "nan"):
+        raise ValueError(f"non-finite gold value: {v!r}")
+    return s + "f"
+
+
+def emit_float_array(name: str, tensor: torch.Tensor) -> str:
+    flat = tensor.detach().flatten().tolist()
+    body = ", ".join(_format_float_literal(v) for v in flat)
+    return (
+        f"static const float {name}[] = {{ {body} }};\n"
+        f"static const size_t {name}_len = {len(flat)};\n"
+    )
+
+
+def emit_int32_array(name: str, tensor: torch.Tensor) -> str:
+    flat = tensor.detach().to(torch.int32).flatten().tolist()
+    body = ", ".join(str(v) for v in flat)
+    return (
+        f"static const int32_t {name}[] = {{ {body} }};\n"
+        f"static const size_t {name}_len = {len(flat)};\n"
+    )
+
+
+def _hand_check_max_forward(x, kernel_size, stride, padding, dilation):
+    """Numpy-level sanity check: for each output position, max over the
+    valid window. Used as a self-check against PyTorch's MaxPool1d output."""
+    import math
+    B, C, L = x.shape
+    in_padded_L = L + 2 * padding
+    eff_k = (kernel_size - 1) * dilation + 1
+    out_L = (in_padded_L - eff_k) // stride + 1
+    out = torch.full((B, C, out_L), -math.inf)
+    for b in range(B):
+        for c in range(C):
+            for o in range(out_L):
+                start = o * stride - padding
+                vals = []
+                for k in range(kernel_size):
+                    idx = start + k * dilation
+                    if 0 <= idx < L:
+                        vals.append(x[b, c, idx].item())
+                if vals:
+                    out[b, c, o] = max(vals)
+                else:
+                    out[b, c, o] = 0.0
+    return out
+
+
+def _run_max_fixture(name, x, *, kernel_size, stride, padding, dilation,
+                     loss_grad_kind="ones"):
+    """Run forward + autograd-backward on a MaxPool1d fixture; return all arrays.
+
+    loss_grad_kind: "ones" -> lossGrad = torch.ones_like(y) (default);
+                    "randn" -> lossGrad = torch.randn_like(y), reproducible via seed.
+    """
+    x_in = x.clone().detach().requires_grad_(True)
+
+    # PyTorch's nn.functional.max_pool1d returns (output) by default; with
+    # return_indices=True it returns (output, indices). The indices are 1D
+    # input positions per output position (no batch/channel offset), matching
+    # our argmax convention exactly.
+    y, idx = F.max_pool1d(
+        x_in, kernel_size=kernel_size, stride=stride,
+        padding=padding, dilation=dilation, return_indices=True,
+    )
+
+    # Self-check forward against hand-computed reference.
+    expected_y = _hand_check_max_forward(
+        x_in.detach(), kernel_size, stride, padding, dilation,
+    )
+    assert torch.allclose(y.detach(), expected_y, atol=1e-5), (
+        f"{name}: PyTorch max_pool1d forward disagrees with hand-derived reference"
+    )
+
+    if loss_grad_kind == "ones":
+        gy = torch.ones_like(y)
+    elif loss_grad_kind == "randn":
+        torch.manual_seed(hash(name) & 0xFFFF)
+        gy = torch.randn_like(y)
+    else:
+        raise ValueError(loss_grad_kind)
+
+    y.backward(gy)
+
+    return {
+        "name": name,
+        "x": x_in.detach(),
+        "y": y.detach(),
+        "argmax": idx.detach(),    # int64 in PyTorch; we cast to int32 in emit_int32_array
+        "dx": x_in.grad.detach(),
+        "gy": gy.detach(),
+        "loss_grad_kind": loss_grad_kind,
+    }
+
+
+def fixture_basic():
+    # B=1, C=1, L=4, K=2, stride=1, VALID
+    x = torch.tensor([[[1.0, 4.0, 2.0, 3.0]]])
+    return _run_max_fixture("basic", x, kernel_size=2, stride=1, padding=0, dilation=1)
+
+
+def fixture_multi_channel():
+    # B=1, C=3, L=5, K=2, stride=1, VALID
+    torch.manual_seed(101)
+    x = torch.randn(1, 3, 5)
+    return _run_max_fixture("multiChannel", x, kernel_size=2, stride=1,
+                            padding=0, dilation=1)
+
+
+def fixture_multi_batch():
+    # B=4, C=2, L=4, K=2, stride=1, VALID
+    torch.manual_seed(102)
+    x = torch.randn(4, 2, 4)
+    return _run_max_fixture("multiBatch", x, kernel_size=2, stride=1,
+                            padding=0, dilation=1)
+
+
+def fixture_with_stride_and_dilation():
+    # B=1, C=1, L=9, K=2, stride=3, dilation=2, VALID
+    # Effective kernel span = (2-1)*2+1 = 3; output length = (9-3)/3+1 = 3.
+    # Using random lossGrad (Errata 3) so positional mutations are non-vacuous.
+    torch.manual_seed(103)
+    x = torch.randn(1, 1, 9)
+    return _run_max_fixture("withStrideAndDilation", x,
+                            kernel_size=2, stride=3, padding=0, dilation=2,
+                            loss_grad_kind="randn")
+
+
+def fixture_with_same_padding():
+    # B=1, C=1, L=5, K=3, stride=1, dilation=1.
+    # SAME for K=3, S=1, D=1 -> total pad = 2; padLeft=1, padRight=1 (symmetric).
+    # Output length = 5. Edge windows at outPos=0 (validCount=2, drops left)
+    # and outPos=4 (validCount=2, drops right) — exercises Errata 4.
+    x = torch.tensor([[[5.0, 1.0, 4.0, 2.0, 6.0]]])
+    return _run_max_fixture("withSamePadding", x, kernel_size=3, stride=1,
+                            padding=1, dilation=1)
+
+
+def fixture_edge_cases():
+    # B=1, C=1, L=4, K=1, stride=1, VALID. K=1 -> identity pool;
+    # output equals input, argmax equals position index, propLoss = lossGrad.
+    # Ensures the validCount-loop with N=1 doesn't have an off-by-one
+    # (e.g., loop bound `i < validCount - 1` would compute -INFINITY here).
+    x = torch.tensor([[[7.0, -2.0, 3.0, 0.5]]])
+    return _run_max_fixture("edgeCases", x, kernel_size=1, stride=1,
+                            padding=0, dilation=1)
+
+
+def emit_fixture(parts, fx):
+    pre = f"maxPool1d_{fx['name']}"
+    parts.append(emit_float_array(f"input_{pre}", fx["x"]))
+    parts.append(emit_float_array(f"expectedForward_{pre}", fx["y"]))
+    parts.append(emit_int32_array(f"expectedArgmax_{pre}", fx["argmax"]))
+    parts.append(emit_float_array(f"expectedPropLoss_{pre}", fx["dx"]))
+    if fx["loss_grad_kind"] != "ones":
+        parts.append(emit_float_array(f"lossGrad_{pre}", fx["gy"]))
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out", required=True, type=Path)
+    args = ap.parse_args()
+
+    parts = [
+        "// AUTOGENERATED by generate_expected_max_pool_1d.py — DO NOT EDIT\n",
+        "#ifndef ODT_EXPECTED_MAX_POOL_1D_H\n",
+        "#define ODT_EXPECTED_MAX_POOL_1D_H\n",
+        "#include <stdint.h>\n",
+        "#include <stdlib.h>\n\n",
+    ]
+
+    fixtures = [
+        fixture_basic(),
+        fixture_multi_channel(),
+        fixture_multi_batch(),
+        fixture_with_stride_and_dilation(),
+        fixture_with_same_padding(),
+        fixture_edge_cases(),
+    ]
+    for fx in fixtures:
+        emit_fixture(parts, fx)
+
+    parts.append("\n#endif // ODT_EXPECTED_MAX_POOL_1D_H\n")
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text("".join(parts))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

PR 3 of 3 in the Conv1d/Pool-family expansion (spec: `docs/superpowers/specs/2026-05-06-conv1d-and-sliding-window-design.md`).

Adds two new Layer-3 ops, both built on PR 1's `SlidingWindow1d` utility:

- **MaxPool1d**: forward writes per-output argmax indices into a caller-allocated INT32 tensor; backward scatters lossGrad into propLoss[b, c, argmax]. Sentinel -1 handles theoretical-only empty-window case (in-practice unreachable per spec §6.3).
- **AvgPool1d**: forward computes mean over each window; backward scatters lossGrad/kernel_size to all valid input positions. Divisor is `kernel_size` always (count_include_pad=True / A1 semantics per spec §6.4 / §11).

Layer 3 is alloc-free; argmax/output/propLoss buffers are caller-owned.

Layer registry extended: `MAXPOOL1D` and `AVGPOOL1D` enum entries (slotted between `CONV1D_TRANSPOSED` and `SOFTMAX`); union members and `layerFunctions[]` entries registered. Optimizer.c `case MAXPOOL1D / AVGPOOL1D: return 0;` (no trainable params) added.

## Test plan

PyTorch-derived gold-value generators run via `uv run`; CMake regenerates them on script change.

- [x] MaxPool: 9 RUN_TEST entries — basic forward/backward, calcOutputShape, argmaxIndicesContent, multiChannel, multiBatch, withStrideAndDilation, withSamePadding (left+right edge), edgeCases (K=1).
- [x] AvgPool: 7 RUN_TEST entries — basic forward/backward, multiChannel, multiBatch, withStrideAndDilation, withSamePadding, edgeCases (K=L=4).
- [x] All `withStrideAndDilation` fixtures use `torch.randn_like(y)` lossGrad to keep positional mutations non-vacuous (per `codebase_uniform_lossgrad_mutation_vacuity`).
- [x] All SAME fixtures exercise BOTH left-edge and right-edge truncation in the same window set (PR 1 Errata 4).
- [x] Mutation-tested per task; vacuous mutations are explicitly substituted or deferred to fixtures that exercise the missing axis.
- [x] Allocation-locality grep clean.
- [ ] Full CI green on the PR.

Closes #6 (Conv1d/ConvT empty-stub — already addressed by PR 2 for Conv side; this PR completes the Pool side that the spec scope absorbs).

NOTE: PR is stacked on `develop`. Per `feedback_github_auto_close_default_branch`, "Closes #NN" only triggers GitHub's auto-close on default-branch (`main`) merges. After develop→main merge, manual `gh issue close 6` is required if not yet closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)