### PR TITLE
fix(layer): Linear factory bias via matmul-with-bias (forward seed + backward reduce)

### DIFF
--- a/src/arithmetic/Matmul.c
+++ b/src/arithmetic/Matmul.c
@@ -10,6 +10,7 @@
 #define MATMUL_FUNC_SYM_INT32 matmulSymIntTensors
 #endif
 
+#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -22,7 +23,8 @@
 
 size_t matmulInstructionCounter = 0;
 
-void matmulIntTensors(tensor_t *aTensor, tensor_t *bTensor, tensor_t *outputTensor) {
+static void matmulIntCore(tensor_t *aTensor, tensor_t *bTensor, tensor_t *outputTensor,
+                          const int32_t *biasSeed) {
     if (aTensor->shape->numberOfDimensions > 2 || bTensor->shape->numberOfDimensions > 2) {
         PRINT_ERROR("Matmul only supports up to 2D Tensors");
         exit(1);
@@ -30,7 +32,6 @@ void matmulIntTensors(tensor_t *aTensor, tensor_t *bTensor, tensor_t *outputTens
 
     size_t aNumberOfDims = aTensor->shape->numberOfDimensions;
     size_t *aDims = aTensor->shape->dimensions;
-
     size_t bNumberOfDims = bTensor->shape->numberOfDimensions;
     size_t *bDims = bTensor->shape->dimensions;
 
@@ -44,12 +45,7 @@ void matmulIntTensors(tensor_t *aTensor, tensor_t *bTensor, tensor_t *outputTens
     }
 
     size_t bRows = getDimensionsByIndex(bTensor, 0);
-    size_t bColumns = 0;
-    if (bNumberOfDims < 2) {
-        bColumns = 1;
-    } else {
-        bColumns = getDimensionsByIndex(bTensor, 1);
-    }
+    size_t bColumns = (bNumberOfDims < 2) ? 1 : getDimensionsByIndex(bTensor, 1);
 
     size_t resultCounter = 0;
 
@@ -60,9 +56,8 @@ void matmulIntTensors(tensor_t *aTensor, tensor_t *bTensor, tensor_t *outputTens
     }
 
     for (size_t rowIndex = 0; rowIndex < aRows; rowIndex++) {
-
         for (size_t columnIndex = 0; columnIndex < bColumns; columnIndex++) {
-            int32_t result = 0;
+            int32_t result = biasSeed ? biasSeed[columnIndex] : 0;
             for (size_t i = 0; i < aColumns; i++) {
                 size_t aByteIndex = 0;
                 if (aNumberOfDims == 1) {
@@ -73,7 +68,6 @@ void matmulIntTensors(tensor_t *aTensor, tensor_t *bTensor, tensor_t *outputTens
                         aNumberOfDims, aDims, aIndices, aTensor->shape->orderOfDimensions);
                     aByteIndex = aValueIndex * sizeof(int32_t);
                 }
-
                 int32_t aValue = readBytesAsInt32(&aTensor->data[aByteIndex]);
 
                 size_t bByteIndex = 0;
@@ -85,96 +79,25 @@ void matmulIntTensors(tensor_t *aTensor, tensor_t *bTensor, tensor_t *outputTens
                         bNumberOfDims, bDims, bIndices, bTensor->shape->orderOfDimensions);
                     bByteIndex = bValueIndex * sizeof(int32_t);
                 }
-
                 int32_t bValue = readBytesAsInt32(&bTensor->data[bByteIndex]);
 
                 result += mulInt32s(aValue, bValue);
             }
 
             size_t outputByteIndex = resultCounter * sizeof(int32_t);
-
             writeInt32ToByteArray(result, &outputTensor->data[outputByteIndex]);
             resultCounter++;
         }
     }
 }
 
+void matmulIntTensors(tensor_t *aTensor, tensor_t *bTensor, tensor_t *outputTensor) {
+    matmulIntCore(aTensor, bTensor, outputTensor, NULL);
+}
+
 void matmulIntTensorsWithInstructionCounter(tensor_t *aTensor, tensor_t *bTensor,
                                             tensor_t *outputTensor) {
-    if (aTensor->shape->numberOfDimensions > 2 || bTensor->shape->numberOfDimensions > 2) {
-        PRINT_ERROR("Matmul only supports up to 2D Tensors");
-        exit(1);
-    }
-
-    size_t aNumberOfDims = aTensor->shape->numberOfDimensions;
-    size_t *aDims = aTensor->shape->dimensions;
-
-    size_t bNumberOfDims = bTensor->shape->numberOfDimensions;
-    size_t *bDims = bTensor->shape->dimensions;
-
-    size_t aRows, aColumns;
-    if (aNumberOfDims < 2) {
-        aRows = 1;
-        aColumns = getDimensionsByIndex(aTensor, 0);
-    } else {
-        aRows = getDimensionsByIndex(aTensor, 0);
-        aColumns = getDimensionsByIndex(aTensor, 1);
-    }
-
-    size_t bRows = getDimensionsByIndex(bTensor, 0);
-    size_t bColumns = 0;
-    if (bNumberOfDims < 2) {
-        bColumns = 1;
-    } else {
-        bColumns = getDimensionsByIndex(bTensor, 1);
-    }
-
-    size_t resultCounter = 0;
-
-    if (aColumns != bRows) {
-        PRINT_ERROR("Rows dont match Columns");
-        PRINT_DEBUG("aColumns: %lu, bRows: %lu\n", aColumns, bRows);
-        exit(1);
-    }
-
-    for (size_t rowIndex = 0; rowIndex < aRows; rowIndex++) {
-
-        for (size_t columnIndex = 0; columnIndex < bColumns; columnIndex++) {
-            int32_t result = 0;
-            for (size_t i = 0; i < aColumns; i++) {
-                size_t aByteIndex = 0;
-                if (aNumberOfDims == 1) {
-                    aByteIndex = i * sizeof(int32_t);
-                } else {
-                    size_t aIndices[] = {rowIndex, i};
-                    size_t aValueIndex = calcElementIndexByIndices(
-                        aNumberOfDims, aDims, aIndices, aTensor->shape->orderOfDimensions);
-                    aByteIndex = aValueIndex * sizeof(int32_t);
-                }
-
-                int32_t aValue = readBytesAsInt32(&aTensor->data[aByteIndex]);
-
-                size_t bByteIndex = 0;
-                if (bNumberOfDims == 1) {
-                    bByteIndex = i * sizeof(int32_t);
-                } else {
-                    size_t bIndices[] = {i, columnIndex};
-                    size_t bValueIndex = calcElementIndexByIndices(
-                        bNumberOfDims, bDims, bIndices, bTensor->shape->orderOfDimensions);
-                    bByteIndex = bValueIndex * sizeof(int32_t);
-                }
-
-                int32_t bValue = readBytesAsInt32(&bTensor->data[bByteIndex]);
-
-                result += mulInt32s(aValue, bValue);
-            }
-
-            size_t outputByteIndex = resultCounter * sizeof(int32_t);
-
-            writeInt32ToByteArray(result, &outputTensor->data[outputByteIndex]);
-            resultCounter++;
-        }
-    }
+    matmulIntCore(aTensor, bTensor, outputTensor, NULL);
     ++matmulInstructionCounter;
 }
 
@@ -314,6 +237,43 @@ void matmulSymIntTensorsWithInstructionCounter(tensor_t *aTensor, tensor_t *bTen
 
 void matmulSymInt32Tensors(tensor_t *aTensor, tensor_t *bTensor, tensor_t *outputTensor) {
     MATMUL_FUNC_SYM_INT32(aTensor, bTensor, outputTensor);
+}
+
+void matmulSymInt32TensorsWithBias(tensor_t *aTensor, tensor_t *bTensor, tensor_t *outputTensor,
+                                   tensor_t *bias) {
+    if (bias == NULL) {
+        matmulIntCore(aTensor, bTensor, outputTensor, NULL);
+    } else {
+        size_t bColumns =
+            (bTensor->shape->numberOfDimensions < 2) ? 1 : getDimensionsByIndex(bTensor, 1);
+        if (bias->shape->numberOfDimensions != 1) {
+            PRINT_ERROR("matmulSymInt32TensorsWithBias: bias must be rank-1");
+            exit(1);
+        }
+        if (getDimensionsByIndex(bias, 0) != bColumns) {
+            PRINT_ERROR("matmulSymInt32TensorsWithBias: bias length != output columns");
+            exit(1);
+        }
+
+        float aScale = ((symInt32QConfig_t *)aTensor->quantization->qConfig)->scale;
+        float bScale = ((symInt32QConfig_t *)bTensor->quantization->qConfig)->scale;
+        float biasScale = ((symInt32QConfig_t *)bias->quantization->qConfig)->scale;
+        float outputScale = aScale * bScale;
+
+        /* Rescale the bias into the accumulator's scale: one fixed-point op per
+         * output column (small: == outFeatures), outside the MAC loop. */
+        int32_t seed[bColumns];
+        for (size_t c = 0; c < bColumns; c++) {
+            int32_t biasIntC = readBytesAsInt32(&bias->data[c * sizeof(int32_t)]);
+            seed[c] = (int32_t)roundf((float)biasIntC * biasScale / outputScale);
+        }
+        matmulIntCore(aTensor, bTensor, outputTensor, seed);
+    }
+
+    symInt32QConfig_t *aQC = aTensor->quantization->qConfig;
+    symInt32QConfig_t *bQC = bTensor->quantization->qConfig;
+    symInt32QConfig_t *outputQC = outputTensor->quantization->qConfig;
+    outputQC->scale = aQC->scale * bQC->scale;
 }
 
 size_t getMatmulInstructionCounter() {

--- a/src/arithmetic/Matmul.c
+++ b/src/arithmetic/Matmul.c
@@ -196,12 +196,8 @@ void matmulFloat32TensorsWithBias(tensor_t *aTensor, tensor_t *bTensor, tensor_t
     if (bias != NULL) {
         size_t bColumns =
             (bTensor->shape->numberOfDimensions < 2) ? 1 : getDimensionsByIndex(bTensor, 1);
-        if (bias->shape->numberOfDimensions != 1) {
-            PRINT_ERROR("matmulFloat32TensorsWithBias: bias must be rank-1");
-            exit(1);
-        }
-        if (getDimensionsByIndex(bias, 0) != bColumns) {
-            PRINT_ERROR("matmulFloat32TensorsWithBias: bias length != output columns");
+        if (calcNumberOfElementsByTensor(bias) != bColumns) {
+            PRINT_ERROR("matmulFloat32TensorsWithBias: bias element count != output columns");
             exit(1);
         }
         seed = bias->data;
@@ -246,12 +242,8 @@ void matmulSymInt32TensorsWithBias(tensor_t *aTensor, tensor_t *bTensor, tensor_
     } else {
         size_t bColumns =
             (bTensor->shape->numberOfDimensions < 2) ? 1 : getDimensionsByIndex(bTensor, 1);
-        if (bias->shape->numberOfDimensions != 1) {
-            PRINT_ERROR("matmulSymInt32TensorsWithBias: bias must be rank-1");
-            exit(1);
-        }
-        if (getDimensionsByIndex(bias, 0) != bColumns) {
-            PRINT_ERROR("matmulSymInt32TensorsWithBias: bias length != output columns");
+        if (calcNumberOfElementsByTensor(bias) != bColumns) {
+            PRINT_ERROR("matmulSymInt32TensorsWithBias: bias element count != output columns");
             exit(1);
         }
 

--- a/src/arithmetic/Matmul.c
+++ b/src/arithmetic/Matmul.c
@@ -182,8 +182,8 @@ void matmulInt32Tensors(tensor_t *aTensor, tensor_t *bTensor, tensor_t *outputTe
     MATMUL_FUNC_INT(aTensor, bTensor, outputTensor);
 }
 
-void matmulFloatTensors(tensor_t *aTensor, tensor_t *bTensor, tensor_t *outputTensor) {
-
+static void matmulFloatCore(tensor_t *aTensor, tensor_t *bTensor, tensor_t *outputTensor,
+                            const uint8_t *biasSeed) {
     if (aTensor->shape->numberOfDimensions > 2 || bTensor->shape->numberOfDimensions > 2) {
         PRINT_ERROR("Matmul only supports up to 2D Tensors");
         exit(1);
@@ -191,7 +191,6 @@ void matmulFloatTensors(tensor_t *aTensor, tensor_t *bTensor, tensor_t *outputTe
 
     size_t aNumberOfDims = aTensor->shape->numberOfDimensions;
     size_t *aDims = aTensor->shape->dimensions;
-
     size_t bNumberOfDims = bTensor->shape->numberOfDimensions;
     size_t *bDims = bTensor->shape->dimensions;
 
@@ -222,12 +221,12 @@ void matmulFloatTensors(tensor_t *aTensor, tensor_t *bTensor, tensor_t *outputTe
     }
 
     for (size_t rowIndex = 0; rowIndex < aRows; rowIndex++) {
-
         for (size_t columnIndex = 0; columnIndex < bColumns; columnIndex++) {
-            float result = 0;
+            float result = biasSeed
+                               ? readBytesAsFloat((uint8_t *)&biasSeed[columnIndex * sizeof(float)])
+                               : 0.0f;
             for (size_t i = 0; i < aColumns; i++) {
                 size_t aByteIndex = 0;
-
                 if (aNumberOfDims == 1) {
                     aByteIndex = i * sizeof(float);
                 } else {
@@ -236,7 +235,6 @@ void matmulFloatTensors(tensor_t *aTensor, tensor_t *bTensor, tensor_t *outputTe
                         aNumberOfDims, aDims, aIndices, aTensor->shape->orderOfDimensions);
                     aByteIndex = aValueIndex * sizeof(float);
                 }
-
                 float aValue = readBytesAsFloat(&aTensor->data[aByteIndex]);
 
                 size_t bByteIndex = 0;
@@ -244,105 +242,48 @@ void matmulFloatTensors(tensor_t *aTensor, tensor_t *bTensor, tensor_t *outputTe
                     bByteIndex = i * sizeof(float);
                 } else {
                     size_t bIndices[] = {i, columnIndex};
-
                     size_t bValueIndex = calcElementIndexByIndices(
                         bNumberOfDims, bDims, bIndices, bTensor->shape->orderOfDimensions);
                     bByteIndex = bValueIndex * sizeof(float);
                 }
-
                 float bValue = readBytesAsFloat(&bTensor->data[bByteIndex]);
                 result += mulFloat32s(aValue, bValue);
             }
 
             size_t outputByteIndex = resultCounter * sizeof(float);
-
             writeFloatToByteArray(result, &outputTensor->data[outputByteIndex]);
             resultCounter++;
         }
     }
 }
 
+void matmulFloatTensors(tensor_t *aTensor, tensor_t *bTensor, tensor_t *outputTensor) {
+    matmulFloatCore(aTensor, bTensor, outputTensor, NULL);
+}
+
 void matmulFloatTensorsWithInstructionCounter(tensor_t *aTensor, tensor_t *bTensor,
                                               tensor_t *outputTensor) {
-    if (aTensor->shape->numberOfDimensions > 2 || bTensor->shape->numberOfDimensions > 2) {
-        PRINT_ERROR("Matmul only supports up to 2D Tensors");
-        exit(1);
-    }
-
-    size_t aNumberOfDims = aTensor->shape->numberOfDimensions;
-    size_t *aDims = aTensor->shape->dimensions;
-
-    size_t bNumberOfDims = bTensor->shape->numberOfDimensions;
-    size_t *bDims = bTensor->shape->dimensions;
-
-    size_t aRows, aColumns = 0;
-    if (aNumberOfDims < 2) {
-        aRows = 1;
-        aColumns = getDimensionsByIndex(aTensor, 0);
-    } else {
-        aRows = getDimensionsByIndex(aTensor, 0);
-        aColumns = getDimensionsByIndex(aTensor, 1);
-    }
-
-    size_t bRows, bColumns = 0;
-    if (bNumberOfDims < 2) {
-        bRows = getDimensionsByIndex(bTensor, 0);
-        bColumns = 1;
-    } else {
-        bRows = getDimensionsByIndex(bTensor, 0);
-        bColumns = getDimensionsByIndex(bTensor, 1);
-    }
-
-    size_t resultCounter = 0;
-
-    // printf("aCol: %lu, bRows: %lu\n", aColumns, bRows);
-
-    if (aColumns != bRows) {
-        PRINT_ERROR("Rows dont match Columns");
-        PRINT_DEBUG("aColumns: %lu, bRows: %lu\n", aColumns, bRows);
-        exit(1);
-    }
-
-    for (size_t rowIndex = 0; rowIndex < aRows; rowIndex++) {
-
-        for (size_t columnIndex = 0; columnIndex < bColumns; columnIndex++) {
-            float result = 0;
-            for (size_t i = 0; i < aColumns; i++) {
-                size_t aByteIndex = 0;
-
-                if (aNumberOfDims == 1) {
-                    aByteIndex = i * sizeof(float);
-                } else {
-                    size_t aIndices[] = {rowIndex, i};
-                    size_t aValueIndex = calcElementIndexByIndices(
-                        aNumberOfDims, aDims, aIndices, aTensor->shape->orderOfDimensions);
-                    aByteIndex = aValueIndex * sizeof(float);
-                }
-
-                float aValue = readBytesAsFloat(&aTensor->data[aByteIndex]);
-
-                size_t bByteIndex = 0;
-                if (bNumberOfDims == 1) {
-                    bByteIndex = i * sizeof(float);
-                } else {
-                    size_t bIndices[] = {i, columnIndex};
-
-                    size_t bValueIndex = calcElementIndexByIndices(
-                        bNumberOfDims, bDims, bIndices, bTensor->shape->orderOfDimensions);
-                    bByteIndex = bValueIndex * sizeof(float);
-                }
-
-                float bValue = readBytesAsFloat(&bTensor->data[bByteIndex]);
-                result += mulFloat32s(aValue, bValue);
-            }
-
-            size_t outputByteIndex = resultCounter * sizeof(float);
-
-            writeFloatToByteArray(result, &outputTensor->data[outputByteIndex]);
-            resultCounter++;
-        }
-    }
+    matmulFloatCore(aTensor, bTensor, outputTensor, NULL);
     ++matmulInstructionCounter;
+}
+
+void matmulFloat32TensorsWithBias(tensor_t *aTensor, tensor_t *bTensor, tensor_t *outputTensor,
+                                  tensor_t *bias) {
+    const uint8_t *seed = NULL;
+    if (bias != NULL) {
+        size_t bColumns =
+            (bTensor->shape->numberOfDimensions < 2) ? 1 : getDimensionsByIndex(bTensor, 1);
+        if (bias->shape->numberOfDimensions != 1) {
+            PRINT_ERROR("matmulFloat32TensorsWithBias: bias must be rank-1");
+            exit(1);
+        }
+        if (getDimensionsByIndex(bias, 0) != bColumns) {
+            PRINT_ERROR("matmulFloat32TensorsWithBias: bias length != output columns");
+            exit(1);
+        }
+        seed = bias->data;
+    }
+    matmulFloatCore(aTensor, bTensor, outputTensor, seed);
 }
 
 void matmulFloat32Tensors(tensor_t *aTensor, tensor_t *bTensor, tensor_t *outputTensor) {

--- a/src/arithmetic/include/Matmul.h
+++ b/src/arithmetic/include/Matmul.h
@@ -16,6 +16,9 @@ void matmulSymInt32Tensors(tensor_t *aTensor, tensor_t *bTensor, tensor_t *outpu
 void matmulFloat32TensorsWithBias(tensor_t *aTensor, tensor_t *bTensor, tensor_t *outputTensor,
                                   tensor_t *bias);
 
+void matmulSymInt32TensorsWithBias(tensor_t *aTensor, tensor_t *bTensor, tensor_t *outputTensor,
+                                   tensor_t *bias);
+
 size_t getMatmulInstructionCounter();
 
 #endif // ENV5_RUNTIME_MATMUL_H

--- a/src/arithmetic/include/Matmul.h
+++ b/src/arithmetic/include/Matmul.h
@@ -13,6 +13,9 @@ void matmulFloat32Tensors(tensor_t *aTensor, tensor_t *bTensor, tensor_t *output
 
 void matmulSymInt32Tensors(tensor_t *aTensor, tensor_t *bTensor, tensor_t *outputTensor);
 
+void matmulFloat32TensorsWithBias(tensor_t *aTensor, tensor_t *bTensor, tensor_t *outputTensor,
+                                  tensor_t *bias);
+
 size_t getMatmulInstructionCounter();
 
 #endif // ENV5_RUNTIME_MATMUL_H

--- a/src/layer/Linear.c
+++ b/src/layer/Linear.c
@@ -1,5 +1,7 @@
 #define SOURCE_FILE "LINEAR"
 
+#include <math.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -120,7 +122,20 @@ void linearCalcWeightGradsFloatWithConversion(linearConfig_t *linearConfig, tens
 }
 
 void linearCalcBiasGradsFloat32(tensor_t *loss, tensor_t *biasGrad) {
-    addFloat32TensorsInplace(biasGrad, loss);
+    /* Reduce the loss over the batch (leading) axis into the rank-1 bias grad:
+     * biasGrad[f] += sum_n loss[n,f]. Mirrors conv1dCalcBiasGradsFloat32. */
+    size_t numFeatures = calcNumberOfElementsByTensor(biasGrad);
+    size_t numLoss = calcNumberOfElementsByTensor(loss);
+    size_t batch = (numFeatures == 0) ? 0 : numLoss / numFeatures;
+    float *bg = (float *)biasGrad->data;
+    float *l = (float *)loss->data;
+    for (size_t f = 0; f < numFeatures; f++) {
+        float sum = 0.0f;
+        for (size_t n = 0; n < batch; n++) {
+            sum += l[n * numFeatures + f];
+        }
+        bg[f] += sum;
+    }
 }
 
 void linearCalcBiasGradsFloatWithConversion(linearConfig_t *linearConfig, tensor_t *loss) {
@@ -297,7 +312,23 @@ void linearCalcWeightGradsSymInt32WithConversion(linearConfig_t *linearConfig, t
 }
 
 void linearCalcBiasGradsSymInt32(tensor_t *biasGrads, tensor_t *loss) {
-    addSymInt32TensorsInplace(biasGrads, loss);
+    /* Reduce loss over the batch axis into the rank-1 bias grad, rescaling from
+     * the loss scale into the bias-grad scale (fixed-point), mirroring the
+     * forward seed convention. */
+    size_t numFeatures = calcNumberOfElementsByTensor(biasGrads);
+    size_t numLoss = calcNumberOfElementsByTensor(loss);
+    size_t batch = (numFeatures == 0) ? 0 : numLoss / numFeatures;
+    int32_t *bg = (int32_t *)biasGrads->data;
+    int32_t *l = (int32_t *)loss->data;
+    float lossScale = ((symInt32QConfig_t *)loss->quantization->qConfig)->scale;
+    float bgScale = ((symInt32QConfig_t *)biasGrads->quantization->qConfig)->scale;
+    for (size_t f = 0; f < numFeatures; f++) {
+        int64_t sum = 0;
+        for (size_t n = 0; n < batch; n++) {
+            sum += l[n * numFeatures + f];
+        }
+        bg[f] += (int32_t)roundf((float)sum * lossScale / bgScale);
+    }
 }
 
 void linearCalcBiasGradsSymInt32WithConversion(linearConfig_t *linearConfig, tensor_t *loss) {

--- a/src/layer/Linear.c
+++ b/src/layer/Linear.c
@@ -24,17 +24,14 @@ void linearInitConfig(linearConfig_t *linearConfig, parameter_t *weights, parame
 
 void linearForwardFloat(tensor_t *w, tensor_t *b, tensor_t *input, tensor_t *output) {
     transposeTensor(w, 0, 1);
-    matmulFloat32Tensors(input, w, output);
+    matmulFloat32TensorsWithBias(input, w, output, b);
     transposeTensor(w, 0, 1);
-    addFloat32TensorsInplace(output, b);
 }
 
 void linearForwardSymInt32(tensor_t *w, tensor_t *b, tensor_t *input, tensor_t *output) {
     transposeTensor(w, 0, 1);
-    matmulSymInt32Tensors(input, w, output);
+    matmulSymInt32TensorsWithBias(input, w, output, b);
     transposeTensor(w, 0, 1);
-
-    addSymInt32TensorsInplace(output, b);
 }
 
 void linearForward(layer_t *linearLayer, tensor_t *input, tensor_t *output) {

--- a/test/unit/arithmetic/UnitTestMatmul.c
+++ b/test/unit/arithmetic/UnitTestMatmul.c
@@ -269,6 +269,72 @@ void testMatmulSymInt32Tensors() {
     TEST_ASSERT_EQUAL_FLOAT_ARRAY(expected, actual.data, 4);
 }
 
+void testMatmulFloat32TensorsWithBiasBroadcastsOverRows() {
+    /* a = [[1,2,3],[4,5,6]] (2x3), b = [[1,4],[2,5],[3,6]] (3x2). */
+    float aData[] = {1.f, 2.f, 3.f, 4.f, 5.f, 6.f};
+    size_t aDims[] = {2, 3};
+    size_t aOrder[] = {0, 1};
+    shape_t aShape = {.dimensions = aDims, .orderOfDimensions = aOrder, .numberOfDimensions = 2};
+    quantization_t aQ = {.type = FLOAT32};
+    tensor_t aTensor = {.data = (uint8_t *)aData, .shape = &aShape, .quantization = &aQ, .sparsity = NULL};
+
+    float bData[] = {1.f, 4.f, 2.f, 5.f, 3.f, 6.f};
+    size_t bDims[] = {3, 2};
+    size_t bOrder[] = {0, 1};
+    shape_t bShape = {.dimensions = bDims, .orderOfDimensions = bOrder, .numberOfDimensions = 2};
+    quantization_t bQ = {.type = FLOAT32};
+    tensor_t bTensor = {.data = (uint8_t *)bData, .shape = &bShape, .quantization = &bQ, .sparsity = NULL};
+
+    /* bias = [10, 20] (rank-1, length == output columns == 2). */
+    float biasData[] = {10.f, 20.f};
+    size_t biasDims[] = {2};
+    size_t biasOrder[] = {0};
+    shape_t biasShape = {.dimensions = biasDims, .orderOfDimensions = biasOrder, .numberOfDimensions = 1};
+    quantization_t biasQ = {.type = FLOAT32};
+    tensor_t biasTensor = {.data = (uint8_t *)biasData, .shape = &biasShape, .quantization = &biasQ, .sparsity = NULL};
+
+    float outputData[] = {0, 0, 0, 0};
+    size_t outputDims[] = {2, 2};
+    size_t outputOrder[] = {0, 1};
+    shape_t outputShape = {.dimensions = outputDims, .orderOfDimensions = outputOrder, .numberOfDimensions = 2};
+    quantization_t outputQ = {.type = FLOAT32};
+    tensor_t outputTensor = {.data = (uint8_t *)outputData, .shape = &outputShape, .quantization = &outputQ, .sparsity = NULL};
+
+    matmulFloat32TensorsWithBias(&aTensor, &bTensor, &outputTensor, &biasTensor);
+
+    /* plain matmul = [[14,32],[32,77]]; + bias [10,20] per row = [[24,52],[42,97]]. */
+    float expected[] = {24.f, 52.f, 42.f, 97.f};
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(expected, outputTensor.data, 4);
+}
+
+void testMatmulFloat32TensorsWithBiasNullEqualsPlain() {
+    float aData[] = {1.1f, 2.4f, 3.9f};
+    size_t aDims[] = {3};
+    size_t aOrder[] = {0};
+    shape_t aShape = {.dimensions = aDims, .orderOfDimensions = aOrder, .numberOfDimensions = 1};
+    quantization_t aQ = {.type = FLOAT32};
+    tensor_t aTensor = {.data = (uint8_t *)aData, .shape = &aShape, .quantization = &aQ, .sparsity = NULL};
+
+    float bData[] = {1.5f, 2.9f, 3.3f};
+    size_t bDims[] = {3};
+    size_t bOrder[] = {0};
+    shape_t bShape = {.dimensions = bDims, .orderOfDimensions = bOrder, .numberOfDimensions = 1};
+    quantization_t bQ = {.type = FLOAT32};
+    tensor_t bTensor = {.data = (uint8_t *)bData, .shape = &bShape, .quantization = &bQ, .sparsity = NULL};
+
+    float outputData[] = {0};
+    size_t outputDims[] = {1};
+    size_t outputOrder[] = {0};
+    shape_t outputShape = {.dimensions = outputDims, .orderOfDimensions = outputOrder, .numberOfDimensions = 1};
+    quantization_t outputQ = {.type = FLOAT32};
+    tensor_t outputTensor = {.data = (uint8_t *)outputData, .shape = &outputShape, .quantization = &outputQ, .sparsity = NULL};
+
+    matmulFloat32TensorsWithBias(&aTensor, &bTensor, &outputTensor, NULL);
+
+    float expected[] = {21.48f};
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(expected, outputTensor.data, 1);
+}
+
 void setUp() {}
 void tearDown() {}
 
@@ -279,6 +345,8 @@ int main(void) {
     RUN_TEST(testMatmulInt32WithVector);
     RUN_TEST(testMatmulFloatVectors);
     RUN_TEST(testMatmulSymInt32Tensors);
+    RUN_TEST(testMatmulFloat32TensorsWithBiasBroadcastsOverRows);
+    RUN_TEST(testMatmulFloat32TensorsWithBiasNullEqualsPlain);
 
     return UNITY_END();
 }

--- a/test/unit/arithmetic/UnitTestMatmul.c
+++ b/test/unit/arithmetic/UnitTestMatmul.c
@@ -276,29 +276,37 @@ void testMatmulFloat32TensorsWithBiasBroadcastsOverRows() {
     size_t aOrder[] = {0, 1};
     shape_t aShape = {.dimensions = aDims, .orderOfDimensions = aOrder, .numberOfDimensions = 2};
     quantization_t aQ = {.type = FLOAT32};
-    tensor_t aTensor = {.data = (uint8_t *)aData, .shape = &aShape, .quantization = &aQ, .sparsity = NULL};
+    tensor_t aTensor = {
+        .data = (uint8_t *)aData, .shape = &aShape, .quantization = &aQ, .sparsity = NULL};
 
     float bData[] = {1.f, 4.f, 2.f, 5.f, 3.f, 6.f};
     size_t bDims[] = {3, 2};
     size_t bOrder[] = {0, 1};
     shape_t bShape = {.dimensions = bDims, .orderOfDimensions = bOrder, .numberOfDimensions = 2};
     quantization_t bQ = {.type = FLOAT32};
-    tensor_t bTensor = {.data = (uint8_t *)bData, .shape = &bShape, .quantization = &bQ, .sparsity = NULL};
+    tensor_t bTensor = {
+        .data = (uint8_t *)bData, .shape = &bShape, .quantization = &bQ, .sparsity = NULL};
 
     /* bias = [10, 20] (rank-1, length == output columns == 2). */
     float biasData[] = {10.f, 20.f};
     size_t biasDims[] = {2};
     size_t biasOrder[] = {0};
-    shape_t biasShape = {.dimensions = biasDims, .orderOfDimensions = biasOrder, .numberOfDimensions = 1};
+    shape_t biasShape = {
+        .dimensions = biasDims, .orderOfDimensions = biasOrder, .numberOfDimensions = 1};
     quantization_t biasQ = {.type = FLOAT32};
-    tensor_t biasTensor = {.data = (uint8_t *)biasData, .shape = &biasShape, .quantization = &biasQ, .sparsity = NULL};
+    tensor_t biasTensor = {
+        .data = (uint8_t *)biasData, .shape = &biasShape, .quantization = &biasQ, .sparsity = NULL};
 
     float outputData[] = {0, 0, 0, 0};
     size_t outputDims[] = {2, 2};
     size_t outputOrder[] = {0, 1};
-    shape_t outputShape = {.dimensions = outputDims, .orderOfDimensions = outputOrder, .numberOfDimensions = 2};
+    shape_t outputShape = {
+        .dimensions = outputDims, .orderOfDimensions = outputOrder, .numberOfDimensions = 2};
     quantization_t outputQ = {.type = FLOAT32};
-    tensor_t outputTensor = {.data = (uint8_t *)outputData, .shape = &outputShape, .quantization = &outputQ, .sparsity = NULL};
+    tensor_t outputTensor = {.data = (uint8_t *)outputData,
+                             .shape = &outputShape,
+                             .quantization = &outputQ,
+                             .sparsity = NULL};
 
     matmulFloat32TensorsWithBias(&aTensor, &bTensor, &outputTensor, &biasTensor);
 
@@ -313,26 +321,98 @@ void testMatmulFloat32TensorsWithBiasNullEqualsPlain() {
     size_t aOrder[] = {0};
     shape_t aShape = {.dimensions = aDims, .orderOfDimensions = aOrder, .numberOfDimensions = 1};
     quantization_t aQ = {.type = FLOAT32};
-    tensor_t aTensor = {.data = (uint8_t *)aData, .shape = &aShape, .quantization = &aQ, .sparsity = NULL};
+    tensor_t aTensor = {
+        .data = (uint8_t *)aData, .shape = &aShape, .quantization = &aQ, .sparsity = NULL};
 
     float bData[] = {1.5f, 2.9f, 3.3f};
     size_t bDims[] = {3};
     size_t bOrder[] = {0};
     shape_t bShape = {.dimensions = bDims, .orderOfDimensions = bOrder, .numberOfDimensions = 1};
     quantization_t bQ = {.type = FLOAT32};
-    tensor_t bTensor = {.data = (uint8_t *)bData, .shape = &bShape, .quantization = &bQ, .sparsity = NULL};
+    tensor_t bTensor = {
+        .data = (uint8_t *)bData, .shape = &bShape, .quantization = &bQ, .sparsity = NULL};
 
     float outputData[] = {0};
     size_t outputDims[] = {1};
     size_t outputOrder[] = {0};
-    shape_t outputShape = {.dimensions = outputDims, .orderOfDimensions = outputOrder, .numberOfDimensions = 1};
+    shape_t outputShape = {
+        .dimensions = outputDims, .orderOfDimensions = outputOrder, .numberOfDimensions = 1};
     quantization_t outputQ = {.type = FLOAT32};
-    tensor_t outputTensor = {.data = (uint8_t *)outputData, .shape = &outputShape, .quantization = &outputQ, .sparsity = NULL};
+    tensor_t outputTensor = {.data = (uint8_t *)outputData,
+                             .shape = &outputShape,
+                             .quantization = &outputQ,
+                             .sparsity = NULL};
 
     matmulFloat32TensorsWithBias(&aTensor, &bTensor, &outputTensor, NULL);
 
     float expected[] = {21.48f};
     TEST_ASSERT_EQUAL_FLOAT_ARRAY(expected, outputTensor.data, 1);
+}
+
+void testMatmulSymInt32TensorsWithBiasRescalesBias() {
+    tensor_t aTensor;
+    int32_t aData[] = {1, 2, 3, 4, 5, 6};
+    size_t aDims[] = {2, 3};
+    size_t aOrder[] = {0, 1};
+    shape_t aShape;
+    setShape(&aShape, aDims, 2, aOrder);
+    symInt32QConfig_t aQC;
+    initSymInt32QConfig(HTE, &aQC);
+    aQC.scale = 2.f;
+    quantization_t aQ;
+    initSymInt32Quantization(&aQC, &aQ);
+    setTensorValues(&aTensor, (uint8_t *)aData, &aShape, &aQ, NULL);
+
+    tensor_t bTensor;
+    int32_t bData[] = {1, 4, 2, 5, 3, 6};
+    size_t bDims[] = {3, 2};
+    size_t bOrder[] = {0, 1};
+    shape_t bShape;
+    setShape(&bShape, bDims, 2, bOrder);
+    symInt32QConfig_t bQC;
+    initSymInt32QConfig(HTE, &bQC);
+    bQC.scale = 1.f;
+    quantization_t bQ;
+    initSymInt32Quantization(&bQC, &bQ);
+    setTensorValues(&bTensor, (uint8_t *)bData, &bShape, &bQ, NULL);
+
+    tensor_t biasTensor;
+    int32_t biasData[] = {1, 2};
+    size_t biasDims[] = {2};
+    size_t biasOrder[] = {0};
+    shape_t biasShape;
+    setShape(&biasShape, biasDims, 1, biasOrder);
+    symInt32QConfig_t biasQC;
+    initSymInt32QConfig(HTE, &biasQC);
+    biasQC.scale = 4.f;
+    quantization_t biasQ;
+    initSymInt32Quantization(&biasQC, &biasQ);
+    setTensorValues(&biasTensor, (uint8_t *)biasData, &biasShape, &biasQ, NULL);
+
+    tensor_t outputTensor;
+    int32_t outputData[4];
+    size_t outputDims[] = {2, 2};
+    size_t outputOrder[] = {0, 1};
+    shape_t outputShape;
+    setShape(&outputShape, outputDims, 2, outputOrder);
+    symInt32QConfig_t outputQC;
+    initSymInt32QConfig(HTE, &outputQC);
+    quantization_t outputQ;
+    initSymInt32Quantization(&outputQC, &outputQ);
+    setTensorValues(&outputTensor, (uint8_t *)outputData, &outputShape, &outputQ, NULL);
+
+    matmulSymInt32TensorsWithBias(&aTensor, &bTensor, &outputTensor, &biasTensor);
+
+    /* a_real (scale 2) @ b = [[28,64],[64,154]]; + bias_real [4,8] = [[32,72],[68,162]]. */
+    float expected[] = {32.f, 72.f, 68.f, 162.f};
+    float actualData[4];
+    quantization_t actualQ;
+    initFloat32Quantization(&actualQ);
+    tensor_t actual;
+    setTensorValues(&actual, (uint8_t *)actualData, &outputShape, &actualQ, NULL);
+    convertTensor(&outputTensor, &actual);
+
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(expected, actual.data, 4);
 }
 
 void setUp() {}
@@ -347,6 +427,7 @@ int main(void) {
     RUN_TEST(testMatmulSymInt32Tensors);
     RUN_TEST(testMatmulFloat32TensorsWithBiasBroadcastsOverRows);
     RUN_TEST(testMatmulFloat32TensorsWithBiasNullEqualsPlain);
+    RUN_TEST(testMatmulSymInt32TensorsWithBiasRescalesBias);
 
     return UNITY_END();
 }

--- a/test/unit/layer/UnitTestLinear.c
+++ b/test/unit/layer/UnitTestLinear.c
@@ -14,6 +14,145 @@
 #include "TensorConversion.h"
 #include "unity.h"
 
+void testLinearForwardFloatRank1BiasRank2Output() {
+    size_t *weightDims = reserveMemory(2 * sizeof(size_t));
+    weightDims[0] = 2;
+    weightDims[1] = 3;
+    size_t *weightOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, weightOrder);
+    shape_t *weightShape = reserveMemory(sizeof(shape_t));
+    setShape(weightShape, weightDims, 2, weightOrder);
+    tensor_t *weightsParam = initTensor(weightShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(weightsParam, (float[]){-1.f, 2.f, -3.f, 4.f, 5.f, -6.f}, 6);
+    parameter_t *weights = parameterInit(weightsParam, NULL);
+
+    size_t *biasDims = reserveMemory(1 * sizeof(size_t));
+    biasDims[0] = 2;
+    size_t *biasOrder = reserveMemory(1 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(1, biasOrder);
+    shape_t *biasShape = reserveMemory(sizeof(shape_t));
+    setShape(biasShape, biasDims, 1, biasOrder);
+    tensor_t *biasParam = initTensor(biasShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(biasParam, (float[]){-1.f, 3.f}, 2);
+    parameter_t *bias = parameterInit(biasParam, NULL);
+
+    size_t *inputDims = reserveMemory(2 * sizeof(size_t));
+    inputDims[0] = 1;
+    inputDims[1] = 3;
+    size_t *inputOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, inputOrder);
+    shape_t *inputShape = reserveMemory(sizeof(shape_t));
+    setShape(inputShape, inputDims, 2, inputOrder);
+    tensor_t *input = initTensor(inputShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(input, (float[]){0.f, 1.f, 2.f}, 3);
+
+    size_t *outputDims = reserveMemory(2 * sizeof(size_t));
+    outputDims[0] = 1;
+    outputDims[1] = 2;
+    size_t *outputOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, outputOrder);
+    shape_t *outputShape = reserveMemory(sizeof(shape_t));
+    setShape(outputShape, outputDims, 2, outputOrder);
+    tensor_t *output = initTensor(outputShape, quantizationInitFloat(), NULL);
+
+    quantization_t *testQ = quantizationInitFloat();
+    layer_t *linearLayer = linearLayerInitLegacy(weights, bias, testQ, testQ, testQ, testQ);
+
+    linearForward(linearLayer, input, output);
+
+    float captured[2];
+    captured[0] = ((float *)output->data)[0];
+    captured[1] = ((float *)output->data)[1];
+
+    freeLinearLayerLegacy(linearLayer);
+    freeTensor(output);
+    freeTensor(input);
+    freeParameter(bias);
+    freeParameter(weights);
+    freeQuantization(testQ);
+
+    float expected[] = {-5.f, -4.f};
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(expected, captured, 2);
+}
+
+void testLinearForwardSymInt32Rank1BiasRank2Output() {
+    size_t numberOfOutputs = 2;
+
+    size_t *weightDims = reserveMemory(2 * sizeof(size_t));
+    weightDims[0] = 2;
+    weightDims[1] = 3;
+    size_t *weightOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, weightOrder);
+    shape_t *weightShape = reserveMemory(sizeof(shape_t));
+    setShape(weightShape, weightDims, 2, weightOrder);
+    tensor_t *weightsParam = initTensor(weightShape, quantizationInitSymInt32(HTE), NULL);
+    tensorFillFromFloatBuffer(weightsParam, (float[]){-1.f, 2.f, -3.f, 4.f, 5.f, -6.f}, 6);
+    parameter_t *weights = parameterInit(weightsParam, NULL);
+
+    /* RANK-1 sym bias [2]. */
+    size_t *biasDims = reserveMemory(1 * sizeof(size_t));
+    biasDims[0] = 2;
+    size_t *biasOrder = reserveMemory(1 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(1, biasOrder);
+    shape_t *biasShape = reserveMemory(sizeof(shape_t));
+    setShape(biasShape, biasDims, 1, biasOrder);
+    tensor_t *biasParam = initTensor(biasShape, quantizationInitSymInt32(HTE), NULL);
+    tensorFillFromFloatBuffer(biasParam, (float[]){-1.f, 3.f}, 2);
+    parameter_t *bias = parameterInit(biasParam, NULL);
+
+    size_t *inputDims = reserveMemory(2 * sizeof(size_t));
+    inputDims[0] = 1;
+    inputDims[1] = 3;
+    size_t *inputOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, inputOrder);
+    shape_t *inputShape = reserveMemory(sizeof(shape_t));
+    setShape(inputShape, inputDims, 2, inputOrder);
+    tensor_t *input = initTensor(inputShape, quantizationInitSymInt32(HTE), NULL);
+    tensorFillFromFloatBuffer(input, (float[]){0.f, 1.f, 2.f}, 3);
+
+    size_t *outputDims = reserveMemory(2 * sizeof(size_t));
+    outputDims[0] = 1;
+    outputDims[1] = 2;
+    size_t *outputOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, outputOrder);
+    shape_t *outputShape = reserveMemory(sizeof(shape_t));
+    setShape(outputShape, outputDims, 2, outputOrder);
+    tensor_t *output = initTensor(outputShape, quantizationInitSymInt32(HTE), NULL);
+
+    quantization_t *test = quantizationInitSymInt32(HTE);
+    layer_t *linearLayer = linearLayerInitLegacy(weights, bias, test, test, test, test);
+
+    linearForward(linearLayer, input, output);
+
+    size_t *outFloatDims = reserveMemory(2 * sizeof(size_t));
+    outFloatDims[0] = 1;
+    outFloatDims[1] = 2;
+    size_t *outFloatOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, outFloatOrder);
+    shape_t *outFloatShape = reserveMemory(sizeof(shape_t));
+    setShape(outFloatShape, outFloatDims, 2, outFloatOrder);
+    tensor_t *outputFloat = initTensor(outFloatShape, quantizationInitFloat(), NULL);
+    convertTensor(output, outputFloat);
+
+    float captured[2];
+    for (size_t i = 0; i < numberOfOutputs; i++) {
+        captured[i] = ((float *)outputFloat->data)[i];
+    }
+
+    freeTensor(outputFloat);
+    freeLinearLayerLegacy(linearLayer);
+    freeTensor(output);
+    freeTensor(input);
+    freeParameter(bias);
+    freeParameter(weights);
+    freeQuantization(test);
+
+    float expected[] = {-5.f, -4.f};
+    for (size_t i = 0; i < numberOfOutputs; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(0.1f, expected[i], captured[i]);
+    }
+}
+
 void setUp() {}
 void tearDown() {}
 
@@ -796,9 +935,11 @@ void testLinearLayerInitOwningFreesAllAllocationsWithoutLeak(void) {
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(testLinearForwardFloat);
+    RUN_TEST(testLinearForwardFloatRank1BiasRank2Output);
     RUN_TEST(testLinearBackwardFloat);
 
     RUN_TEST(testLinearForwardSymInt32);
+    RUN_TEST(testLinearForwardSymInt32Rank1BiasRank2Output);
     RUN_TEST(testLinearBackwardSymInt32);
     RUN_TEST(testLinearLayerInitAndFreeRoundTrip);
 

--- a/test/unit/layer/UnitTestLinear.c
+++ b/test/unit/layer/UnitTestLinear.c
@@ -153,6 +153,239 @@ void testLinearForwardSymInt32Rank1BiasRank2Output() {
     }
 }
 
+void testLinearBackwardFloatRank1Bias() {
+    size_t *weightDims = reserveMemory(2 * sizeof(size_t));
+    weightDims[0] = 2;
+    weightDims[1] = 3;
+    size_t *weightOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, weightOrder);
+    shape_t *weightShape = reserveMemory(sizeof(shape_t));
+    setShape(weightShape, weightDims, 2, weightOrder);
+    tensor_t *weightsParam = initTensor(weightShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(weightsParam, (float[]){-1.f, 2.f, -3.f, 4.f, 5.f, -6.f}, 6);
+    tensor_t *weightsGrad = gradInitFloat(weightsParam, NULL);
+    parameter_t *weights = parameterInit(weightsParam, weightsGrad);
+
+    /* RANK-1 bias [2] -> rank-1 bias grad. */
+    size_t *biasDims = reserveMemory(1 * sizeof(size_t));
+    biasDims[0] = 2;
+    size_t *biasOrder = reserveMemory(1 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(1, biasOrder);
+    shape_t *biasShape = reserveMemory(sizeof(shape_t));
+    setShape(biasShape, biasDims, 1, biasOrder);
+    tensor_t *biasParam = initTensor(biasShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(biasParam, (float[]){-1.f, 3.f}, 2);
+    tensor_t *biasGrad = gradInitFloat(biasParam, NULL);
+    parameter_t *bias = parameterInit(biasParam, biasGrad);
+
+    size_t *fwdDims = reserveMemory(2 * sizeof(size_t));
+    fwdDims[0] = 1;
+    fwdDims[1] = 3;
+    size_t *fwdOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, fwdOrder);
+    shape_t *fwdShape = reserveMemory(sizeof(shape_t));
+    setShape(fwdShape, fwdDims, 2, fwdOrder);
+    tensor_t *forwardInput = initTensor(fwdShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(forwardInput, (float[]){0.f, 1.f, 2.f}, 3);
+
+    size_t *lossDims = reserveMemory(2 * sizeof(size_t));
+    lossDims[0] = 1;
+    lossDims[1] = 2;
+    size_t *lossOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, lossOrder);
+    shape_t *lossShape = reserveMemory(sizeof(shape_t));
+    setShape(lossShape, lossDims, 2, lossOrder);
+    tensor_t *loss = initTensor(lossShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(loss, (float[]){-4.f, -3.f}, 2);
+
+    size_t *propLossDims = reserveMemory(2 * sizeof(size_t));
+    propLossDims[0] = 1;
+    propLossDims[1] = 3;
+    size_t *propLossOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, propLossOrder);
+    shape_t *propLossShape = reserveMemory(sizeof(shape_t));
+    setShape(propLossShape, propLossDims, 2, propLossOrder);
+    tensor_t *propLoss = initTensor(propLossShape, quantizationInitFloat(), NULL);
+
+    quantization_t *testQ = quantizationInitFloat();
+    layer_t *linearLayer = linearLayerInitLegacy(weights, bias, testQ, testQ, testQ, testQ);
+
+    linearBackward(linearLayer, forwardInput, loss, propLoss);
+
+    size_t numWeightElements = calcNumberOfElementsByShape(weights->param->shape);
+    size_t numBiasElements = calcNumberOfElementsByShape(bias->param->shape);
+    size_t numPropLossElements = calcNumberOfElementsByTensor(propLoss);
+
+    float capturedWeightGrad[6];
+    for (size_t i = 0; i < numWeightElements; i++) {
+        capturedWeightGrad[i] = ((float *)weights->grad->data)[i];
+    }
+    float capturedBiasGrad[2];
+    for (size_t i = 0; i < numBiasElements; i++) {
+        capturedBiasGrad[i] = ((float *)bias->grad->data)[i];
+    }
+    float capturedPropLoss[3];
+    for (size_t i = 0; i < numPropLossElements; i++) {
+        capturedPropLoss[i] = ((float *)propLoss->data)[i];
+    }
+
+    freeLinearLayerLegacy(linearLayer);
+    freeTensor(propLoss);
+    freeTensor(loss);
+    freeTensor(forwardInput);
+    freeParameter(bias);
+    freeParameter(weights);
+    freeQuantization(testQ);
+
+    float expected_weight_grad[] = {0.f, -4.f, -8.f, 0.f, -3.f, -6.f};
+    float expected_bias_grad[] = {-4.f, -3.f};
+    float expected_propagated_loss[] = {-8.f, -23.f, 30.f};
+
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(expected_weight_grad, capturedWeightGrad, numWeightElements);
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(expected_propagated_loss, capturedPropLoss, numPropLossElements);
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(expected_bias_grad, capturedBiasGrad, numBiasElements);
+}
+
+void testLinearBackwardSymInt32Rank1Bias() {
+    size_t numberOfWeights = 6;
+    size_t numberOfBiases = 2;
+    size_t numberOfForwardInputs = 3;
+
+    /* 1. Build heap weights parameter (SymInt32, shape 2x3) with grad. */
+    size_t *weightDims = reserveMemory(2 * sizeof(size_t));
+    weightDims[0] = 2;
+    weightDims[1] = 3;
+    size_t *weightOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, weightOrder);
+    shape_t *weightShape = reserveMemory(sizeof(shape_t));
+    setShape(weightShape, weightDims, 2, weightOrder);
+    tensor_t *weightsParam = initTensor(weightShape, quantizationInitSymInt32(HTE), NULL);
+    tensorFillFromFloatBuffer(weightsParam, (float[]){-1.f, 2.f, -3.f, 4.f, 5.f, -6.f}, 6);
+    tensor_t *weightsGrad = gradInitSymInt32(weightsParam, HTE, NULL);
+    parameter_t *weights = parameterInit(weightsParam, weightsGrad);
+
+    /* 2. Build heap bias parameter (SymInt32, RANK-1 shape [2]) with grad. */
+    size_t *biasDims = reserveMemory(1 * sizeof(size_t));
+    biasDims[0] = 2;
+    size_t *biasOrder = reserveMemory(1 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(1, biasOrder);
+    shape_t *biasShape = reserveMemory(sizeof(shape_t));
+    setShape(biasShape, biasDims, 1, biasOrder);
+    tensor_t *biasParam = initTensor(biasShape, quantizationInitSymInt32(HTE), NULL);
+    tensorFillFromFloatBuffer(biasParam, (float[]){-1.f, 3.f}, 2);
+    tensor_t *biasGrad = gradInitSymInt32(biasParam, HTE, NULL);
+    parameter_t *bias = parameterInit(biasParam, biasGrad);
+
+    /* 3. Build heap forwardInput tensor (SymInt32, shape 1x3). */
+    size_t *fwdDims = reserveMemory(2 * sizeof(size_t));
+    fwdDims[0] = 1;
+    fwdDims[1] = 3;
+    size_t *fwdOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, fwdOrder);
+    shape_t *fwdShape = reserveMemory(sizeof(shape_t));
+    setShape(fwdShape, fwdDims, 2, fwdOrder);
+    tensor_t *forwardInput = initTensor(fwdShape, quantizationInitSymInt32(HTE), NULL);
+    tensorFillFromFloatBuffer(forwardInput, (float[]){0.f, 1.f, 2.f}, 3);
+
+    /* 4. Build heap loss tensor (SymInt32, shape 1x2). */
+    size_t *lossDims = reserveMemory(2 * sizeof(size_t));
+    lossDims[0] = 1;
+    lossDims[1] = 2;
+    size_t *lossOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, lossOrder);
+    shape_t *lossShape = reserveMemory(sizeof(shape_t));
+    setShape(lossShape, lossDims, 2, lossOrder);
+    tensor_t *loss = initTensor(lossShape, quantizationInitSymInt32(HTE), NULL);
+    tensorFillFromFloatBuffer(loss, (float[]){-4.f, -3.f}, 2);
+
+    /* 5. Build heap propLoss tensor (SymInt32, shape (3,)). */
+    size_t *propLossDims = reserveMemory(1 * sizeof(size_t));
+    propLossDims[0] = numberOfForwardInputs;
+    size_t *propLossOrder = reserveMemory(1 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(1, propLossOrder);
+    shape_t *propLossShape = reserveMemory(sizeof(shape_t));
+    setShape(propLossShape, propLossDims, 1, propLossOrder);
+    tensor_t *propLoss = initTensor(propLossShape, quantizationInitSymInt32(HTE), NULL);
+
+    /* 6. Build layer (shared SymInt32 quantization). */
+    quantization_t *test = quantizationInitSymInt32(HTE);
+    layer_t *linearLayer = linearLayerInitLegacy(weights, bias, test, test, test, test);
+
+    linearBackward(linearLayer, forwardInput, loss, propLoss);
+
+    /* 7. Convert SymInt32 grads back to Float for comparison. */
+    size_t *wgDims = reserveMemory(2 * sizeof(size_t));
+    wgDims[0] = 2;
+    wgDims[1] = 3;
+    size_t *wgOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, wgOrder);
+    shape_t *wgShape = reserveMemory(sizeof(shape_t));
+    setShape(wgShape, wgDims, 2, wgOrder);
+    tensor_t *weightGradFloat = initTensor(wgShape, quantizationInitFloat(), NULL);
+    convertTensor(weights->grad, weightGradFloat);
+
+    /* RANK-1 bias-grad convert-back block. */
+    size_t *bgDims = reserveMemory(1 * sizeof(size_t));
+    bgDims[0] = 2;
+    size_t *bgOrder = reserveMemory(1 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(1, bgOrder);
+    shape_t *bgShape = reserveMemory(sizeof(shape_t));
+    setShape(bgShape, bgDims, 1, bgOrder);
+    tensor_t *biasGradFloat = initTensor(bgShape, quantizationInitFloat(), NULL);
+    convertTensor(bias->grad, biasGradFloat);
+
+    size_t *plDims = reserveMemory(1 * sizeof(size_t));
+    plDims[0] = numberOfForwardInputs;
+    size_t *plOrder = reserveMemory(1 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(1, plOrder);
+    shape_t *plShape = reserveMemory(sizeof(shape_t));
+    setShape(plShape, plDims, 1, plOrder);
+    tensor_t *propLossFloat = initTensor(plShape, quantizationInitFloat(), NULL);
+    convertTensor(propLoss, propLossFloat);
+
+    /* 8. CAPTURE. */
+    float capturedWeightGrad[6];
+    for (size_t i = 0; i < numberOfWeights; i++) {
+        capturedWeightGrad[i] = ((float *)weightGradFloat->data)[i];
+    }
+    float capturedBiasGrad[2];
+    for (size_t i = 0; i < numberOfBiases; i++) {
+        capturedBiasGrad[i] = ((float *)biasGradFloat->data)[i];
+    }
+    float capturedPropLoss[3];
+    for (size_t i = 0; i < numberOfForwardInputs; i++) {
+        capturedPropLoss[i] = ((float *)propLossFloat->data)[i];
+    }
+
+    /* 9. FREE. */
+    freeTensor(propLossFloat);
+    freeTensor(biasGradFloat);
+    freeTensor(weightGradFloat);
+    freeLinearLayerLegacy(linearLayer);
+    freeTensor(propLoss);
+    freeTensor(loss);
+    freeTensor(forwardInput);
+    freeParameter(bias);
+    freeParameter(weights);
+    freeQuantization(test);
+
+    /* 10. ASSERT. */
+    float expectedWeightGrads[] = {0.f, -4.f, -8.f, 0.f, -3.f, -6.f};
+    for (size_t i = 0; i < numberOfWeights; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(0.1f, expectedWeightGrads[i], capturedWeightGrad[i]);
+    }
+
+    float expectedBiasGrads[] = {-4.f, -3.f};
+    for (size_t i = 0; i < numberOfBiases; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(0.1f, expectedBiasGrads[i], capturedBiasGrad[i]);
+    }
+
+    float expectedPropagatedLoss[] = {-8.f, -23.f, 30.f};
+    for (size_t i = 0; i < numberOfForwardInputs; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(.2f, expectedPropagatedLoss[i], capturedPropLoss[i]);
+    }
+}
+
 void setUp() {}
 void tearDown() {}
 
@@ -937,10 +1170,12 @@ int main(void) {
     RUN_TEST(testLinearForwardFloat);
     RUN_TEST(testLinearForwardFloatRank1BiasRank2Output);
     RUN_TEST(testLinearBackwardFloat);
+    RUN_TEST(testLinearBackwardFloatRank1Bias);
 
     RUN_TEST(testLinearForwardSymInt32);
     RUN_TEST(testLinearForwardSymInt32Rank1BiasRank2Output);
     RUN_TEST(testLinearBackwardSymInt32);
+    RUN_TEST(testLinearBackwardSymInt32Rank1Bias);
     RUN_TEST(testLinearLayerInitAndFreeRoundTrip);
 
     RUN_TEST(testLinearBackwardFloatWithMismatchedQuantizations);


### PR DESCRIPTION
## Problem

The `c-bit-parity` CI job crashes at "Run HAR v2 in BIT_PARITY mode" (this is why `main`/`develop` are red):

```
BIT_PARITY: loaded state_dict from examples/har_classifier/weights
[ARITHMETIC: doDimensionsMatch] Rank mismatch: 2 vs 1
```

## Root cause

The new layer-factory builds the Linear **bias as rank-1** `[outFeatures]` (`allocateLinearBias`), but the inference harness sizes the Linear **output as rank-2** `[batch, outFeatures]`. The in-place bias add requires identical rank (`doDimensionsMatch` → `exit(1)`). Legacy examples hand-build a rank-2 `[1, F]` bias and so avoided it; the factory's rank-1 bias triggers it. The same defect exists in the backward bias-grad (rank-1 grad + rank-2 loss → "Rank mismatch: 1 vs 2"), which would crash training.

## Fix

Make Linear's bias handling mirror Conv's — **seed the accumulator going forward, reduce over the batch going back** — so the bias rank never has to match an activation rank:

- **Forward:** new `matmulFloat32TensorsWithBias` / `matmulSymInt32TensorsWithBias` seed the per-output-column dot-product accumulator with the bias (the `Conv1dKernel` idiom). `linearForwardFloat` / `linearForwardSymInt32` use them and drop the rank-mismatched add. The bias is validated by **element count**, so both `[F]` and `[1, F]` biases are accepted (no regression for legacy rank-2 bias). The shared matmul loop is collapsed into one core per dtype (plain variants delegate with a NULL seed).
- **Backward:** `linearCalcBiasGradsFloat32` / `linearCalcBiasGradsSymInt32` reduce the loss over the batch axis into the rank-1 bias-grad (mirrors `conv1dCalcBiasGradsFloat32`).
- **SymInt32:** the bias seed/reduce **rescales** into the accumulator scale — `round(bias_int · biasScale / (aScale · bScale))` — because a raw int seed would drop the bias by ~9 orders of magnitude under dynamic per-tensor scaling. (FLOAT32 is the CI path; sym is unit-tested only.)
- Conv1d / Conv1dTransposed are unchanged (they already seed/reduce their bias).

## Verification

- **54/54 unit tests pass**; the new matmul + Linear forward/backward tests are mutation-checked.
- Both v2 binaries now **run to completion** — the `Rank mismatch` crash is gone.

## Scope note (important)

This fixes the **crash**. The `c-bit-parity` job will still be **red at the diff steps**, because the v2 example forwards are not parity-faithful with PyTorch (HAR collapses to a single class; ECG reconstruction is uncorrelated). That is a **separate, pre-existing** bug, tracked in #177 — ECG (which has no Linear and no matmul) is broken too, which proves that divergence is independent of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
