### PR TITLE
feat(tensor): add BOOL bit-packed dtype + SYM Lückenschluss

### DIFF
--- a/src/tensor/Quantization.c
+++ b/src/tensor/Quantization.c
@@ -42,6 +42,11 @@ void initFloat32Quantization(quantization_t *quantization) {
     quantization->qConfig = NULL;
 }
 
+void initBoolQuantization(quantization_t *quantization) {
+    quantization->type = BOOL;
+    quantization->qConfig = NULL;
+}
+
 void initSymInt32Quantization(symInt32QConfig_t *symInt32QConfig, quantization_t *quantization) {
     quantization->type = SYM_INT32;
     quantization->qConfig = symInt32QConfig;

--- a/src/tensor/Tensor.c
+++ b/src/tensor/Tensor.c
@@ -37,10 +37,16 @@ size_t calcBytesPerElement(quantization_t *quantization) {
         return sizeof(float);
     case SYM_INT32:
         return sizeof(int32_t);
+    case SYM: {
+        symQConfig_t *symQC = quantization->qConfig;
+        return (size_t)ceilf((float)symQC->qBits / 8.0f);
+    }
     case ASYM:
         asymQConfig_t *asymQConfig = quantization->qConfig;
         uint32_t qBits = asymQConfig->qBits;
         return ceil((float)qBits / (float)8);
+    case BOOL:
+        return 1;
     default:
         PRINT_ERROR("Unknown QType!");
         exit(1);
@@ -55,9 +61,15 @@ size_t calcBitsPerElement(quantization_t *quantization) {
         return sizeof(float) * 8;
     case SYM_INT32:
         return sizeof(int32_t) * 8;
+    case SYM: {
+        symQConfig_t *symQC = quantization->qConfig;
+        return symQC->qBits;
+    }
     case ASYM:
         asymQConfig_t *asymQConfig = quantization->qConfig;
         return asymQConfig->qBits;
+    case BOOL:
+        return 1;
     default:
         PRINT_ERROR("Unknown QType!");
         exit(1);
@@ -83,12 +95,40 @@ size_t calcNumberOfBytesForData(quantization_t *q, size_t numberOfElements) {
         return numberOfElements * sizeof(int32_t);
     case SYM_INT32:
         return numberOfElements * sizeof(int32_t);
+    case SYM:
+        return (calcBitsPerElement(q) * numberOfElements + 7) / 8;
     case ASYM:
         size_t bitsPerElement = calcBitsPerElement(q);
         return (bitsPerElement * numberOfElements + 7) / 8;
+    case BOOL:
+        return (numberOfElements + 7) / 8;
     default:
         PRINT_ERROR("Unknown QType!");
         exit(1);
+    }
+}
+
+bool tensorBoolGet(tensor_t const *tensor, size_t flatIndex) {
+    if (tensor->quantization->type != BOOL) {
+        PRINT_ERROR("tensorBoolGet called on non-BOOL tensor");
+        exit(1);
+    }
+    size_t byteIndex = flatIndex / 8;
+    size_t bitIndex = flatIndex % 8;
+    return ((tensor->data[byteIndex] >> bitIndex) & 1u) != 0;
+}
+
+void tensorBoolSet(tensor_t *tensor, size_t flatIndex, bool value) {
+    if (tensor->quantization->type != BOOL) {
+        PRINT_ERROR("tensorBoolSet called on non-BOOL tensor");
+        exit(1);
+    }
+    size_t byteIndex = flatIndex / 8;
+    size_t bitIndex = flatIndex % 8;
+    if (value) {
+        tensor->data[byteIndex] |= (uint8_t)(1u << bitIndex);
+    } else {
+        tensor->data[byteIndex] &= (uint8_t)~(1u << bitIndex);
     }
 }
 
@@ -318,6 +358,17 @@ void printTensor(tensor_t *t) {
             printf("%i\n", t->data[i]);
         }
         break;
+    case BOOL:
+        printf("BOOL\n");
+        printf("[");
+        for (size_t i = 0; i < numValues; i++) {
+            printf("%d", tensorBoolGet(t, i) ? 1 : 0);
+            if (i + 1 < numValues) {
+                printf(", ");
+            }
+        }
+        printf("]\n");
+        break;
     default:
         printf("WTF\n");
     }
@@ -378,6 +429,10 @@ void copyQuantization(quantization_t *dest, quantization_t *src) {
         symInt32QConfig_t *destQC = dest->qConfig;
         symInt32QConfig_t *srcQC = src->qConfig;
         memcpy(destQC, srcQC, sizeof(symInt32QConfig_t));
+        break;
+    case BOOL:
+        dest->type = BOOL;
+        dest->qConfig = NULL;
         break;
     default:
         PRINT_ERROR("Unknown QType!");

--- a/src/tensor/include/Quantization.h
+++ b/src/tensor/include/Quantization.h
@@ -3,7 +3,7 @@
 
 #include "Rounding.h"
 
-typedef enum qtype { INT32, FLOAT32, SYM_INT32, SYM, ASYM } qtype_t;
+typedef enum qtype { INT32, FLOAT32, SYM_INT32, SYM, ASYM, BOOL } qtype_t;
 
 typedef struct symInt32QConfig {
     float scale;
@@ -38,6 +38,7 @@ void initAsymQConfig(uint8_t qBits, roundingMode_t roundingMode, asymQConfig_t *
 
 void initInt32Quantization(quantization_t *quantization);
 void initFloat32Quantization(quantization_t *quantization);
+void initBoolQuantization(quantization_t *quantization);
 
 void initSymInt32Quantization(symInt32QConfig_t *symInt32QConfig, quantization_t *quantization);
 void initSymQuantization(symQConfig_t *symQConfig, quantization_t *quantization);

--- a/src/tensor/include/Tensor.h
+++ b/src/tensor/include/Tensor.h
@@ -1,6 +1,7 @@
 #ifndef ODT_TENSOR_H
 #define ODT_TENSOR_H
 
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -44,6 +45,9 @@ uint8_t readByte(uint8_t data, uint8_t startbit, uint8_t endbit);
 
 void byteConversion(uint8_t *dataIn, size_t dataInBits, uint8_t *dataOut, size_t dataOutBits,
                     size_t numValues);
+
+bool tensorBoolGet(tensor_t const *tensor, size_t flatIndex);
+void tensorBoolSet(tensor_t *tensor, size_t flatIndex, bool value);
 
 tensor_t *getParamFromParameter(parameter_t *parameter);
 tensor_t *getGradFromParameter(parameter_t *parameter);

--- a/src/userApi/tensor/QuantizationApi.c
+++ b/src/userApi/tensor/QuantizationApi.c
@@ -31,3 +31,9 @@ quantization_t *quantizationInitAsym(uint8_t qBits, roundingMode_t roundingMode)
     initAsymQuantization(qC, q);
     return q;
 }
+
+quantization_t *quantizationInitBool(void) {
+    quantization_t *q = reserveMemory(sizeof(quantization_t));
+    initBoolQuantization(q);
+    return q;
+}

--- a/src/userApi/tensor/TensorApi.c
+++ b/src/userApi/tensor/TensorApi.c
@@ -125,6 +125,21 @@ void tensorFillFromFloatBuffer(tensor_t *tensor, const float *source, size_t cou
     convertTensor(&srcView, tensor);
 }
 
+void tensorFillFromBoolBuffer(tensor_t *tensor, const bool *source, size_t count) {
+    size_t expected = calcNumberOfElementsByTensor(tensor);
+    if (count != expected) {
+        PRINT_ERROR("tensorFillFromBoolBuffer count mismatch (expected vs given)");
+        exit(1);
+    }
+    if (tensor->quantization->type != BOOL) {
+        PRINT_ERROR("tensorFillFromBoolBuffer requires BOOL-quantized tensor");
+        exit(1);
+    }
+    for (size_t i = 0; i < count; i++) {
+        tensorBoolSet(tensor, i, source[i]);
+    }
+}
+
 void initDistribution(tensor_t *tensor, const distribution_t *distribution) {
     if (tensor->quantization->type != FLOAT32) {
         PRINT_ERROR("initDistribution only supports FLOAT32 in this iteration");

--- a/src/userApi/tensor/include/QuantizationApi.h
+++ b/src/userApi/tensor/include/QuantizationApi.h
@@ -33,4 +33,12 @@ quantization_t *quantizationInitSymInt32(roundingMode_t roundingMode);
  */
 quantization_t *quantizationInitAsym(uint8_t qBits, roundingMode_t roundingMode);
 
+/* Note: uses (void) explicitly; siblings use () for historical K&R-style; the
+ * _Static_assert in UnitTestTensorApi pattern-matches (*)(void). */
+/*! Initializes bool quantization.
+ *
+ * \returns Pointer to initialized quantization
+ */
+quantization_t *quantizationInitBool(void);
+
 #endif // QUANTIZATIONAPI_H

--- a/src/userApi/tensor/include/TensorApi.h
+++ b/src/userApi/tensor/include/TensorApi.h
@@ -136,6 +136,17 @@ void initDistribution(tensor_t *tensor, const distribution_t *distribution);
  */
 void tensorFillFromFloatBuffer(tensor_t *tensor, const float *source, size_t count);
 
+/*! Copies `count` unpacked bools from a caller-owned source into a
+ *  bit-packed BOOL tensor's data buffer. Caller retains ownership
+ *  of `source`. Tensor must be BOOL-quantized and have its data buffer
+ *  already allocated (via initTensor).
+ *
+ *  \param tensor: Pre-initialized BOOL tensor.
+ *  \param source: Caller-owned bool array.
+ *  \param count: Number of bools; must equal the tensor's element count.
+ */
+void tensorFillFromBoolBuffer(tensor_t *tensor, const bool *source, size_t count);
+
 /*! Initializes int32 gradient tensor to match given param tensor.
  *
  * \param param: Pointer to param tensor

--- a/test/unit/tensor/CMakeLists.txt
+++ b/test/unit/tensor/CMakeLists.txt
@@ -32,3 +32,12 @@ add_elastic_ai_unit_test(
         QuantizationApi
         StorageApi
 )
+add_executable(UnitTestTensorBool UnitTestTensorBool.c)
+target_link_libraries(UnitTestTensorBool PRIVATE
+        unity
+        Tensor
+        Rounding
+        Quantization
+        StorageApi
+)
+__register_target_as_unit_test(UnitTestTensorBool)

--- a/test/unit/tensor/UnitTestTensor.c
+++ b/test/unit/tensor/UnitTestTensor.c
@@ -234,6 +234,37 @@ void testCopyTensor() {
     TEST_ASSERT_EQUAL_size_t_ARRAY(expectedOrderOfDims, dest.shape->orderOfDimensions, 2);
 }
 
+void test_calcBitsPerElement_Sym_qBits3() {
+    symQConfig_t cfg = {.scale = 1.0f, .qBits = 3, .roundingMode = HTE};
+    quantization_t q;
+    initSymQuantization(&cfg, &q);
+    TEST_ASSERT_EQUAL_size_t(3, calcBitsPerElement(&q));
+}
+
+void test_calcBytesPerElement_Sym_qBits3() {
+    symQConfig_t cfg = {.scale = 1.0f, .qBits = 3, .roundingMode = HTE};
+    quantization_t q;
+    initSymQuantization(&cfg, &q);
+    /* ceil(3/8) = 1 */
+    TEST_ASSERT_EQUAL_size_t(1, calcBytesPerElement(&q));
+}
+
+void test_calcNumberOfBytesForData_Sym_qBits3_N10() {
+    symQConfig_t cfg = {.scale = 1.0f, .qBits = 3, .roundingMode = HTE};
+    quantization_t q;
+    initSymQuantization(&cfg, &q);
+    /* ceil(3*10 / 8) = ceil(30/8) = 4 */
+    TEST_ASSERT_EQUAL_size_t(4, calcNumberOfBytesForData(&q, 10));
+}
+
+void test_calcNumberOfBytesForData_Sym_qBits5_N4() {
+    symQConfig_t cfg = {.scale = 1.0f, .qBits = 5, .roundingMode = HTE};
+    quantization_t q;
+    initSymQuantization(&cfg, &q);
+    /* ceil(5*4 / 8) = ceil(20/8) = 3 */
+    TEST_ASSERT_EQUAL_size_t(3, calcNumberOfBytesForData(&q, 4));
+}
+
 void setUp() {}
 void tearDown() {}
 
@@ -254,5 +285,10 @@ int main(void) {
     RUN_TEST(testReadByte);
 
     RUN_TEST(testCopyTensor);
+
+    RUN_TEST(test_calcBitsPerElement_Sym_qBits3);
+    RUN_TEST(test_calcBytesPerElement_Sym_qBits3);
+    RUN_TEST(test_calcNumberOfBytesForData_Sym_qBits3_N10);
+    RUN_TEST(test_calcNumberOfBytesForData_Sym_qBits5_N4);
     return UNITY_END();
 }

--- a/test/unit/tensor/UnitTestTensorApi.c
+++ b/test/unit/tensor/UnitTestTensorApi.c
@@ -31,6 +31,16 @@ _Static_assert(_Generic((&tensorFillFromFloatBuffer),
                    default: 0),
                "tensorFillFromFloatBuffer must take (tensor_t *, const float *, size_t)");
 
+/* Compile-time contract: quantizationInitBool returns quantization_t *. */
+_Static_assert(_Generic((&quantizationInitBool), quantization_t *(*)(void): 1, default: 0),
+               "quantizationInitBool must take () and return quantization_t *");
+
+/* Compile-time contract: tensorFillFromBoolBuffer takes (tensor_t *, const bool *, size_t). */
+_Static_assert(_Generic((&tensorFillFromBoolBuffer),
+                   void (*)(tensor_t *, const bool *, size_t): 1,
+                   default: 0),
+               "tensorFillFromBoolBuffer must take (tensor_t *, const bool *, size_t)");
+
 void setUp() {}
 void tearDown() {}
 
@@ -141,6 +151,16 @@ static tensor_t *makeFloatTensorForDistTest(size_t d0, size_t d1) {
     shape_t *shape = reserveMemory(sizeof(shape_t));
     setShape(shape, dims, 2, order);
     return initTensor(shape, quantizationInitFloat(), NULL);
+}
+
+static tensor_t *makeBoolTensorN(size_t n) {
+    size_t *dims = reserveMemory(1 * sizeof(size_t));
+    dims[0] = n;
+    size_t *order = reserveMemory(1 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(1, order);
+    shape_t *shape = reserveMemory(sizeof(shape_t));
+    setShape(shape, dims, 1, order);
+    return initTensor(shape, quantizationInitBool(), NULL);
 }
 
 void testInitDistribution_Zeros_AllValuesAreZero(void) {
@@ -314,6 +334,27 @@ void testInitDistribution_KaimingNormal_NotAllZero(void) {
 
     /* ASSERT. */
     TEST_ASSERT_TRUE(any_nonzero);
+}
+
+void testTensorFillFromBoolBuffer_RoundTrip_N12(void) {
+    /* N=12 → 2 bytes; mixed pattern across byte boundary. */
+    const bool source[12] = {true,  false, false, true,  true, false,
+                             false, true,  true,  false, true, true};
+
+    tensor_t *t = makeBoolTensorN(12);
+    tensorFillFromBoolBuffer(t, source, 12);
+
+    /* CAPTURE before free. */
+    bool captured[12];
+    for (size_t i = 0; i < 12; i++) {
+        captured[i] = tensorBoolGet(t, i);
+    }
+    freeTensor(t);
+
+    /* ASSERT on captured. */
+    for (size_t i = 0; i < 12; i++) {
+        TEST_ASSERT_EQUAL(source[i], captured[i]);
+    }
 }
 
 static void fillTensorFromStackArrayThatGoesOutOfScope(tensor_t *t) {
@@ -564,5 +605,6 @@ int main(void) {
     RUN_TEST(testInitDistribution_XavierNormal_NotAllZero);
     RUN_TEST(testInitDistribution_KaimingUniform_NotAllZero);
     RUN_TEST(testInitDistribution_KaimingNormal_NotAllZero);
+    RUN_TEST(testTensorFillFromBoolBuffer_RoundTrip_N12);
     return UNITY_END();
 }

--- a/test/unit/tensor/UnitTestTensorBool.c
+++ b/test/unit/tensor/UnitTestTensorBool.c
@@ -1,0 +1,222 @@
+#include "Quantization.h"
+#include "Tensor.h"
+#include "unity.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+/* Compile-time contract: initBoolQuantization takes (quantization_t *). */
+_Static_assert(_Generic((&initBoolQuantization), void (*)(quantization_t *): 1, default: 0),
+               "initBoolQuantization must take (quantization_t *)");
+
+/* Compile-time contract: tensorBoolGet / tensorBoolSet signatures. */
+_Static_assert(_Generic((&tensorBoolGet), bool (*)(tensor_t const *, size_t): 1, default: 0),
+               "tensorBoolGet must take (tensor_t const *, size_t) and return bool");
+
+_Static_assert(_Generic((&tensorBoolSet), void (*)(tensor_t *, size_t, bool): 1, default: 0),
+               "tensorBoolSet must take (tensor_t *, size_t, bool)");
+
+void setUp() {}
+void tearDown() {}
+
+void test_calcNumberOfBytesForData_Bool_N3() {
+    quantization_t q;
+    initBoolQuantization(&q);
+    TEST_ASSERT_EQUAL_size_t(1, calcNumberOfBytesForData(&q, 3));
+}
+
+void test_calcNumberOfBytesForData_Bool_N8() {
+    quantization_t q;
+    initBoolQuantization(&q);
+    TEST_ASSERT_EQUAL_size_t(1, calcNumberOfBytesForData(&q, 8));
+}
+
+void test_calcNumberOfBytesForData_Bool_N9() {
+    quantization_t q;
+    initBoolQuantization(&q);
+    TEST_ASSERT_EQUAL_size_t(2, calcNumberOfBytesForData(&q, 9));
+}
+
+void test_calcNumberOfBytesForData_Bool_N17() {
+    quantization_t q;
+    initBoolQuantization(&q);
+    TEST_ASSERT_EQUAL_size_t(3, calcNumberOfBytesForData(&q, 17));
+}
+
+void test_calcBytesPerElement_Bool() {
+    quantization_t q;
+    initBoolQuantization(&q);
+    TEST_ASSERT_EQUAL_size_t(1, calcBytesPerElement(&q));
+}
+
+void test_calcBitsPerElement_Bool() {
+    quantization_t q;
+    initBoolQuantization(&q);
+    TEST_ASSERT_EQUAL_size_t(1, calcBitsPerElement(&q));
+}
+
+void test_tensorBoolGet_AfterZeroInit_AllFalse() {
+    /* N=10 → 2 bytes; data is zero-initialized stack array */
+    uint8_t data[2] = {0, 0};
+    size_t dims[] = {10};
+    size_t orderOfDims[] = {0};
+    shape_t shape = {.numberOfDimensions = 1, .dimensions = dims, .orderOfDimensions = orderOfDims};
+    quantization_t q;
+    initBoolQuantization(&q);
+    tensor_t t;
+    setTensorValues(&t, data, &shape, &q, NULL);
+
+    for (size_t i = 0; i < 10; i++) {
+        TEST_ASSERT_FALSE(tensorBoolGet(&t, i));
+    }
+}
+
+void test_tensorBoolSetGet_RoundTrip_KnownPattern() {
+    /* Pattern with mix of byte boundaries (i=7→8) and last-byte padding. */
+    uint8_t data[2] = {0, 0};
+    size_t dims[] = {10};
+    size_t orderOfDims[] = {0};
+    shape_t shape = {.numberOfDimensions = 1, .dimensions = dims, .orderOfDimensions = orderOfDims};
+    quantization_t q;
+    initBoolQuantization(&q);
+    tensor_t t;
+    setTensorValues(&t, data, &shape, &q, NULL);
+
+    const bool expected[10] = {true, false, true, true, false, false, true, false, false, true};
+    for (size_t i = 0; i < 10; i++) {
+        tensorBoolSet(&t, i, expected[i]);
+    }
+    for (size_t i = 0; i < 10; i++) {
+        TEST_ASSERT_EQUAL(expected[i], tensorBoolGet(&t, i));
+    }
+}
+
+void test_tensorBoolSet_PreservesNeighborBits() {
+    /* Set bit 3, verify bits 0,1,2,4,5,6,7 are unchanged (zero). */
+    uint8_t data[1] = {0};
+    size_t dims[] = {8};
+    size_t orderOfDims[] = {0};
+    shape_t shape = {.numberOfDimensions = 1, .dimensions = dims, .orderOfDimensions = orderOfDims};
+    quantization_t q;
+    initBoolQuantization(&q);
+    tensor_t t;
+    setTensorValues(&t, data, &shape, &q, NULL);
+
+    tensorBoolSet(&t, 3, true);
+
+    /* Bit 3 only → byte value should be 0b00001000 = 8 (LSB-first). */
+    TEST_ASSERT_EQUAL_UINT8(0b00001000, data[0]);
+}
+
+void test_tensorBoolSet_PaddingBitsRemainZero_N3() {
+    /* N=3: bits 3..7 are padding, must stay zero after setting bits 0,1,2. */
+    uint8_t data[1] = {0};
+    size_t dims[] = {3};
+    size_t orderOfDims[] = {0};
+    shape_t shape = {.numberOfDimensions = 1, .dimensions = dims, .orderOfDimensions = orderOfDims};
+    quantization_t q;
+    initBoolQuantization(&q);
+    tensor_t t;
+    setTensorValues(&t, data, &shape, &q, NULL);
+
+    tensorBoolSet(&t, 0, true);
+    tensorBoolSet(&t, 1, true);
+    tensorBoolSet(&t, 2, true);
+
+    /* Bits 0,1,2 set; bits 3..7 zero → 0b00000111 = 7. */
+    TEST_ASSERT_EQUAL_UINT8(0b00000111, data[0]);
+}
+
+void test_tensorBoolSet_ClearsBit() {
+    /* Start with byte=0xFF, clear bit 2, expect 0xFB. */
+    uint8_t data[1] = {0xFF};
+    size_t dims[] = {8};
+    size_t orderOfDims[] = {0};
+    shape_t shape = {.numberOfDimensions = 1, .dimensions = dims, .orderOfDimensions = orderOfDims};
+    quantization_t q;
+    initBoolQuantization(&q);
+    tensor_t t;
+    setTensorValues(&t, data, &shape, &q, NULL);
+
+    tensorBoolSet(&t, 2, false);
+
+    TEST_ASSERT_EQUAL_UINT8(0b11111011, data[0]);
+}
+
+void test_copyTensorBool_AllBitsMatch() {
+    /* Source: 10 elements with known pattern. */
+    uint8_t srcData[2];
+    uint8_t dstData[2] = {0, 0};
+
+    /* Build src with pattern via accessor (round-tripped previously). */
+    size_t srcDims[] = {10};
+    size_t srcOrder[] = {0};
+    shape_t srcShape = {
+        .numberOfDimensions = 1, .dimensions = srcDims, .orderOfDimensions = srcOrder};
+    quantization_t qSrc;
+    initBoolQuantization(&qSrc);
+    tensor_t src;
+    /* Zero src first so set-only test is deterministic. */
+    memset(srcData, 0, sizeof(srcData));
+    setTensorValues(&src, srcData, &srcShape, &qSrc, NULL);
+
+    const bool pattern[10] = {true, true, false, true, false, true, false, false, true, true};
+    for (size_t i = 0; i < 10; i++) {
+        tensorBoolSet(&src, i, pattern[i]);
+    }
+
+    /* Build dst with matching size; copyTensor will fill shape/quant/data. */
+    size_t dstDims[1];
+    size_t dstOrder[1];
+    shape_t dstShape = {
+        .numberOfDimensions = 0, .dimensions = dstDims, .orderOfDimensions = dstOrder};
+    quantization_t qDst;
+    initFloat32Quantization(&qDst); /* will be overwritten by copyQuantization */
+    tensor_t dst;
+    setTensorValues(&dst, dstData, &dstShape, &qDst, NULL);
+
+    copyTensor(&dst, &src);
+
+    /* Assert dst->quantization->type now BOOL. */
+    TEST_ASSERT_EQUAL_INT(BOOL, dst.quantization->type);
+
+    /* Assert bit-for-bit equality via accessor. */
+    for (size_t i = 0; i < 10; i++) {
+        TEST_ASSERT_EQUAL(pattern[i], tensorBoolGet(&dst, i));
+    }
+}
+
+void test_printTensorBool_Smoke() {
+    /* Just verify no crash on a small BOOL tensor; output goes to stdout. */
+    uint8_t data[1] = {0b00000101}; /* bits 0 and 2 set */
+    size_t dims[] = {3};
+    size_t orderOfDims[] = {0};
+    shape_t shape = {.numberOfDimensions = 1, .dimensions = dims, .orderOfDimensions = orderOfDims};
+    quantization_t q;
+    initBoolQuantization(&q);
+    tensor_t t;
+    setTensorValues(&t, data, &shape, &q, NULL);
+
+    printTensor(&t); /* must return cleanly */
+    TEST_PASS();
+}
+
+int main(void) {
+    UNITY_BEGIN();
+    RUN_TEST(test_calcNumberOfBytesForData_Bool_N3);
+    RUN_TEST(test_calcNumberOfBytesForData_Bool_N8);
+    RUN_TEST(test_calcNumberOfBytesForData_Bool_N9);
+    RUN_TEST(test_calcNumberOfBytesForData_Bool_N17);
+    RUN_TEST(test_calcBytesPerElement_Bool);
+    RUN_TEST(test_calcBitsPerElement_Bool);
+    RUN_TEST(test_tensorBoolGet_AfterZeroInit_AllFalse);
+    RUN_TEST(test_tensorBoolSetGet_RoundTrip_KnownPattern);
+    RUN_TEST(test_tensorBoolSet_PreservesNeighborBits);
+    RUN_TEST(test_tensorBoolSet_PaddingBitsRemainZero_N3);
+    RUN_TEST(test_tensorBoolSet_ClearsBit);
+    RUN_TEST(test_copyTensorBool_AllBitsMatch);
+    RUN_TEST(test_printTensorBool_Smoke);
+    return UNITY_END();
+}


### PR DESCRIPTION
## Summary

- Adds `BOOL` value to `qtype_t` representing 1-bit-per-element bit-packed storage.
- Adds `initBoolQuantization` (stack-fill) and `quantizationInitBool` (heap, Two-Tier convention).
- Adds `tensorBoolGet` / `tensorBoolSet` bit accessors and `tensorFillFromBoolBuffer` userApi helper.
- Wires BOOL into five dispatch switches in `src/tensor/Tensor.c` (`calcBytesPerElement`, `calcBitsPerElement`, `calcNumberOfBytesForData`, `copyQuantization`, `printTensor`).
- Bundles the SYM-Lückenschluss bugfix as a separate commit — the three calc-function switches were missing SYM cases pre-existing and would trip `default: PRINT_ERROR; exit(1)`.

## Architecture

BOOL is bit-packed (1 bit per element, LSB-first within each byte, matching the existing `getBitmask` / `readByte` / `writeByte` convention). Last-byte padding is always zero by construction (init zeroes the buffer, set/get touch only the target bit). `qConfig` is `NULL` for BOOL (no scale/zero-point parameters).

This is the prerequisite for the upcoming Dropout layer (#149) — the per-element mask between forward and backward needs ~32× less memory bit-packed.

## Test Plan

- [x] `test/unit/tensor/UnitTestTensorBool.c` (new) — 13 tests covering byte/bit counts, accessors, padding invariants, copyTensor, printTensor.
- [x] `test/unit/tensor/UnitTestTensor.c` — 4 SYM regression tests for the three calc functions.
- [x] `test/unit/tensor/UnitTestTensorApi.c` — `tensorFillFromBoolBuffer` round-trip test.
- [x] Mutation testing per spec §7.3 — all 7 mutations caught (table below).
- [x] Full `ctest` 43/43 green on macOS host.

## Verified Mutations

| # | Mutation | Test that fired |
|---|---|---|
| 1 | `tensorBoolSet` bit-index off-by-one | `test_tensorBoolSetGet_RoundTrip_KnownPattern` |
| 2 | `tensorBoolGet` bit-index off-by-one | `test_tensorBoolSetGet_RoundTrip_KnownPattern` |
| 3 | `calcNumberOfBytesForData` BOOL truncated divide | `test_calcNumberOfBytesForData_Bool_N3` |
| 4 | `calcBitsPerElement` SYM case removed | `test_calcBitsPerElement_Sym_qBits3` |
| 5 | `tensorFillFromBoolBuffer` loop no-op | `testTensorFillFromBoolBuffer_RoundTrip_N12` |
| 6 | `copyQuantization` BOOL case removed | `test_copyTensorBool_AllBitsMatch` |
| 7 | `tensorBoolSet` byte-index off-by-one | `testTensorFillFromBoolBuffer_RoundTrip_N12` |

## References

Closes #169 (BOOL bit-packed dtype implementation)
Closes #170 (SYM-Lückenschluss in three calc functions)

See also #160 (N=0 latent hazard — behavior inherited unchanged)
See also #171 (`copyQuantization` missing INT32/SYM/ASYM cases — separate scope, this PR adds only BOOL)
See also #172 (`calcBytesPerTensor` truncates for sub-byte dtypes — discovered during review, pre-existing)

Note: `Closes #NN` auto-close only triggers on main-merges; develop-merges need manual `gh issue close` per repo convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)