### PR TITLE
chore: ignore .claude/ session-state directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .justfile
 **/.DS_Store
 .cache/
+.claude/
 
 ### Python
 .venv


### PR DESCRIPTION
Adds `.claude/` to `.gitignore` so Claude Code session-state files (e.g. `scheduled_tasks.lock`) don't accidentally land in commits. Surfaced during PR #163's Stage 2 work — the lock file was being tracked by jj because the existing `claude*` pattern in `.gitignore` doesn't match leading-dot directories.

No behavior change beyond the gitignore line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)