### PR TITLE
feat(tensor): config-respecting gradInit — quantized-gradient prerequisite (PR-0)

### DIFF
--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -304,3 +304,37 @@ Runtime assertion of the `dimensions[0] >= 1` contract is deferred to the
 microbatch-B>1 umbrella (#152) — specifically #153. Today (B=1 only) the
 assertion would be effectively a no-op; the protective value materialises
 when B>1 becomes a real feature target.
+
+## Quantized gradient accumulation — known precision Open Problem
+
+As of the quantized-gradient prerequisite (`gradInit`, 2026-06-05) a trainable
+layer's parameter gradient can be stored in the dtype its `backwardMath`
+declares. For SYM_INT32 grads, the per-microbatch accumulation reuses the
+existing `addSymInt32TensorsInplace` ("strategy A", dynamic-rescale): it
+dequantizes both the running grad and the new microbatch grad to float, adds,
+and re-quantizes the running sum to a new absmax-derived scale **on every
+microbatch**.
+
+This is functionally correct end-to-end today, but **not** numerically ideal:
+
+- Quantization noise compounds with the number of microbatches M.
+- The running-sum absmax is pinned by the heaviest microbatch, coarsening the
+  LSB for the accumulated small-gradient mass.
+
+Preliminary characterization (internal simulation, M=100, N=64, σ=1e-3 with a
+10% ×50 heavy tail — *problem characterization only, not a basis for a chosen
+solution*):
+
+| Strategy | Final rel. error vs float64 | Float-free? |
+|---|---|---|
+| A — dynamic-rescale (current) | ~1.5e-4, **grows with M** (2.0e-5 @ step1 → 1.7e-4 @ step100) | No |
+| B — fixed-scale integer accum | ~9.9e-5 | Yes |
+| C — float accum, quantize-at-read | ~2.2e-5 | No |
+
+We deliberately ship strategy A now and do **not** adopt B/C or any homegrown
+numerical scheme. The resolution path is a literature review (stochastic-rounding
+accumulators, error-feedback / residual accumulation, higher-precision master
+grads, block/group scaling, …) → implement or improve a **published** technique.
+Tracked as a separate research task. This note is intentionally public (not
+buried in a private spec) so contributors hitting accuracy issues in quantized
+training know this is a known, expected limitation rather than a bug.

--- a/src/userApi/layer/Conv1dApi.c
+++ b/src/userApi/layer/Conv1dApi.c
@@ -87,7 +87,8 @@ static shape_t *buildOwnedShape(const size_t *srcDims, size_t numberOfDims) {
 }
 
 static parameter_t *allocateConv1dWeights(size_t outChannels, size_t inChannels, size_t groups,
-                                          size_t kernelSize, quantization_t *storageQ) {
+                                          size_t kernelSize, quantization_t *storageQ,
+                                          quantization_t *gradQ) {
     /* Conv1d weight shape: [outChannels, inChannels/groups, kernelSize].
      * Per Conv1d.h:11. */
     if (inChannels % groups != 0) {
@@ -120,17 +121,18 @@ static parameter_t *allocateConv1dWeights(size_t outChannels, size_t inChannels,
     };
     initDistribution(paramTensor, &dist);
 
-    tensor_t *gradTensor = gradInitFloat(paramTensor, NULL);
+    tensor_t *gradTensor = gradInit(paramTensor, gradQ, NULL);
     return parameterInit(paramTensor, gradTensor);
 }
 
-static parameter_t *allocateConv1dBias(size_t outChannels, quantization_t *storageQ) {
+static parameter_t *allocateConv1dBias(size_t outChannels, quantization_t *storageQ,
+                                       quantization_t *gradQ) {
     /* Bias tensor: shape [outChannels]. Zero-initialized via calloc (reserveMemory). */
     shape_t *shape = buildOwnedShape((size_t[]){outChannels}, 1);
     tensor_t *paramTensor = initTensor(shape, getQLike(storageQ), NULL);
     /* No initDistribution(ZEROS) — calloc already gave us zeros. */
 
-    tensor_t *gradTensor = gradInitFloat(paramTensor, NULL);
+    tensor_t *gradTensor = gradInit(paramTensor, gradQ, NULL);
     return parameterInit(paramTensor, gradTensor);
 }
 
@@ -209,9 +211,11 @@ layer_t *conv1dLayerInit(conv1dInit_t *init, layerQuant_t *lq) {
     layer->config = layerCfg;
 
     cfg->kernel = buildConv1dKernel(init);
+    quantization_t *gradQ = quantizationInitFloat(); /* Conv1d backward is FLOAT32-only */
     cfg->weights = allocateConv1dWeights(init->outChannels, init->inChannels, groups,
-                                         init->kernelSize, lq->weightStorage);
-    cfg->bias = hasBias ? allocateConv1dBias(init->outChannels, lq->biasStorage) : NULL;
+                                         init->kernelSize, lq->weightStorage, gradQ);
+    cfg->bias = hasBias ? allocateConv1dBias(init->outChannels, lq->biasStorage, gradQ) : NULL;
+    freeQuantization(gradQ);
     cfg->groups = groups;
     cfg->forwardQ = lq->forwardMath;
     cfg->weightGradQ = lq->backwardMath;
@@ -241,9 +245,11 @@ layer_t *conv1dLayerInitOwning(conv1dInit_t *init, layerQuant_t *lq) {
     /* allocateConv1dWeights / allocateConv1dBias internally clone via getQLike,
      * so the parameter tensors own their quantization_t — caller can drop
      * lq->weightStorage / lq->biasStorage immediately. */
+    quantization_t *gradQ = quantizationInitFloat(); /* Conv1d backward is FLOAT32-only */
     cfg->weights = allocateConv1dWeights(init->outChannels, init->inChannels, groups,
-                                         init->kernelSize, lq->weightStorage);
-    cfg->bias = hasBias ? allocateConv1dBias(init->outChannels, lq->biasStorage) : NULL;
+                                         init->kernelSize, lq->weightStorage, gradQ);
+    cfg->bias = hasBias ? allocateConv1dBias(init->outChannels, lq->biasStorage, gradQ) : NULL;
+    freeQuantization(gradQ);
     cfg->groups = groups;
 
     /* Owning: deep-copy each of the four math quantizations. Always four

--- a/src/userApi/layer/Conv1dTransposedApi.c
+++ b/src/userApi/layer/Conv1dTransposedApi.c
@@ -44,7 +44,8 @@ static shape_t *buildOwnedShape(const size_t *srcDims, size_t numberOfDims) {
 
 static parameter_t *allocateConv1dTransposedWeights(size_t inChannels, size_t outChannels,
                                                     size_t groups, size_t kernelSize,
-                                                    quantization_t *storageQ) {
+                                                    quantization_t *storageQ,
+                                                    quantization_t *gradQ) {
     /* Conv1dTransposed weight shape: [inChannels, outChannels/groups, kernelSize].
      * Note SWAP relative to Conv1d. Per Conv1dTransposed.h:12. */
     if (outChannels % groups != 0) {
@@ -75,14 +76,15 @@ static parameter_t *allocateConv1dTransposedWeights(size_t inChannels, size_t ou
     };
     initDistribution(paramTensor, &dist);
 
-    tensor_t *gradTensor = gradInitFloat(paramTensor, NULL);
+    tensor_t *gradTensor = gradInit(paramTensor, gradQ, NULL);
     return parameterInit(paramTensor, gradTensor);
 }
 
-static parameter_t *allocateConv1dTransposedBias(size_t outChannels, quantization_t *storageQ) {
+static parameter_t *allocateConv1dTransposedBias(size_t outChannels, quantization_t *storageQ,
+                                                 quantization_t *gradQ) {
     shape_t *shape = buildOwnedShape((size_t[]){outChannels}, 1);
     tensor_t *paramTensor = initTensor(shape, getQLike(storageQ), NULL);
-    tensor_t *gradTensor = gradInitFloat(paramTensor, NULL);
+    tensor_t *gradTensor = gradInit(paramTensor, gradQ, NULL);
     return parameterInit(paramTensor, gradTensor);
 }
 
@@ -148,9 +150,12 @@ static layer_t *buildConv1dTransposedLayerSkeleton(conv1dTransposedInit_t *init,
     layer->config = layerCfg;
 
     cfg->kernel = buildConv1dTransposedKernel(init);
+    quantization_t *gradQ = quantizationInitFloat(); /* Conv1dTransposed backward is FLOAT32-only */
     cfg->weights = allocateConv1dTransposedWeights(init->inChannels, init->outChannels, groups,
-                                                   init->kernelSize, lq->weightStorage);
-    cfg->bias = hasBias ? allocateConv1dTransposedBias(init->outChannels, lq->biasStorage) : NULL;
+                                                   init->kernelSize, lq->weightStorage, gradQ);
+    cfg->bias =
+        hasBias ? allocateConv1dTransposedBias(init->outChannels, lq->biasStorage, gradQ) : NULL;
+    freeQuantization(gradQ);
     cfg->groups = groups;
     cfg->outputPadding = init->outputPadding;
     return layer;

--- a/src/userApi/layer/LinearApi.c
+++ b/src/userApi/layer/LinearApi.c
@@ -98,7 +98,7 @@ static shape_t *buildOwnedShape(const size_t *srcDims, size_t numberOfDims) {
 }
 
 static parameter_t *allocateLinearWeights(size_t inFeatures, size_t outFeatures,
-                                          quantization_t *storageQ) {
+                                          quantization_t *storageQ, quantization_t *gradQ) {
     /* Weight tensor: shape [outFeatures, inFeatures]. The tensor takes ownership
      * of `shape` and `quantization`, so we clone the borrowed storageQ via
      * getQLike to avoid tying the tensor's lifetime to the caller's quant. */
@@ -120,18 +120,19 @@ static parameter_t *allocateLinearWeights(size_t inFeatures, size_t outFeatures,
     };
     initDistribution(paramTensor, &dist);
 
-    tensor_t *gradTensor = gradInitFloat(paramTensor, NULL);
+    tensor_t *gradTensor = gradInit(paramTensor, gradQ, NULL);
     return parameterInit(paramTensor, gradTensor);
 }
 
-static parameter_t *allocateLinearBias(size_t outFeatures, quantization_t *storageQ) {
+static parameter_t *allocateLinearBias(size_t outFeatures, quantization_t *storageQ,
+                                       quantization_t *gradQ) {
     /* Bias tensor: shape [outFeatures]. Initialized to ZEROS, which initTensor
      * already provides (reserveMemory == calloc), so no fill is needed. */
     shape_t *shape = buildOwnedShape((size_t[]){outFeatures}, 1);
     tensor_t *paramTensor = initTensor(shape, getQLike(storageQ), NULL);
     /* No initDistribution(ZEROS) call needed: data is already zero from calloc. */
 
-    tensor_t *gradTensor = gradInitFloat(paramTensor, NULL);
+    tensor_t *gradTensor = gradInit(paramTensor, gradQ, NULL);
     return parameterInit(paramTensor, gradTensor);
 }
 
@@ -186,8 +187,10 @@ layer_t *linearLayerInit(linearInit_t *init, layerQuant_t *lq) {
     layerCfg->linear = cfg;
     layer->config = layerCfg;
 
-    cfg->weights = allocateLinearWeights(init->inFeatures, init->outFeatures, lq->weightStorage);
-    cfg->bias = hasBias ? allocateLinearBias(init->outFeatures, lq->biasStorage) : NULL;
+    cfg->weights = allocateLinearWeights(init->inFeatures, init->outFeatures, lq->weightStorage,
+                                         lq->backwardMath);
+    cfg->bias =
+        hasBias ? allocateLinearBias(init->outFeatures, lq->biasStorage, lq->backwardMath) : NULL;
 
     /* Borrowing: store the four quant pointers verbatim, no copy.
      * Per design spec section 4: collapse to a single math Q for forward and
@@ -220,8 +223,10 @@ layer_t *linearLayerInitOwning(linearInit_t *init, layerQuant_t *lq) {
      * T12) internally clone via getQLike, so the parameter tensors hold their
      * own quantization_t copies — the caller can immediately drop the lq's
      * weightStorage/biasStorage pointers without breaking the parameters. */
-    cfg->weights = allocateLinearWeights(init->inFeatures, init->outFeatures, lq->weightStorage);
-    cfg->bias = hasBias ? allocateLinearBias(init->outFeatures, lq->biasStorage) : NULL;
+    cfg->weights = allocateLinearWeights(init->inFeatures, init->outFeatures, lq->weightStorage,
+                                         lq->backwardMath);
+    cfg->bias =
+        hasBias ? allocateLinearBias(init->outFeatures, lq->biasStorage, lq->backwardMath) : NULL;
 
     /* Owning: deep-copy each of the four math quantizations.  Always allocate
      * four separate copies, even if multiple lq slots pointed to the same

--- a/src/userApi/tensor/TensorApi.c
+++ b/src/userApi/tensor/TensorApi.c
@@ -265,12 +265,22 @@ tensor_t *gradInitInt32(tensor_t *param, sparsity_t *sparsity) {
     return initTensor(getShapeLike(param->shape), quantizationInitInt32(), sparsity);
 }
 
+tensor_t *gradInit(tensor_t *param, quantization_t *gradQ, sparsity_t *sparsity) {
+    return initTensor(getShapeLike(param->shape), getQLike(gradQ), sparsity);
+}
+
 tensor_t *gradInitFloat(tensor_t *param, sparsity_t *sparsity) {
-    return initTensor(getShapeLike(param->shape), quantizationInitFloat(), sparsity);
+    quantization_t *floatQ = quantizationInitFloat();
+    tensor_t *grad = gradInit(param, floatQ, sparsity);
+    freeQuantization(floatQ);
+    return grad;
 }
 
 tensor_t *gradInitSymInt32(tensor_t *param, roundingMode_t roundingMode, sparsity_t *sparsity) {
-    return initTensor(getShapeLike(param->shape), quantizationInitSymInt32(roundingMode), sparsity);
+    quantization_t *symQ = quantizationInitSymInt32(roundingMode);
+    tensor_t *grad = gradInit(param, symQ, sparsity);
+    freeQuantization(symQ);
+    return grad;
 }
 
 tensor_t *gradInitAsym(tensor_t *param, uint8_t qBits, roundingMode_t roundingMode,

--- a/src/userApi/tensor/include/TensorApi.h
+++ b/src/userApi/tensor/include/TensorApi.h
@@ -147,6 +147,18 @@ void tensorFillFromFloatBuffer(tensor_t *tensor, const float *source, size_t cou
  */
 void tensorFillFromBoolBuffer(tensor_t *tensor, const bool *source, size_t count);
 
+/*! Initializes a gradient tensor whose quantization is cloned from `gradQ`
+ *  (deep copy via getQLike, so the grad tensor owns its own quantization_t)
+ *  and whose shape is cloned from `param->shape`. This is the config-respecting
+ *  grad-init: a layer's grad takes the dtype its backwardMath config declares.
+ *
+ * \param param: Pointer to param tensor (supplies the shape to clone)
+ * \param gradQ: Quantization template to clone for the grad tensor
+ * \param sparsity: sparsity_t of tensor
+ *
+ * \returns Pointer to initialized gradient tensor
+ */
+tensor_t *gradInit(tensor_t *param, quantization_t *gradQ, sparsity_t *sparsity);
 /*! Initializes int32 gradient tensor to match given param tensor.
  *
  * \param param: Pointer to param tensor

--- a/test/unit/layer/CMakeLists.txt
+++ b/test/unit/layer/CMakeLists.txt
@@ -75,6 +75,10 @@ add_elastic_ai_unit_test(
         Quantization
         Rounding
         StorageApi
+        Add
+        SgdApi
+        Sgd
+        Optimizer
 )
 
 add_elastic_ai_unit_test(

--- a/test/unit/layer/UnitTestLinear.c
+++ b/test/unit/layer/UnitTestLinear.c
@@ -1110,6 +1110,40 @@ void testLinearLayerInitBorrowingBiasFalseLeavesBiasNull(void) {
     freeLinearLayer(layer);
 }
 
+void testLinearLayerInitSymInt32BackwardMathYieldsSymInt32Grad(void) {
+    /* Regression for the "config lies" bug: a Linear built with a SYM_INT32
+     * backwardMath must store SYM_INT32 parameter gradients, not FLOAT32. */
+    quantization_t *fwd = quantizationInitFloat();       /* FLOAT32 forward + storage */
+    quantization_t *bwd = quantizationInitSymInt32(HTE); /* SYM_INT32 backward */
+    layerQuant_t lq = {
+        .forwardMath = fwd,
+        .backwardMath = bwd,
+        .weightStorage = fwd, /* KAIMING init requires FLOAT32 weight storage */
+        .biasStorage = fwd,
+    };
+
+    layer_t *layer = linearLayerInit(
+        &(linearInit_t){
+            .inFeatures = 3,
+            .outFeatures = 2,
+            .bias = BIAS_TRUE,
+        },
+        &lq);
+
+    linearConfig_t *cfg = layer->config->linear;
+    int weightGradType = cfg->weights->grad->quantization->type;
+    int biasGradType = cfg->bias->grad->quantization->type;
+
+    freeLinearLayer(layer);
+    freeQuantization(bwd);
+    freeQuantization(fwd);
+
+    TEST_ASSERT_EQUAL_INT_MESSAGE(SYM_INT32, weightGradType,
+                                  "weight grad must be SYM_INT32 when backwardMath is SYM_INT32");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(SYM_INT32, biasGradType,
+                                  "bias grad must be SYM_INT32 when backwardMath is SYM_INT32");
+}
+
 void testLinearLayerInitOwningDeepCopiesQuantizations(void) {
     quantization_t *q = quantizationInitFloat();
     layerQuant_t lq;
@@ -1185,6 +1219,7 @@ int main(void) {
     RUN_TEST(testLinearLayerInitBorrowingZeroInChannelsAbortsViaPrintError);
     RUN_TEST(testLinearLayerInitBorrowingBiasDefaultResolvesToTrue);
     RUN_TEST(testLinearLayerInitBorrowingBiasFalseLeavesBiasNull);
+    RUN_TEST(testLinearLayerInitSymInt32BackwardMathYieldsSymInt32Grad);
 
     RUN_TEST(testLinearLayerInitOwningDeepCopiesQuantizations);
     RUN_TEST(testLinearLayerInitOwningFreesAllAllocationsWithoutLeak);

--- a/test/unit/layer/UnitTestLinear.c
+++ b/test/unit/layer/UnitTestLinear.c
@@ -1,3 +1,4 @@
+#include <math.h>
 #include <string.h>
 
 #include "DTypes.h"
@@ -6,8 +7,10 @@
 #include "LayerQuant.h"
 #include "Linear.h"
 #include "LinearApi.h"
+#include "Optimizer.h"
 #include "QuantizationApi.h"
 #include "Rounding.h"
+#include "SgdApi.h"
 #include "StorageApi.h"
 #include "Tensor.h"
 #include "TensorApi.h"
@@ -1199,6 +1202,167 @@ void testLinearLayerInitOwningFreesAllAllocationsWithoutLeak(void) {
     TEST_PASS();
 }
 
+/* Helper: build a 1x3 FLOAT32 input tensor with the given values (NULL => zeros). */
+static tensor_t *e2eMakeInput(const float *vals) {
+    size_t *d = reserveMemory(2 * sizeof(size_t));
+    d[0] = 1;
+    d[1] = 3;
+    size_t *o = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, o);
+    shape_t *s = reserveMemory(sizeof(shape_t));
+    setShape(s, d, 2, o);
+    tensor_t *t = initTensor(s, quantizationInitFloat(), NULL);
+    if (vals != NULL) {
+        tensorFillFromFloatBuffer(t, vals, 3);
+    }
+    return t;
+}
+/* Helper: build a 1x2 FLOAT32 loss tensor (NULL => zeros). */
+static tensor_t *e2eMake1x2(const float *vals) {
+    size_t *d = reserveMemory(2 * sizeof(size_t));
+    d[0] = 1;
+    d[1] = 2;
+    size_t *o = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, o);
+    shape_t *s = reserveMemory(sizeof(shape_t));
+    setShape(s, d, 2, o);
+    tensor_t *t = initTensor(s, quantizationInitFloat(), NULL);
+    if (vals != NULL) {
+        tensorFillFromFloatBuffer(t, vals, 2);
+    }
+    return t;
+}
+
+/* Helper: build a 1x3 SYM_INT32 propLoss buffer (the SYM_INT32 backward writes the
+ * propLoss result + scale in place, so its dtype must match propLossQ = SYM_INT32). */
+static tensor_t *e2eMakeSym1x3(void) {
+    size_t *d = reserveMemory(2 * sizeof(size_t));
+    d[0] = 1;
+    d[1] = 3;
+    size_t *o = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, o);
+    shape_t *s = reserveMemory(sizeof(shape_t));
+    setShape(s, d, 2, o);
+    return initTensor(s, quantizationInitSymInt32(HTE), NULL);
+}
+
+void testLinearSymInt32GradAccumulatesOverTwoMicrobatchesAndSteps(void) {
+    /* outFeatures=2, inFeatures=3. forward input [1,2,3], loss [0.5, -0.25].
+     * Two identical microbatches => accumulated weight grad ~= 2 * (loss^T @ input). */
+    const float inputVals[3] = {1.0f, 2.0f, 3.0f};
+    const float lossVals[2] = {0.5f, -0.25f};
+
+    /* ---- SYM_INT32-backward layer (under test) ---- */
+    quantization_t *fwd = quantizationInitFloat();
+    quantization_t *bwd = quantizationInitSymInt32(HTE);
+    layerQuant_t lqSym = {
+        .forwardMath = fwd, .backwardMath = bwd, .weightStorage = fwd, .biasStorage = fwd};
+    layer_t *symLayer = linearLayerInit(
+        &(linearInit_t){.inFeatures = 3, .outFeatures = 2, .bias = BIAS_TRUE}, &lqSym);
+
+    tensor_t *symWGrad = symLayer->config->linear->weights->grad;
+    TEST_ASSERT_EQUAL_INT(SYM_INT32, symWGrad->quantization->type); /* guard */
+
+    tensor_t *symIn1 = e2eMakeInput(inputVals);
+    tensor_t *symLoss1 = e2eMake1x2(lossVals);
+    tensor_t *symProp1 = e2eMakeSym1x3(); /* propLoss [1,3], SYM_INT32 (matches propLossQ) */
+    linearBackward(symLayer, symIn1, symLoss1, symProp1);
+
+    tensor_t *symIn2 = e2eMakeInput(inputVals);
+    tensor_t *symLoss2 = e2eMake1x2(lossVals);
+    tensor_t *symProp2 = e2eMakeSym1x3();
+    linearBackward(symLayer, symIn2, symLoss2, symProp2);
+
+    /* Capture accumulated SYM_INT32 weight grad as float (dequantized). */
+    size_t nW = calcNumberOfElementsByTensor(symWGrad);
+    float symGradFloat[6];
+    {
+        tensor_t gf;
+        quantization_t gfQ;
+        initFloat32Quantization(&gfQ);
+        uint8_t gfData[6 * sizeof(float)];
+        setTensorValuesForConversion(gfData, &gfQ, symWGrad, &gf);
+        convertTensor(symWGrad, &gf);
+        for (size_t i = 0; i < nW; i++) {
+            symGradFloat[i] = ((float *)gf.data)[i];
+        }
+    }
+
+    /* ---- Optimizer step on the SYM_INT32 layer ("updates the param without crashing"). ---- */
+    layer_t *symModel[] = {symLayer};
+    optimizer_t *symOptim = sgdMCreateOptim(0.1f, 0.0f, 0.0f, symModel, 1, SYM_INT32);
+    optimizerFunctions[symOptim->type].step(symOptim);
+    tensor_t *symWParam = symLayer->config->linear->weights->param;
+    int paramFinite = 1;
+    for (size_t i = 0; i < nW; i++) {
+        if (!isfinite(((float *)symWParam->data)[i])) {
+            paramFinite = 0;
+        }
+    }
+
+    /* ---- FLOAT32-backward layer (reference) ---- */
+    quantization_t *fwd2 = quantizationInitFloat();
+    quantization_t *bwd2 = quantizationInitFloat();
+    layerQuant_t lqF = {
+        .forwardMath = fwd2, .backwardMath = bwd2, .weightStorage = fwd2, .biasStorage = fwd2};
+    layer_t *fLayer = linearLayerInit(
+        &(linearInit_t){.inFeatures = 3, .outFeatures = 2, .bias = BIAS_TRUE}, &lqF);
+    tensor_t *fWGrad = fLayer->config->linear->weights->grad;
+
+    tensor_t *fIn1 = e2eMakeInput(inputVals);
+    tensor_t *fLoss1 = e2eMake1x2(lossVals);
+    tensor_t *fProp1 = e2eMakeInput(NULL);
+    linearBackward(fLayer, fIn1, fLoss1, fProp1);
+    tensor_t *fIn2 = e2eMakeInput(inputVals);
+    tensor_t *fLoss2 = e2eMake1x2(lossVals);
+    tensor_t *fProp2 = e2eMakeInput(NULL);
+    linearBackward(fLayer, fIn2, fLoss2, fProp2);
+
+    float refGradFloat[6];
+    for (size_t i = 0; i < nW; i++) {
+        refGradFloat[i] = ((float *)fWGrad->data)[i];
+    }
+
+    /* ---- Compare accumulated grads within SYM_INT32 tolerance ---- */
+    bool gradsClose = true;
+    for (size_t i = 0; i < nW; i++) {
+        if (fabsf(symGradFloat[i] - refGradFloat[i]) > 5e-3f) {
+            gradsClose = false;
+        }
+    }
+
+    freeLinearLayer(fLayer);
+    freeTensor(fProp2);
+    freeTensor(fLoss2);
+    freeTensor(fIn2);
+    freeTensor(fProp1);
+    freeTensor(fLoss1);
+    freeTensor(fIn1);
+    freeQuantization(bwd2);
+    freeQuantization(fwd2);
+
+    /* freeOptimSgdM frees the SYM layer's parameters; do NOT also freeLinearLayer(symLayer)
+     * (double-free). Free the layer/config shell manually (borrowing factory: caller owns
+     * the quantizations, freed separately below). */
+    freeOptimSgdM(symOptim);
+    freeReservedMemory(symLayer->config->linear);
+    freeReservedMemory(symLayer->config);
+    freeReservedMemory(symLayer);
+    freeTensor(symProp2);
+    freeTensor(symLoss2);
+    freeTensor(symIn2);
+    freeTensor(symProp1);
+    freeTensor(symLoss1);
+    freeTensor(symIn1);
+    freeQuantization(bwd);
+    freeQuantization(fwd);
+
+    TEST_ASSERT_TRUE_MESSAGE(gradsClose,
+                             "SYM_INT32 accumulated weight grad diverged from FLOAT32 reference");
+    TEST_ASSERT_TRUE_MESSAGE(paramFinite,
+                             "SYM_INT32 optimizer step left a non-finite weight param");
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(testLinearForwardFloat);
@@ -1220,6 +1384,7 @@ int main(void) {
     RUN_TEST(testLinearLayerInitBorrowingBiasDefaultResolvesToTrue);
     RUN_TEST(testLinearLayerInitBorrowingBiasFalseLeavesBiasNull);
     RUN_TEST(testLinearLayerInitSymInt32BackwardMathYieldsSymInt32Grad);
+    RUN_TEST(testLinearSymInt32GradAccumulatesOverTwoMicrobatchesAndSteps);
 
     RUN_TEST(testLinearLayerInitOwningDeepCopiesQuantizations);
     RUN_TEST(testLinearLayerInitOwningFreesAllAllocationsWithoutLeak);

--- a/test/unit/optimizer/CMakeLists.txt
+++ b/test/unit/optimizer/CMakeLists.txt
@@ -9,4 +9,5 @@ add_elastic_ai_unit_test(
         StorageApi
         LinearApi
         ReluApi
+        LayerQuant
 )

--- a/test/unit/optimizer/UnitTestSgd.c
+++ b/test/unit/optimizer/UnitTestSgd.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 
 #include "Layer.h"
+#include "LayerQuant.h"
 #include "Linear.h"
 #include "LinearApi.h"
 #include "OptimizerApi.h"
@@ -324,10 +325,59 @@ void testSGDZeroGrad() {
     TEST_ASSERT_EQUAL_FLOAT_ARRAY(bGradExpected, capturedBGrad, 2);
 }
 
+void testSgdZeroGradOnSymInt32GradZeroesMantissasAndResetsScale(void) {
+    quantization_t *fwd = quantizationInitFloat();
+    quantization_t *bwd = quantizationInitSymInt32(HTE);
+    layerQuant_t lq = {
+        .forwardMath = fwd, .backwardMath = bwd, .weightStorage = fwd, .biasStorage = fwd};
+    layer_t *layer =
+        linearLayerInit(&(linearInit_t){.inFeatures = 3, .outFeatures = 2, .bias = BIAS_TRUE}, &lq);
+
+    tensor_t *wGrad = layer->config->linear->weights->grad;
+    TEST_ASSERT_EQUAL_INT(SYM_INT32, wGrad->quantization->type); /* guard */
+
+    /* Pre-load non-zero mantissas and a non-1.0 scale to prove the reset. */
+    size_t nW = calcNumberOfElementsByTensor(wGrad);
+    for (size_t i = 0; i < nW; i++) {
+        ((int32_t *)wGrad->data)[i] = 123 + (int32_t)i;
+    }
+    ((symInt32QConfig_t *)wGrad->quantization->qConfig)->scale = 0.07f;
+
+    layer_t *model[] = {layer};
+    optimizer_t *optim = sgdMCreateOptim(0.1f, 0.9f, 0.0f, model, 1, SYM_INT32);
+
+    sgdZeroGrad(optim);
+
+    /* CAPTURE post-zero state. */
+    int allZero = 1;
+    for (size_t i = 0; i < nW; i++) {
+        if (((int32_t *)wGrad->data)[i] != 0) {
+            allZero = 0;
+        }
+    }
+    float scaleAfterZero = ((symInt32QConfig_t *)wGrad->quantization->qConfig)->scale;
+
+    /* Prove subsequent accumulation works: load a fresh int mantissa. */
+    ((int32_t *)wGrad->data)[0] = 5;
+    int accumWorks = (((int32_t *)wGrad->data)[0] == 5);
+
+    freeOptimSgdM(optim); /* frees the layer's parameters */
+    freeReservedMemory(layer->config->linear);
+    freeReservedMemory(layer->config);
+    freeReservedMemory(layer);
+    freeQuantization(bwd);
+    freeQuantization(fwd);
+
+    TEST_ASSERT_TRUE_MESSAGE(allZero, "sgdZeroGrad must zero SYM_INT32 grad mantissas");
+    TEST_ASSERT_FLOAT_WITHIN(1e-6f, 1.0f, scaleAfterZero);
+    TEST_ASSERT_TRUE(accumWorks);
+}
+
 int main() {
     UNITY_BEGIN();
     RUN_TEST(testSgdMCreateOptim);
     RUN_TEST(testSGDStep);
     RUN_TEST(testSGDZeroGrad);
+    RUN_TEST(testSgdZeroGradOnSymInt32GradZeroesMantissasAndResetsScale);
     return UNITY_END();
 }

--- a/test/unit/tensor/UnitTestTensorApi.c
+++ b/test/unit/tensor/UnitTestTensorApi.c
@@ -41,6 +41,13 @@ _Static_assert(_Generic((&tensorFillFromBoolBuffer),
                    default: 0),
                "tensorFillFromBoolBuffer must take (tensor_t *, const bool *, size_t)");
 
+/* Compile-time contract: gradInit takes (tensor_t *, quantization_t *, sparsity_t *)
+ * and returns tensor_t *. Config-respecting grad-init for PR-0. */
+_Static_assert(_Generic((&gradInit),
+                   tensor_t *(*)(tensor_t *, quantization_t *, sparsity_t *): 1,
+                   default: 0),
+               "gradInit must take (tensor_t *, quantization_t *, sparsity_t *)");
+
 void setUp() {}
 void tearDown() {}
 
@@ -581,6 +588,72 @@ void testInitTensor_AllocatesOwnZeroDataBuffer_FreeTensorIsSafe(void) {
      * for an initTensor-allocated tensor. */
 }
 
+void testGradInit_Float32_MatchesParamShapeOwnsOwnQuant(void) {
+    size_t *dims = reserveMemory(2 * sizeof(size_t));
+    dims[0] = 3;
+    dims[1] = 4;
+    size_t *order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, order);
+    shape_t *shape = reserveMemory(sizeof(shape_t));
+    setShape(shape, dims, 2, order);
+
+    tensor_t *param = initTensor(shape, quantizationInitFloat(), NULL);
+
+    quantization_t *gradQ = quantizationInitFloat();
+    tensor_t *grad = gradInit(param, gradQ, NULL);
+
+    /* CAPTURE before frees. */
+    int gradTypeMatches = (grad->quantization->type == FLOAT32);
+    int ownsOwnQuant = (grad->quantization != gradQ); /* getQLike deep-clones */
+    int ownsOwnShape = (grad->shape != param->shape); /* getShapeLike clones */
+    size_t nDims = grad->shape->numberOfDimensions;
+    size_t d0 = grad->shape->dimensions[0];
+    size_t d1 = grad->shape->dimensions[1];
+
+    freeTensor(grad);
+    freeQuantization(gradQ);
+    freeTensor(param);
+
+    TEST_ASSERT_TRUE_MESSAGE(gradTypeMatches, "gradInit FLOAT32 grad dtype mismatch");
+    TEST_ASSERT_TRUE_MESSAGE(ownsOwnQuant, "gradInit must clone quantization (own it)");
+    TEST_ASSERT_TRUE_MESSAGE(ownsOwnShape, "gradInit must clone shape (own it)");
+    TEST_ASSERT_EQUAL_UINT(2, nDims);
+    TEST_ASSERT_EQUAL_UINT(3, d0);
+    TEST_ASSERT_EQUAL_UINT(4, d1);
+}
+
+void testGradInit_SymInt32_MatchesParamShapeAndDtype(void) {
+    size_t *dims = reserveMemory(2 * sizeof(size_t));
+    dims[0] = 2;
+    dims[1] = 5;
+    size_t *order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, order);
+    shape_t *shape = reserveMemory(sizeof(shape_t));
+    setShape(shape, dims, 2, order);
+
+    /* Param can stay FLOAT32; grad dtype is driven solely by gradQ. */
+    tensor_t *param = initTensor(shape, quantizationInitFloat(), NULL);
+
+    quantization_t *gradQ = quantizationInitSymInt32(HTE);
+    tensor_t *grad = gradInit(param, gradQ, NULL);
+
+    int gradTypeMatches = (grad->quantization->type == SYM_INT32);
+    int ownsOwnQuant = (grad->quantization != gradQ);
+    size_t nDims = grad->shape->numberOfDimensions;
+    size_t d0 = grad->shape->dimensions[0];
+    size_t d1 = grad->shape->dimensions[1];
+
+    freeTensor(grad);
+    freeQuantization(gradQ);
+    freeTensor(param);
+
+    TEST_ASSERT_TRUE_MESSAGE(gradTypeMatches, "gradInit SYM_INT32 grad dtype mismatch");
+    TEST_ASSERT_TRUE_MESSAGE(ownsOwnQuant, "gradInit must clone SYM_INT32 quantization");
+    TEST_ASSERT_EQUAL_UINT(2, nDims);
+    TEST_ASSERT_EQUAL_UINT(2, d0);
+    TEST_ASSERT_EQUAL_UINT(5, d1);
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(testTensorInitWithDistribution_Zeros_InitializesProductOfDimsValues);
@@ -597,6 +670,8 @@ int main(void) {
     RUN_TEST(testGradInitInt32_DoesNotAliasParentShape);
     RUN_TEST(testGradInitSymInt32_DoesNotAliasParentShape);
     RUN_TEST(testGradInitAsym_DoesNotAliasParentShape);
+    RUN_TEST(testGradInit_Float32_MatchesParamShapeOwnsOwnQuant);
+    RUN_TEST(testGradInit_SymInt32_MatchesParamShapeAndDtype);
     RUN_TEST(testInitDistribution_Zeros_AllValuesAreZero);
     RUN_TEST(testInitDistribution_Ones_AllValuesAreOne);
     RUN_TEST(testInitDistribution_Uniform_AllValuesInRange);

--- a/test/unit/userAPI/UnitTestConv1dApi.c
+++ b/test/unit/userAPI/UnitTestConv1dApi.c
@@ -196,6 +196,41 @@ void testConv1dLayerInitOwningFreesAllAllocationsWithoutLeak(void) {
     TEST_PASS();
 }
 
+void testConv1dLayerInitKeepsFloat32GradEvenWithSymInt32BackwardMath(void) {
+    /* Conv1d backward is FLOAT32-only; its grad must stay FLOAT32 regardless of
+     * backwardMath, so the gradInit plumbing defaults Conv1d to FLOAT32. */
+    quantization_t *fwd = quantizationInitFloat();
+    quantization_t *bwd = quantizationInitSymInt32(HTE);
+    layerQuant_t lq = {
+        .forwardMath = fwd,
+        .backwardMath = bwd,
+        .weightStorage = fwd,
+        .biasStorage = fwd,
+    };
+
+    layer_t *layer = conv1dLayerInit(
+        &(conv1dInit_t){
+            .inChannels = 2,
+            .outChannels = 4,
+            .kernelSize = 3,
+            .bias = BIAS_TRUE,
+        },
+        &lq);
+
+    conv1dConfig_t *cfg = layer->config->conv1d;
+    int weightGradType = cfg->weights->grad->quantization->type;
+    int biasGradType = cfg->bias->grad->quantization->type;
+
+    freeConv1dLayer(layer);
+    freeQuantization(bwd);
+    freeQuantization(fwd);
+
+    TEST_ASSERT_EQUAL_INT_MESSAGE(
+        FLOAT32, weightGradType, "Conv1d weight grad must stay FLOAT32 (backward is FLOAT32-only)");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(FLOAT32, biasGradType,
+                                  "Conv1d bias grad must stay FLOAT32 (backward is FLOAT32-only)");
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(testConv1dLayerInitBorrowingBuildsLayerWithCorrectShape);
@@ -204,5 +239,6 @@ int main(void) {
     RUN_TEST(testConv1dLayerInitBorrowingPaddingDefaultIsValid);
     RUN_TEST(testConv1dLayerInitOwningDeepCopiesQuantizations);
     RUN_TEST(testConv1dLayerInitOwningFreesAllAllocationsWithoutLeak);
+    RUN_TEST(testConv1dLayerInitKeepsFloat32GradEvenWithSymInt32BackwardMath);
     return UNITY_END();
 }

--- a/test/unit/userAPI/UnitTestConv1dTransposedApi.c
+++ b/test/unit/userAPI/UnitTestConv1dTransposedApi.c
@@ -166,6 +166,39 @@ void testConv1dTransposedLayerInitOwningFreesAllAllocationsWithoutLeak(void) {
     TEST_PASS();
 }
 
+void testConv1dTransposedLayerInitKeepsFloat32Grad(void) {
+    quantization_t *fwd = quantizationInitFloat();
+    quantization_t *bwd = quantizationInitSymInt32(HTE);
+    layerQuant_t lq = {
+        .forwardMath = fwd,
+        .backwardMath = bwd,
+        .weightStorage = fwd,
+        .biasStorage = fwd,
+    };
+
+    layer_t *layer = conv1dTransposedLayerInit(
+        &(conv1dTransposedInit_t){
+            .inChannels = 2,
+            .outChannels = 4,
+            .kernelSize = 3,
+            .bias = BIAS_TRUE,
+        },
+        &lq);
+
+    conv1dTransposedConfig_t *cfg = layer->config->conv1dTransposed;
+    int weightGradType = cfg->weights->grad->quantization->type;
+    int biasGradType = cfg->bias->grad->quantization->type;
+
+    freeConv1dTransposedLayer(layer);
+    freeQuantization(bwd);
+    freeQuantization(fwd);
+
+    TEST_ASSERT_EQUAL_INT_MESSAGE(FLOAT32, weightGradType,
+                                  "Conv1dTransposed weight grad must stay FLOAT32");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(FLOAT32, biasGradType,
+                                  "Conv1dTransposed bias grad must stay FLOAT32");
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(testConv1dTransposedLayerInitBorrowingBuildsLayerWithCorrectShape);
@@ -173,5 +206,6 @@ int main(void) {
     RUN_TEST(testConv1dTransposedLayerInitBorrowingOutputPaddingPropagatesToConfig);
     RUN_TEST(testConv1dTransposedLayerInitOwningDeepCopiesQuantizations);
     RUN_TEST(testConv1dTransposedLayerInitOwningFreesAllAllocationsWithoutLeak);
+    RUN_TEST(testConv1dTransposedLayerInitKeepsFloat32Grad);
     return UNITY_END();
 }


### PR DESCRIPTION
## Summary

Adds `gradInit(param, gradQ, sparsity)` so a trainable layer's parameter-gradient tensor honors the dtype its `backwardMath` / grad-quant config declares — replacing **6 hardcoded `gradInitFloat` sites** (Linear, Conv1d, Conv1dTransposed × weights/bias). This fixes the "config lies" bug (configs could declare SYM_INT32 grads while storage was always FLOAT32) and is the **prerequisite for fully-quantized training** (#148 LayerNorm builds on it).

- **Linear** grads now honor `backwardMath` (SYM_INT32 grads are real storage end-to-end).
- **Conv1d / Conv1dTransposed** keep FLOAT32 grads (their backward is FLOAT32-only) via an explicit FLOAT32 `gradQ`, guarded by tests.
- Confirms SYM_INT32 grads accumulate correctly over microbatches via the **existing** `addSymInt32TensorsInplace` (strategy A) — no layer/optimizer code change.
- Documents the SYM_INT32 grad-accumulation precision degradation as a **known open problem** in `docs/CONVENTIONS.md` (to be solved later with a literature-backed technique — no homegrown scheme shipped).

## Test plan

- `ctest --preset unit_test_debug`: **57/57 passed** (new: gradInit dtype/shape/ownership + signature contract, Linear SYM-grad regression, Conv1d/Conv1dTransposed FLOAT32 guards, end-to-end SYM_INT32 accumulation+step parity, sgdZeroGrad SYM_INT32 reset). Every new behavioral test was mutation-verified.
- `clang-format --dry-run -Werror` clean; allocation-locality grep clean.
- Local ASan skipped (macOS `__asan_init` livelock) → relies on the CI Linux ASan/UBSan job. Python untouched.

## Follow-ups (out of scope)

- `linearCalcPropLossSymInt32WithConversion` does **not** convert its `propLoss` *output* dtype (unlike the weight-grad path, which converts back) — a SYM_INT32-backward layer therefore requires the caller's `propLoss` buffer to be SYM_INT32 (a FLOAT32 buffer → NULL `qConfig` → segfault in `matmulSymIntTensors`). Contract holds today; consider making the propLoss path symmetric.
- Quantized grad-accumulation precision: literature review → published technique (tracked in `docs/CONVENTIONS.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)