### PR TITLE
feat(userApi): layer factory API — PR 1 (infra + Linear/ReLU/Flatten)

### DIFF
--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -126,8 +126,8 @@ consumed by `initTensor` — that is a double-free. The cascade table:
 |-------------------------------------------|----------------------|-------------------------------------|
 | `initTensor(s, q, sp)`                    | `freeTensor(t)`      | data, shape (+dims, +order), q, sp  |
 | `parameterInit(p, g)`                     | `freeParameter(par)` | param tensor + grad (if non-NULL)   |
-| `linearLayerInit(...)`                    | `freeLinearLayer(l)` | layer config wrapper only           |
-| `reluLayerInit(...)`                      | `freeReluLayer(l)`   | layer config wrapper only           |
+| `linearLayerInitLegacy(...)`              | `freeLinearLayerLegacy(l)` | layer config wrapper only     |
+| `reluLayerInitLegacy(...)`                | `freeReluLayerLegacy(l)` | layer config wrapper only       |
 | `softmaxLayerInit(...)`                   | `freeSoftmaxLayer(l)`| layer config wrapper only           |
 | `sgdMCreateOptim(...)`                    | `freeOptimSgdM(o)`   | all registered parameters + states  |
 | `inference(...)` (returns `tensor_t *`)   | `freeTensor(out)`    | as above                            |

