### PR TITLE
feat(layer): Dropout layer (FLOAT32 + SYM_INT32) with swappable Bernoulli sampler

### DIFF
--- a/src/layer/CMakeLists.txt
+++ b/src/layer/CMakeLists.txt
@@ -55,6 +55,17 @@ target_link_libraries(AdaptiveAvgPool1d PRIVATE
         AdaptiveWindow1d
 )
 
+add_library(Dropout Dropout.c)
+target_include_directories(Dropout PUBLIC include)
+target_link_libraries(Dropout PRIVATE
+        DTypes
+        Tensor
+        Layer
+        Common
+        Bernoulli
+        Rounding
+)
+
 add_library(Layer Layer.c)
 target_include_directories(Layer PUBLIC include)
 target_link_libraries(Layer PRIVATE
@@ -70,6 +81,7 @@ target_link_libraries(Layer PRIVATE
         AdaptiveAvgPool1d
         Softmax
         Flatten
+        Dropout
 )
 
 add_library(Linear Linear.c)
@@ -135,6 +147,7 @@ target_link_libraries(CommonLayerLibs INTERFACE
         AdaptiveAvgPool1d
         Softmax
         Flatten
+        Dropout
         Rounding
         Tensor
         Sgd

--- a/src/layer/Dropout.c
+++ b/src/layer/Dropout.c
@@ -77,6 +77,13 @@ static void dropoutForwardSymInt32(dropoutConfig_t *cfg, tensor_t *input, tensor
 void dropoutForward(layer_t *dropoutLayer, tensor_t *input, tensor_t *output) {
     dropoutConfig_t *cfg = dropoutLayer->config->dropout;
     if (cfg->training) {
+        size_t maskElements = calcNumberOfElementsByTensor(cfg->mask);
+        size_t inputElements = calcNumberOfElementsByTensor(input);
+        if (maskElements != inputElements) {
+            PRINT_ERROR("Dropout forward: mask element count (%zu) does not match input (%zu)",
+                        maskElements, inputElements);
+            exit(1);
+        }
         bernoulliFillMask(cfg->mask, 1.0f - cfg->p); // §6.0.5: fill once before dtype apply
     }
     switch (cfg->forwardQ->type) {
@@ -122,6 +129,13 @@ void dropoutBackward(layer_t *dropoutLayer, tensor_t *forwardInput, tensor_t *lo
                      tensor_t *propLoss) {
     (void)forwardInput; // not needed: the stored mask + p fully determine the gradient.
     dropoutConfig_t *cfg = dropoutLayer->config->dropout;
+    size_t maskElements = calcNumberOfElementsByTensor(cfg->mask);
+    size_t lossElements = calcNumberOfElementsByTensor(loss);
+    if (maskElements != lossElements) {
+        PRINT_ERROR("Dropout backward: mask element count (%zu) does not match loss (%zu)",
+                    maskElements, lossElements);
+        exit(1);
+    }
     switch (cfg->backwardQ->type) {
     case FLOAT32:
         dropoutBackwardFloat(cfg, loss, propLoss);

--- a/src/layer/Dropout.c
+++ b/src/layer/Dropout.c
@@ -1,0 +1,145 @@
+#define SOURCE_FILE "DROPOUT"
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "Dropout.h"
+
+#include "Bernoulli.h"
+#include "Common.h"
+#include "Layer.h"
+#include "Quantization.h"
+#include "Tensor.h"
+
+static float dropoutScale(float p) {
+    return 1.0f / (1.0f - p);
+}
+
+void initDropoutConfig(dropoutConfig_t *cfg, float p, tensor_t *mask, quantization_t *forwardQ,
+                       quantization_t *backwardQ) {
+    if (!(p >= 0.0f && p < 1.0f)) {
+        PRINT_ERROR("Dropout: p must be in [0, 1), got %f", (double)p);
+        exit(1);
+    }
+    if (mask == NULL) {
+        PRINT_ERROR("Dropout: mask must not be NULL — caller must pre-allocate a BOOL tensor");
+        exit(1);
+    }
+    cfg->p = p;
+    cfg->training = false;
+    cfg->mask = mask;
+    cfg->forwardQ = forwardQ;
+    cfg->backwardQ = backwardQ;
+    cfg->ownsQuantizations = false;
+}
+
+static void dropoutForwardFloat(dropoutConfig_t *cfg, tensor_t *input, tensor_t *output) {
+    size_t numberOfElements = calcNumberOfElementsByTensor(input);
+    float *in = (float *)input->data;
+    float *out = (float *)output->data;
+
+    if (!cfg->training) {
+        for (size_t i = 0; i < numberOfElements; i++) {
+            out[i] = in[i];
+        }
+        return;
+    }
+
+    float scale = dropoutScale(cfg->p);
+    for (size_t i = 0; i < numberOfElements; i++) {
+        out[i] = tensorBoolGet(cfg->mask, i) ? in[i] * scale : 0.0f;
+    }
+}
+
+static void dropoutForwardSymInt32(dropoutConfig_t *cfg, tensor_t *input, tensor_t *output) {
+    size_t numberOfElements = calcNumberOfElementsByTensor(input);
+    int32_t *in = (int32_t *)input->data;
+    int32_t *out = (int32_t *)output->data;
+    symInt32QConfig_t *inQC = input->quantization->qConfig;
+    symInt32QConfig_t *outQC = output->quantization->qConfig;
+
+    if (!cfg->training) {
+        for (size_t i = 0; i < numberOfElements; i++) {
+            out[i] = in[i];
+        }
+        outQC->scale = inQC->scale;
+        return;
+    }
+
+    float scale = dropoutScale(cfg->p);
+    for (size_t i = 0; i < numberOfElements; i++) {
+        out[i] = tensorBoolGet(cfg->mask, i) ? in[i] : 0;
+    }
+    outQC->scale = inQC->scale * scale; // scale-fold: ints copied unchanged, the 1/(1-p) factor
+                                        // goes into the quant scale
+}
+
+void dropoutForward(layer_t *dropoutLayer, tensor_t *input, tensor_t *output) {
+    dropoutConfig_t *cfg = dropoutLayer->config->dropout;
+    if (cfg->training) {
+        bernoulliFillMask(cfg->mask, 1.0f - cfg->p); // §6.0.5: fill once before dtype apply
+    }
+    switch (cfg->forwardQ->type) {
+    case FLOAT32:
+        dropoutForwardFloat(cfg, input, output);
+        break;
+    case SYM_INT32:
+        dropoutForwardSymInt32(cfg, input, output);
+        break;
+    default:
+        PRINT_ERROR("Dropout forward: quantization type not implemented");
+        exit(1);
+    }
+}
+
+static void dropoutBackwardFloat(dropoutConfig_t *cfg, tensor_t *loss, tensor_t *propLoss) {
+    size_t numberOfElements = calcNumberOfElementsByTensor(loss);
+    float *gradOut = (float *)loss->data;
+    float *gradIn = (float *)propLoss->data;
+    float scale = dropoutScale(cfg->p);
+
+    for (size_t i = 0; i < numberOfElements; i++) {
+        gradIn[i] = tensorBoolGet(cfg->mask, i) ? gradOut[i] * scale : 0.0f;
+    }
+}
+
+static void dropoutBackwardSymInt32(dropoutConfig_t *cfg, tensor_t *loss, tensor_t *propLoss) {
+    size_t numberOfElements = calcNumberOfElementsByTensor(loss);
+    int32_t *gradOut = (int32_t *)loss->data;
+    int32_t *gradIn = (int32_t *)propLoss->data;
+    symInt32QConfig_t *lossQC = loss->quantization->qConfig;
+    symInt32QConfig_t *propLossQC = propLoss->quantization->qConfig;
+    float scale = dropoutScale(cfg->p);
+
+    for (size_t i = 0; i < numberOfElements; i++) {
+        gradIn[i] = tensorBoolGet(cfg->mask, i) ? gradOut[i] : 0;
+    }
+    propLossQC->scale = lossQC->scale * scale; // scale-fold: ints copied unchanged, the 1/(1-p)
+                                               // factor goes into the quant scale
+}
+
+void dropoutBackward(layer_t *dropoutLayer, tensor_t *forwardInput, tensor_t *loss,
+                     tensor_t *propLoss) {
+    (void)forwardInput; // not needed: the stored mask + p fully determine the gradient.
+    dropoutConfig_t *cfg = dropoutLayer->config->dropout;
+    switch (cfg->backwardQ->type) {
+    case FLOAT32:
+        dropoutBackwardFloat(cfg, loss, propLoss);
+        break;
+    case SYM_INT32:
+        dropoutBackwardSymInt32(cfg, loss, propLoss);
+        break;
+    default:
+        PRINT_ERROR("Dropout backward: quantization type not implemented");
+        exit(1);
+    }
+}
+
+void dropoutCalcOutputShape(layer_t *dropoutLayer, shape_t *inputShape, shape_t *outputShape) {
+    (void)dropoutLayer;
+    memcpy(outputShape->dimensions, inputShape->dimensions,
+           inputShape->numberOfDimensions * sizeof(size_t));
+    memcpy(outputShape->orderOfDimensions, inputShape->orderOfDimensions,
+           inputShape->numberOfDimensions * sizeof(size_t));
+    outputShape->numberOfDimensions = inputShape->numberOfDimensions;
+}

--- a/src/layer/Layer.c
+++ b/src/layer/Layer.c
@@ -5,6 +5,7 @@
 #include "AvgPool1d.h"
 #include "Conv1d.h"
 #include "Conv1dTransposed.h"
+#include "Dropout.h"
 #include "Flatten.h"
 #include "Linear.h"
 #include "MaxPool1d.h"
@@ -22,7 +23,8 @@ layerFunctions_t layerFunctions[] = {
     [SOFTMAX] = {softmaxForward, softmaxBackward, softmaxCalcOutputShape},
     [FLATTEN] = {flattenForward, flattenBackward, flattenCalcOutputShape},
     [ADAPTIVE_AVGPOOL1D] = {adaptiveAvgPool1dForward, adaptiveAvgPool1dBackward,
-                            adaptiveAvgPool1dCalcOutputShape}};
+                            adaptiveAvgPool1dCalcOutputShape},
+    [DROPOUT] = {dropoutForward, dropoutBackward, dropoutCalcOutputShape}};
 
 void initLayer(layer_t *layer, layerType_t type, layerConfig_t *config) {
     layer->type = type;

--- a/src/layer/include/Dropout.h
+++ b/src/layer/include/Dropout.h
@@ -1,0 +1,27 @@
+#ifndef ODT_DROPOUT_H
+#define ODT_DROPOUT_H
+
+#include <stdbool.h>
+
+#include "Tensor.h"
+
+typedef struct layer layer_t;
+
+typedef struct dropoutConfig {
+    float p;        // drop probability, must be in [0, 1)
+    bool training;  // false = identity (eval); set true by the training loop
+    tensor_t *mask; // BOOL, shape == input/output; pre-allocated by caller
+    quantization_t *forwardQ;
+    quantization_t *backwardQ;
+    bool ownsQuantizations;
+} dropoutConfig_t;
+
+void initDropoutConfig(dropoutConfig_t *cfg, float p, tensor_t *mask, quantization_t *forwardQ,
+                       quantization_t *backwardQ);
+
+void dropoutForward(layer_t *dropoutLayer, tensor_t *input, tensor_t *output);
+void dropoutBackward(layer_t *dropoutLayer, tensor_t *forwardInput, tensor_t *loss,
+                     tensor_t *propLoss);
+void dropoutCalcOutputShape(layer_t *dropoutLayer, shape_t *inputShape, shape_t *outputShape);
+
+#endif // ODT_DROPOUT_H

--- a/src/layer/include/Layer.h
+++ b/src/layer/include/Layer.h
@@ -11,6 +11,7 @@ typedef struct conv1dTransposedConfig conv1dTransposedConfig_t;
 typedef struct maxPool1dConfig maxPool1dConfig_t;
 typedef struct avgPool1dConfig avgPool1dConfig_t;
 typedef struct adaptiveAvgPool1dConfig adaptiveAvgPool1dConfig_t;
+typedef struct dropoutConfig dropoutConfig_t;
 
 typedef enum layerType {
     LINEAR,
@@ -22,7 +23,8 @@ typedef enum layerType {
     SOFTMAX,
     FLATTEN,
     QUANTIZATION,
-    ADAPTIVE_AVGPOOL1D
+    ADAPTIVE_AVGPOOL1D,
+    DROPOUT
 } layerType_t;
 
 typedef enum layerQType { FLOAT_LAYER, ASYM_LAYER } layerQType_t;
@@ -36,6 +38,7 @@ typedef union layerConfig {
     maxPool1dConfig_t *maxPool1d;
     avgPool1dConfig_t *avgPool1d;
     adaptiveAvgPool1dConfig_t *adaptiveAvgPool1d;
+    dropoutConfig_t *dropout;
 } layerConfig_t;
 
 typedef struct layer {

--- a/src/optimizer/Optimizer.c
+++ b/src/optimizer/Optimizer.c
@@ -19,6 +19,7 @@ static size_t calcNumberOfStatesByLayerType(const layerType_t type) {
     case MAXPOOL1D:
     case AVGPOOL1D:
     case ADAPTIVE_AVGPOOL1D:
+    case DROPOUT:
         return 0;
     case CONV1D:
     case CONV1D_TRANSPOSED:

--- a/src/rng/Bernoulli.c
+++ b/src/rng/Bernoulli.c
@@ -1,0 +1,27 @@
+#define SOURCE_FILE "BERNOULLI"
+
+#include "Bernoulli.h"
+
+#include "RNG.h"
+#include "Tensor.h"
+
+void bernoulliFillMaskReference(tensor_t *mask, float probTrue) {
+    size_t numberOfElements = calcNumberOfElementsByTensor(mask);
+    for (size_t i = 0; i < numberOfElements; i++) {
+        tensorBoolSet(mask, i, rngNextFloat() < probTrue);
+    }
+}
+
+static bernoulliFillMaskFn_t activeFn = bernoulliFillMaskReference;
+
+void bernoulliFillMask(tensor_t *mask, float probTrue) {
+    activeFn(mask, probTrue);
+}
+
+void bernoulliSetFillMaskFn(bernoulliFillMaskFn_t fn) {
+    activeFn = fn ? fn : bernoulliFillMaskReference;
+}
+
+bernoulliFillMaskFn_t bernoulliGetFillMaskFn(void) {
+    return activeFn;
+}

--- a/src/rng/CMakeLists.txt
+++ b/src/rng/CMakeLists.txt
@@ -1,2 +1,10 @@
 add_library(RNG RNG.c)
 target_include_directories(RNG PUBLIC include)
+
+add_library(Bernoulli Bernoulli.c)
+target_include_directories(Bernoulli PUBLIC include)
+target_link_libraries(Bernoulli PRIVATE
+        RNG
+        Tensor
+        Rounding
+)

--- a/src/rng/include/Bernoulli.h
+++ b/src/rng/include/Bernoulli.h
@@ -1,0 +1,27 @@
+#ifndef BERNOULLI_H
+#define BERNOULLI_H
+
+#include "Tensor.h"
+
+/*! Fills `mask` (a BOOL tensor) with independent Bernoulli draws: each bit is
+ *  set (1) with probability `probTrue`, clear (0) with probability 1-probTrue.
+ *  Uses the canonical RNG (`rngNextFloat`); seed via `rngSetSeed` for
+ *  reproducibility. `mask` must be BOOL-quantized with its data buffer
+ *  allocated. */
+void bernoulliFillMask(tensor_t *mask, float probTrue);
+
+/*! Signature of a Bernoulli mask-fill implementation, for swapping in
+ *  optimized variants (SIMD, bit-parallel, hardware RNG). */
+typedef void (*bernoulliFillMaskFn_t)(tensor_t *mask, float probTrue);
+
+/*! The reference implementation (XorShift32 inverse-transform). Exported so it
+ *  can be restored after swapping. */
+void bernoulliFillMaskReference(tensor_t *mask, float probTrue);
+
+/*! Install a sampler implementation. Passing NULL restores the reference. */
+void bernoulliSetFillMaskFn(bernoulliFillMaskFn_t fn);
+
+/*! Returns the currently active sampler (for save/restore in tests). */
+bernoulliFillMaskFn_t bernoulliGetFillMaskFn(void);
+
+#endif // BERNOULLI_H

--- a/src/userApi/InferenceApi.c
+++ b/src/userApi/InferenceApi.c
@@ -9,6 +9,7 @@
 #include "Common.h"
 #include "Conv1d.h"
 #include "Conv1dTransposed.h"
+#include "Dropout.h"
 #include "InferenceApi.h"
 #include "Layer.h"
 #include "Linear.h"
@@ -54,6 +55,9 @@ static void initBufferOutput(tensor_t *buffer, layer_t *currentLayer, shape_t *i
         break;
     case ADAPTIVE_AVGPOOL1D:
         currentQ = currentLayer->config->adaptiveAvgPool1d->forwardQ;
+        break;
+    case DROPOUT:
+        currentQ = currentLayer->config->dropout->forwardQ;
         break;
     default:
         PRINT_ERROR("Unknown Layer Type!");

--- a/src/userApi/LayerWeightsApi.c
+++ b/src/userApi/LayerWeightsApi.c
@@ -74,6 +74,7 @@ void layerLoadWeights(layer_t *layer, float *weightData, float *biasData) {
     case MAXPOOL1D:
     case AVGPOOL1D:
     case ADAPTIVE_AVGPOOL1D:
+    case DROPOUT:
         PRINT_ERROR("layerLoadWeights: layer type %d has no parameters to load", (int)layer->type);
         exit(1);
     case CONV1D_TRANSPOSED: {

--- a/src/userApi/StateDictApi.c
+++ b/src/userApi/StateDictApi.c
@@ -18,6 +18,7 @@ static bool layerHasParameters(layer_t *layer) {
     case MAXPOOL1D:
     case AVGPOOL1D:
     case ADAPTIVE_AVGPOOL1D:
+    case DROPOUT:
     case QUANTIZATION:
         return false;
     default:

--- a/src/userApi/layer/CMakeLists.txt
+++ b/src/userApi/layer/CMakeLists.txt
@@ -115,3 +115,14 @@ target_link_libraries(AdaptivePool1dApi PRIVATE
         Rounding
         StorageApi
 )
+
+add_library(DropoutApi DropoutApi.c)
+target_include_directories(DropoutApi PUBLIC include)
+target_link_libraries(DropoutApi PRIVATE
+        Tensor
+        Layer
+        Dropout
+        Common
+        Rounding
+        StorageApi
+)

--- a/src/userApi/layer/DropoutApi.c
+++ b/src/userApi/layer/DropoutApi.c
@@ -1,0 +1,32 @@
+#define SOURCE_FILE "DROPOUT_API"
+
+#include "DropoutApi.h"
+
+#include "Dropout.h"
+#include "Layer.h"
+#include "StorageApi.h"
+#include "Tensor.h"
+
+layer_t *dropoutLayerInit(float p, tensor_t *mask, quantization_t *forwardQ,
+                          quantization_t *backwardQ) {
+    layer_t *layer = reserveMemory(sizeof(layer_t));
+    layer->type = DROPOUT;
+
+    layerConfig_t *layerCfg = reserveMemory(sizeof(layerConfig_t));
+    dropoutConfig_t *cfg = reserveMemory(sizeof(dropoutConfig_t));
+    layerCfg->dropout = cfg;
+    layer->config = layerCfg;
+
+    initDropoutConfig(cfg, p, mask, forwardQ, backwardQ);
+
+    return layer;
+}
+
+void freeDropoutLayer(layer_t *dropoutLayer) {
+    if (dropoutLayer == NULL) {
+        return;
+    }
+    freeReservedMemory(dropoutLayer->config->dropout);
+    freeReservedMemory(dropoutLayer->config);
+    freeReservedMemory(dropoutLayer);
+}

--- a/src/userApi/layer/DropoutApi.c
+++ b/src/userApi/layer/DropoutApi.c
@@ -26,7 +26,18 @@ void freeDropoutLayer(layer_t *dropoutLayer) {
     if (dropoutLayer == NULL) {
         return;
     }
-    freeReservedMemory(dropoutLayer->config->dropout);
+    dropoutConfig_t *cfg = dropoutLayer->config->dropout;
+    if (cfg->ownsQuantizations) {
+        if (cfg->forwardQ != NULL) {
+            freeReservedMemory(cfg->forwardQ->qConfig);
+            freeReservedMemory(cfg->forwardQ);
+        }
+        if (cfg->backwardQ != NULL && cfg->backwardQ != cfg->forwardQ) {
+            freeReservedMemory(cfg->backwardQ->qConfig);
+            freeReservedMemory(cfg->backwardQ);
+        }
+    }
+    freeReservedMemory(cfg);
     freeReservedMemory(dropoutLayer->config);
     freeReservedMemory(dropoutLayer);
 }

--- a/src/userApi/layer/include/DropoutApi.h
+++ b/src/userApi/layer/include/DropoutApi.h
@@ -1,0 +1,18 @@
+#ifndef ODT_DROPOUT_API_H
+#define ODT_DROPOUT_API_H
+
+#include "Dropout.h"
+#include "Layer.h"
+#include "Tensor.h"
+
+/*! Builds a Dropout layer. Borrows `forwardQ`, `backwardQ`, and `mask`
+ *  (caller retains ownership; ownsQuantizations = false). `mask` must be a
+ *  pre-allocated BOOL tensor whose element count equals the layer input's. */
+layer_t *dropoutLayerInit(float p, tensor_t *mask, quantization_t *forwardQ,
+                          quantization_t *backwardQ);
+
+/*! Frees the layer_t + its config wrappers. Does NOT free the borrowed mask or
+ *  quantizations (ownsQuantizations is false). */
+void freeDropoutLayer(layer_t *dropoutLayer);
+
+#endif // ODT_DROPOUT_API_H

--- a/src/userApi/optimizer/SgdApi.c
+++ b/src/userApi/optimizer/SgdApi.c
@@ -127,6 +127,7 @@ optimizer_t *sgdMCreateOptim(float learningRate, float momentumFactor, float wei
         case MAXPOOL1D:
         case AVGPOOL1D:
         case ADAPTIVE_AVGPOOL1D:
+        case DROPOUT:
             break;
         default:
             PRINT_ERROR("Unknown Layer Type");

--- a/src/userApi/training_loop/calculate_grads/CalculateGradsSequential.c
+++ b/src/userApi/training_loop/calculate_grads/CalculateGradsSequential.c
@@ -11,6 +11,7 @@
 #include "Common.h"
 #include "Conv1d.h"
 #include "Conv1dTransposed.h"
+#include "Dropout.h"
 #include "Layer.h"
 #include "Linear.h"
 #include "LossFunction.h"
@@ -21,12 +22,21 @@
 #include "TensorApi.h"
 #include "TrainingLoopApiInternal.h"
 
+static void setDropoutLayersTraining(layer_t **model, size_t modelSize, bool training) {
+    for (size_t i = 0; i < modelSize; i++) {
+        if (model[i]->type == DROPOUT) {
+            model[i]->config->dropout->training = training;
+        }
+    }
+}
+
 trainingStats_t *calculateGradsSequential(layer_t **model, size_t modelSize,
                                           lossConfig_t lossConfig, reduction_t forwardReduction,
                                           tensor_t *input, tensor_t *label) {
 
     tensor_t *layerOutputs[modelSize + 1];
     layerOutputs[0] = input;
+    setDropoutLayersTraining(model, modelSize, true);
     initLayerOutputs(layerOutputs, model, modelSize);
 
     // Forward pass
@@ -72,6 +82,7 @@ trainingStats_t *calculateGradsSequential(layer_t **model, size_t modelSize,
     deInitGradTensor(&gradNext);
     deInitLayerOutputs(layerOutputs, modelSize);
 
+    setDropoutLayersTraining(model, modelSize, false);
     return trainingStats;
 }
 
@@ -111,6 +122,9 @@ static void initLayerOutputs(tensor_t **layerOutputs, layer_t **model, size_t si
             break;
         case ADAPTIVE_AVGPOOL1D:
             currentQ = currentLayer->config->adaptiveAvgPool1d->forwardQ;
+            break;
+        case DROPOUT:
+            currentQ = currentLayer->config->dropout->forwardQ;
             break;
         default:
             PRINT_ERROR("Unknown Layer Type!");

--- a/test/unit/layer/CMakeLists.txt
+++ b/test/unit/layer/CMakeLists.txt
@@ -190,4 +190,5 @@ add_elastic_ai_unit_test(
         Quantization
         Rounding
         StorageApi
+        DropoutApi
 )

--- a/test/unit/layer/CMakeLists.txt
+++ b/test/unit/layer/CMakeLists.txt
@@ -176,3 +176,18 @@ add_elastic_ai_unit_test(
 )
 add_dependencies(UnitTestAdaptiveAvgPool1d generate_expected_adaptive_avg_pool_1d)
 target_include_directories(UnitTestAdaptiveAvgPool1d PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+
+add_elastic_ai_unit_test(
+        LIB_UNDER_TEST
+        Dropout
+        MORE_LIBS
+        CommonLayerLibs
+        Bernoulli
+        RNG
+        TensorApi
+        QuantizationApi
+        LayerQuant
+        Quantization
+        Rounding
+        StorageApi
+)

--- a/test/unit/layer/UnitTestDropout.c
+++ b/test/unit/layer/UnitTestDropout.c
@@ -1,0 +1,416 @@
+#define SOURCE_FILE "UNIT_TEST_DROPOUT"
+
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include "Bernoulli.h"
+#include "Dropout.h"
+#include "Layer.h"
+#include "Quantization.h"
+#include "QuantizationApi.h"
+#include "StorageApi.h"
+#include "Tensor.h"
+#include "TensorApi.h"
+#include "unity.h"
+
+void setUp(void) {}
+void tearDown(void) {}
+
+/* ---- shared builders ---- */
+
+static tensor_t *buildFloatTensor(size_t n, const float *vals) {
+    size_t *dims = reserveMemory(sizeof(size_t));
+    dims[0] = n;
+    size_t *order = reserveMemory(sizeof(size_t));
+    setOrderOfDimsForNewTensor(1, order);
+    shape_t *shape = reserveMemory(sizeof(shape_t));
+    setShape(shape, dims, 1, order);
+    tensor_t *t = initTensor(shape, quantizationInitFloat(), NULL);
+    if (vals != NULL) {
+        tensorFillFromFloatBuffer(t, (float *)vals, n);
+    }
+    return t;
+}
+
+static tensor_t *buildBoolMask(size_t n) {
+    size_t *dims = reserveMemory(sizeof(size_t));
+    dims[0] = n;
+    size_t *order = reserveMemory(sizeof(size_t));
+    setOrderOfDimsForNewTensor(1, order);
+    shape_t *shape = reserveMemory(sizeof(shape_t));
+    setShape(shape, dims, 1, order);
+    return initTensor(shape, quantizationInitBool(), NULL);
+}
+
+/* Wraps a dropoutConfig in a stack layer_t for direct forward/backward calls. */
+static layer_t makeDropoutLayer(dropoutConfig_t *dcfg, layerConfig_t *lcfg) {
+    lcfg->dropout = dcfg;
+    layer_t layer = {.type = DROPOUT, .config = lcfg};
+    return layer;
+}
+
+void testForwardEvalIdentityFloat(void) {
+    size_t n = 4;
+    float in[] = {1.f, -2.f, 3.f, -4.f};
+    tensor_t *input = buildFloatTensor(n, in);
+    tensor_t *output = buildFloatTensor(n, NULL);
+    tensor_t *mask = buildBoolMask(n);
+
+    quantization_t *fq = quantizationInitFloat();
+    quantization_t *bq = quantizationInitFloat();
+    dropoutConfig_t dcfg;
+    initDropoutConfig(&dcfg, 0.5f, mask, fq, bq); // training defaults to false
+    layerConfig_t lcfg;
+    layer_t layer = makeDropoutLayer(&dcfg, &lcfg);
+
+    dropoutForward(&layer, input, output);
+
+    float captured[4];
+    for (size_t i = 0; i < n; i++) {
+        captured[i] = ((float *)output->data)[i];
+    }
+
+    freeQuantization(bq);
+    freeQuantization(fq);
+    freeTensor(mask);
+    freeTensor(output);
+    freeTensor(input);
+
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(in, captured, n);
+}
+
+void testForwardEvalIdentitySymInt32(void) {
+    size_t n = 4;
+
+    size_t *dims = reserveMemory(sizeof(size_t));
+    dims[0] = n;
+    size_t *order = reserveMemory(sizeof(size_t));
+    setOrderOfDimsForNewTensor(1, order);
+    shape_t *shape = reserveMemory(sizeof(shape_t));
+    setShape(shape, dims, 1, order);
+    tensor_t *symIn = initTensor(shape, quantizationInitSymInt32(HTE), NULL);
+    int32_t inInts[] = {10, -20, 30, -40};
+    for (size_t i = 0; i < n; i++) {
+        ((int32_t *)symIn->data)[i] = inInts[i];
+    }
+    ((symInt32QConfig_t *)symIn->quantization->qConfig)->scale = 0.1f;
+
+    size_t *odims = reserveMemory(sizeof(size_t));
+    odims[0] = n;
+    size_t *oorder = reserveMemory(sizeof(size_t));
+    setOrderOfDimsForNewTensor(1, oorder);
+    shape_t *oshape = reserveMemory(sizeof(shape_t));
+    setShape(oshape, odims, 1, oorder);
+    tensor_t *symOut = initTensor(oshape, quantizationInitSymInt32(HTE), NULL);
+
+    tensor_t *mask = buildBoolMask(n);
+    quantization_t *fq = quantizationInitSymInt32(HTE);
+    quantization_t *bq = quantizationInitSymInt32(HTE);
+    dropoutConfig_t dcfg;
+    initDropoutConfig(&dcfg, 0.5f, mask, fq, bq); // eval mode
+    layerConfig_t lcfg;
+    layer_t layer = makeDropoutLayer(&dcfg, &lcfg);
+
+    dropoutForward(&layer, symIn, symOut);
+
+    int32_t capturedInts[4];
+    for (size_t i = 0; i < n; i++) {
+        capturedInts[i] = ((int32_t *)symOut->data)[i];
+    }
+    float outScale = ((symInt32QConfig_t *)symOut->quantization->qConfig)->scale;
+
+    freeQuantization(bq);
+    freeQuantization(fq);
+    freeTensor(mask);
+    freeTensor(symOut);
+    freeTensor(symIn);
+
+    TEST_ASSERT_EQUAL_INT32_ARRAY(inInts, capturedInts, n);
+    TEST_ASSERT_FLOAT_WITHIN(1e-6f, 0.1f, outScale);
+}
+
+/* Stub sampler: keep even indices (bit 1), drop odd (bit 0). Ignores probTrue. */
+static void stubKeepEven(tensor_t *mask, float probTrue) {
+    (void)probTrue;
+    size_t n = calcNumberOfElementsByTensor(mask);
+    for (size_t i = 0; i < n; i++) {
+        tensorBoolSet(mask, i, (i % 2) == 0);
+    }
+}
+
+void testForwardTrainingFloatScalesAndDrops(void) {
+    size_t n = 4;
+    float in[] = {1.f, 2.f, 3.f, 4.f};
+    tensor_t *input = buildFloatTensor(n, in);
+    tensor_t *output = buildFloatTensor(n, NULL);
+    tensor_t *mask = buildBoolMask(n);
+
+    quantization_t *fq = quantizationInitFloat();
+    quantization_t *bq = quantizationInitFloat();
+    dropoutConfig_t dcfg;
+    initDropoutConfig(&dcfg, 0.5f, mask, fq, bq);
+    dcfg.training = true;
+    layerConfig_t lcfg;
+    layer_t layer = makeDropoutLayer(&dcfg, &lcfg);
+
+    bernoulliFillMaskFn_t saved = bernoulliGetFillMaskFn();
+    bernoulliSetFillMaskFn(stubKeepEven);
+    dropoutForward(&layer, input, output);
+    bernoulliSetFillMaskFn(saved);
+
+    float captured[4];
+    for (size_t i = 0; i < n; i++) {
+        captured[i] = ((float *)output->data)[i];
+    }
+
+    freeQuantization(bq);
+    freeQuantization(fq);
+    freeTensor(mask);
+    freeTensor(output);
+    freeTensor(input);
+
+    // s = 1/(1-0.5) = 2; keep even idx (×2), drop odd (→0).
+    float expected[] = {2.f, 0.f, 6.f, 0.f};
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(expected, captured, n);
+}
+
+void testForwardTrainingSymInt32ScaleFold(void) {
+    size_t n = 4;
+    size_t *dims = reserveMemory(sizeof(size_t));
+    dims[0] = n;
+    size_t *order = reserveMemory(sizeof(size_t));
+    setOrderOfDimsForNewTensor(1, order);
+    shape_t *shape = reserveMemory(sizeof(shape_t));
+    setShape(shape, dims, 1, order);
+    tensor_t *symIn = initTensor(shape, quantizationInitSymInt32(HTE), NULL);
+    int32_t inInts[] = {10, -20, 30, 40};
+    for (size_t i = 0; i < n; i++) {
+        ((int32_t *)symIn->data)[i] = inInts[i];
+    }
+    ((symInt32QConfig_t *)symIn->quantization->qConfig)->scale = 0.1f;
+
+    size_t *odims = reserveMemory(sizeof(size_t));
+    odims[0] = n;
+    size_t *oorder = reserveMemory(sizeof(size_t));
+    setOrderOfDimsForNewTensor(1, oorder);
+    shape_t *oshape = reserveMemory(sizeof(shape_t));
+    setShape(oshape, odims, 1, oorder);
+    tensor_t *symOut = initTensor(oshape, quantizationInitSymInt32(HTE), NULL);
+
+    tensor_t *mask = buildBoolMask(n);
+    quantization_t *fq = quantizationInitSymInt32(HTE);
+    quantization_t *bq = quantizationInitSymInt32(HTE);
+    dropoutConfig_t dcfg;
+    initDropoutConfig(&dcfg, 0.5f, mask, fq, bq);
+    dcfg.training = true;
+    layerConfig_t lcfg;
+    layer_t layer = makeDropoutLayer(&dcfg, &lcfg);
+
+    bernoulliFillMaskFn_t saved = bernoulliGetFillMaskFn();
+    bernoulliSetFillMaskFn(stubKeepEven);
+    dropoutForward(&layer, symIn, symOut);
+    bernoulliSetFillMaskFn(saved);
+
+    int32_t capturedInts[4];
+    for (size_t i = 0; i < n; i++) {
+        capturedInts[i] = ((int32_t *)symOut->data)[i];
+    }
+    float outScale = ((symInt32QConfig_t *)symOut->quantization->qConfig)->scale;
+
+    freeQuantization(bq);
+    freeQuantization(fq);
+    freeTensor(mask);
+    freeTensor(symOut);
+    freeTensor(symIn);
+
+    // keep even idx → int copied, drop odd → 0; scale folded ×2 (s=1/(1-0.5)).
+    int32_t expectedInts[] = {10, 0, 30, 0};
+    TEST_ASSERT_EQUAL_INT32_ARRAY(expectedInts, capturedInts, n);
+    TEST_ASSERT_FLOAT_WITHIN(1e-6f, 0.2f, outScale);
+}
+
+static void fillMaskKeepEven(tensor_t *mask) {
+    size_t n = calcNumberOfElementsByTensor(mask);
+    for (size_t i = 0; i < n; i++) {
+        tensorBoolSet(mask, i, (i % 2) == 0);
+    }
+}
+
+void testBackwardFloatUsesMaskAndScale(void) {
+    size_t n = 4;
+    tensor_t *forwardInput = buildFloatTensor(n, (float[]){1.f, 1.f, 1.f, 1.f});
+    float grad[] = {1.f, 2.f, 3.f, 4.f};
+    tensor_t *loss = buildFloatTensor(n, grad);
+    tensor_t *propLoss = buildFloatTensor(n, NULL);
+    tensor_t *mask = buildBoolMask(n);
+    fillMaskKeepEven(mask); // simulate the mask the forward pass produced
+
+    quantization_t *fq = quantizationInitFloat();
+    quantization_t *bq = quantizationInitFloat();
+    dropoutConfig_t dcfg;
+    initDropoutConfig(&dcfg, 0.5f, mask, fq, bq);
+    dcfg.training = true;
+    layerConfig_t lcfg;
+    layer_t layer = makeDropoutLayer(&dcfg, &lcfg);
+
+    dropoutBackward(&layer, forwardInput, loss, propLoss);
+
+    float captured[4];
+    for (size_t i = 0; i < n; i++) {
+        captured[i] = ((float *)propLoss->data)[i];
+    }
+
+    freeQuantization(bq);
+    freeQuantization(fq);
+    freeTensor(mask);
+    freeTensor(propLoss);
+    freeTensor(loss);
+    freeTensor(forwardInput);
+
+    // s=2; kept idx: grad×2, dropped idx: 0.
+    float expected[] = {2.f, 0.f, 6.f, 0.f};
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(expected, captured, n);
+}
+
+void testBackwardSymInt32UsesMaskAndScaleFold(void) {
+    size_t n = 4;
+
+    size_t *ldims = reserveMemory(sizeof(size_t));
+    ldims[0] = n;
+    size_t *lorder = reserveMemory(sizeof(size_t));
+    setOrderOfDimsForNewTensor(1, lorder);
+    shape_t *lshape = reserveMemory(sizeof(shape_t));
+    setShape(lshape, ldims, 1, lorder);
+    tensor_t *loss = initTensor(lshape, quantizationInitSymInt32(HTE), NULL);
+    int32_t gradInts[] = {5, 6, 7, 8};
+    for (size_t i = 0; i < n; i++) {
+        ((int32_t *)loss->data)[i] = gradInts[i];
+    }
+    ((symInt32QConfig_t *)loss->quantization->qConfig)->scale = 0.2f;
+
+    size_t *pdims = reserveMemory(sizeof(size_t));
+    pdims[0] = n;
+    size_t *porder = reserveMemory(sizeof(size_t));
+    setOrderOfDimsForNewTensor(1, porder);
+    shape_t *pshape = reserveMemory(sizeof(shape_t));
+    setShape(pshape, pdims, 1, porder);
+    tensor_t *propLoss = initTensor(pshape, quantizationInitSymInt32(HTE), NULL);
+
+    tensor_t *mask = buildBoolMask(n);
+    fillMaskKeepEven(mask);
+
+    quantization_t *fq = quantizationInitSymInt32(HTE);
+    quantization_t *bq = quantizationInitSymInt32(HTE);
+    dropoutConfig_t dcfg;
+    initDropoutConfig(&dcfg, 0.5f, mask, fq, bq);
+    dcfg.training = true;
+    layerConfig_t lcfg;
+    layer_t layer = makeDropoutLayer(&dcfg, &lcfg);
+
+    dropoutBackward(&layer, NULL, loss, propLoss);
+
+    int32_t capturedInts[4];
+    for (size_t i = 0; i < n; i++) {
+        capturedInts[i] = ((int32_t *)propLoss->data)[i];
+    }
+    float outScale = ((symInt32QConfig_t *)propLoss->quantization->qConfig)->scale;
+
+    freeQuantization(bq);
+    freeQuantization(fq);
+    freeTensor(mask);
+    freeTensor(propLoss);
+    freeTensor(loss);
+
+    int32_t expectedInts[] = {5, 0, 7, 0};
+    TEST_ASSERT_EQUAL_INT32_ARRAY(expectedInts, capturedInts, n);
+    TEST_ASSERT_FLOAT_WITHIN(1e-6f, 0.4f, outScale); // 0.2 × 2
+}
+
+void testVtableForwardIdentityFloat(void) {
+    size_t n = 3;
+    float in[] = {7.f, 8.f, 9.f};
+    tensor_t *input = buildFloatTensor(n, in);
+    tensor_t *output = buildFloatTensor(n, NULL);
+    tensor_t *mask = buildBoolMask(n);
+
+    quantization_t *fq = quantizationInitFloat();
+    quantization_t *bq = quantizationInitFloat();
+    dropoutConfig_t dcfg;
+    initDropoutConfig(&dcfg, 0.5f, mask, fq, bq); // eval
+    layerConfig_t lcfg;
+    layer_t layer = makeDropoutLayer(&dcfg, &lcfg);
+
+    layerFunctions_t fns = layerFunctions[DROPOUT];
+    fns.forward(&layer, input, output);
+
+    float captured[3];
+    for (size_t i = 0; i < n; i++) {
+        captured[i] = ((float *)output->data)[i];
+    }
+
+    freeQuantization(bq);
+    freeQuantization(fq);
+    freeTensor(mask);
+    freeTensor(output);
+    freeTensor(input);
+
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(in, captured, n);
+}
+
+void testCalcOutputShapeIsIdentity(void) {
+    size_t *dims = reserveMemory(2 * sizeof(size_t));
+    dims[0] = 2;
+    dims[1] = 5;
+    size_t *order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, order);
+    shape_t *inShape = reserveMemory(sizeof(shape_t));
+    setShape(inShape, dims, 2, order);
+
+    size_t *odims = reserveMemory(2 * sizeof(size_t));
+    size_t *oorder = reserveMemory(2 * sizeof(size_t));
+    shape_t *outShape = reserveMemory(sizeof(shape_t));
+    outShape->dimensions = odims;
+    outShape->orderOfDimensions = oorder;
+    outShape->numberOfDimensions = 0;
+
+    tensor_t *mask = buildBoolMask(10);
+    quantization_t *fq = quantizationInitFloat();
+    quantization_t *bq = quantizationInitFloat();
+    dropoutConfig_t dcfg;
+    initDropoutConfig(&dcfg, 0.5f, mask, fq, bq);
+    layerConfig_t lcfg;
+    layer_t layer = makeDropoutLayer(&dcfg, &lcfg);
+
+    dropoutCalcOutputShape(&layer, inShape, outShape);
+
+    size_t nd = outShape->numberOfDimensions;
+    size_t d0 = outShape->dimensions[0];
+    size_t d1 = outShape->dimensions[1];
+
+    freeQuantization(bq);
+    freeQuantization(fq);
+    freeTensor(mask);
+    freeReservedMemory(outShape);
+    freeReservedMemory(oorder);
+    freeReservedMemory(odims);
+    freeReservedMemory(inShape);
+    freeReservedMemory(order);
+    freeReservedMemory(dims);
+
+    TEST_ASSERT_EQUAL_UINT(2, nd);
+    TEST_ASSERT_EQUAL_UINT(2, d0);
+    TEST_ASSERT_EQUAL_UINT(5, d1);
+}
+
+int main(void) {
+    UNITY_BEGIN();
+    RUN_TEST(testForwardEvalIdentityFloat);
+    RUN_TEST(testForwardEvalIdentitySymInt32);
+    RUN_TEST(testForwardTrainingFloatScalesAndDrops);
+    RUN_TEST(testForwardTrainingSymInt32ScaleFold);
+    RUN_TEST(testBackwardFloatUsesMaskAndScale);
+    RUN_TEST(testBackwardSymInt32UsesMaskAndScaleFold);
+    RUN_TEST(testVtableForwardIdentityFloat);
+    RUN_TEST(testCalcOutputShapeIsIdentity);
+    return UNITY_END();
+}

--- a/test/unit/layer/UnitTestDropout.c
+++ b/test/unit/layer/UnitTestDropout.c
@@ -5,6 +5,7 @@
 
 #include "Bernoulli.h"
 #include "Dropout.h"
+#include "DropoutApi.h"
 #include "Layer.h"
 #include "Quantization.h"
 #include "QuantizationApi.h"
@@ -402,6 +403,39 @@ void testCalcOutputShapeIsIdentity(void) {
     TEST_ASSERT_EQUAL_UINT(5, d1);
 }
 
+void testFactoryBuildsAndForwards(void) {
+    size_t n = 3;
+    float in[] = {4.f, 5.f, 6.f};
+    tensor_t *input = buildFloatTensor(n, in);
+    tensor_t *output = buildFloatTensor(n, NULL);
+    tensor_t *mask = buildBoolMask(n);
+    quantization_t *fq = quantizationInitFloat();
+    quantization_t *bq = quantizationInitFloat();
+
+    layer_t *layer = dropoutLayerInit(0.5f, mask, fq, bq);
+    bool typeOk = (layer->type == DROPOUT);
+    float pOk = layer->config->dropout->p;
+    bool trainingDefaultFalse = (layer->config->dropout->training == false);
+
+    layerFunctions[DROPOUT].forward(layer, input, output); // eval → identity
+    float captured[3];
+    for (size_t i = 0; i < n; i++) {
+        captured[i] = ((float *)output->data)[i];
+    }
+
+    freeDropoutLayer(layer);
+    freeQuantization(bq);
+    freeQuantization(fq);
+    freeTensor(mask);
+    freeTensor(output);
+    freeTensor(input);
+
+    TEST_ASSERT_TRUE(typeOk);
+    TEST_ASSERT_FLOAT_WITHIN(1e-6f, 0.5f, pOk);
+    TEST_ASSERT_TRUE(trainingDefaultFalse);
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(in, captured, n);
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(testForwardEvalIdentityFloat);
@@ -412,5 +446,6 @@ int main(void) {
     RUN_TEST(testBackwardSymInt32UsesMaskAndScaleFold);
     RUN_TEST(testVtableForwardIdentityFloat);
     RUN_TEST(testCalcOutputShapeIsIdentity);
+    RUN_TEST(testFactoryBuildsAndForwards);
     return UNITY_END();
 }

--- a/test/unit/layer/UnitTestDropout.c
+++ b/test/unit/layer/UnitTestDropout.c
@@ -436,6 +436,77 @@ void testFactoryBuildsAndForwards(void) {
     TEST_ASSERT_EQUAL_FLOAT_ARRAY(in, captured, n);
 }
 
+void testForwardTrainingP0KeepsAllNoScale(void) {
+    size_t n = 4;
+    float in[] = {1.f, 2.f, 3.f, 4.f};
+    tensor_t *input = buildFloatTensor(n, in);
+    tensor_t *output = buildFloatTensor(n, NULL);
+    tensor_t *mask = buildBoolMask(n);
+
+    quantization_t *fq = quantizationInitFloat();
+    quantization_t *bq = quantizationInitFloat();
+    dropoutConfig_t dcfg;
+    initDropoutConfig(&dcfg, 0.0f, mask, fq, bq);
+    dcfg.training = true;
+    layerConfig_t lcfg;
+    layer_t layer = makeDropoutLayer(&dcfg, &lcfg);
+
+    // p=0 → reference sampler fills probTrue=1.0 → all keep; scale=1/(1-0)=1 → identity.
+    bernoulliFillMaskFn_t saved = bernoulliGetFillMaskFn();
+    bernoulliSetFillMaskFn(bernoulliFillMaskReference);
+    dropoutForward(&layer, input, output);
+    bernoulliSetFillMaskFn(saved);
+
+    float captured[4];
+    for (size_t i = 0; i < n; i++) {
+        captured[i] = ((float *)output->data)[i];
+    }
+    freeQuantization(bq);
+    freeQuantization(fq);
+    freeTensor(mask);
+    freeTensor(output);
+    freeTensor(input);
+
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(in, captured, n);
+}
+
+void testForwardTrainingFloatP025Scale(void) {
+    size_t n = 4;
+    float in[] = {4.f, 8.f, 12.f, 16.f};
+    tensor_t *input = buildFloatTensor(n, in);
+    tensor_t *output = buildFloatTensor(n, NULL);
+    tensor_t *mask = buildBoolMask(n);
+
+    quantization_t *fq = quantizationInitFloat();
+    quantization_t *bq = quantizationInitFloat();
+    dropoutConfig_t dcfg;
+    initDropoutConfig(&dcfg, 0.25f, mask, fq, bq);
+    dcfg.training = true;
+    layerConfig_t lcfg;
+    layer_t layer = makeDropoutLayer(&dcfg, &lcfg);
+
+    bernoulliFillMaskFn_t saved = bernoulliGetFillMaskFn();
+    bernoulliSetFillMaskFn(stubKeepEven);
+    dropoutForward(&layer, input, output);
+    bernoulliSetFillMaskFn(saved);
+
+    float captured[4];
+    for (size_t i = 0; i < n; i++) {
+        captured[i] = ((float *)output->data)[i];
+    }
+    freeQuantization(bq);
+    freeQuantization(fq);
+    freeTensor(mask);
+    freeTensor(output);
+    freeTensor(input);
+
+    // s = 1/(1-0.25) = 1.33333; keep even idx (×s), drop odd → 0.
+    float expected[] = {5.33333f, 0.f, 16.0f, 0.f};
+    for (size_t i = 0; i < n; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(1e-3f, expected[i], captured[i]);
+    }
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(testForwardEvalIdentityFloat);
@@ -447,5 +518,7 @@ int main(void) {
     RUN_TEST(testVtableForwardIdentityFloat);
     RUN_TEST(testCalcOutputShapeIsIdentity);
     RUN_TEST(testFactoryBuildsAndForwards);
+    RUN_TEST(testForwardTrainingP0KeepsAllNoScale);
+    RUN_TEST(testForwardTrainingFloatP025Scale);
     return UNITY_END();
 }

--- a/test/unit/rng/CMakeLists.txt
+++ b/test/unit/rng/CMakeLists.txt
@@ -2,3 +2,15 @@ add_elastic_ai_unit_test(
         LIB_UNDER_TEST
         RNG
 )
+
+add_elastic_ai_unit_test(
+        LIB_UNDER_TEST
+        Bernoulli
+        MORE_LIBS
+        RNG
+        Tensor
+        Rounding
+        TensorApi
+        QuantizationApi
+        StorageApi
+)

--- a/test/unit/rng/UnitTestBernoulli.c
+++ b/test/unit/rng/UnitTestBernoulli.c
@@ -1,0 +1,134 @@
+#define SOURCE_FILE "UNIT_TEST_BERNOULLI"
+
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include "Bernoulli.h"
+#include "QuantizationApi.h"
+#include "RNG.h"
+#include "StorageApi.h"
+#include "Tensor.h"
+#include "TensorApi.h"
+#include "unity.h"
+
+void setUp(void) {}
+void tearDown(void) {}
+
+static tensor_t *buildBoolTensor(size_t n) {
+    size_t *dims = reserveMemory(sizeof(size_t));
+    dims[0] = n;
+    size_t *order = reserveMemory(sizeof(size_t));
+    setOrderOfDimsForNewTensor(1, order);
+    shape_t *shape = reserveMemory(sizeof(shape_t));
+    setShape(shape, dims, 1, order);
+    return initTensor(shape, quantizationInitBool(), NULL);
+}
+
+static size_t countSetBits(tensor_t *mask, size_t n) {
+    size_t set = 0;
+    for (size_t i = 0; i < n; i++) {
+        if (tensorBoolGet(mask, i)) {
+            set++;
+        }
+    }
+    return set;
+}
+
+void testReferenceRateApproxProbTrue(void) {
+    size_t n = 10000;
+    tensor_t *mask = buildBoolTensor(n);
+    rngSetSeed(12345u);
+
+    bernoulliFillMask(mask, 0.3f);
+    size_t set = countSetBits(mask, n);
+
+    freeTensor(mask);
+
+    // ~30% of bits set; tolerate sampling noise on 10k draws.
+    TEST_ASSERT_FLOAT_WITHIN(0.03f, 0.3f, (float)set / (float)n);
+}
+
+void testReferenceEdgeAllZero(void) {
+    size_t n = 256;
+    tensor_t *mask = buildBoolTensor(n);
+    rngSetSeed(1u);
+
+    bernoulliFillMask(mask, 0.0f);
+    size_t set = countSetBits(mask, n);
+
+    freeTensor(mask);
+    TEST_ASSERT_EQUAL_UINT(0, set);
+}
+
+void testReferenceEdgeAllOne(void) {
+    size_t n = 256;
+    tensor_t *mask = buildBoolTensor(n);
+    rngSetSeed(1u);
+
+    bernoulliFillMask(mask, 1.0f);
+    size_t set = countSetBits(mask, n);
+
+    freeTensor(mask);
+    TEST_ASSERT_EQUAL_UINT(256, set);
+}
+
+void testDeterministicUnderSameSeed(void) {
+    size_t n = 512;
+    tensor_t *a = buildBoolTensor(n);
+    tensor_t *b = buildBoolTensor(n);
+
+    rngSetSeed(999u);
+    bernoulliFillMask(a, 0.5f);
+    rngSetSeed(999u);
+    bernoulliFillMask(b, 0.5f);
+
+    bool identical = true;
+    for (size_t i = 0; i < n; i++) {
+        if (tensorBoolGet(a, i) != tensorBoolGet(b, i)) {
+            identical = false;
+            break;
+        }
+    }
+
+    freeTensor(b);
+    freeTensor(a);
+    TEST_ASSERT_TRUE(identical);
+}
+
+static void stubFillAllSet(tensor_t *mask, float probTrue) {
+    (void)probTrue;
+    size_t n = calcNumberOfElementsByTensor(mask);
+    for (size_t i = 0; i < n; i++) {
+        tensorBoolSet(mask, i, true);
+    }
+}
+
+void testSwapMechanismInstallsAndRestores(void) {
+    size_t n = 64;
+    tensor_t *mask = buildBoolTensor(n);
+
+    bernoulliFillMaskFn_t saved = bernoulliGetFillMaskFn();
+    bernoulliSetFillMaskFn(stubFillAllSet);
+
+    bool active = (bernoulliGetFillMaskFn() == stubFillAllSet);
+    bernoulliFillMask(mask, 0.0f); // probTrue 0 but stub ignores it → all set
+    size_t setAfterStub = countSetBits(mask, n);
+
+    bernoulliSetFillMaskFn(saved);
+    bool restored = (bernoulliGetFillMaskFn() == saved);
+
+    freeTensor(mask);
+    TEST_ASSERT_TRUE(active);
+    TEST_ASSERT_EQUAL_UINT(64, setAfterStub);
+    TEST_ASSERT_TRUE(restored);
+}
+
+int main(void) {
+    UNITY_BEGIN();
+    RUN_TEST(testReferenceRateApproxProbTrue);
+    RUN_TEST(testReferenceEdgeAllZero);
+    RUN_TEST(testReferenceEdgeAllOne);
+    RUN_TEST(testDeterministicUnderSameSeed);
+    RUN_TEST(testSwapMechanismInstallsAndRestores);
+    return UNITY_END();
+}

--- a/test/unit/userAPI/CMakeLists.txt
+++ b/test/unit/userAPI/CMakeLists.txt
@@ -144,6 +144,32 @@ add_elastic_ai_unit_test(
         TensorApi
 )
 
+add_executable(UnitTestDropoutIntegration UnitTestDropoutIntegration.c)
+target_link_libraries(UnitTestDropoutIntegration PRIVATE
+        unity
+        TrainingLoopApi
+        CalculateGradsSequential
+        CommonLayerLibs
+        DropoutApi
+        Dropout
+        Bernoulli
+        RNG
+        SgdApi
+        Sgd
+        Optimizer
+        StateDictApi
+        LayerQuant
+        LayerCommon
+        LinearApi
+        TensorApi
+        QuantizationApi
+        LossFunction
+        InferenceApi
+        DataLoader
+        StorageApi
+)
+__register_target_as_unit_test(UnitTestDropoutIntegration)
+
 add_executable(UnitTestAdaptiveAvgPool1dIntegration UnitTestAdaptiveAvgPool1dIntegration.c)
 target_link_libraries(UnitTestAdaptiveAvgPool1dIntegration PRIVATE
         unity

--- a/test/unit/userAPI/UnitTestDropoutIntegration.c
+++ b/test/unit/userAPI/UnitTestDropoutIntegration.c
@@ -1,0 +1,244 @@
+#define SOURCE_FILE "UNIT_TEST_DROPOUT_INTEGRATION"
+
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include <math.h>
+
+#include "Bernoulli.h"
+#include "CalculateGradsSequential.h"
+#include "Dropout.h"
+#include "DropoutApi.h"
+#include "InferenceApi.h"
+#include "Layer.h"
+#include "LinearApi.h"
+#include "LossFunction.h"
+#include "Optimizer.h"
+#include "QuantizationApi.h"
+#include "SgdApi.h"
+#include "StateDictApi.h"
+#include "StorageApi.h"
+#include "Tensor.h"
+#include "TensorApi.h"
+#include "unity.h"
+
+void setUp(void) {}
+void tearDown(void) {}
+
+static void stubKeepEven(tensor_t *mask, float probTrue) {
+    (void)probTrue;
+    size_t n = calcNumberOfElementsByTensor(mask);
+    for (size_t i = 0; i < n; i++) {
+        tensorBoolSet(mask, i, (i % 2) == 0);
+    }
+}
+
+static tensor_t *build2DFloat(size_t b, size_t f, const float *data, size_t n) {
+    size_t *dims = reserveMemory(2 * sizeof(size_t));
+    dims[0] = b;
+    dims[1] = f;
+    size_t *order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, order);
+    shape_t *shape = reserveMemory(sizeof(shape_t));
+    setShape(shape, dims, 2, order);
+    tensor_t *t = initTensor(shape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(t, (float *)data, n);
+    return t;
+}
+
+static tensor_t *buildBoolMask(size_t n) {
+    size_t *dims = reserveMemory(sizeof(size_t));
+    dims[0] = n;
+    size_t *order = reserveMemory(sizeof(size_t));
+    setOrderOfDimsForNewTensor(1, order);
+    shape_t *shape = reserveMemory(sizeof(shape_t));
+    setShape(shape, dims, 1, order);
+    return initTensor(shape, quantizationInitBool(), NULL);
+}
+
+// Exercises CalculateGradsSequential initLayerOutputs DROPOUT case + the
+// training-flag lifecycle: training-mode forward (output != input), flag
+// restored to false afterward.
+void testTrainingStep_DropoutActiveThenFlagRestored(void) {
+    quantization_t *fq = quantizationInitFloat();
+    quantization_t *bq = quantizationInitFloat();
+    tensor_t *mask = buildBoolMask(4);
+    layer_t *drop = dropoutLayerInit(0.5f, mask, fq, bq);
+    layer_t *model[1] = {drop};
+
+    tensor_t *input = build2DFloat(1, 4, (float[]){1.f, 2.f, 3.f, 4.f}, 4);
+    tensor_t *label = build2DFloat(1, 4, (float[]){0.f, 0.f, 0.f, 0.f}, 4);
+
+    bernoulliFillMaskFn_t saved = bernoulliGetFillMaskFn();
+    bernoulliSetFillMaskFn(stubKeepEven);
+    trainingStats_t *stats = calculateGradsSequential(
+        model, 1, (lossConfig_t){.funcType = MSE, .backwardReduction = REDUCTION_SUM},
+        REDUCTION_SUM, input, label);
+    bernoulliSetFillMaskFn(saved);
+
+    bool statsNotNull = (stats != NULL);
+    float o0 = (stats && stats->output) ? ((float *)stats->output->data)[0] : -1.f;
+    float o1 = (stats && stats->output) ? ((float *)stats->output->data)[1] : -1.f;
+    float o2 = (stats && stats->output) ? ((float *)stats->output->data)[2] : -1.f;
+    bool flagRestored = (drop->config->dropout->training == false);
+
+    freeTrainingStats(stats);
+    freeTensor(label);
+    freeTensor(input);
+    freeDropoutLayer(drop);
+    freeTensor(mask);
+    freeQuantization(bq);
+    freeQuantization(fq);
+
+    TEST_ASSERT_TRUE(statsNotNull);
+    TEST_ASSERT_FLOAT_WITHIN(1e-5f, 2.f, o0);
+    TEST_ASSERT_FLOAT_WITHIN(1e-5f, 0.f, o1);
+    TEST_ASSERT_FLOAT_WITHIN(1e-5f, 6.f, o2);
+    TEST_ASSERT_TRUE(flagRestored);
+}
+
+// Exercises InferenceApi initBufferOutput DROPOUT case + vtable forward.
+// Inference => training flag false => identity.
+void testInference_DropoutIsIdentity(void) {
+    quantization_t *fq = quantizationInitFloat();
+    quantization_t *bq = quantizationInitFloat();
+    tensor_t *mask = buildBoolMask(4);
+    layer_t *drop = dropoutLayerInit(0.5f, mask, fq, bq);
+    layer_t *model[1] = {drop};
+
+    tensor_t *input = build2DFloat(1, 4, (float[]){1.f, 2.f, 3.f, 4.f}, 4);
+    tensor_t *output = inference(model, 1, input);
+
+    bool outNotNull = (output != NULL);
+    float captured[4];
+    for (size_t i = 0; i < 4; i++) {
+        captured[i] = (output && output->data) ? ((float *)output->data)[i] : -1.f;
+    }
+
+    freeTensor(output);
+    freeTensor(input);
+    freeDropoutLayer(drop);
+    freeTensor(mask);
+    freeQuantization(bq);
+    freeQuantization(fq);
+
+    TEST_ASSERT_TRUE(outNotNull);
+    float expected[] = {1.f, 2.f, 3.f, 4.f};
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(expected, captured, 4);
+}
+
+// Exercises Optimizer.calcNumberOfStatesByLayerType + SgdApi state-alloc:
+// Dropout is parameter-less => zero optimizer state.
+void testOptimizer_ZeroStatesForDropout(void) {
+    quantization_t *fq = quantizationInitFloat();
+    quantization_t *bq = quantizationInitFloat();
+    tensor_t *mask = buildBoolMask(4);
+    layer_t *drop = dropoutLayerInit(0.5f, mask, fq, bq);
+    layer_t *model[1] = {drop};
+
+    size_t numStates = calcTotalNumberOfStates(model, 1);
+    optimizer_t *optim = sgdMCreateOptim(0.01f, 0.9f, 0.0f, model, 1, FLOAT32);
+    size_t sizeStates = optim->sizeStates;
+
+    freeOptimSgdM(optim);
+    freeDropoutLayer(drop);
+    freeTensor(mask);
+    freeQuantization(bq);
+    freeQuantization(fq);
+
+    TEST_ASSERT_EQUAL_UINT(0, numStates);
+    TEST_ASSERT_EQUAL_UINT(0, sizeStates);
+}
+
+// Exercises StateDictApi.layerHasParameters: a parameter-less model with zero
+// entries must load without error.
+void testStateDictLoad_DropoutNoParams(void) {
+    quantization_t *fq = quantizationInitFloat();
+    quantization_t *bq = quantizationInitFloat();
+    tensor_t *mask = buildBoolMask(4);
+    layer_t *drop = dropoutLayerInit(0.5f, mask, fq, bq);
+    layer_t *model[1] = {drop};
+
+    modelLoadStateDict(model, 1, NULL, 0); // must return without exiting
+
+    freeDropoutLayer(drop);
+    freeTensor(mask);
+    freeQuantization(bq);
+    freeQuantization(fq);
+    TEST_PASS();
+}
+
+static parameter_t *buildFloatParam(size_t rows, size_t cols) {
+    size_t *dims = reserveMemory(2 * sizeof(size_t));
+    dims[0] = rows;
+    dims[1] = cols;
+    size_t *order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, order);
+    shape_t *shape = reserveMemory(sizeof(shape_t));
+    setShape(shape, dims, 2, order);
+    tensor_t *param = initTensor(shape, quantizationInitFloat(), NULL);
+    tensor_t *grad = gradInitFloat(param, NULL);
+    return parameterInit(param, grad);
+}
+
+// Exercises a Linear(4→4) → Dropout(0.5) → Linear(4→4) model through one MSE
+// training step, verifying that dropout's propLoss is correctly consumed by
+// the upstream Linear backward pass.
+void testMultiLayer_LinearDropoutLinear_BackwardCompletes(void) {
+    quantization_t *q = quantizationInitFloat();
+
+    parameter_t *w0 = buildFloatParam(4, 4);
+    parameter_t *b0 = buildFloatParam(1, 4);
+    layer_t *linear0 = linearLayerInitLegacy(w0, b0, q, q, q, q);
+
+    tensor_t *mask = buildBoolMask(4);
+    layer_t *drop = dropoutLayerInit(0.5f, mask, q, q);
+
+    parameter_t *w1 = buildFloatParam(4, 4);
+    parameter_t *b1 = buildFloatParam(1, 4);
+    layer_t *linear1 = linearLayerInitLegacy(w1, b1, q, q, q, q);
+
+    layer_t *model[3] = {linear0, drop, linear1};
+
+    tensor_t *input = build2DFloat(1, 4, (float[]){1.f, 2.f, 3.f, 4.f}, 4);
+    tensor_t *label = build2DFloat(1, 4, (float[]){0.f, 0.f, 0.f, 0.f}, 4);
+
+    bernoulliFillMaskFn_t saved = bernoulliGetFillMaskFn();
+    bernoulliSetFillMaskFn(stubKeepEven);
+    trainingStats_t *stats = calculateGradsSequential(
+        model, 3, (lossConfig_t){.funcType = MSE, .backwardReduction = REDUCTION_SUM},
+        REDUCTION_SUM, input, label);
+    bernoulliSetFillMaskFn(saved);
+
+    bool statsNotNull = (stats != NULL);
+    float loss = stats ? stats->loss : -1.f;
+    bool lossFinite = (loss == loss) && (fabsf(loss) < 1e30f);
+    size_t outElems = (stats && stats->output) ? calcNumberOfElementsByTensor(stats->output) : 0;
+
+    freeTrainingStats(stats);
+    freeTensor(label);
+    freeTensor(input);
+    freeLinearLayerLegacy(linear1);
+    freeParameter(w1);
+    freeParameter(b1);
+    freeDropoutLayer(drop);
+    freeTensor(mask);
+    freeLinearLayerLegacy(linear0);
+    freeParameter(w0);
+    freeParameter(b0);
+    freeQuantization(q);
+
+    TEST_ASSERT_TRUE(statsNotNull);
+    TEST_ASSERT_TRUE(lossFinite);
+    TEST_ASSERT_EQUAL_UINT(4, outElems);
+}
+
+int main(void) {
+    UNITY_BEGIN();
+    RUN_TEST(testTrainingStep_DropoutActiveThenFlagRestored);
+    RUN_TEST(testInference_DropoutIsIdentity);
+    RUN_TEST(testOptimizer_ZeroStatesForDropout);
+    RUN_TEST(testStateDictLoad_DropoutNoParams);
+    RUN_TEST(testMultiLayer_LinearDropoutLinear_BackwardCompletes);
+    return UNITY_END();
+}


### PR DESCRIPTION
## Summary

Implements a `Dropout` layer (#149) matching PyTorch `nn.Dropout` semantics — inverted dropout in training (zero each element with probability `p`, scale survivors by `1/(1-p)`), identity in eval — for both **FLOAT32** and **SYM_INT32**. Element-wise; channel-wise `Dropout1d` is left as a possible follow-up.

## Design highlights

- **External, runtime-swappable Bernoulli sampler** (`src/rng/Bernoulli.{h,c}`): `bernoulliFillMask(mask, probTrue)` dispatches through a settable function pointer (default = XorShift32 inverse-transform reference), so optimized variants (SIMD / bit-parallel / hardware RNG) can be dropped in later. Fills a bit-packed **BOOL** mask (1 bit/element).
- **SYM_INT32 scale-fold**: instead of requantizing int values, the `1/(1-p)` factor is folded into the quantization scale (`out_scale = in_scale * s`), which is exact, rounding-free, and consistent with the passthrough-scale convention of the other element-wise layers (ReLU). Backward mirrors this.
- **Train/eval via a per-layer flag, set by the training loop** — no global mutable state (thread-safe on multi-core MCUs). `calculateGradsSequential` sets `training=true` before the forward pass and restores `false` after backward; inference therefore always sees identity.
- **Caller-pre-allocated mask** (mirrors `MaxPool1d.argmaxIndices`), with a size guard that rejects a mask whose element count != the tensor's.

## What's included

- New modules: `src/rng/Bernoulli.{h,c}`, `src/layer/Dropout.{h,c}`, `src/userApi/layer/DropoutApi.{h,c}`.
- `DROPOUT` registered at every layer-type dispatch site: vtable, `initLayerOutputs`, `initBufferOutput`, `Optimizer` (zero optimizer state), `SgdApi`, `StateDictApi` (no parameters), `LayerWeightsApi`.
- Tests: `UnitTestBernoulli` (5), `UnitTestDropout` (11), `UnitTestDropoutIntegration` (5, incl. a `Linear -> Dropout -> Linear` training step). Strict TDD throughout (each commit RED -> GREEN).

## Verification

- clang-format clean; `CC=gcc unit_test` build + **ctest 57/57** pass.
- The `unit_test_asan` (ASan/UBSan) preset and `pytest` could **not** be run locally — both currently hang in the macOS dev environment (unrelated to this C-only change; the `npy_writer` pytest hang is pre-existing). **CI runs them on Linux** — please rely on the CI result for those two gates.

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)
