### PR TITLE
fix(examples): guard shape_buf overflow in npy_writer

### DIFF
--- a/examples/_shared/npy_writer.c
+++ b/examples/_shared/npy_writer.c
@@ -2,9 +2,28 @@
 
 #include "npy_writer.h"
 
+#include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+/* Append a printf-formatted string into `buf` starting at `offset`. Returns
+ * the new offset on success, or -1 on truncation, encoding error, or if the
+ * caller passed an already-out-of-range offset. Avoids the unsigned underflow
+ * trap of computing `buf_size - offset` when `offset >= buf_size`. */
+static int appendBounded(char *buf, size_t buf_size, int offset, const char *fmt, ...) {
+    if (offset < 0 || (size_t)offset >= buf_size) {
+        return -1;
+    }
+    va_list args;
+    va_start(args, fmt);
+    int written = vsnprintf(buf + offset, buf_size - (size_t)offset, fmt, args);
+    va_end(args);
+    if (written < 0 || (size_t)written >= buf_size - (size_t)offset) {
+        return -1;
+    }
+    return offset + written;
+}
 
 static int writeNpy(const char *path, const void *data, const size_t *shape, size_t ndim,
                     const char *dtype_descr, /* "<f4" or "<i4" */
@@ -17,17 +36,20 @@ static int writeNpy(const char *path, const void *data, const size_t *shape, siz
     /* Build dict header: {'descr': '<f4', 'fortran_order': False, 'shape': (a, b, c), } */
     char shape_buf[256];
     int shape_len = 0;
-    shape_len += snprintf(shape_buf + shape_len, sizeof(shape_buf) - shape_len, "(");
+    shape_len = appendBounded(shape_buf, sizeof(shape_buf), shape_len, "(");
     for (size_t i = 0; i < ndim; ++i) {
-        shape_len += snprintf(shape_buf + shape_len, sizeof(shape_buf) - (size_t)shape_len, "%zu,",
-                              shape[i]);
+        shape_len = appendBounded(shape_buf, sizeof(shape_buf), shape_len, "%zu,", shape[i]);
     }
     if (ndim == 0) {
-        shape_len += snprintf(shape_buf + shape_len, sizeof(shape_buf) - (size_t)shape_len, ",");
+        shape_len = appendBounded(shape_buf, sizeof(shape_buf), shape_len, ",");
     }
     /* ndim == 1: already has trailing comma from the loop above */
     /* ndim > 1:  numpy accepts trailing comma in tuple literal */
-    shape_len += snprintf(shape_buf + shape_len, sizeof(shape_buf) - (size_t)shape_len, ")");
+    shape_len = appendBounded(shape_buf, sizeof(shape_buf), shape_len, ")");
+    if (shape_len < 0) {
+        fclose(f);
+        return 6;
+    }
 
     char dict[512];
     int dict_len =

--- a/python/tests/test_npy_writer.py
+++ b/python/tests/test_npy_writer.py
@@ -2,28 +2,41 @@
 that calls npyWriteFloat32 / npyWriteInt32 with known buffers, then
 np.load()-ing the output and asserting it matches.
 """
+import shutil
 import subprocess
 import sys
 import tempfile
 from pathlib import Path
 
 import numpy as np
+import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
-def _compile_writer_test_harness(harness_src: Path) -> str:
-    """Compile harness_src against examples/_shared/npy_writer.c."""
+def _compile_writer_test_harness(harness_src: Path, *, sanitize: bool = False) -> str:
+    """Compile harness_src against examples/_shared/npy_writer.c.
+
+    When sanitize=True, instrument with AddressSanitizer + UndefinedBehaviorSanitizer
+    so OOB writes / unsigned overflows are caught at runtime. Requires clang.
+    """
     writer_c = REPO_ROOT / "examples" / "_shared" / "npy_writer.c"
     writer_h = REPO_ROOT / "examples" / "_shared"
     binary = tempfile.NamedTemporaryFile(suffix="", delete=False).name
-    subprocess.run(
-        [
-            "cc", "-std=c11", "-O0", f"-I{writer_h}",
-            str(harness_src), str(writer_c), "-o", binary,
-        ],
-        check=True,
-    )
+    cmd = [
+        "cc" if not sanitize else "clang",
+        "-std=c11", "-O0", f"-I{writer_h}",
+        str(harness_src), str(writer_c), "-o", binary,
+    ]
+    if sanitize:
+        cmd[1:1] = [
+            "-fsanitize=address,undefined",
+            "-fno-sanitize=function",
+            "-fno-omit-frame-pointer",
+            "-fno-sanitize-recover=all",
+            "-g",
+        ]
+    subprocess.run(cmd, check=True)
     return binary
 
 
@@ -66,3 +79,50 @@ def test_npy_writer_round_trips_int32(tmp_path):
     assert arr.dtype == np.int32
     assert arr.shape == (8,)
     assert np.array_equal(arr, np.arange(8, dtype=np.int32))
+
+
+def test_npy_writer_rejects_high_rank_shape_that_overflows_buf(tmp_path):
+    """High-rank shapes serialize to >256 chars and used to silently overflow
+    the internal shape_buf[256] (issue #165). Compiled with ASan+UBSan so any
+    OOB write or unsigned underflow trips the sanitizers; the test also asserts
+    that npyWriteFloat32 returns a non-zero rc instead of writing a corrupt
+    file."""
+    if shutil.which("clang") is None:
+        pytest.skip("clang required for sanitizer build")
+    harness = tmp_path / "harness.c"
+    out = tmp_path / "out.npy"
+    # ndim=200 with all-1 dims: leading "(" + 200 * "1," = 1 + 400 = 401 chars,
+    # well past the 256-byte shape_buf. Without the fix, the unsigned subtraction
+    # `sizeof(shape_buf) - shape_len` underflows and snprintf writes OOB.
+    harness.write_text(f"""
+        #include "npy_writer.h"
+        #include <stddef.h>
+        int main(void) {{
+            size_t shape[200];
+            for (size_t i = 0; i < 200; ++i) shape[i] = 1;
+            float data[1] = {{1.0f}};
+            return npyWriteFloat32("{out}", data, shape, 200);
+        }}
+    """)
+    binary = _compile_writer_test_harness(harness, sanitize=True)
+    result = subprocess.run(
+        [binary],
+        env={
+            "ASAN_OPTIONS": "abort_on_error=0:halt_on_error=1:strict_string_checks=1",
+            "UBSAN_OPTIONS": "print_stacktrace=1:halt_on_error=1",
+        },
+        capture_output=True,
+        text=True,
+    )
+    # rc must be non-zero (the writer must detect shape-buffer truncation),
+    # and the sanitizers must not have aborted.
+    assert "AddressSanitizer" not in result.stderr, (
+        f"ASan tripped on stack-buffer overflow:\n{result.stderr}"
+    )
+    assert "runtime error" not in result.stderr, (
+        f"UBSan tripped on unsigned overflow / OOB index:\n{result.stderr}"
+    )
+    assert result.returncode != 0, (
+        f"writeNpy returned 0 on a shape that overflows shape_buf; expected "
+        f"a non-zero error code. stderr: {result.stderr!r}"
+    )


### PR DESCRIPTION
## Summary

Fix the latent buffer-bounds bug in `examples/_shared/npy_writer.c` flagged in #165.

`writeNpy` filled `shape_buf[256]` via a snprintf loop whose remaining-size argument `sizeof(shape_buf) - shape_len` unsigned-underflowed when `shape_len` exceeded 256. The underflowed huge `size_t` bypassed snprintf's bounds check and allowed OOB writes — caught by UBSan at `npy_writer.c:22` as `index 257 out of bounds for type 'char[256]'`. Triggered by high-rank shapes (ndim ~120+, or smaller with multi-digit dims).

## What changed

- Extracted `appendBounded` helper in `npy_writer.c` that wraps `vsnprintf` with explicit bounds checking (`offset >= buf_size` → -1; truncation → -1).
- Replaced the 4 inline `snprintf` sites for `shape_buf` with `appendBounded` calls; single `rc=6` returned at end if any indicates truncation.
- Added `#include <stdarg.h>` for `va_list`.

## Test plan

- [x] Added `test_npy_writer_rejects_high_rank_shape_that_overflows_buf` (TDD: written before the fix). Compiles an ASan+UBSan harness with ndim=200, asserts no sanitizer trip and rc != 0.
- [x] **Without the fix:** test fails with `UndefinedBehaviorSanitizer: runtime error: index 257 out of bounds for type 'char[256]'` at `npy_writer.c:22`.
- [x] **With the fix:** test passes (rc=6, no sanitizer trips).
- [x] Full CI: alloc-locality OK, format OK, `unit_test` (gcc) 42/42, `unit_test_asan` 42/42, `pytest` 22 passed (was 21, +1 new test).

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)