--- a/examples/ecg_anomaly_ae/train_c.c
+++ b/examples/ecg_anomaly_ae/train_c.c
@@ -272,7 +272,7 @@ static void buildModel(layer_t **model) {
         buildParam(XAVIER_UNIFORM, e1_w_data, e1_w_dims, 3, IN_CHANNELS * E1_K, E1_OUT * E1_K);
     parameter_t *e1_b = buildParam(ZEROS, e1_b_data, e1_b_dims, 1, 1, E1_OUT);
     model[0] = conv1dLayerInit(e1_w, e1_b, e1k, q, q, q, q);
-    model[1] = reluLayerInit(quantizationInitFloat(), quantizationInitFloat());
+    model[1] = reluLayerInitLegacy(quantizationInitFloat(), quantizationInitFloat());
 
     /* Block P1: MaxPool1d(K=2, S=2). 70 → 35. */
     model[2] = buildMaxPool1dLayer(/*K*/ 2, /*S*/ 2, /*outC*/ E1_OUT, /*outLen*/ 35);
@@ -285,7 +285,7 @@ static void buildModel(layer_t **model) {
     parameter_t *e2_b = buildParam(ZEROS, e2_b_data, e2_b_dims, 1, 1, E2_OUT);
     model[3] = conv1dLayerInit(e2_w, e2_b, e2k, quantizationInitFloat(), quantizationInitFloat(),
                                quantizationInitFloat(), quantizationInitFloat());
-    model[4] = reluLayerInit(quantizationInitFloat(), quantizationInitFloat());
+    model[4] = reluLayerInitLegacy(quantizationInitFloat(), quantizationInitFloat());
 
     /* Block P2: AvgPool1d(K=5, S=5). 35 → 7 (bottleneck). */
     model[5] = buildAvgPool1dLayer(/*K*/ 5, /*S*/ 5);
@@ -298,7 +298,7 @@ static void buildModel(layer_t **model) {
     parameter_t *d1_b = buildParam(ZEROS, d1_b_data, d1_b_dims, 1, 1, D1_OUT);
     model[6] = buildConv1dTransposedLayer(d1_w, d1_b, /*K*/ D1_K, /*S*/ D1_S,
                                           /*outputPadding*/ 0, /*groups*/ 1);
-    model[7] = reluLayerInit(quantizationInitFloat(), quantizationInitFloat());
+    model[7] = reluLayerInitLegacy(quantizationInitFloat(), quantizationInitFloat());
 
     /* Block D2: Conv1dTransposed(8→4, K=2, S=2, op=0). 35 → 70. ReLU. */
     parameter_t *d2_w =
@@ -306,7 +306,7 @@ static void buildModel(layer_t **model) {
     parameter_t *d2_b = buildParam(ZEROS, d2_b_data, d2_b_dims, 1, 1, D2_OUT);
     model[8] = buildConv1dTransposedLayer(d2_w, d2_b, /*K*/ D2_K, /*S*/ D2_S,
                                           /*outputPadding*/ 0, /*groups*/ 1);
-    model[9] = reluLayerInit(quantizationInitFloat(), quantizationInitFloat());
+    model[9] = reluLayerInitLegacy(quantizationInitFloat(), quantizationInitFloat());
 
     /* Block D3: Conv1dTransposed(4→1, K=2, S=2, op=0). 70 → 140. NO ReLU on final. */
     parameter_t *d3_w =

--- a/examples/har_classifier/train_c.c
+++ b/examples/har_classifier/train_c.c
@@ -265,7 +265,7 @@ static void buildModel(layer_t **model) {
         buildParam(XAVIER_UNIFORM, c1_w_data, c1_w_dims, 3, IN_CHANNELS * C1_K, C1_OUT * C1_K);
     parameter_t *c1_b = buildParam(ZEROS, c1_b_data, c1_b_dims, 1, 1, C1_OUT);
     model[0] = conv1dLayerInit(c1_w, c1_b, k1, q1, q2, q3, q4);
-    model[1] = reluLayerInit(quantizationInitFloat(), quantizationInitFloat());
+    model[1] = reluLayerInitLegacy(quantizationInitFloat(), quantizationInitFloat());
     model[2] = buildMaxPool1dLayer(2, 2, C1_OUT, LEN_INPUT / 2);
 
     /* Block 2: Conv1d(16->32, K=5, padding=SAME), ReLU, MaxPool(K=2,S=2). */
@@ -276,7 +276,7 @@ static void buildModel(layer_t **model) {
     parameter_t *c2_b = buildParam(ZEROS, c2_b_data, c2_b_dims, 1, 1, C2_OUT);
     model[3] = conv1dLayerInit(c2_w, c2_b, k2, quantizationInitFloat(), quantizationInitFloat(),
                                quantizationInitFloat(), quantizationInitFloat());
-    model[4] = reluLayerInit(quantizationInitFloat(), quantizationInitFloat());
+    model[4] = reluLayerInitLegacy(quantizationInitFloat(), quantizationInitFloat());
     model[5] = buildMaxPool1dLayer(2, 2, C2_OUT, LEN_INPUT / 4);
 
     /* Block 3: Conv1d(32->64, K=3, padding=SAME), ReLU, AvgPool(K=32,S=32). */
@@ -287,15 +287,15 @@ static void buildModel(layer_t **model) {
     parameter_t *c3_b = buildParam(ZEROS, c3_b_data, c3_b_dims, 1, 1, C3_OUT);
     model[6] = conv1dLayerInit(c3_w, c3_b, k3, quantizationInitFloat(), quantizationInitFloat(),
                                quantizationInitFloat(), quantizationInitFloat());
-    model[7] = reluLayerInit(quantizationInitFloat(), quantizationInitFloat());
+    model[7] = reluLayerInitLegacy(quantizationInitFloat(), quantizationInitFloat());
     model[8] = buildAvgPool1dLayer(LEN_INPUT / 4, LEN_INPUT / 4);
 
     /* Head: Flatten, Linear(64 -> 6), Softmax. */
     model[9] = flattenLayerInit();
     parameter_t *fc_w = buildParam(XAVIER_UNIFORM, fc_w_data, fc_w_dims, 2, C3_OUT, NUM_CLASSES);
     parameter_t *fc_b = buildParam(ZEROS, fc_b_data, fc_b_dims, 2, 1, NUM_CLASSES);
-    model[10] = linearLayerInit(fc_w, fc_b, quantizationInitFloat(), quantizationInitFloat(),
-                                quantizationInitFloat(), quantizationInitFloat());
+    model[10] = linearLayerInitLegacy(fc_w, fc_b, quantizationInitFloat(), quantizationInitFloat(),
+                                      quantizationInitFloat(), quantizationInitFloat());
     model[11] = softmaxLayerInit(quantizationInitFloat(), quantizationInitFloat());
 }
 

--- a/src/layer/include/Linear.h
+++ b/src/layer/include/Linear.h
@@ -1,5 +1,7 @@
 #ifndef ENV5_RUNTIME_LINEAR_H
 #define ENV5_RUNTIME_LINEAR_H
+#include <stdbool.h>
+
 #include "Tensor.h"
 
 typedef struct layer layer_t;
@@ -12,6 +14,9 @@ typedef struct linearConfig {
     quantization_t *weightGradQ;
     quantization_t *biasGradQ;
     quantization_t *propLossQ;
+
+    bool ownsQuantizations; /* true → free* will tear down forwardQ/weightGradQ/biasGradQ/propLossQ
+                               and their qConfigs */
 } linearConfig_t;
 
 void linearInitConfig(linearConfig_t *linearConfig, parameter_t *weights, parameter_t *bias,

--- a/src/layer/include/Relu.h
+++ b/src/layer/include/Relu.h
@@ -1,6 +1,8 @@
 #ifndef ENV5_RUNTIME_RELU_H
 #define ENV5_RUNTIME_RELU_H
 
+#include <stdbool.h>
+
 #include "Tensor.h"
 
 typedef struct layer layer_t;
@@ -8,6 +10,7 @@ typedef struct layer layer_t;
 typedef struct reluConfig {
     quantization_t *forwardQ;
     quantization_t *backwardQ;
+    bool ownsQuantizations;
 } reluConfig_t;
 
 void reluInit(reluConfig_t *reluConfig, quantization_t *forwardQ, quantization_t *backwardQ);

--- a/src/userApi/CMakeLists.txt
+++ b/src/userApi/CMakeLists.txt
@@ -5,6 +5,9 @@ add_subdirectory(tensor)
 add_subdirectory(training_loop)
 
 
+add_library(LayerCommon INTERFACE)
+target_include_directories(LayerCommon INTERFACE include)
+
 add_library(InferenceApi InferenceApi.c)
 target_include_directories(InferenceApi PUBLIC include)
 target_link_libraries(InferenceApi PRIVATE
@@ -27,5 +30,33 @@ target_link_libraries(StorageApi PRIVATE
         Tensor
         Rounding
         Common
+)
+
+add_library(LayerQuant LayerQuant.c)
+target_include_directories(LayerQuant PUBLIC include)
+target_link_libraries(LayerQuant PRIVATE
+        Quantization
+        Rounding
+)
+
+add_library(LayerWeightsApi LayerWeightsApi.c)
+target_include_directories(LayerWeightsApi PUBLIC include)
+target_link_libraries(LayerWeightsApi PRIVATE
+        Common
+        Layer
+        Linear
+        Rounding
+        Tensor
+)
+
+add_library(StateDictApi StateDictApi.c)
+target_include_directories(StateDictApi PUBLIC include)
+target_link_libraries(StateDictApi PRIVATE
+        Common
+        Layer
+        LayerWeightsApi
+        StorageApi
+        Tensor
+        Rounding
 )
 

--- a/src/userApi/LayerQuant.c
+++ b/src/userApi/LayerQuant.c
@@ -1,0 +1,10 @@
+#define SOURCE_FILE "LAYER_QUANT"
+
+#include "LayerQuant.h"
+
+void layerQuantInitUniform(layerQuant_t *lq, quantization_t *q) {
+    lq->forwardMath = q;
+    lq->backwardMath = q;
+    lq->weightStorage = q;
+    lq->biasStorage = q;
+}

--- a/src/userApi/LayerWeightsApi.c
+++ b/src/userApi/LayerWeightsApi.c
@@ -1,0 +1,62 @@
+#define SOURCE_FILE "LAYER_WEIGHTS_API"
+
+#include "LayerWeightsApi.h"
+#include "Common.h"
+#include "Linear.h"
+#include "Tensor.h"
+#include <stdlib.h>
+#include <string.h>
+
+void layerLoadWeights(layer_t *layer, float *weightData, float *biasData) {
+    if (layer == NULL) {
+        PRINT_ERROR("layerLoadWeights: layer is NULL");
+        exit(1);
+    }
+    if (weightData == NULL) {
+        PRINT_ERROR("layerLoadWeights: weightData is NULL");
+        exit(1);
+    }
+
+    switch (layer->type) {
+    case LINEAR: {
+        linearConfig_t *cfg = layer->config->linear;
+        if (cfg->weights == NULL) {
+            PRINT_ERROR("layerLoadWeights LINEAR: layer has no weight parameter");
+            exit(1);
+        }
+        tensor_t *weightTensor = cfg->weights->param;
+        size_t numWeightElements = calcNumberOfElementsByTensor(weightTensor);
+        memcpy(weightTensor->data, weightData, numWeightElements * sizeof(float));
+
+        if (cfg->bias != NULL) {
+            if (biasData == NULL) {
+                PRINT_ERROR("layerLoadWeights LINEAR: layer has bias but biasData is NULL");
+                exit(1);
+            }
+            tensor_t *biasTensor = cfg->bias->param;
+            size_t numBiasElements = calcNumberOfElementsByTensor(biasTensor);
+            memcpy(biasTensor->data, biasData, numBiasElements * sizeof(float));
+        } else if (biasData != NULL) {
+            PRINT_ERROR("layerLoadWeights LINEAR: layer has no bias but biasData is non-NULL");
+            exit(1);
+        }
+        break;
+    }
+    case RELU:
+    case SOFTMAX:
+    case FLATTEN:
+    case MAXPOOL1D:
+    case AVGPOOL1D:
+        PRINT_ERROR("layerLoadWeights: layer type %d has no parameters to load", (int)layer->type);
+        exit(1);
+    case CONV1D:
+    case CONV1D_TRANSPOSED:
+        PRINT_ERROR("layerLoadWeights: layer type %d dispatch not implemented (TODO PR 2)",
+                    (int)layer->type);
+        exit(1);
+    default:
+        PRINT_ERROR("layerLoadWeights: dispatch not implemented for layer type %d",
+                    (int)layer->type);
+        exit(1);
+    }
+}

--- a/src/userApi/StateDictApi.c
+++ b/src/userApi/StateDictApi.c
@@ -1,0 +1,62 @@
+#define SOURCE_FILE "STATE_DICT_API"
+
+#include "StateDictApi.h"
+#include "Common.h"
+#include "LayerWeightsApi.h"
+#include <stdbool.h>
+#include <stdlib.h>
+
+static bool layerHasParameters(layer_t *layer) {
+    switch (layer->type) {
+    case LINEAR:
+    case CONV1D:
+    case CONV1D_TRANSPOSED:
+        return true;
+    case RELU:
+    case SOFTMAX:
+    case FLATTEN:
+    case MAXPOOL1D:
+    case AVGPOOL1D:
+    case QUANTIZATION:
+        return false;
+    default:
+        PRINT_ERROR("layerHasParameters: unknown layer type %d", (int)layer->type);
+        exit(1);
+    }
+}
+
+void modelLoadStateDict(layer_t **model, size_t numLayers, stateDictEntry_t *entries,
+                        size_t numEntries) {
+    /* First pass: count param layers and verify entry count matches. */
+    size_t numParamLayers = 0;
+    for (size_t i = 0; i < numLayers; i++) {
+        if (layerHasParameters(model[i])) {
+            numParamLayers++;
+        }
+    }
+    if (numParamLayers != numEntries) {
+        PRINT_ERROR("modelLoadStateDict: model has %zu param layers but %zu entries provided",
+                    numParamLayers, numEntries);
+        exit(1);
+    }
+
+    /* Second pass: load each param layer in order. */
+    size_t entryIdx = 0;
+    for (size_t i = 0; i < numLayers; i++) {
+        if (!layerHasParameters(model[i])) {
+            continue;
+        }
+        stateDictEntry_t *e = &entries[entryIdx];
+        if (e->weightData == NULL) {
+            if (e->name != NULL) {
+                PRINT_ERROR("modelLoadStateDict: entry '%s' (#%zu): weightData is NULL", e->name,
+                            entryIdx);
+            } else {
+                PRINT_ERROR("modelLoadStateDict: entry #%zu: weightData is NULL", entryIdx);
+            }
+            exit(1);
+        }
+        layerLoadWeights(model[i], e->weightData, e->biasData);
+        entryIdx++;
+    }
+}

--- a/src/userApi/include/LayerCommon.h
+++ b/src/userApi/include/LayerCommon.h
@@ -1,0 +1,18 @@
+#ifndef LAYER_COMMON_H
+#define LAYER_COMMON_H
+
+#include <assert.h>
+
+/*! Bias presence tri-state for layer init structs.
+ *  BIAS_DEFAULT lands at C99 zero-init; factories resolve it to the PyTorch
+ *  default for that layer type (true for Conv / Linear).  */
+typedef enum {
+    BIAS_DEFAULT = 0,
+    BIAS_TRUE = 1,
+    BIAS_FALSE = 2,
+} bias_t;
+
+_Static_assert(BIAS_DEFAULT == 0,
+               "BIAS_DEFAULT must be enum value 0 so .bias zero-init defaults to PyTorch default");
+
+#endif /* LAYER_COMMON_H */

--- a/src/userApi/include/LayerQuant.h
+++ b/src/userApi/include/LayerQuant.h
@@ -1,0 +1,25 @@
+#ifndef LAYER_QUANT_H
+#define LAYER_QUANT_H
+
+#include "Quantization.h"
+
+/*! Per-layer quantization profile.
+ *
+ *  Each layer factory reads only the fields it needs (documented in each
+ *  layer's header).  For every field it reads, NULL is a fatal error
+ *  (PRINT_ERROR + exit).  Fields the layer doesn't read are ignored, so a
+ *  single fully-populated layerQuant_t can be shared across all layers in
+ *  a model.  */
+typedef struct layerQuant {
+    quantization_t *forwardMath;   /* REQUIRED for every layer except Flatten */
+    quantization_t *backwardMath;  /* REQUIRED for every layer except Flatten */
+    quantization_t *weightStorage; /* REQUIRED for Conv1d / Conv1dTransposed / Linear */
+    quantization_t
+        *biasStorage; /* REQUIRED for Conv1d / Conv1dTransposed / Linear when bias is enabled */
+} layerQuant_t;
+
+/*! Populate all four slots of `lq` with the same `q`.  Convenience for the
+ *  common all-same-quantization case.  Caller retains ownership of `q`. */
+void layerQuantInitUniform(layerQuant_t *lq, quantization_t *q);
+
+#endif /* LAYER_QUANT_H */

--- a/src/userApi/include/LayerWeightsApi.h
+++ b/src/userApi/include/LayerWeightsApi.h
@@ -1,0 +1,19 @@
+#ifndef LAYER_WEIGHTS_API_H
+#define LAYER_WEIGHTS_API_H
+
+#include "Layer.h"
+
+/*! Overwrite the (already-initialized) weight and bias tensors of `layer`
+ *  from the provided buffers. Dispatches by layer->type.
+ *
+ *  Errors (PRINT_ERROR + exit):
+ *   - layer == NULL or weightData == NULL
+ *   - layer has no parameters (ReLU/Softmax/Flatten/MaxPool/AvgPool)
+ *   - biasData == NULL but layer was built with bias enabled
+ *   - biasData != NULL but layer was built with bias disabled
+ *
+ *  Buffer length is the responsibility of the caller — it must match the
+ *  tensor allocation the factory performed for this layer. */
+void layerLoadWeights(layer_t *layer, float *weightData, float *biasData);
+
+#endif /* LAYER_WEIGHTS_API_H */

--- a/src/userApi/include/StateDictApi.h
+++ b/src/userApi/include/StateDictApi.h
@@ -1,0 +1,26 @@
+#ifndef STATE_DICT_API_H
+#define STATE_DICT_API_H
+
+#include "Layer.h"
+#include <stddef.h>
+
+typedef struct stateDictEntry {
+    const char *name; /* OPTIONAL — used only in error messages */
+    float *weightData;
+    float *biasData; /* NULL allowed iff the corresponding layer has no bias */
+} stateDictEntry_t;
+
+/*! Load weights/biases from entries[] into the parameter layers of model,
+ *  in the order they appear. Param-less layers are skipped.
+ *
+ *  Errors (PRINT_ERROR + exit):
+ *   - numEntries != count of param layers in model
+ *   - any entry's weightData == NULL
+ *   - bias presence in entry does not match bias presence in the corresponding layer
+ *
+ *  Error messages include entries[i].name if non-NULL, otherwise the
+ *  param-layer index (0-based). */
+void modelLoadStateDict(layer_t **model, size_t numLayers, stateDictEntry_t *entries,
+                        size_t numEntries);
+
+#endif /* STATE_DICT_API_H */

--- a/src/userApi/layer/CMakeLists.txt
+++ b/src/userApi/layer/CMakeLists.txt
@@ -15,9 +15,13 @@ target_include_directories(LinearApi PUBLIC include)
 target_link_libraries(LinearApi PRIVATE
         Tensor
         TensorApi
+        QuantizationApi
         Rounding
         Layer
         Linear
+        LayerCommon
+        LayerQuant
+        Distributions
         Common
         StorageApi
 )
@@ -29,6 +33,8 @@ target_link_libraries(ReluApi PRIVATE
         Rounding
         Layer
         Relu
+        LayerQuant
+        Quantization
         Common
         StorageApi
 )

--- a/src/userApi/layer/LinearApi.c
+++ b/src/userApi/layer/LinearApi.c
@@ -1,10 +1,17 @@
 #define SOURCE_FILE "LINEAR_API"
 
+#include <stdbool.h>
 #include <stdlib.h>
+#include <string.h>
 
+#include "Common.h"
+#include "Distributions.h"
 #include "Layer.h"
+#include "LayerCommon.h"
+#include "LayerQuant.h"
 #include "Linear.h"
 #include "LinearApi.h"
+#include "QuantizationApi.h"
 #include "StorageApi.h"
 #include "Tensor.h"
 #include "TensorApi.h"
@@ -26,6 +33,7 @@ layer_t *linearLayerInit(parameter_t *weights, parameter_t *bias, quantization_t
     linearConfig->weightGradQ = weightGradsQ;
     linearConfig->biasGradQ = biasGradsQ;
     linearConfig->propLossQ = propLossQ;
+    linearConfig->ownsQuantizations = false;
 
     linearLayer->config = layerConfig;
 
@@ -44,6 +52,7 @@ layer_t *linearLayerInitNonTrainable(tensor_t *weights, tensor_t *bias, quantiza
     linearConfig->weights = parameterInit(weights, NULL);
     linearConfig->bias = parameterInit(bias, NULL);
     linearConfig->forwardQ = forwardQ;
+    linearConfig->ownsQuantizations = false;
 
     linearLayer->config = layerConfig;
 
@@ -52,6 +61,275 @@ layer_t *linearLayerInitNonTrainable(tensor_t *weights, tensor_t *bias, quantiza
 
 void freeLinearLayer(layer_t *linearLayer) {
     freeReservedMemory(linearLayer->config->linear);
+    freeReservedMemory(linearLayer->config);
+    freeReservedMemory(linearLayer);
+}
+
+/* ============================================================================
+ * New factory API — layerQuant_t profile + linearInit_t struct (PR 1).
+ * ========================================================================== */
+
+static bool resolveLinearBias(bias_t b) {
+    switch (b) {
+    case BIAS_DEFAULT:
+        return true; /* PyTorch parity for Linear */
+    case BIAS_TRUE:
+        return true;
+    case BIAS_FALSE:
+        return false;
+    default:
+        PRINT_ERROR("linearLayerInit: invalid bias value (got %d)", (int)b);
+        exit(1);
+    }
+}
+
+/*! Build a heap-owned shape_t with the given dims; the tensor that this shape
+ *  is passed to takes ownership and freeTensor cascades into freeShape. */
+static shape_t *buildOwnedShape(const size_t *srcDims, size_t numberOfDims) {
+    size_t *dims = reserveMemory(numberOfDims * sizeof(size_t));
+    for (size_t i = 0; i < numberOfDims; i++) {
+        dims[i] = srcDims[i];
+    }
+    size_t *order = reserveMemory(numberOfDims * sizeof(size_t));
+    setOrderOfDimsForNewTensor(numberOfDims, order);
+    shape_t *shape = reserveMemory(sizeof(shape_t));
+    setShape(shape, dims, numberOfDims, order);
+    return shape;
+}
+
+static parameter_t *allocateLinearWeights(size_t inFeatures, size_t outFeatures,
+                                          quantization_t *storageQ) {
+    /* Weight tensor: shape [outFeatures, inFeatures]. The tensor takes ownership
+     * of `shape` and `quantization`, so we clone the borrowed storageQ via
+     * getQLike to avoid tying the tensor's lifetime to the caller's quant. */
+    shape_t *shape = buildOwnedShape((size_t[]){outFeatures, inFeatures}, 2);
+    tensor_t *paramTensor = initTensor(shape, getQLike(storageQ), NULL);
+
+    /* PyTorch-aligned default: Kaiming uniform with fan_in mode.
+     * Note: PyTorch's actual default uses a=sqrt(5); bit-identical parity
+     * requires Issue C (distribution parametrization). The current
+     * tensorInitWithDistribution gain (sqrtf(2.0f)) is preserved here. */
+    if (storageQ->type != FLOAT32) {
+        PRINT_ERROR("linearLayerInit: KAIMING_UNIFORM init currently requires FLOAT32 "
+                    "weight storage (Issue C will lift this limit)");
+        exit(1);
+    }
+    distribution_t dist = {
+        .type = KAIMING_UNIFORM,
+        .params.kaiming = {.gain = 1.4142135623730951f /* sqrtf(2.0f) */, .fanMode = inFeatures},
+    };
+    initDistribution(paramTensor, &dist);
+
+    tensor_t *gradTensor = gradInitFloat(paramTensor, NULL);
+    return parameterInit(paramTensor, gradTensor);
+}
+
+static parameter_t *allocateLinearBias(size_t outFeatures, quantization_t *storageQ) {
+    /* Bias tensor: shape [outFeatures]. Initialized to ZEROS, which initTensor
+     * already provides (reserveMemory == calloc), so no fill is needed. */
+    shape_t *shape = buildOwnedShape((size_t[]){outFeatures}, 1);
+    tensor_t *paramTensor = initTensor(shape, getQLike(storageQ), NULL);
+    /* No initDistribution(ZEROS) call needed: data is already zero from calloc. */
+
+    tensor_t *gradTensor = gradInitFloat(paramTensor, NULL);
+    return parameterInit(paramTensor, gradTensor);
+}
+
+static void validateLinearInit(linearInit_t *init) {
+    if (init == NULL) {
+        PRINT_ERROR("linearLayerInit: init pointer is NULL");
+        exit(1);
+    }
+    if (init->inFeatures == 0) {
+        PRINT_ERROR("linearLayerInit: inFeatures must be > 0 (got 0)");
+        exit(1);
+    }
+    if (init->outFeatures == 0) {
+        PRINT_ERROR("linearLayerInit: outFeatures must be > 0 (got 0)");
+        exit(1);
+    }
+}
+
+static void validateLayerQuantForLinear(layerQuant_t *lq, bool hasBias) {
+    if (lq == NULL) {
+        PRINT_ERROR("linearLayerInit: lq pointer is NULL");
+        exit(1);
+    }
+    if (lq->forwardMath == NULL) {
+        PRINT_ERROR("linearLayerInit: layerQuant.forwardMath must be set");
+        exit(1);
+    }
+    if (lq->backwardMath == NULL) {
+        PRINT_ERROR("linearLayerInit: layerQuant.backwardMath must be set");
+        exit(1);
+    }
+    if (lq->weightStorage == NULL) {
+        PRINT_ERROR("linearLayerInit: layerQuant.weightStorage must be set");
+        exit(1);
+    }
+    if (hasBias && lq->biasStorage == NULL) {
+        PRINT_ERROR("linearLayerInit: layerQuant.biasStorage must be set when bias is enabled");
+        exit(1);
+    }
+}
+
+layer_t *linearLayerInit(linearInit_t *init, layerQuant_t *lq) {
+    validateLinearInit(init);
+    bool hasBias = resolveLinearBias(init->bias);
+    validateLayerQuantForLinear(lq, hasBias);
+
+    layer_t *layer = reserveMemory(sizeof(layer_t));
+    layer->type = LINEAR;
+
+    layerConfig_t *layerCfg = reserveMemory(sizeof(layerConfig_t));
+    linearConfig_t *cfg = reserveMemory(sizeof(linearConfig_t));
+    layerCfg->linear = cfg;
+    layer->config = layerCfg;
+
+    cfg->weights = allocateLinearWeights(init->inFeatures, init->outFeatures, lq->weightStorage);
+    cfg->bias = hasBias ? allocateLinearBias(init->outFeatures, lq->biasStorage) : NULL;
+
+    /* Borrowing: store the four quant pointers verbatim, no copy.
+     * Per design spec section 4: collapse to a single math Q for forward and
+     * a single math Q for backward (the 4-slot split was empirically never
+     * used). */
+    cfg->forwardQ = lq->forwardMath;
+    cfg->weightGradQ = lq->backwardMath;
+    cfg->biasGradQ = lq->backwardMath;
+    cfg->propLossQ = lq->backwardMath;
+    cfg->ownsQuantizations = false;
+
+    return layer;
+}
+
+/*! Deep-copies a quantization_t and its qConfig.
+ *
+ *  Returns NULL if `src` is NULL.  Caller owns the returned allocation; free via:
+ *      freeReservedMemory(result->qConfig);
+ *      freeReservedMemory(result);
+ *
+ *  qConfig size is dispatched by `src->type`.  BOOL has no qConfig (aligned with
+ *  the BOOL dtype added per the BOOL tensor spec). */
+static quantization_t *deepCopyQuantization(quantization_t *src) {
+    if (src == NULL) {
+        return NULL;
+    }
+
+    quantization_t *dst = reserveMemory(sizeof(quantization_t));
+    dst->type = src->type;
+
+    size_t cfgSize = 0;
+    switch (src->type) {
+    case FLOAT32:
+        cfgSize = 0;
+        break; /* no qConfig */
+    case INT32:
+        cfgSize = 0;
+        break;
+    case BOOL:
+        cfgSize = 0;
+        break; /* BOOL has no qConfig */
+    case SYM_INT32:
+        cfgSize = sizeof(symInt32QConfig_t);
+        break;
+    case SYM:
+        cfgSize = sizeof(symQConfig_t);
+        break;
+    case ASYM:
+        cfgSize = sizeof(asymQConfig_t);
+        break;
+    default:
+        PRINT_ERROR("linearLayerInitOwning: cannot deep-copy quantization with unknown type %d",
+                    (int)src->type);
+        exit(1);
+    }
+
+    if (cfgSize == 0) {
+        dst->qConfig = NULL;
+    } else {
+        dst->qConfig = reserveMemory(cfgSize);
+        memcpy(dst->qConfig, src->qConfig, cfgSize);
+    }
+    return dst;
+}
+
+layer_t *linearLayerInitOwning(linearInit_t *init, layerQuant_t *lq) {
+    validateLinearInit(init);
+    bool hasBias = resolveLinearBias(init->bias);
+    validateLayerQuantForLinear(lq, hasBias);
+
+    layer_t *layer = reserveMemory(sizeof(layer_t));
+    layer->type = LINEAR;
+
+    layerConfig_t *layerCfg = reserveMemory(sizeof(layerConfig_t));
+    linearConfig_t *cfg = reserveMemory(sizeof(linearConfig_t));
+    layerCfg->linear = cfg;
+    layer->config = layerCfg;
+
+    /* Allocate parameters using lq->weightStorage / lq->biasStorage as the
+     * SOURCE of the tensor's owned quantization.  The allocator helpers (from
+     * T12) internally clone via getQLike, so the parameter tensors hold their
+     * own quantization_t copies — the caller can immediately drop the lq's
+     * weightStorage/biasStorage pointers without breaking the parameters. */
+    cfg->weights = allocateLinearWeights(init->inFeatures, init->outFeatures, lq->weightStorage);
+    cfg->bias = hasBias ? allocateLinearBias(init->outFeatures, lq->biasStorage) : NULL;
+
+    /* Owning: deep-copy each of the four math quantizations.  Always allocate
+     * four separate copies, even if multiple lq slots pointed to the same
+     * physical instance — this keeps free* simple (no dedup logic needed
+     * for the math slots).  */
+    cfg->forwardQ = deepCopyQuantization(lq->forwardMath);
+    cfg->weightGradQ = deepCopyQuantization(lq->backwardMath);
+    cfg->biasGradQ = deepCopyQuantization(lq->backwardMath);
+    cfg->propLossQ = deepCopyQuantization(lq->backwardMath);
+    cfg->ownsQuantizations = true;
+
+    return layer;
+}
+
+void freeLinearLayer(layer_t *linearLayer) {
+    if (linearLayer == NULL) {
+        return;
+    }
+    linearConfig_t *cfg = linearLayer->config->linear;
+
+    /* Tear down weight parameter (param tensor + grad tensor + their data + shape).
+     * freeParameter handles the NULL-grad case post-#106. */
+    if (cfg->weights != NULL) {
+        freeParameter(cfg->weights);
+    }
+    if (cfg->bias != NULL) {
+        freeParameter(cfg->bias);
+    }
+
+    /* Owning-variant only — tear down the four quantization_t and their qConfigs.
+     * Defensive dedup: the Owning factory (Task 14) will always allocate four
+     * separate copies, but if a caller of the Borrowing variant happened to use
+     * the same pointer in multiple lq slots, we'd double-free without these
+     * checks. Borrowing has ownsQuantizations=false, so this branch is skipped
+     * for it; the dedup is purely a defensive guard for future maintenance. */
+    if (cfg->ownsQuantizations) {
+        if (cfg->forwardQ != NULL) {
+            freeReservedMemory(cfg->forwardQ->qConfig);
+            freeReservedMemory(cfg->forwardQ);
+        }
+        if (cfg->weightGradQ != NULL && cfg->weightGradQ != cfg->forwardQ) {
+            freeReservedMemory(cfg->weightGradQ->qConfig);
+            freeReservedMemory(cfg->weightGradQ);
+        }
+        if (cfg->biasGradQ != NULL && cfg->biasGradQ != cfg->forwardQ &&
+            cfg->biasGradQ != cfg->weightGradQ) {
+            freeReservedMemory(cfg->biasGradQ->qConfig);
+            freeReservedMemory(cfg->biasGradQ);
+        }
+        if (cfg->propLossQ != NULL && cfg->propLossQ != cfg->forwardQ &&
+            cfg->propLossQ != cfg->weightGradQ && cfg->propLossQ != cfg->biasGradQ) {
+            freeReservedMemory(cfg->propLossQ->qConfig);
+            freeReservedMemory(cfg->propLossQ);
+        }
+    }
+
+    freeReservedMemory(cfg);
     freeReservedMemory(linearLayer->config);
     freeReservedMemory(linearLayer);
 }

--- a/src/userApi/layer/LinearApi.c
+++ b/src/userApi/layer/LinearApi.c
@@ -16,9 +16,9 @@
 #include "Tensor.h"
 #include "TensorApi.h"
 
-layer_t *linearLayerInit(parameter_t *weights, parameter_t *bias, quantization_t *forwardQ,
-                         quantization_t *weightGradsQ, quantization_t *biasGradsQ,
-                         quantization_t *propLossQ) {
+layer_t *linearLayerInitLegacy(parameter_t *weights, parameter_t *bias, quantization_t *forwardQ,
+                               quantization_t *weightGradsQ, quantization_t *biasGradsQ,
+                               quantization_t *propLossQ) {
     layer_t *linearLayer = reserveMemory(sizeof(layer_t));
 
     linearLayer->type = LINEAR;
@@ -40,7 +40,8 @@ layer_t *linearLayerInit(parameter_t *weights, parameter_t *bias, quantization_t
     return linearLayer;
 }
 
-layer_t *linearLayerInitNonTrainable(tensor_t *weights, tensor_t *bias, quantization_t *forwardQ) {
+layer_t *linearLayerInitNonTrainableLegacy(tensor_t *weights, tensor_t *bias,
+                                           quantization_t *forwardQ) {
     layer_t *linearLayer = reserveMemory(sizeof(layer_t));
 
     linearLayer->type = LINEAR;
@@ -59,7 +60,7 @@ layer_t *linearLayerInitNonTrainable(tensor_t *weights, tensor_t *bias, quantiza
     return linearLayer;
 }
 
-void freeLinearLayer(layer_t *linearLayer) {
+void freeLinearLayerLegacy(layer_t *linearLayer) {
     freeReservedMemory(linearLayer->config->linear);
     freeReservedMemory(linearLayer->config);
     freeReservedMemory(linearLayer);

--- a/src/userApi/layer/ReluApi.c
+++ b/src/userApi/layer/ReluApi.c
@@ -1,7 +1,13 @@
 #define SOURCE_FILE "RELU_API"
 
-#include "ReluApi.h"
+#include <stdbool.h>
+#include <stdlib.h> /* exit */
+#include <string.h> /* memcpy */
+
+#include "Common.h" /* PRINT_ERROR */
+#include "LayerQuant.h"
 #include "Relu.h"
+#include "ReluApi.h"
 #include "StorageApi.h"
 
 layer_t *reluLayerInit(quantization_t *forwardQ, quantization_t *backwardQ) {
@@ -15,6 +21,7 @@ layer_t *reluLayerInit(quantization_t *forwardQ, quantization_t *backwardQ) {
     reluConfig->relu = reluCfg;
     reluCfg->forwardQ = forwardQ;
     reluCfg->backwardQ = backwardQ;
+    reluCfg->ownsQuantizations = false;
 
     reluLayer->config = reluConfig;
 
@@ -23,6 +30,123 @@ layer_t *reluLayerInit(quantization_t *forwardQ, quantization_t *backwardQ) {
 
 void freeReluLayer(layer_t *reluLayer) {
     freeReservedMemory(reluLayer->config->relu);
+    freeReservedMemory(reluLayer->config);
+    freeReservedMemory(reluLayer);
+}
+
+/* ============================================================================
+ * New factory API — layerQuant_t profile (PR 1).
+ * ========================================================================== */
+
+static quantization_t *reluDeepCopyQuantization(quantization_t *src) {
+    if (src == NULL) {
+        return NULL;
+    }
+
+    quantization_t *dst = reserveMemory(sizeof(quantization_t));
+    dst->type = src->type;
+
+    size_t cfgSize = 0;
+    switch (src->type) {
+    case FLOAT32:
+        cfgSize = 0;
+        break;
+    case INT32:
+        cfgSize = 0;
+        break;
+    case BOOL:
+        cfgSize = 0;
+        break;
+    case SYM_INT32:
+        cfgSize = sizeof(symInt32QConfig_t);
+        break;
+    case SYM:
+        cfgSize = sizeof(symQConfig_t);
+        break;
+    case ASYM:
+        cfgSize = sizeof(asymQConfig_t);
+        break;
+    default:
+        PRINT_ERROR("reluLayerInitOwning: unknown quantization type %d", (int)src->type);
+        exit(1);
+    }
+    if (cfgSize == 0) {
+        dst->qConfig = NULL;
+    } else {
+        dst->qConfig = reserveMemory(cfgSize);
+        memcpy(dst->qConfig, src->qConfig, cfgSize);
+    }
+    return dst;
+}
+
+static void validateLayerQuantForRelu(layerQuant_t *lq) {
+    if (lq == NULL) {
+        PRINT_ERROR("reluLayerInit: lq pointer is NULL");
+        exit(1);
+    }
+    if (lq->forwardMath == NULL) {
+        PRINT_ERROR("reluLayerInit: layerQuant.forwardMath must be set");
+        exit(1);
+    }
+    if (lq->backwardMath == NULL) {
+        PRINT_ERROR("reluLayerInit: layerQuant.backwardMath must be set");
+        exit(1);
+    }
+}
+
+layer_t *reluLayerInit(layerQuant_t *lq) {
+    validateLayerQuantForRelu(lq);
+
+    layer_t *layer = reserveMemory(sizeof(layer_t));
+    layer->type = RELU;
+
+    layerConfig_t *layerCfg = reserveMemory(sizeof(layerConfig_t));
+    reluConfig_t *cfg = reserveMemory(sizeof(reluConfig_t));
+    layerCfg->relu = cfg;
+    layer->config = layerCfg;
+
+    cfg->forwardQ = lq->forwardMath;
+    cfg->backwardQ = lq->backwardMath;
+    cfg->ownsQuantizations = false;
+
+    return layer;
+}
+
+layer_t *reluLayerInitOwning(layerQuant_t *lq) {
+    validateLayerQuantForRelu(lq);
+
+    layer_t *layer = reserveMemory(sizeof(layer_t));
+    layer->type = RELU;
+
+    layerConfig_t *layerCfg = reserveMemory(sizeof(layerConfig_t));
+    reluConfig_t *cfg = reserveMemory(sizeof(reluConfig_t));
+    layerCfg->relu = cfg;
+    layer->config = layerCfg;
+
+    cfg->forwardQ = reluDeepCopyQuantization(lq->forwardMath);
+    cfg->backwardQ = reluDeepCopyQuantization(lq->backwardMath);
+    cfg->ownsQuantizations = true;
+
+    return layer;
+}
+
+void freeReluLayer(layer_t *reluLayer) {
+    if (reluLayer == NULL) {
+        return;
+    }
+    reluConfig_t *cfg = reluLayer->config->relu;
+
+    if (cfg->ownsQuantizations) {
+        if (cfg->forwardQ != NULL) {
+            freeReservedMemory(cfg->forwardQ->qConfig);
+            freeReservedMemory(cfg->forwardQ);
+        }
+        if (cfg->backwardQ != NULL && cfg->backwardQ != cfg->forwardQ) {
+            freeReservedMemory(cfg->backwardQ->qConfig);
+            freeReservedMemory(cfg->backwardQ);
+        }
+    }
+    freeReservedMemory(cfg);
     freeReservedMemory(reluLayer->config);
     freeReservedMemory(reluLayer);
 }

--- a/src/userApi/layer/ReluApi.c
+++ b/src/userApi/layer/ReluApi.c
@@ -10,7 +10,7 @@
 #include "ReluApi.h"
 #include "StorageApi.h"
 
-layer_t *reluLayerInit(quantization_t *forwardQ, quantization_t *backwardQ) {
+layer_t *reluLayerInitLegacy(quantization_t *forwardQ, quantization_t *backwardQ) {
     layer_t *reluLayer = reserveMemory(sizeof(layer_t));
 
     reluLayer->type = RELU;
@@ -28,7 +28,7 @@ layer_t *reluLayerInit(quantization_t *forwardQ, quantization_t *backwardQ) {
     return reluLayer;
 }
 
-void freeReluLayer(layer_t *reluLayer) {
+void freeReluLayerLegacy(layer_t *reluLayer) {
     freeReservedMemory(reluLayer->config->relu);
     freeReservedMemory(reluLayer->config);
     freeReservedMemory(reluLayer);

--- a/src/userApi/layer/include/LinearApi.h
+++ b/src/userApi/layer/include/LinearApi.h
@@ -2,13 +2,41 @@
 #define ODT_LINEAR_H
 
 #include "Layer.h"
+#include "LayerCommon.h"
+#include "LayerQuant.h"
 
-layer_t *linearLayerInit(parameter_t *weights, parameter_t *bias, quantization_t *forwardQ,
-                         quantization_t *weightGradsQ, quantization_t *biasGradsQ,
-                         quantization_t *propLossQ);
+/* Legacy (pre-2026-05-15 factory API) — retained during PR 1/2 coexistence window.
+ * New code should use the linearInit_t-based factories declared in a later PR. */
+layer_t *linearLayerInitLegacy(parameter_t *weights, parameter_t *bias, quantization_t *forwardQ,
+                               quantization_t *weightGradsQ, quantization_t *biasGradsQ,
+                               quantization_t *propLossQ);
 
-layer_t *linearLayerInitNonTrainable(tensor_t *weights, tensor_t *bias, quantization_t *forwardQ);
+layer_t *linearLayerInitNonTrainableLegacy(tensor_t *weights, tensor_t *bias,
+                                           quantization_t *forwardQ);
 
+void freeLinearLayerLegacy(layer_t *linearLayer);
+
+typedef struct linearInit {
+    /* REQUIRED — factory aborts if 0 */
+    size_t inFeatures;
+    size_t outFeatures;
+    /* OPTIONAL */
+    bias_t bias; /* BIAS_DEFAULT (0) → resolves to true */
+} linearInit_t;
+
+/*! Borrowing variant — factory stores the four quantization_t* pointers from
+ *  `lq` directly. Caller retains ownership of `lq` and the quantizations;
+ *  `lq` itself can be a compound literal that dies after the call. */
+layer_t *linearLayerInit(linearInit_t *init, layerQuant_t *lq);
+
+/*! Owning variant — factory deep-copies everything reachable from `lq`.
+ *  Caller can free `lq` and all four quantization_t* immediately after
+ *  the factory returns. free*Layer will tear down the copies. */
+layer_t *linearLayerInitOwning(linearInit_t *init, layerQuant_t *lq);
+
+/*! Tears down everything the factory allocated (parameters, kernel if any,
+ *  internal config, layer). Reads config->ownsQuantizations to decide
+ *  whether to also tear down the four quantization_t* and their qConfigs. */
 void freeLinearLayer(layer_t *linearLayer);
 
 #endif // ODT_LINEAR_H

--- a/src/userApi/layer/include/ReluApi.h
+++ b/src/userApi/layer/include/ReluApi.h
@@ -4,9 +4,9 @@
 #include "Layer.h"
 #include "LayerQuant.h"
 
-layer_t *reluLayerInit(quantization_t *forwardQ, quantization_t *backwardQ);
-
-void freeReluLayer(layer_t *reluLayer);
+/* Legacy (pre-2026-05-15 factory API) — retained during PR 1/2 coexistence window. */
+layer_t *reluLayerInitLegacy(quantization_t *forwardQ, quantization_t *backwardQ);
+void freeReluLayerLegacy(layer_t *reluLayer);
 
 /*! Borrowing variant — stores lq->forwardMath and lq->backwardMath as the
  *  layer's forwardQ / backwardQ pointers. Caller retains ownership of lq. */

--- a/src/userApi/layer/include/ReluApi.h
+++ b/src/userApi/layer/include/ReluApi.h
@@ -2,9 +2,22 @@
 #define ODT_RELU_H
 
 #include "Layer.h"
+#include "LayerQuant.h"
 
 layer_t *reluLayerInit(quantization_t *forwardQ, quantization_t *backwardQ);
 
+void freeReluLayer(layer_t *reluLayer);
+
+/*! Borrowing variant — stores lq->forwardMath and lq->backwardMath as the
+ *  layer's forwardQ / backwardQ pointers. Caller retains ownership of lq. */
+layer_t *reluLayerInit(layerQuant_t *lq);
+
+/*! Owning variant — deep-copies lq->forwardMath and lq->backwardMath.
+ *  Caller can drop lq + quantizations immediately. */
+layer_t *reluLayerInitOwning(layerQuant_t *lq);
+
+/*! Tears down the layer. Reads config->ownsQuantizations to decide whether
+ *  to also free the two quantization_t* and their qConfigs. */
 void freeReluLayer(layer_t *reluLayer);
 
 #endif // ODT_RELU_H

--- a/src/userApi/tensor/QuantizationApi.c
+++ b/src/userApi/tensor/QuantizationApi.c
@@ -24,6 +24,22 @@ quantization_t *quantizationInitSymInt32(roundingMode_t roundingMode) {
     return q;
 }
 
+quantization_t *quantizationInitSymInt32WithBits(roundingMode_t roundingMode, uint8_t qMaxBits) {
+    quantization_t *q = reserveMemory(sizeof(quantization_t));
+    symInt32QConfig_t *qC = reserveMemory(sizeof(symInt32QConfig_t));
+    initSymInt32QConfigWithQMaxBits(roundingMode, qC, qMaxBits);
+    initSymInt32Quantization(qC, q);
+    return q;
+}
+
+quantization_t *quantizationInitSym(uint8_t qBits, roundingMode_t roundingMode) {
+    quantization_t *q = reserveMemory(sizeof(quantization_t));
+    symQConfig_t *qC = reserveMemory(sizeof(symQConfig_t));
+    initSymQConfig(qBits, roundingMode, qC);
+    initSymQuantization(qC, q);
+    return q;
+}
+
 quantization_t *quantizationInitAsym(uint8_t qBits, roundingMode_t roundingMode) {
     quantization_t *q = reserveMemory(sizeof(quantization_t));
     asymQConfig_t *qC = reserveMemory(sizeof(asymQConfig_t));

--- a/src/userApi/tensor/include/QuantizationApi.h
+++ b/src/userApi/tensor/include/QuantizationApi.h
@@ -24,6 +24,21 @@ quantization_t *quantizationInitInt32();
  */
 quantization_t *quantizationInitSymInt32(roundingMode_t roundingMode);
 
+/*! SymInt32 with explicit qMaxBits.  The existing quantizationInitSymInt32(rm)
+ *  hardcodes qMaxBits=16; this variant lets callers specify the active bit
+ *  width for fixed-point arithmetic (e.g. 12 bits for tighter dynamic range,
+ *  32 bits for full int32 range).
+ *
+ * \param roundingMode: Rounding mode to be used
+ * \param qMaxBits: Active bit width for fixed-point arithmetic
+ *
+ * \returns Pointer to initialized quantization
+ */
+quantization_t *quantizationInitSymInt32WithBits(roundingMode_t roundingMode, uint8_t qMaxBits);
+
+/*! Sub-byte symmetric quantization with explicit bit width and rounding. */
+quantization_t *quantizationInitSym(uint8_t qBits, roundingMode_t roundingMode);
+
 /*! Initializes asym quantization.
  *
  * \param qBits: Number of bits for qMax

--- a/test/unit/layer/CMakeLists.txt
+++ b/test/unit/layer/CMakeLists.txt
@@ -71,6 +71,9 @@ add_elastic_ai_unit_test(
         TensorApi
         QuantizationApi
         LinearApi
+        LayerQuant
+        Quantization
+        Rounding
         StorageApi
 )
 
@@ -82,6 +85,9 @@ add_elastic_ai_unit_test(
         ReluApi
         TensorApi
         QuantizationApi
+        LayerQuant
+        Quantization
+        Rounding
         StorageApi
 )
 

--- a/test/unit/layer/UnitTestLinear.c
+++ b/test/unit/layer/UnitTestLinear.c
@@ -2,6 +2,8 @@
 
 #include "DTypes.h"
 #include "Layer.h"
+#include "LayerCommon.h"
+#include "LayerQuant.h"
 #include "Linear.h"
 #include "LinearApi.h"
 #include "QuantizationApi.h"
@@ -643,6 +645,154 @@ void testLinearLayerInitAndFreeRoundTrip(void) {
     freeLinearLayer(linearLayer);
 }
 
+/* ============================================================================
+ * Tests for the new layerQuant_t / linearInit_t factory API (PR 1).
+ * ========================================================================== */
+
+void testLinearLayerInitBorrowingBuildsLayerWithCorrectShapeAndStoresQuantPointers(void) {
+    quantization_t *q = quantizationInitFloat();
+    layerQuant_t lq;
+    layerQuantInitUniform(&lq, q);
+
+    layer_t *layer = linearLayerInit(
+        &(linearInit_t){
+            .inFeatures = 3,
+            .outFeatures = 2,
+            .bias = BIAS_TRUE,
+        },
+        &lq);
+
+    TEST_ASSERT_NOT_NULL(layer);
+    TEST_ASSERT_EQUAL_INT(LINEAR, layer->type);
+
+    linearConfig_t *cfg = layer->config->linear;
+    TEST_ASSERT_NOT_NULL(cfg);
+    TEST_ASSERT_FALSE(cfg->ownsQuantizations);
+
+    /* Borrowing variant stores pointers verbatim */
+    TEST_ASSERT_EQUAL_PTR(q, cfg->forwardQ);
+    TEST_ASSERT_EQUAL_PTR(q, cfg->weightGradQ);
+    TEST_ASSERT_EQUAL_PTR(q, cfg->biasGradQ);
+    TEST_ASSERT_EQUAL_PTR(q, cfg->propLossQ);
+
+    /* Weights allocated with shape [outFeatures, inFeatures] */
+    TEST_ASSERT_NOT_NULL(cfg->weights);
+    tensor_t *weightTensor = cfg->weights->param;
+    TEST_ASSERT_NOT_NULL(weightTensor);
+    TEST_ASSERT_EQUAL_UINT(2, weightTensor->shape->numberOfDimensions);
+    TEST_ASSERT_EQUAL_UINT(2, weightTensor->shape->dimensions[0]); /* outFeatures */
+    TEST_ASSERT_EQUAL_UINT(3, weightTensor->shape->dimensions[1]); /* inFeatures */
+
+    /* Bias allocated with shape [outFeatures] */
+    TEST_ASSERT_NOT_NULL(cfg->bias);
+    tensor_t *biasTensor = cfg->bias->param;
+    TEST_ASSERT_NOT_NULL(biasTensor);
+    TEST_ASSERT_EQUAL_UINT(1, biasTensor->shape->numberOfDimensions);
+    TEST_ASSERT_EQUAL_UINT(2, biasTensor->shape->dimensions[0]);
+
+    freeLinearLayer(layer);
+}
+
+void testLinearLayerInitBorrowingZeroInChannelsAbortsViaPrintError(void) {
+    /* Factory abort on missing required field — covered by design contract;
+     * cannot assert PRINT_ERROR + exit from Unity. Marker test. */
+    TEST_IGNORE_MESSAGE("Factory abort on missing required field — covered by design contract; "
+                        "cannot assert PRINT_ERROR + exit from Unity.");
+}
+
+void testLinearLayerInitBorrowingBiasDefaultResolvesToTrue(void) {
+    quantization_t *q = quantizationInitFloat();
+    layerQuant_t lq;
+    layerQuantInitUniform(&lq, q);
+
+    layer_t *layer = linearLayerInit(
+        &(linearInit_t){
+            .inFeatures = 4,
+            .outFeatures = 1,
+            /* .bias omitted -> BIAS_DEFAULT (0) -> resolves to true */
+        },
+        &lq);
+
+    linearConfig_t *cfg = layer->config->linear;
+    TEST_ASSERT_NOT_NULL(cfg->bias); /* bias parameter was allocated */
+
+    freeLinearLayer(layer);
+}
+
+void testLinearLayerInitBorrowingBiasFalseLeavesBiasNull(void) {
+    quantization_t *q = quantizationInitFloat();
+    layerQuant_t lq;
+    layerQuantInitUniform(&lq, q);
+
+    layer_t *layer = linearLayerInit(
+        &(linearInit_t){
+            .inFeatures = 4,
+            .outFeatures = 1,
+            .bias = BIAS_FALSE,
+        },
+        &lq);
+
+    linearConfig_t *cfg = layer->config->linear;
+    TEST_ASSERT_NULL(cfg->bias); /* bias parameter not allocated */
+
+    freeLinearLayer(layer);
+}
+
+void testLinearLayerInitOwningDeepCopiesQuantizations(void) {
+    quantization_t *q = quantizationInitFloat();
+    layerQuant_t lq;
+    layerQuantInitUniform(&lq, q);
+
+    layer_t *layer = linearLayerInitOwning(
+        &(linearInit_t){
+            .inFeatures = 3,
+            .outFeatures = 2,
+            .bias = BIAS_TRUE,
+        },
+        &lq);
+
+    linearConfig_t *cfg = layer->config->linear;
+
+    /* Owning variant: cfg->forwardQ is a fresh allocation, NOT the original q */
+    TEST_ASSERT_NOT_EQUAL(q, cfg->forwardQ);
+    TEST_ASSERT_NOT_EQUAL(q, cfg->weightGradQ);
+    TEST_ASSERT_NOT_EQUAL(q, cfg->biasGradQ);
+    TEST_ASSERT_NOT_EQUAL(q, cfg->propLossQ);
+
+    /* But the copy has equal type to the original */
+    TEST_ASSERT_EQUAL_INT(q->type, cfg->forwardQ->type);
+
+    /* ownsQuantizations flag is set */
+    TEST_ASSERT_TRUE(cfg->ownsQuantizations);
+
+    freeLinearLayer(layer);
+}
+
+void testLinearLayerInitOwningFreesAllAllocationsWithoutLeak(void) {
+    /* Build + free 5 layers — if anything leaks, valgrind will catch it
+     * during CI (not asserted here, just exercise the path). */
+    for (int i = 0; i < 5; i++) {
+        quantization_t *q = quantizationInitFloat();
+        layerQuant_t lq;
+        layerQuantInitUniform(&lq, q);
+
+        layer_t *layer = linearLayerInitOwning(
+            &(linearInit_t){
+                .inFeatures = 8,
+                .outFeatures = 4,
+                .bias = BIAS_TRUE,
+            },
+            &lq);
+
+        freeLinearLayer(layer);
+        /* Note: caller-side q deliberately not freed — it's caller-owned and
+         * the Owning factory has its own copies. q leaks but that's the
+         * existing pattern in this codebase (quantizationInit* returns heap,
+         * never freed). */
+    }
+    TEST_PASS();
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(testLinearForwardFloat);
@@ -654,5 +804,13 @@ int main(void) {
 
     RUN_TEST(testLinearBackwardFloatWithMismatchedQuantizations);
     RUN_TEST(testLinearLayerInitNonTrainable);
+
+    RUN_TEST(testLinearLayerInitBorrowingBuildsLayerWithCorrectShapeAndStoresQuantPointers);
+    RUN_TEST(testLinearLayerInitBorrowingZeroInChannelsAbortsViaPrintError);
+    RUN_TEST(testLinearLayerInitBorrowingBiasDefaultResolvesToTrue);
+    RUN_TEST(testLinearLayerInitBorrowingBiasFalseLeavesBiasNull);
+
+    RUN_TEST(testLinearLayerInitOwningDeepCopiesQuantizations);
+    RUN_TEST(testLinearLayerInitOwningFreesAllAllocationsWithoutLeak);
     return UNITY_END();
 }

--- a/test/unit/layer/UnitTestLinear.c
+++ b/test/unit/layer/UnitTestLinear.c
@@ -63,7 +63,7 @@ void testLinearForwardFloat() {
 
     /* 5. Build the layer with shared float quantization. */
     quantization_t *testQ = quantizationInitFloat();
-    layer_t *linearLayer = linearLayerInit(weights, bias, testQ, testQ, testQ, testQ);
+    layer_t *linearLayer = linearLayerInitLegacy(weights, bias, testQ, testQ, testQ, testQ);
 
     linearForward(linearLayer, input, output);
 
@@ -73,7 +73,7 @@ void testLinearForwardFloat() {
     captured[1] = ((float *)output->data)[1];
 
     /* 7. FREE. freeLinearLayer releases only the layer config wrapper. */
-    freeLinearLayer(linearLayer);
+    freeLinearLayerLegacy(linearLayer);
     freeTensor(output);
     freeTensor(input);
     freeParameter(bias);
@@ -146,7 +146,7 @@ void testLinearBackwardFloat() {
 
     /* 6. Build the layer. */
     quantization_t *testQ = quantizationInitFloat();
-    layer_t *linearLayer = linearLayerInit(weights, bias, testQ, testQ, testQ, testQ);
+    layer_t *linearLayer = linearLayerInitLegacy(weights, bias, testQ, testQ, testQ, testQ);
 
     linearBackward(linearLayer, forwardInput, loss, propLoss);
 
@@ -169,7 +169,7 @@ void testLinearBackwardFloat() {
     }
 
     /* 8. FREE. */
-    freeLinearLayer(linearLayer);
+    freeLinearLayerLegacy(linearLayer);
     freeTensor(propLoss);
     freeTensor(loss);
     freeTensor(forwardInput);
@@ -239,7 +239,7 @@ void testLinearForwardSymInt32() {
 
     /* 5. Build layer (shared SymInt32 quantization). */
     quantization_t *test = quantizationInitSymInt32(HTE);
-    layer_t *linearLayer = linearLayerInit(weights, bias, test, test, test, test);
+    layer_t *linearLayer = linearLayerInitLegacy(weights, bias, test, test, test, test);
 
     linearForward(linearLayer, input, output);
 
@@ -262,7 +262,7 @@ void testLinearForwardSymInt32() {
 
     /* 8. FREE. */
     freeTensor(outputFloat);
-    freeLinearLayer(linearLayer);
+    freeLinearLayerLegacy(linearLayer);
     freeTensor(output);
     freeTensor(input);
     freeParameter(bias);
@@ -340,7 +340,7 @@ void testLinearBackwardSymInt32() {
 
     /* 6. Build layer (shared SymInt32 quantization). */
     quantization_t *test = quantizationInitSymInt32(HTE);
-    layer_t *linearLayer = linearLayerInit(weights, bias, test, test, test, test);
+    layer_t *linearLayer = linearLayerInitLegacy(weights, bias, test, test, test, test);
 
     linearBackward(linearLayer, forwardInput, loss, propLoss);
 
@@ -393,7 +393,7 @@ void testLinearBackwardSymInt32() {
     freeTensor(propLossFloat);
     freeTensor(biasGradFloat);
     freeTensor(weightGradFloat);
-    freeLinearLayer(linearLayer);
+    freeLinearLayerLegacy(linearLayer);
     freeTensor(propLoss);
     freeTensor(loss);
     freeTensor(forwardInput);
@@ -490,7 +490,7 @@ void testLinearBackwardFloatWithMismatchedQuantizations() {
 
     /* 6. Build the layer with shared float quantization. */
     quantization_t *testQ = quantizationInitFloat();
-    layer_t *linearLayer = linearLayerInit(weights, bias, testQ, testQ, testQ, testQ);
+    layer_t *linearLayer = linearLayerInitLegacy(weights, bias, testQ, testQ, testQ, testQ);
 
     linearBackward(linearLayer, forwardInput, lossAsym, propLoss);
 
@@ -513,7 +513,7 @@ void testLinearBackwardFloatWithMismatchedQuantizations() {
     }
 
     /* 8. FREE. */
-    freeLinearLayer(linearLayer);
+    freeLinearLayerLegacy(linearLayer);
     freeTensor(propLoss);
     freeTensor(lossAsym);
     freeTensor(forwardInput);
@@ -565,7 +565,7 @@ void testLinearLayerInitNonTrainable(void) {
 
     /* 3. Build the non-trainable layer. */
     quantization_t *forwardQ = quantizationInitFloat();
-    layer_t *layer = linearLayerInitNonTrainable(weights, bias, forwardQ);
+    layer_t *layer = linearLayerInitNonTrainableLegacy(weights, bias, forwardQ);
 
     /* Wiring asserts (read into stack locals before any free). */
     int capturedLayerNotNull = (layer != NULL);
@@ -608,7 +608,7 @@ void testLinearLayerInitNonTrainable(void) {
      *    freeParameter is NULL-grad-safe (post-#106, H3). */
     parameter_t *weightsParam = config->weights;
     parameter_t *biasParam = config->bias;
-    freeLinearLayer(layer);
+    freeLinearLayerLegacy(layer);
     freeTensor(output);
     freeTensor(input);
     freeParameter(biasParam);
@@ -636,13 +636,13 @@ void testLinearLayerInitAndFreeRoundTrip(void) {
      * parameters/quantization (those are externally owned). So NULL is a
      * valid stand-in here — keeps the test focused on the StorageApi
      * lifecycle, not on tensor ownership. */
-    layer_t *linearLayer = linearLayerInit(NULL, NULL, NULL, NULL, NULL, NULL);
+    layer_t *linearLayer = linearLayerInitLegacy(NULL, NULL, NULL, NULL, NULL, NULL);
     TEST_ASSERT_NOT_NULL(linearLayer);
     TEST_ASSERT_EQUAL_INT(LINEAR, linearLayer->type);
     TEST_ASSERT_NOT_NULL(linearLayer->config);
     TEST_ASSERT_NOT_NULL(linearLayer->config->linear);
 
-    freeLinearLayer(linearLayer);
+    freeLinearLayerLegacy(linearLayer);
 }
 
 /* ============================================================================

--- a/test/unit/layer/UnitTestRelu.c
+++ b/test/unit/layer/UnitTestRelu.c
@@ -36,7 +36,7 @@ void testReluForwardFloat() {
 
     /* 3. Build shared float quantization for the layer. */
     quantization_t *floatQ = quantizationInitFloat();
-    layer_t *reluLayer = reluLayerInit(floatQ, floatQ);
+    layer_t *reluLayer = reluLayerInitLegacy(floatQ, floatQ);
 
     /* 4. Exercise. */
     reluForward(reluLayer, input, output);
@@ -47,7 +47,7 @@ void testReluForwardFloat() {
 
     /* 6. FREE in reverse-init order. freeReluLayer releases only the layer
      *    config wrapper; the shared floatQ is freed exactly once at the end. */
-    freeReluLayer(reluLayer);
+    freeReluLayerLegacy(reluLayer);
     freeTensor(output);
     freeTensor(input);
     freeQuantization(floatQ);
@@ -83,7 +83,7 @@ void testReluForwardSymInt32() {
 
     /* 3. Shared SymInt32 quantization for the layer. */
     quantization_t *symIntQ = quantizationInitSymInt32(HTE);
-    layer_t *reluLayer = reluLayerInit(symIntQ, symIntQ);
+    layer_t *reluLayer = reluLayerInitLegacy(symIntQ, symIntQ);
     layerFunctions_t reluFns = layerFunctions[RELU];
     reluFns.forward(reluLayer, input, output);
 
@@ -107,7 +107,7 @@ void testReluForwardSymInt32() {
 
     /* 6. FREE. */
     freeTensor(outputFloat);
-    freeReluLayer(reluLayer);
+    freeReluLayerLegacy(reluLayer);
     freeTensor(output);
     freeTensor(input);
     freeQuantization(symIntQ);
@@ -153,7 +153,7 @@ void testReluBackwardFloat() {
 
     /* 4. Build the layer with shared float quantization. */
     quantization_t *floatQ = quantizationInitFloat();
-    layer_t *reluLayer = reluLayerInit(floatQ, floatQ);
+    layer_t *reluLayer = reluLayerInitLegacy(floatQ, floatQ);
     layerFunctions_t reluFns = layerFunctions[RELU];
     reluFns.backward(reluLayer, forwardInput, loss, propLoss);
 
@@ -164,7 +164,7 @@ void testReluBackwardFloat() {
     }
 
     /* 6. FREE. */
-    freeReluLayer(reluLayer);
+    freeReluLayerLegacy(reluLayer);
     freeTensor(propLoss);
     freeTensor(loss);
     freeTensor(forwardInput);
@@ -209,7 +209,7 @@ void testReluBackwardSymInt32() {
 
     /* 4. Build layer with shared SymInt32 quantization. */
     quantization_t *symIntQ = quantizationInitSymInt32(HTE);
-    layer_t *reluLayer = reluLayerInit(symIntQ, symIntQ);
+    layer_t *reluLayer = reluLayerInitLegacy(symIntQ, symIntQ);
     layerFunctions_t reluFns = layerFunctions[RELU];
     reluFns.backward(reluLayer, forwardInput, loss, propLoss);
 
@@ -231,7 +231,7 @@ void testReluBackwardSymInt32() {
 
     /* 7. FREE. */
     freeTensor(propLossFloat);
-    freeReluLayer(reluLayer);
+    freeReluLayerLegacy(reluLayer);
     freeTensor(propLoss);
     freeTensor(loss);
     freeTensor(forwardInput);
@@ -251,13 +251,13 @@ void testReluLayerInitAndFreeRoundTrip(void) {
      * the inner reluConfig; post-fix it is leak-clean (verified via the
      * LSan sweep). NULL is acceptable for the quantization arguments —
      * reluLayerInit only stores them, freeReluLayer doesn't touch them. */
-    layer_t *reluLayer = reluLayerInit(NULL, NULL);
+    layer_t *reluLayer = reluLayerInitLegacy(NULL, NULL);
     TEST_ASSERT_NOT_NULL(reluLayer);
     TEST_ASSERT_EQUAL_INT(RELU, reluLayer->type);
     TEST_ASSERT_NOT_NULL(reluLayer->config);
     TEST_ASSERT_NOT_NULL(reluLayer->config->relu);
 
-    freeReluLayer(reluLayer);
+    freeReluLayerLegacy(reluLayer);
 }
 
 /* ============================================================================

--- a/test/unit/layer/UnitTestRelu.c
+++ b/test/unit/layer/UnitTestRelu.c
@@ -1,4 +1,5 @@
 #include "DTypes.h"
+#include "LayerQuant.h"
 #include "Quantization.h"
 #include "QuantizationApi.h"
 #include "Relu.h"
@@ -259,6 +260,51 @@ void testReluLayerInitAndFreeRoundTrip(void) {
     freeReluLayer(reluLayer);
 }
 
+/* ============================================================================
+ * Tests for the new layerQuant_t-based factory API (PR 1).
+ * ========================================================================== */
+
+void testReluLayerInitBorrowingStoresLqPointers(void) {
+    quantization_t *qFwd = quantizationInitFloat();
+    quantization_t *qBwd = quantizationInitFloat();
+    layerQuant_t lq = {
+        .forwardMath = qFwd,
+        .backwardMath = qBwd,
+        /* weightStorage / biasStorage ignored by ReLU */
+    };
+
+    layer_t *layer = reluLayerInit(&lq);
+
+    TEST_ASSERT_NOT_NULL(layer);
+    TEST_ASSERT_EQUAL_INT(RELU, layer->type);
+
+    reluConfig_t *cfg = layer->config->relu;
+    TEST_ASSERT_EQUAL_PTR(qFwd, cfg->forwardQ);
+    TEST_ASSERT_EQUAL_PTR(qBwd, cfg->backwardQ);
+    TEST_ASSERT_FALSE(cfg->ownsQuantizations);
+
+    freeReluLayer(layer);
+}
+
+void testReluLayerInitOwningDeepCopiesLqPointers(void) {
+    quantization_t *qFwd = quantizationInitFloat();
+    quantization_t *qBwd = quantizationInitFloat();
+    layerQuant_t lq = {
+        .forwardMath = qFwd,
+        .backwardMath = qBwd,
+    };
+
+    layer_t *layer = reluLayerInitOwning(&lq);
+
+    reluConfig_t *cfg = layer->config->relu;
+    TEST_ASSERT_NOT_EQUAL(qFwd, cfg->forwardQ);
+    TEST_ASSERT_NOT_EQUAL(qBwd, cfg->backwardQ);
+    TEST_ASSERT_EQUAL_INT(qFwd->type, cfg->forwardQ->type);
+    TEST_ASSERT_TRUE(cfg->ownsQuantizations);
+
+    freeReluLayer(layer);
+}
+
 void setUp() {}
 void tearDown() {}
 
@@ -271,5 +317,8 @@ int main(void) {
     RUN_TEST(testReluBackwardSymInt32);
 
     RUN_TEST(testReluLayerInitAndFreeRoundTrip);
+
+    RUN_TEST(testReluLayerInitBorrowingStoresLqPointers);
+    RUN_TEST(testReluLayerInitOwningDeepCopiesLqPointers);
     return UNITY_END();
 }

--- a/test/unit/optimizer/UnitTestSgd.c
+++ b/test/unit/optimizer/UnitTestSgd.c
@@ -80,9 +80,9 @@ void testSgdMCreateOptim() {
     tensorFillFromFloatBuffer(b1Grad, (float[]){0.f}, 1);
     parameter_t *bias1 = parameterInit(b1Param, b1Grad);
 
-    layer_t *linear0 = linearLayerInit(weights0, bias0, layerQ, layerQ, layerQ, layerQ);
-    layer_t *relu0 = reluLayerInit(layerQ, layerQ);
-    layer_t *linear1 = linearLayerInit(weights1, bias1, layerQ, layerQ, layerQ, layerQ);
+    layer_t *linear0 = linearLayerInitLegacy(weights0, bias0, layerQ, layerQ, layerQ, layerQ);
+    layer_t *relu0 = reluLayerInitLegacy(layerQ, layerQ);
+    layer_t *linear1 = linearLayerInitLegacy(weights1, bias1, layerQ, layerQ, layerQ, layerQ);
 
     layer_t *model[] = {linear0, relu0, linear1};
     size_t sizeModel = sizeof(model) / sizeof(model[0]);
@@ -150,9 +150,9 @@ void testSgdMCreateOptim() {
      * (and their grads) registered with the optimizer (per SgdApi.c:85-93,
      * mirroring the post-#110 ownership contract). */
     freeOptimSgdM(optim);
-    freeLinearLayer(linear1);
-    freeReluLayer(relu0);
-    freeLinearLayer(linear0);
+    freeLinearLayerLegacy(linear1);
+    freeReluLayerLegacy(relu0);
+    freeLinearLayerLegacy(linear0);
     freeQuantization(layerQ);
 
     /* ASSERT. */
@@ -204,7 +204,7 @@ void testSGDStep() {
     tensorFillFromFloatBuffer(biasGrad, (float[]){1.f, 3.f}, 2);
     parameter_t *bias = parameterInit(biasParam, biasGrad);
 
-    layer_t *linear = linearLayerInit(weights, bias, layerQ, layerQ, layerQ, layerQ);
+    layer_t *linear = linearLayerInitLegacy(weights, bias, layerQ, layerQ, layerQ, layerQ);
 
     layer_t *model[] = {linear};
     size_t modelSize = 1;
@@ -241,7 +241,7 @@ void testSGDStep() {
 
     /* FREE in reverse-init order. */
     freeOptimSgdM(sgd);
-    freeLinearLayer(linear);
+    freeLinearLayerLegacy(linear);
     freeQuantization(layerQ);
 
     /* ASSERT. */
@@ -290,7 +290,7 @@ void testSGDZeroGrad() {
     tensorFillFromFloatBuffer(biasGrad, (float[]){1.f, 3.f}, 2);
     parameter_t *bias = parameterInit(biasParam, biasGrad);
 
-    layer_t *linear = linearLayerInit(weights, bias, layerQ, layerQ, layerQ, layerQ);
+    layer_t *linear = linearLayerInitLegacy(weights, bias, layerQ, layerQ, layerQ, layerQ);
 
     layer_t *model[] = {linear};
     size_t modelSize = 1;
@@ -314,7 +314,7 @@ void testSGDZeroGrad() {
 
     /* FREE in reverse-init order. */
     freeOptimSgdM(sgd);
-    freeLinearLayer(linear);
+    freeLinearLayerLegacy(linear);
     freeQuantization(layerQ);
 
     /* ASSERT. */

--- a/test/unit/serial/UnitTestDeserialize.c
+++ b/test/unit/serial/UnitTestDeserialize.c
@@ -112,9 +112,9 @@ void testSerializeAndDeserializeModel() {
     tensor_t *serialBias0Grad = gradInitFloat(serialBias0Param, NULL);
     parameter_t *serialBias0 = parameterInit(serialBias0Param, serialBias0Grad);
 
-    layer_t *serialLinear0 = linearLayerInit(serialWeight0, serialBias0, serialLayerQ, serialLayerQ,
-                                             serialLayerQ, serialLayerQ);
-    layer_t *serialRelu = reluLayerInit(serialLayerQ, serialLayerQ);
+    layer_t *serialLinear0 = linearLayerInitLegacy(serialWeight0, serialBias0, serialLayerQ,
+                                                   serialLayerQ, serialLayerQ, serialLayerQ);
+    layer_t *serialRelu = reluLayerInitLegacy(serialLayerQ, serialLayerQ);
 
     float serialWeight1Data[10 * 20];
     for (size_t i = 0; i < 10 * 20; i++) {
@@ -132,8 +132,8 @@ void testSerializeAndDeserializeModel() {
     tensor_t *serialBias1Grad = gradInitFloat(serialBias1Param, NULL);
     parameter_t *serialBias1 = parameterInit(serialBias1Param, serialBias1Grad);
 
-    layer_t *serialLinear1 = linearLayerInit(serialWeight1, serialBias1, serialLayerQ, serialLayerQ,
-                                             serialLayerQ, serialLayerQ);
+    layer_t *serialLinear1 = linearLayerInitLegacy(serialWeight1, serialBias1, serialLayerQ,
+                                                   serialLayerQ, serialLayerQ, serialLayerQ);
     layer_t *serialSoftmax = softmaxLayerInit(serialLayerQ, serialLayerQ);
 
     layer_t *serialModel[] = {serialLinear0, serialRelu, serialLinear1, serialSoftmax};
@@ -152,9 +152,10 @@ void testSerializeAndDeserializeModel() {
     tensor_t *deserialBias0Grad = gradInitFloat(deserialBias0Param, NULL);
     parameter_t *deserialBias0 = parameterInit(deserialBias0Param, deserialBias0Grad);
 
-    layer_t *deserialLinear0 = linearLayerInit(deserialWeight0, deserialBias0, deserialLayerQ,
-                                               deserialLayerQ, deserialLayerQ, deserialLayerQ);
-    layer_t *deserialRelu = reluLayerInit(deserialLayerQ, deserialLayerQ);
+    layer_t *deserialLinear0 =
+        linearLayerInitLegacy(deserialWeight0, deserialBias0, deserialLayerQ, deserialLayerQ,
+                              deserialLayerQ, deserialLayerQ);
+    layer_t *deserialRelu = reluLayerInitLegacy(deserialLayerQ, deserialLayerQ);
 
     tensor_t *deserialWeight1Param = makeFloatTensor2D(10, 20, NULL, 0);
     tensor_t *deserialWeight1Grad = gradInitFloat(deserialWeight1Param, NULL);
@@ -164,8 +165,9 @@ void testSerializeAndDeserializeModel() {
     tensor_t *deserialBias1Grad = gradInitFloat(deserialBias1Param, NULL);
     parameter_t *deserialBias1 = parameterInit(deserialBias1Param, deserialBias1Grad);
 
-    layer_t *deserialLinear1 = linearLayerInit(deserialWeight1, deserialBias1, deserialLayerQ,
-                                               deserialLayerQ, deserialLayerQ, deserialLayerQ);
+    layer_t *deserialLinear1 =
+        linearLayerInitLegacy(deserialWeight1, deserialBias1, deserialLayerQ, deserialLayerQ,
+                              deserialLayerQ, deserialLayerQ);
     layer_t *deserialSoftmax = softmaxLayerInit(deserialLayerQ, deserialLayerQ);
 
     layer_t *deserialModel[] = {deserialLinear0, deserialRelu, deserialLinear1, deserialSoftmax};
@@ -245,21 +247,21 @@ void testSerializeAndDeserializeModel() {
      * wrapper; parameters and the shared layerQ are caller-managed (per
      * docs/CONVENTIONS.md "Test memory discipline"). */
     freeSoftmaxLayer(deserialSoftmax);
-    freeLinearLayer(deserialLinear1);
+    freeLinearLayerLegacy(deserialLinear1);
     freeParameter(deserialBias1);
     freeParameter(deserialWeight1);
-    freeReluLayer(deserialRelu);
-    freeLinearLayer(deserialLinear0);
+    freeReluLayerLegacy(deserialRelu);
+    freeLinearLayerLegacy(deserialLinear0);
     freeParameter(deserialBias0);
     freeParameter(deserialWeight0);
     freeQuantization(deserialLayerQ);
 
     freeSoftmaxLayer(serialSoftmax);
-    freeLinearLayer(serialLinear1);
+    freeLinearLayerLegacy(serialLinear1);
     freeParameter(serialBias1);
     freeParameter(serialWeight1);
-    freeReluLayer(serialRelu);
-    freeLinearLayer(serialLinear0);
+    freeReluLayerLegacy(serialRelu);
+    freeLinearLayerLegacy(serialLinear0);
     freeParameter(serialBias0);
     freeParameter(serialWeight0);
     freeQuantization(serialLayerQ);

--- a/test/unit/tensor/UnitTestTensorApi.c
+++ b/test/unit/tensor/UnitTestTensorApi.c
@@ -393,7 +393,7 @@ void testTensorFillFromFloatBuffer_CopiesValues_SourceCanGoOutOfScope(void) {
 }
 
 void testFreeParameter_NullGrad_DoesNotSegfault(void) {
-    /* H3 regression: linearLayerInitNonTrainable passes NULL for grad into
+    /* H3 regression: linearLayerInitNonTrainableLegacy passes NULL for grad into
      * parameterInit; today freeParameter dereferences it and crashes. */
     size_t *dims = reserveMemory(2 * sizeof(size_t));
     dims[0] = 1;

--- a/test/unit/userAPI/CMakeLists.txt
+++ b/test/unit/userAPI/CMakeLists.txt
@@ -6,6 +6,49 @@ add_elastic_ai_unit_test(
 
 add_elastic_ai_unit_test(
         LIB_UNDER_TEST
+        LayerQuant
+        MORE_LIBS
+        QuantizationApi
+        Quantization
+        Rounding
+)
+
+
+add_elastic_ai_unit_test(
+        LIB_UNDER_TEST
+        LayerWeightsApi
+        MORE_LIBS
+        LinearApi
+        QuantizationApi
+        LayerQuant
+        LayerCommon
+        Quantization
+        Rounding
+        Linear
+        Tensor
+)
+
+
+add_elastic_ai_unit_test(
+        LIB_UNDER_TEST
+        StateDictApi
+        MORE_LIBS
+        LinearApi
+        ReluApi
+        LayerQuant
+        QuantizationApi
+        LayerWeightsApi
+        LayerCommon
+        Quantization
+        Rounding
+        Linear
+        Relu
+        Tensor
+)
+
+
+add_elastic_ai_unit_test(
+        LIB_UNDER_TEST
         InferenceApi
         MORE_LIBS
         CommonLayerLibs
@@ -115,3 +158,12 @@ target_link_libraries(UnitTestOptimizerScaling PRIVATE
         StorageApi
 )
 __register_target_as_unit_test(UnitTestOptimizerScaling)
+
+add_executable(UnitTestQuantizationApiBitsControl UnitTestQuantizationApiBitsControl.c)
+target_link_libraries(UnitTestQuantizationApiBitsControl PRIVATE
+        unity
+        QuantizationApi
+        Quantization
+        Rounding
+)
+__register_target_as_unit_test(UnitTestQuantizationApiBitsControl)

--- a/test/unit/userAPI/UnitTestFlattenIntegration.c
+++ b/test/unit/userAPI/UnitTestFlattenIntegration.c
@@ -50,7 +50,7 @@ void testCalculateGradsSequential_WithFlattenFirst_DoesNotCrash(void) {
     parameter_t *b0 = parameterInit(b0Param, b0Grad);
 
     layer_t *flatten = flattenLayerInit();
-    layer_t *linear = linearLayerInit(w0, b0, q, q, q, q);
+    layer_t *linear = linearLayerInitLegacy(w0, b0, q, q, q, q);
     layer_t *softmax = softmaxLayerInit(q, q);
     layer_t *model[3] = {flatten, linear, softmax};
 
@@ -94,7 +94,7 @@ void testCalculateGradsSequential_WithFlattenFirst_DoesNotCrash(void) {
     freeTensor(label);
     freeTensor(input);
     freeSoftmaxLayer(softmax);
-    freeLinearLayer(linear);
+    freeLinearLayerLegacy(linear);
     freeFlattenLayer(flatten);
     freeParameter(b0);
     freeParameter(w0);

--- a/test/unit/userAPI/UnitTestInferenceApi.c
+++ b/test/unit/userAPI/UnitTestInferenceApi.c
@@ -51,8 +51,8 @@ void testInferenceLinearReluFloat() {
     tensorFillFromFloatBuffer(input, (float[]){0.f, 1.f, 2.f}, 3);
 
     /* 5. Build layers; both layers share the same q (no ownership transfer). */
-    layer_t *linear = linearLayerInit(weights, bias, q, q, q, q);
-    layer_t *relu = reluLayerInit(q, q);
+    layer_t *linear = linearLayerInitLegacy(weights, bias, q, q, q, q);
+    layer_t *relu = reluLayerInitLegacy(q, q);
     layer_t *model[] = {linear, relu};
 
     /* 6. Exercise the system. */
@@ -70,8 +70,8 @@ void testInferenceLinearReluFloat() {
      *    - freeParameter cascades to param + grad via freeTensor (TensorApi.c:389).
      *    - The shared q is freed exactly once at the end. */
     freeTensor(output);
-    freeReluLayer(relu);
-    freeLinearLayer(linear);
+    freeReluLayerLegacy(relu);
+    freeLinearLayerLegacy(linear);
     freeTensor(input);
     freeParameter(bias);
     freeParameter(weights);
@@ -126,8 +126,8 @@ void testInferenceLinearReluSymInt32() {
     tensorFillFromFloatBuffer(input, (float[]){0.f, 1.f, 2.f}, 3);
 
     /* Layers. */
-    layer_t *linear = linearLayerInit(weights, bias, q, q, q, q);
-    layer_t *relu = reluLayerInit(q, q);
+    layer_t *linear = linearLayerInitLegacy(weights, bias, q, q, q, q);
+    layer_t *relu = reluLayerInitLegacy(q, q);
     layer_t *model[] = {linear, relu};
 
     /* Run inference (returns a heap tensor in SymInt32 form). */
@@ -153,8 +153,8 @@ void testInferenceLinearReluSymInt32() {
     /* FREE in reverse-init order. */
     freeTensor(outputFloat);
     freeTensor(outputSymInt32);
-    freeReluLayer(relu);
-    freeLinearLayer(linear);
+    freeReluLayerLegacy(relu);
+    freeLinearLayerLegacy(linear);
     freeTensor(input);
     freeParameter(bias);
     freeParameter(weights);
@@ -219,8 +219,8 @@ void testInferenceWithLossLinearReluFloat() {
     tensorFillFromFloatBuffer(label0, (float[]){59.f, -23.f}, 2);
 
     /* Layers. */
-    layer_t *linear = linearLayerInit(weights, bias, q, q, q, q);
-    layer_t *relu = reluLayerInit(q, q);
+    layer_t *linear = linearLayerInitLegacy(weights, bias, q, q, q, q);
+    layer_t *relu = reluLayerInitLegacy(q, q);
     layer_t *model[] = {linear, relu};
 
     /* Run inferenceWithLoss. inferenceStats owns its `output` tensor; its
@@ -236,8 +236,8 @@ void testInferenceWithLossLinearReluFloat() {
 
     /* FREE in reverse-init order. */
     freeInferenceStats(inferenceStats);
-    freeReluLayer(relu);
-    freeLinearLayer(linear);
+    freeReluLayerLegacy(relu);
+    freeLinearLayerLegacy(linear);
     freeTensor(label0);
     freeTensor(input);
     freeParameter(bias);

--- a/test/unit/userAPI/UnitTestLayerQuant.c
+++ b/test/unit/userAPI/UnitTestLayerQuant.c
@@ -1,0 +1,39 @@
+#define SOURCE_FILE "UNIT_TEST_LAYER_QUANT"
+
+#include "LayerQuant.h"
+#include "QuantizationApi.h"
+#include "unity.h"
+
+void setUp() {}
+void tearDown() {}
+
+void testLayerQuantInitUniformSetsAllFourSlotsToTheSamePointer(void) {
+    quantization_t *q = quantizationInitFloat();
+
+    layerQuant_t lq = {0};
+    layerQuantInitUniform(&lq, q);
+
+    TEST_ASSERT_EQUAL_PTR(q, lq.forwardMath);
+    TEST_ASSERT_EQUAL_PTR(q, lq.backwardMath);
+    TEST_ASSERT_EQUAL_PTR(q, lq.weightStorage);
+    TEST_ASSERT_EQUAL_PTR(q, lq.biasStorage);
+}
+
+void testLayerQuantInitUniformDoesNotMutateTheQuantization(void) {
+    quantization_t *q = quantizationInitFloat();
+    qtype_t typeBefore = q->type;
+    void *configBefore = q->qConfig;
+
+    layerQuant_t lq = {0};
+    layerQuantInitUniform(&lq, q);
+
+    TEST_ASSERT_EQUAL_INT(typeBefore, q->type);
+    TEST_ASSERT_EQUAL_PTR(configBefore, q->qConfig);
+}
+
+int main(void) {
+    UNITY_BEGIN();
+    RUN_TEST(testLayerQuantInitUniformSetsAllFourSlotsToTheSamePointer);
+    RUN_TEST(testLayerQuantInitUniformDoesNotMutateTheQuantization);
+    return UNITY_END();
+}

--- a/test/unit/userAPI/UnitTestLayerWeightsApi.c
+++ b/test/unit/userAPI/UnitTestLayerWeightsApi.c
@@ -1,0 +1,72 @@
+#define SOURCE_FILE "UNIT_TEST_LAYER_WEIGHTS_API"
+
+#include "LayerCommon.h"
+#include "LayerQuant.h"
+#include "LayerWeightsApi.h"
+#include "Linear.h"
+#include "LinearApi.h"
+#include "QuantizationApi.h"
+#include "Tensor.h"
+#include "unity.h"
+
+void setUp() {}
+void tearDown() {}
+
+void testLayerLoadWeightsLinearOverwritesWeightAndBiasTensors(void) {
+    quantization_t *q = quantizationInitFloat();
+    layerQuant_t lq;
+    layerQuantInitUniform(&lq, q);
+
+    layer_t *layer = linearLayerInit(
+        &(linearInit_t){
+            .inFeatures = 3,
+            .outFeatures = 2,
+            .bias = BIAS_TRUE,
+        },
+        &lq);
+
+    float weightData[6] = {1.f, 2.f, 3.f, 4.f, 5.f, 6.f};
+    float biasData[2] = {-1.f, -2.f};
+
+    layerLoadWeights(layer, weightData, biasData);
+
+    linearConfig_t *cfg = layer->config->linear;
+    float *loadedWeights = (float *)cfg->weights->param->data;
+    float *loadedBias = (float *)cfg->bias->param->data;
+
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(weightData, loadedWeights, 6);
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(biasData, loadedBias, 2);
+
+    freeLinearLayer(layer);
+}
+
+void testLayerLoadWeightsLinearNoBiasAcceptsNullBiasData(void) {
+    quantization_t *q = quantizationInitFloat();
+    layerQuant_t lq;
+    layerQuantInitUniform(&lq, q);
+
+    layer_t *layer = linearLayerInit(
+        &(linearInit_t){
+            .inFeatures = 3,
+            .outFeatures = 2,
+            .bias = BIAS_FALSE,
+        },
+        &lq);
+
+    float weightData[6] = {1.f, 2.f, 3.f, 4.f, 5.f, 6.f};
+    layerLoadWeights(layer, weightData, NULL);
+
+    linearConfig_t *cfg = layer->config->linear;
+    float *loadedWeights = (float *)cfg->weights->param->data;
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(weightData, loadedWeights, 6);
+    TEST_ASSERT_NULL(cfg->bias);
+
+    freeLinearLayer(layer);
+}
+
+int main(void) {
+    UNITY_BEGIN();
+    RUN_TEST(testLayerLoadWeightsLinearOverwritesWeightAndBiasTensors);
+    RUN_TEST(testLayerLoadWeightsLinearNoBiasAcceptsNullBiasData);
+    return UNITY_END();
+}

--- a/test/unit/userAPI/UnitTestMnistSmoke.c
+++ b/test/unit/userAPI/UnitTestMnistSmoke.c
@@ -128,8 +128,8 @@ static void buildModel(layer_t **model, quantization_t **q_out) {
     tensor_t *b0Grad = gradInitFloat(b0Param, NULL);
     parameter_t *b0 = parameterInit(b0Param, b0Grad);
 
-    model[0] = linearLayerInit(w0, b0, q, q, q, q);
-    model[1] = reluLayerInit(q, q);
+    model[0] = linearLayerInitLegacy(w0, b0, q, q, q, q);
+    model[1] = reluLayerInitLegacy(q, q);
 
     distribution_t xavier1 = {
         .type = XAVIER_UNIFORM,
@@ -161,7 +161,7 @@ static void buildModel(layer_t **model, quantization_t **q_out) {
     tensor_t *b1Grad = gradInitFloat(b1Param, NULL);
     parameter_t *b1 = parameterInit(b1Param, b1Grad);
 
-    model[2] = linearLayerInit(w1, b1, q, q, q, q);
+    model[2] = linearLayerInitLegacy(w1, b1, q, q, q, q);
     model[3] = softmaxLayerInit(q, q);
 }
 
@@ -216,9 +216,9 @@ void testMnistSmoke_FullTrainingPipelineReducesLoss() {
      * Do NOT also call freeParameter on w0/b0/w1/b1 — would be a double-free. */
     freeOptimSgdM(sgd);
     freeSoftmaxLayer(model[3]);
-    freeLinearLayer(model[2]);
-    freeReluLayer(model[1]);
-    freeLinearLayer(model[0]);
+    freeLinearLayerLegacy(model[2]);
+    freeReluLayerLegacy(model[1]);
+    freeLinearLayerLegacy(model[0]);
     freeDataLoader(evalDl);
     freeDataLoader(trainDl);
     freeQuantization(q);
@@ -276,9 +276,9 @@ void testMnistSmoke_SnprintfGmtimeRBetweenSetupAndTrainingRun_NoSilentExit() {
 
     freeOptimSgdM(sgd);
     freeSoftmaxLayer(model[3]);
-    freeLinearLayer(model[2]);
-    freeReluLayer(model[1]);
-    freeLinearLayer(model[0]);
+    freeLinearLayerLegacy(model[2]);
+    freeReluLayerLegacy(model[1]);
+    freeLinearLayerLegacy(model[0]);
     freeDataLoader(evalDl);
     freeDataLoader(trainDl);
     freeQuantization(q);

--- a/test/unit/userAPI/UnitTestMultiLayerTraining.c
+++ b/test/unit/userAPI/UnitTestMultiLayerTraining.c
@@ -56,8 +56,8 @@ void testMultiLayerBackward_WithCrossEntropy_DoesNotCrash() {
     tensor_t *b0Grad = gradInitFloat(b0Param, NULL);
     parameter_t *b0 = parameterInit(b0Param, b0Grad);
 
-    layer_t *linear0 = linearLayerInit(w0, b0, q, q, q, q);
-    layer_t *relu = reluLayerInit(q, q);
+    layer_t *linear0 = linearLayerInitLegacy(w0, b0, q, q, q, q);
+    layer_t *relu = reluLayerInitLegacy(q, q);
 
     /* Layer 1 weights w1 (2x4, ZEROS). */
     size_t *w1Dims = reserveMemory(2 * sizeof(size_t));
@@ -85,7 +85,7 @@ void testMultiLayerBackward_WithCrossEntropy_DoesNotCrash() {
     tensor_t *b1Grad = gradInitFloat(b1Param, NULL);
     parameter_t *b1 = parameterInit(b1Param, b1Grad);
 
-    layer_t *linear1 = linearLayerInit(w1, b1, q, q, q, q);
+    layer_t *linear1 = linearLayerInitLegacy(w1, b1, q, q, q, q);
     layer_t *softmax = softmaxLayerInit(q, q);
 
     layer_t *model[] = {linear0, relu, linear1, softmax};
@@ -127,11 +127,11 @@ void testMultiLayerBackward_WithCrossEntropy_DoesNotCrash() {
     freeTensor(label);
     freeTensor(input);
     freeSoftmaxLayer(softmax);
-    freeLinearLayer(linear1);
+    freeLinearLayerLegacy(linear1);
     freeParameter(b1);
     freeParameter(w1);
-    freeReluLayer(relu);
-    freeLinearLayer(linear0);
+    freeReluLayerLegacy(relu);
+    freeLinearLayerLegacy(linear0);
     freeParameter(b0);
     freeParameter(w0);
     freeQuantization(q);
@@ -175,8 +175,8 @@ void testMultiLayerBackward_WithManualInit_DoesNotCrash() {
     tensor_t *b0Grad = gradInitFloat(b0Param, NULL);
     parameter_t *b0 = parameterInit(b0Param, b0Grad);
 
-    layer_t *linear0 = linearLayerInit(w0, b0, q, q, q, q);
-    layer_t *relu = reluLayerInit(q, q);
+    layer_t *linear0 = linearLayerInitLegacy(w0, b0, q, q, q, q);
+    layer_t *relu = reluLayerInitLegacy(q, q);
 
     /* Layer 1 weights w1 (2x4, manual). */
     size_t *w1Dims = reserveMemory(2 * sizeof(size_t));
@@ -204,7 +204,7 @@ void testMultiLayerBackward_WithManualInit_DoesNotCrash() {
     tensor_t *b1Grad = gradInitFloat(b1Param, NULL);
     parameter_t *b1 = parameterInit(b1Param, b1Grad);
 
-    layer_t *linear1 = linearLayerInit(w1, b1, q, q, q, q);
+    layer_t *linear1 = linearLayerInitLegacy(w1, b1, q, q, q, q);
     layer_t *softmax = softmaxLayerInit(q, q);
 
     layer_t *model[] = {linear0, relu, linear1, softmax};
@@ -258,11 +258,11 @@ void testMultiLayerBackward_WithManualInit_DoesNotCrash() {
     freeTensor(label);
     freeTensor(input);
     freeSoftmaxLayer(softmax);
-    freeLinearLayer(linear1);
+    freeLinearLayerLegacy(linear1);
     freeParameter(b1);
     freeParameter(w1);
-    freeReluLayer(relu);
-    freeLinearLayer(linear0);
+    freeReluLayerLegacy(relu);
+    freeLinearLayerLegacy(linear0);
     freeParameter(b0);
     freeParameter(w0);
     freeQuantization(q);
@@ -304,8 +304,8 @@ void testMultiLayerTraining_MultipleSteps_GradsAccumulate() {
     tensor_t *b0Grad = gradInitFloat(b0Param, NULL);
     parameter_t *b0 = parameterInit(b0Param, b0Grad);
 
-    layer_t *linear0 = linearLayerInit(w0, b0, q, q, q, q);
-    layer_t *relu = reluLayerInit(q, q);
+    layer_t *linear0 = linearLayerInitLegacy(w0, b0, q, q, q, q);
+    layer_t *relu = reluLayerInitLegacy(q, q);
 
     /* Layer 1 weights w1 (2x4). */
     size_t *w1Dims = reserveMemory(2 * sizeof(size_t));
@@ -333,7 +333,7 @@ void testMultiLayerTraining_MultipleSteps_GradsAccumulate() {
     tensor_t *b1Grad = gradInitFloat(b1Param, NULL);
     parameter_t *b1 = parameterInit(b1Param, b1Grad);
 
-    layer_t *linear1 = linearLayerInit(w1, b1, q, q, q, q);
+    layer_t *linear1 = linearLayerInitLegacy(w1, b1, q, q, q, q);
     layer_t *softmax = softmaxLayerInit(q, q);
 
     layer_t *model[] = {linear0, relu, linear1, softmax};
@@ -390,9 +390,9 @@ void testMultiLayerTraining_MultipleSteps_GradsAccumulate() {
     freeTensor(input);
     freeOptimSgdM(sgd);
     freeSoftmaxLayer(softmax);
-    freeLinearLayer(linear1);
-    freeReluLayer(relu);
-    freeLinearLayer(linear0);
+    freeLinearLayerLegacy(linear1);
+    freeReluLayerLegacy(relu);
+    freeLinearLayerLegacy(linear0);
     freeQuantization(q);
 
     /* ASSERT on captured. */

--- a/test/unit/userAPI/UnitTestOptimizerScaling.c
+++ b/test/unit/userAPI/UnitTestOptimizerScaling.c
@@ -61,7 +61,7 @@ static optimizer_t *buildOneLayerOptimWithGrads(layer_t **modelOut, parameter_t 
 
     quantization_t testQ;
     initFloat32Quantization(&testQ);
-    layer_t *linear = linearLayerInit(w, b, &testQ, &testQ, &testQ, &testQ);
+    layer_t *linear = linearLayerInitLegacy(w, b, &testQ, &testQ, &testQ, &testQ);
     modelOut[0] = linear;
     *wOut = w;
     *bOut = b;
@@ -98,7 +98,7 @@ void testScaleOptimizerGradients_DoublesGradients() {
 
     /* FREE. freeOptimSgdM cascades to both parameters. */
     freeOptimSgdM(sgd);
-    freeLinearLayer(model[0]);
+    freeLinearLayerLegacy(model[0]);
 
     /* ASSERT — every grad doubled. */
     for (size_t i = 0; i < 6; i++) {
@@ -129,7 +129,7 @@ void testScaleOptimizerGradients_FactorZero_DoesNotAbort() {
     float capturedFirst = ((float *)w->grad->data)[0];
 
     freeOptimSgdM(sgd);
-    freeLinearLayer(model[0]);
+    freeLinearLayerLegacy(model[0]);
 
     TEST_ASSERT_EQUAL_FLOAT(0.0f, capturedFirst);
 }
@@ -150,7 +150,7 @@ void testScaleOptimizerGradients_FactorNaN_DoesNotAbort() {
     float captured = ((float *)w->grad->data)[0];
 
     freeOptimSgdM(sgd);
-    freeLinearLayer(model[0]);
+    freeLinearLayerLegacy(model[0]);
 
     /* NaN != NaN by IEEE 754. */
     TEST_ASSERT_TRUE(captured != captured);
@@ -212,7 +212,7 @@ static optimizer_t *buildSymInt32OneLayerOptim(layer_t **modelOut, parameter_t *
     parameter_t *b = parameterInit(bParam, bGrad);
 
     quantization_t *layerQ = quantizationInitSymInt32(HTE);
-    layer_t *linear = linearLayerInit(w, b, layerQ, layerQ, layerQ, layerQ);
+    layer_t *linear = linearLayerInitLegacy(w, b, layerQ, layerQ, layerQ, layerQ);
     modelOut[0] = linear;
     *wOut = w;
     *bOut = b;
@@ -244,7 +244,7 @@ void testScaleOptimizerGradients_SymInt32_ScalesScaleOnly() {
     float capturedBScale = ((symInt32QConfig_t *)b->grad->quantization->qConfig)->scale;
 
     freeOptimSgdM(sgd);
-    freeLinearLayer(model[0]);
+    freeLinearLayerLegacy(model[0]);
 
     /* int32 storage is byte-for-byte unchanged. */
     for (size_t i = 0; i < 6; i++) {
@@ -304,7 +304,7 @@ void testScaleOptimizerGradients_SymInt32_DequantEquivalence() {
     }
 
     freeOptimSgdM(sgd);
-    freeLinearLayer(model[0]);
+    freeLinearLayerLegacy(model[0]);
 
     for (size_t i = 0; i < 6; i++) {
         TEST_ASSERT_FLOAT_WITHIN(1e-6f, wDequantBeforeTimesFactor[i], wDequantAfter[i]);
@@ -367,7 +367,7 @@ void testScaleOptimizerGradients_SymInt32_MomentumSgdAppliesScaledGradient() {
     }
 
     freeOptimSgdM(sgd);
-    freeLinearLayer(model[0]);
+    freeLinearLayerLegacy(model[0]);
 
     /* Tolerance accounts for the int32 round-trip in sgdStepSymInt32 — the
      * intermediate float value gets requantized through wScale0 (post-step

--- a/test/unit/userAPI/UnitTestQuantizationApiBitsControl.c
+++ b/test/unit/userAPI/UnitTestQuantizationApiBitsControl.c
@@ -1,0 +1,46 @@
+#define SOURCE_FILE "UNIT_TEST_QUANTIZATION_API_BITS_CONTROL"
+
+#include "Quantization.h"
+#include "QuantizationApi.h"
+#include "Rounding.h"
+#include "unity.h"
+
+void setUp() {}
+void tearDown() {}
+
+void testQuantizationInitSymInt32WithBitsSetsBitsAndRoundingMode(void) {
+    quantization_t *q = quantizationInitSymInt32WithBits(SRHTE, 12);
+
+    TEST_ASSERT_EQUAL_INT(SYM_INT32, q->type);
+    TEST_ASSERT_NOT_NULL(q->qConfig);
+
+    symInt32QConfig_t *cfg = (symInt32QConfig_t *)q->qConfig;
+    TEST_ASSERT_EQUAL_UINT8(12, cfg->qMaxBits);
+    TEST_ASSERT_EQUAL_INT(SRHTE, cfg->roundingMode);
+}
+
+void testQuantizationInitSymInt32WithBitsAcceptsMaxBits32(void) {
+    quantization_t *q = quantizationInitSymInt32WithBits(HTE, 32);
+
+    symInt32QConfig_t *cfg = (symInt32QConfig_t *)q->qConfig;
+    TEST_ASSERT_EQUAL_UINT8(32, cfg->qMaxBits);
+}
+
+void testQuantizationInitSymBuildsQConfigWithSpecifiedBitsAndRounding(void) {
+    quantization_t *q = quantizationInitSym(4, HTE);
+
+    TEST_ASSERT_EQUAL_INT(SYM, q->type);
+    TEST_ASSERT_NOT_NULL(q->qConfig);
+
+    symQConfig_t *cfg = (symQConfig_t *)q->qConfig;
+    TEST_ASSERT_EQUAL_UINT8(4, cfg->qBits);
+    TEST_ASSERT_EQUAL_INT(HTE, cfg->roundingMode);
+}
+
+int main(void) {
+    UNITY_BEGIN();
+    RUN_TEST(testQuantizationInitSymInt32WithBitsSetsBitsAndRoundingMode);
+    RUN_TEST(testQuantizationInitSymInt32WithBitsAcceptsMaxBits32);
+    RUN_TEST(testQuantizationInitSymBuildsQConfigWithSpecifiedBitsAndRounding);
+    return UNITY_END();
+}

--- a/test/unit/userAPI/UnitTestStateDictApi.c
+++ b/test/unit/userAPI/UnitTestStateDictApi.c
@@ -1,0 +1,67 @@
+#define SOURCE_FILE "UNIT_TEST_STATE_DICT_API"
+
+#include "LayerCommon.h"
+#include "LayerQuant.h"
+#include "Linear.h"
+#include "LinearApi.h"
+#include "QuantizationApi.h"
+#include "ReluApi.h"
+#include "StateDictApi.h"
+#include "unity.h"
+
+void setUp() {}
+void tearDown() {}
+
+void testModelLoadStateDictLoadsTwoLinearLayersSkippingRelu(void) {
+    quantization_t *q = quantizationInitFloat();
+    layerQuant_t lq;
+    layerQuantInitUniform(&lq, q);
+
+    layer_t *model[3];
+    model[0] =
+        linearLayerInit(&(linearInit_t){.inFeatures = 3, .outFeatures = 2, .bias = BIAS_TRUE}, &lq);
+    model[1] = reluLayerInit(&lq);
+    model[2] =
+        linearLayerInit(&(linearInit_t){.inFeatures = 2, .outFeatures = 1, .bias = BIAS_TRUE}, &lq);
+
+    float w0[6] = {1, 2, 3, 4, 5, 6};
+    float b0[2] = {10, 20};
+    float w1[2] = {7, 8};
+    float b1[1] = {99};
+
+    modelLoadStateDict(model, 3,
+                       (stateDictEntry_t[]){
+                           {.name = "fc1", .weightData = w0, .biasData = b0},
+                           {.name = "fc2", .weightData = w1, .biasData = b1},
+                       },
+                       2);
+
+    linearConfig_t *cfg0 = model[0]->config->linear;
+    linearConfig_t *cfg2 = model[2]->config->linear;
+    float *fc1Weights = (float *)cfg0->weights->param->data;
+    float *fc1Bias = (float *)cfg0->bias->param->data;
+    float *fc2Weights = (float *)cfg2->weights->param->data;
+    float *fc2Bias = (float *)cfg2->bias->param->data;
+
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(w0, fc1Weights, 6);
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(b0, fc1Bias, 2);
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(w1, fc2Weights, 2);
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(b1, fc2Bias, 1);
+
+    freeLinearLayer(model[0]);
+    freeReluLayer(model[1]);
+    freeLinearLayer(model[2]);
+}
+
+void testModelLoadStateDictCountMismatchIsCoveredByDesign(void) {
+    /* Count-mismatch fires PRINT_ERROR + exit; Unity cannot catch.
+     * Documented in spec section 12. This test exists as a marker. */
+    TEST_IGNORE_MESSAGE("Count mismatch path fires exit() — covered by design contract.");
+}
+
+int main(void) {
+    UNITY_BEGIN();
+    RUN_TEST(testModelLoadStateDictLoadsTwoLinearLayersSkippingRelu);
+    RUN_TEST(testModelLoadStateDictCountMismatchIsCoveredByDesign);
+    return UNITY_END();
+}

--- a/test/unit/userAPI/UnitTestTrainingLoopApi.c
+++ b/test/unit/userAPI/UnitTestTrainingLoopApi.c
@@ -48,7 +48,7 @@ void testCalculateGradsSequential_MatchesPyTorch() {
 
     quantization_t testQ;
     initFloat32Quantization(&testQ);
-    layer_t *linear = linearLayerInit(weights, bias, &testQ, &testQ, &testQ, &testQ);
+    layer_t *linear = linearLayerInitLegacy(weights, bias, &testQ, &testQ, &testQ, &testQ);
 
     layer_t *model[] = {linear};
     size_t sizeModel = 1;
@@ -116,7 +116,7 @@ void testCalculateGradsSequential_MatchesPyTorch() {
     freeTensor(input2);
     freeTensor(input1);
     freeTensor(input0);
-    freeLinearLayer(linear);
+    freeLinearLayerLegacy(linear);
 
     /* ASSERT on captured. */
     const float errorPercent = 0.03f;
@@ -138,7 +138,7 @@ void testEvaluationBatch_ReturnsAverageLoss() {
 
     quantization_t testQ;
     initFloat32Quantization(&testQ);
-    layer_t *linear = linearLayerInit(w, b, &testQ, &testQ, &testQ, &testQ);
+    layer_t *linear = linearLayerInitLegacy(w, b, &testQ, &testQ, &testQ, &testQ);
     layer_t *model[] = {linear};
 
     /* Create 2 samples manually */
@@ -180,7 +180,7 @@ void testEvaluationBatch_ReturnsAverageLoss() {
     freeTensor(input1);
     freeTensor(label0);
     freeTensor(input0);
-    freeLinearLayer(linear);
+    freeLinearLayerLegacy(linear);
     freeParameter(b);
     freeParameter(w);
 
@@ -269,7 +269,7 @@ void testEvaluationEpoch_ReturnsAverageLossAcrossBatches() {
 
     quantization_t testQ;
     initFloat32Quantization(&testQ);
-    layer_t *linear = linearLayerInit(w, b, &testQ, &testQ, &testQ, &testQ);
+    layer_t *linear = linearLayerInitLegacy(w, b, &testQ, &testQ, &testQ, &testQ);
     layer_t *model[] = {linear};
 
     dataLoader_t *dl =
@@ -282,7 +282,7 @@ void testEvaluationEpoch_ReturnsAverageLossAcrossBatches() {
 
     /* FREE. */
     freeDataLoader(dl);
-    freeLinearLayer(linear);
+    freeLinearLayerLegacy(linear);
     freeParameter(b);
     freeParameter(w);
     freeEpochDataset();
@@ -310,7 +310,7 @@ void testEvaluationEpoch_MinibatchMatchesMicrobatchAverage() {
 
     quantization_t testQ;
     initFloat32Quantization(&testQ);
-    layer_t *linear = linearLayerInit(w, b, &testQ, &testQ, &testQ, &testQ);
+    layer_t *linear = linearLayerInitLegacy(w, b, &testQ, &testQ, &testQ, &testQ);
     layer_t *model[] = {linear};
 
     /* batchSize=2 → 2 minibatches of 2 samples each
@@ -326,7 +326,7 @@ void testEvaluationEpoch_MinibatchMatchesMicrobatchAverage() {
 
     /* FREE. */
     freeDataLoader(dl);
-    freeLinearLayer(linear);
+    freeLinearLayerLegacy(linear);
     freeParameter(b);
     freeParameter(w);
     freeEpochDataset();
@@ -347,7 +347,7 @@ void testTrainingBatchDefault_ReturnsAverageLossAndAccumulatesGrads() {
 
     quantization_t testQ;
     initFloat32Quantization(&testQ);
-    layer_t *linear = linearLayerInit(w, b, &testQ, &testQ, &testQ, &testQ);
+    layer_t *linear = linearLayerInitLegacy(w, b, &testQ, &testQ, &testQ, &testQ);
     layer_t *model[] = {linear};
 
     /* Compute expected: run calculateGradsSequential manually per sample */
@@ -402,7 +402,7 @@ void testTrainingBatchDefault_ReturnsAverageLossAndAccumulatesGrads() {
     freeTensor(in1);
     freeTensor(lb0);
     freeTensor(in0);
-    freeLinearLayer(linear);
+    freeLinearLayerLegacy(linear);
     freeParameter(b);
     freeParameter(w);
 
@@ -421,7 +421,7 @@ void testTrainingBatchDefault_SumAggregatesWithoutDivision() {
 
     quantization_t testQ;
     initFloat32Quantization(&testQ);
-    layer_t *linear = linearLayerInit(w, b, &testQ, &testQ, &testQ, &testQ);
+    layer_t *linear = linearLayerInitLegacy(w, b, &testQ, &testQ, &testQ, &testQ);
     layer_t *model[] = {linear};
 
     tensor_t *in0 = buildFloatTensor2D(1, 3, (float[]){-4.f, 1.f, 9.f}, 3);
@@ -469,7 +469,7 @@ void testTrainingBatchDefault_SumAggregatesWithoutDivision() {
     freeTensor(in1);
     freeTensor(lb0);
     freeTensor(in0);
-    freeLinearLayer(linear);
+    freeLinearLayerLegacy(linear);
     freeParameter(b);
     freeParameter(w);
 
@@ -490,7 +490,7 @@ void testTrainingEpochDefault_DoesOptimizerStepPerBatch() {
 
     quantization_t testQ;
     initFloat32Quantization(&testQ);
-    layer_t *linear = linearLayerInit(w, b, &testQ, &testQ, &testQ, &testQ);
+    layer_t *linear = linearLayerInitLegacy(w, b, &testQ, &testQ, &testQ, &testQ);
     layer_t *model[] = {linear};
     size_t sizeModel = 1;
 
@@ -528,7 +528,7 @@ void testTrainingEpochDefault_DoesOptimizerStepPerBatch() {
      * those (would double-free). */
     freeOptimSgdM(sgd);
     freeDataLoader(dl);
-    freeLinearLayer(linear);
+    freeLinearLayerLegacy(linear);
     freeEpochDataset();
 
     /* ASSERT. */
@@ -553,7 +553,7 @@ void testTrainingEpochDefault_MinibatchStepsOncePerMinibatch() {
 
     quantization_t testQ;
     initFloat32Quantization(&testQ);
-    layer_t *linear = linearLayerInit(w, b, &testQ, &testQ, &testQ, &testQ);
+    layer_t *linear = linearLayerInitLegacy(w, b, &testQ, &testQ, &testQ, &testQ);
     layer_t *model[] = {linear};
     size_t sizeModel = 1;
 
@@ -588,7 +588,7 @@ void testTrainingEpochDefault_MinibatchStepsOncePerMinibatch() {
     /* FREE. */
     freeOptimSgdM(sgd);
     freeDataLoader(dl);
-    freeLinearLayer(linear);
+    freeLinearLayerLegacy(linear);
     freeEpochDataset();
 
     /* ASSERT. */
@@ -607,7 +607,7 @@ void testTrainingRun_ReturnsResult() {
 
     quantization_t testQ;
     initFloat32Quantization(&testQ);
-    layer_t *linear = linearLayerInit(w, b, &testQ, &testQ, &testQ, &testQ);
+    layer_t *linear = linearLayerInitLegacy(w, b, &testQ, &testQ, &testQ, &testQ);
     layer_t *model[] = {linear};
 
     optimizer_t *sgd = sgdMCreateOptim(0.01f, 0.f, 0.f, model, 1, FLOAT32);
@@ -631,7 +631,7 @@ void testTrainingRun_ReturnsResult() {
     freeOptimSgdM(sgd);
     freeDataLoader(evalDl);
     freeDataLoader(trainDl);
-    freeLinearLayer(linear);
+    freeLinearLayerLegacy(linear);
     freeEpochDataset();
 
     /* ASSERT. */
@@ -669,7 +669,7 @@ void testTrainingRun_CallsCallbackEachEpochWithStats() {
 
     quantization_t testQ;
     initFloat32Quantization(&testQ);
-    layer_t *linear = linearLayerInit(w, b, &testQ, &testQ, &testQ, &testQ);
+    layer_t *linear = linearLayerInitLegacy(w, b, &testQ, &testQ, &testQ, &testQ);
     layer_t *model[] = {linear};
 
     optimizer_t *sgd = sgdMCreateOptim(0.01f, 0.f, 0.f, model, 1, FLOAT32);
@@ -699,7 +699,7 @@ void testTrainingRun_CallsCallbackEachEpochWithStats() {
     freeOptimSgdM(sgd);
     freeDataLoader(evalDl);
     freeDataLoader(trainDl);
-    freeLinearLayer(linear);
+    freeLinearLayerLegacy(linear);
     freeEpochDataset();
 
     /* ASSERT. Callback was invoked once per epoch, in order. */
@@ -727,7 +727,7 @@ void testEvaluationEpochWithMetrics_AllCorrect() {
 
     quantization_t testQ;
     initFloat32Quantization(&testQ);
-    layer_t *linear = linearLayerInit(w, b, &testQ, &testQ, &testQ, &testQ);
+    layer_t *linear = linearLayerInitLegacy(w, b, &testQ, &testQ, &testQ, &testQ);
     layer_t *model[] = {linear};
 
     dataLoader_t *dl =
@@ -746,7 +746,7 @@ void testEvaluationEpochWithMetrics_AllCorrect() {
 
     /* FREE. */
     freeDataLoader(dl);
-    freeLinearLayer(linear);
+    freeLinearLayerLegacy(linear);
     freeParameter(b);
     freeParameter(w);
     freeEpochDataset();
@@ -837,7 +837,7 @@ void testTrainingEpochDefault_MeanScalesGradByOneOverNF() {
 
     quantization_t testQ;
     initFloat32Quantization(&testQ);
-    layer_t *linear = linearLayerInit(w, b, &testQ, &testQ, &testQ, &testQ);
+    layer_t *linear = linearLayerInitLegacy(w, b, &testQ, &testQ, &testQ, &testQ);
     layer_t *model[] = {linear};
 
     /* momentumFactor=0 makes SGD_M behave like plain SGD. */
@@ -858,7 +858,7 @@ void testTrainingEpochDefault_MeanScalesGradByOneOverNF() {
 
     freeOptimSgdM(sgd);
     freeDataLoader(dl);
-    freeLinearLayer(linear);
+    freeLinearLayerLegacy(linear);
     freeSingleSampleDataset();
 
     TEST_ASSERT_FLOAT_WITHIN(1e-4f, 0.995f, capturedW00);
@@ -940,7 +940,7 @@ void testEvaluationEpochWithMetrics_PartiallyCorrect() {
 
     quantization_t testQ;
     initFloat32Quantization(&testQ);
-    layer_t *linear = linearLayerInit(w, b, &testQ, &testQ, &testQ, &testQ);
+    layer_t *linear = linearLayerInitLegacy(w, b, &testQ, &testQ, &testQ, &testQ);
     layer_t *model[] = {linear};
 
     dataLoader_t *dl =
@@ -957,7 +957,7 @@ void testEvaluationEpochWithMetrics_PartiallyCorrect() {
 
     /* FREE. */
     freeDataLoader(dl);
-    freeLinearLayer(linear);
+    freeLinearLayerLegacy(linear);
     freeParameter(b);
     freeParameter(w);
     freePartialDataset();
@@ -1048,7 +1048,7 @@ void testEvaluationEpochWithMetrics_HandlesZeroPredictionClass() {
 
     quantization_t testQ;
     initFloat32Quantization(&testQ);
-    layer_t *linear = linearLayerInit(w, b, &testQ, &testQ, &testQ, &testQ);
+    layer_t *linear = linearLayerInitLegacy(w, b, &testQ, &testQ, &testQ, &testQ);
     layer_t *model[] = {linear};
 
     dataLoader_t *dl =
@@ -1065,7 +1065,7 @@ void testEvaluationEpochWithMetrics_HandlesZeroPredictionClass() {
 
     /* FREE. */
     freeDataLoader(dl);
-    freeLinearLayer(linear);
+    freeLinearLayerLegacy(linear);
     freeParameter(b);
     freeParameter(w);
     freeZeroPredDataset();
@@ -1103,7 +1103,7 @@ void testEvaluationEpochWithReport_ReturnsConfusionMatrix() {
 
     quantization_t testQ;
     initFloat32Quantization(&testQ);
-    layer_t *linear = linearLayerInit(w, b, &testQ, &testQ, &testQ, &testQ);
+    layer_t *linear = linearLayerInitLegacy(w, b, &testQ, &testQ, &testQ, &testQ);
     layer_t *model[] = {linear};
 
     dataLoader_t *dl =
@@ -1124,7 +1124,7 @@ void testEvaluationEpochWithReport_ReturnsConfusionMatrix() {
 
     /* FREE. */
     freeDataLoader(dl);
-    freeLinearLayer(linear);
+    freeLinearLayerLegacy(linear);
     freeParameter(b);
     freeParameter(w);
     freePartialDataset();
@@ -1155,7 +1155,7 @@ void testInferenceWithLoss_PropagatesForwardReductionSum() {
 
     quantization_t testQ;
     initFloat32Quantization(&testQ);
-    layer_t *linear = linearLayerInit(w, b, &testQ, &testQ, &testQ, &testQ);
+    layer_t *linear = linearLayerInitLegacy(w, b, &testQ, &testQ, &testQ, &testQ);
     layer_t *model[] = {linear};
 
     tensor_t *input = buildFloatTensor2D(1, 2, (float[]){5.f, 1.f}, 2);
@@ -1172,7 +1172,7 @@ void testInferenceWithLoss_PropagatesForwardReductionSum() {
     freeInferenceStats(meanStats);
     freeTensor(label);
     freeTensor(input);
-    freeLinearLayer(linear);
+    freeLinearLayerLegacy(linear);
     freeParameter(b);
     freeParameter(w);
 
@@ -1196,7 +1196,7 @@ void testTrainingEpochDefault_SumBackwardSkipsOptimizerScaling() {
 
     quantization_t testQ;
     initFloat32Quantization(&testQ);
-    layer_t *linear = linearLayerInit(w, b, &testQ, &testQ, &testQ, &testQ);
+    layer_t *linear = linearLayerInitLegacy(w, b, &testQ, &testQ, &testQ, &testQ);
     layer_t *model[] = {linear};
 
     /* Use a very small learning rate so SUM doesn't NaN — SUM gradients are
@@ -1229,7 +1229,7 @@ void testTrainingEpochDefault_SumBackwardSkipsOptimizerScaling() {
 
     freeOptimSgdM(sgd);
     freeDataLoader(dl);
-    freeLinearLayer(linear);
+    freeLinearLayerLegacy(linear);
     freeEpochDataset();
 
     TEST_ASSERT_TRUE(capturedChanged);
@@ -1253,7 +1253,7 @@ void testTrainingEpochDefault_MeanForwardSumBackward_MixedCombination() {
 
     quantization_t testQ;
     initFloat32Quantization(&testQ);
-    layer_t *linear = linearLayerInit(w, b, &testQ, &testQ, &testQ, &testQ);
+    layer_t *linear = linearLayerInitLegacy(w, b, &testQ, &testQ, &testQ, &testQ);
     layer_t *model[] = {linear};
 
     optimizer_t *sgd = sgdMCreateOptim(0.001f, 0.f, 0.f, model, 1, FLOAT32);
@@ -1284,7 +1284,7 @@ void testTrainingEpochDefault_MeanForwardSumBackward_MixedCombination() {
 
     freeOptimSgdM(sgd);
     freeDataLoader(dl);
-    freeLinearLayer(linear);
+    freeLinearLayerLegacy(linear);
     freeEpochDataset();
 
     TEST_ASSERT_TRUE(capturedChanged);
@@ -1306,7 +1306,7 @@ void testEvaluationEpoch_FlatAggregator_DivisionByTotalSamples() {
 
     quantization_t testQ;
     initFloat32Quantization(&testQ);
-    layer_t *linear = linearLayerInit(w, b, &testQ, &testQ, &testQ, &testQ);
+    layer_t *linear = linearLayerInitLegacy(w, b, &testQ, &testQ, &testQ, &testQ);
     layer_t *model[] = {linear};
 
     /* batchSize=2 → 2 batches of 2 samples; per-sample MSE losses are
@@ -1323,7 +1323,7 @@ void testEvaluationEpoch_FlatAggregator_DivisionByTotalSamples() {
     float capturedMean = meanLoss;
 
     freeDataLoader(dl);
-    freeLinearLayer(linear);
+    freeLinearLayerLegacy(linear);
     freeParameter(b);
     freeParameter(w);
     freeEpochDataset();
@@ -1343,7 +1343,7 @@ void testEvaluationEpoch_SumPath_ReturnsRawTotal() {
 
     quantization_t testQ;
     initFloat32Quantization(&testQ);
-    layer_t *linear = linearLayerInit(w, b, &testQ, &testQ, &testQ, &testQ);
+    layer_t *linear = linearLayerInitLegacy(w, b, &testQ, &testQ, &testQ, &testQ);
     layer_t *model[] = {linear};
 
     dataLoader_t *dl =
@@ -1356,7 +1356,7 @@ void testEvaluationEpoch_SumPath_ReturnsRawTotal() {
     float capturedSum = sumLoss;
 
     freeDataLoader(dl);
-    freeLinearLayer(linear);
+    freeLinearLayerLegacy(linear);
     freeParameter(b);
     freeParameter(w);
     freeEpochDataset();
@@ -1380,7 +1380,7 @@ void testTrainingRun_HardcodesForwardReductionMean() {
 
     quantization_t testQ;
     initFloat32Quantization(&testQ);
-    layer_t *linear = linearLayerInit(w, b, &testQ, &testQ, &testQ, &testQ);
+    layer_t *linear = linearLayerInitLegacy(w, b, &testQ, &testQ, &testQ, &testQ);
     layer_t *model[] = {linear};
 
     optimizer_t *sgd = sgdMCreateOptim(0.01f, 0.f, 0.f, model, 1, FLOAT32);
@@ -1406,7 +1406,7 @@ void testTrainingRun_HardcodesForwardReductionMean() {
     freeOptimSgdM(sgd);
     freeDataLoader(evalDl);
     freeDataLoader(trainDl);
-    freeLinearLayer(linear);
+    freeLinearLayerLegacy(linear);
     freeEpochDataset();
 
     TEST_ASSERT_TRUE(capturedTrain > 0.0f && capturedTrain < 100.0f);


### PR DESCRIPTION
## Summary

Introduces the new layer factory API per `docs/superpowers/specs/2026-05-15-layer-factory-api-design.md`:

- **New types**: `layerQuant_t` (4-slot quantization profile, strict-required-per-relevant-field), `bias_t` tri-state enum (`BIAS_DEFAULT`/`TRUE`/`FALSE`), `linearInit_t` (designated-init-friendly config struct)
- **New userApi modules**: `LayerQuant`, `LayerWeightsApi`, `StateDictApi`
- **New `QuantizationApi` builders**: `quantizationInitSymInt32WithBits(rm, bits)`, `quantizationInitSym(bits, rm)`
- **Rewritten `linearLayerInit`** + new `linearLayerInitOwning` (Borrowing/Owning variants — `ownsQuantizations` flag drives free-time teardown)
- **Rewritten `reluLayerInit`** + new `reluLayerInitOwning`
- **Renamed pre-existing factories to `*Legacy`** for two-binary coexistence (strategy Z) — `linearLayerInitLegacy`, `linearLayerInitNonTrainableLegacy`, `freeLinearLayerLegacy`, `reluLayerInitLegacy`, `freeReluLayerLegacy`

Three layers chosen to exercise the three distinct factory shapes:
- **Linear** — params + geometry + bias + quant (full case)
- **ReLU** — no params, no geometry, has quant
- **Flatten** — unchanged from existing signature (already matches new spec; no rewrite needed)

PR 2 will add Conv1d, Conv1dTransposed, MaxPool1d, AvgPool1d, Softmax factories + example migration (`har_classifier_v2`, `ecg_anomaly_ae_v2`) + bit-parity CI step. A separate cleanup PR after PR 2 drops the `*Legacy` variants.

## Test plan

- [x] All unit tests pass on `unit_test_debug` preset (47/47)
- [x] All unit tests pass on `unit_test_error` preset (47/47, strict log level)
- [x] All unit tests pass on production `unit_test` preset (42/42)
- [x] Python tests pass (22/22)
- [x] Local `ci` script green (C + Python combined)
- [x] TDD red→green discipline followed throughout (failing test committed separately, then GREEN commit)
- [ ] Reviewer check: `layerQuant_t` field-relevance docs match what each layer actually reads
- [ ] Reviewer check: `freeLinearLayer`/`freeReluLayer` Owning-variant teardown matches `ownsQuantizations=true` factory side

## Spec

[`docs/superpowers/specs/2026-05-15-layer-factory-api-design.md`](docs/superpowers/specs/2026-05-15-layer-factory-api-design.md) (gitignored, local working spec)

[`docs/superpowers/plans/2026-05-15-layer-factory-api-pr1.md`](docs/superpowers/plans/2026-05-15-layer-factory-api-pr1.md) (gitignored, local implementation plan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)