### PR TITLE
feat: SYM_INT32 LayerNorm forward — verified scale-folding scheme (PR-2 of #148)

### DIFF
--- a/src/layer/CMakeLists.txt
+++ b/src/layer/CMakeLists.txt
@@ -72,6 +72,7 @@ target_link_libraries(LayerNorm PRIVATE
         DTypes
         Tensor
         Arithmetic
+        Rounding
         Layer
         Common
 )

--- a/src/layer/LayerNorm.c
+++ b/src/layer/LayerNorm.c
@@ -1,6 +1,7 @@
 #define SOURCE_FILE "LAYERNORM"
 
 #include <math.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -10,6 +11,7 @@
 #include "Common.h"
 #include "Layer.h"
 #include "Quantization.h"
+#include "Rounding.h"
 #include "Tensor.h"
 
 void initLayerNormConfig(layerNormConfig_t *cfg, parameter_t *gamma, parameter_t *beta,
@@ -113,6 +115,225 @@ static void layerNormGroupStats(tensor_t *t, size_t numNormDims, size_t g, size_
     *outInvSigma = 1.0f / sqrtf(var + eps); /* eps INSIDE sqrt */
 }
 
+/* The SYM_INT32 path reinterprets tensor data as int32 mantissas; a FLOAT32
+ * buffer read that way is silent garbage, so fail fast. qMaxBits > 16 would
+ * break two int32 bounds: the per-group mantissa-sum accumulator and the
+ * affine product q*gamma_q <= qMax^2 (spec: int64 is NOT used). NOTE: the
+ * guard can only check the config — int16-range mantissas are the SYM_INT32
+ * input CONTRACT; upstream ops must deliver requantized mantissas — an open
+ * inter-layer requantization question for the quantized-training epic (#137). */
+static void layerNormValidateSymTensor(tensor_t *t, const char *what) {
+    if (t->quantization->type != SYM_INT32) {
+        PRINT_ERROR("LayerNorm SYM_INT32: %s must be SYM_INT32", what);
+        exit(1);
+    }
+    symInt32QConfig_t *qc = t->quantization->qConfig;
+    if (qc->qMaxBits > 16) {
+        PRINT_ERROR("LayerNorm SYM_INT32: %s qMaxBits (%u) exceeds 16", what,
+                    (unsigned)qc->qMaxBits);
+        exit(1);
+    }
+}
+
+/* Per-group stats from SYM_INT32 mantissas: int32 accumulator for the mantissa
+ * sum (mantissas are int16-range per the qMaxBits<=16 guard, so an int32 sum
+ * holds ~65536 terms), then a float pass for the biased variance (/N, NOT N-1)
+ * with eps INSIDE the sqrt. SYM twin of layerNormGroupStats (which reads float
+ * data directly and remains the single source of truth for the FLOAT32
+ * forward+backward); PR-3's SYM backward must recompute through THIS helper. */
+static void layerNormGroupStatsSymInt32(tensor_t *t, size_t numNormDims, size_t g, size_t N,
+                                        float eps, float inScale, float *outMean,
+                                        float *outInvSigma) {
+    int32_t *in = (int32_t *)t->data;
+    int32_t sumQ = 0;
+    for (size_t j = 0; j < N; j++) {
+        sumQ += in[layerNormPhysOffset(t, numNormDims, g, j)];
+    }
+    float mean = inScale * ((float)sumQ / (float)N);
+
+    float var = 0.0f;
+    for (size_t j = 0; j < N; j++) {
+        float d = (float)in[layerNormPhysOffset(t, numNormDims, g, j)] * inScale - mean;
+        var += d * d;
+    }
+    var /= (float)N; /* BIASED — divide by N, not N-1 */
+
+    *outMean = mean;
+    *outInvSigma = 1.0f / sqrtf(var + eps); /* eps INSIDE sqrt */
+}
+
+/* Affine y = gamma*n + beta as a SEPARATE quantized elementwise stage, applied
+ * in-place over the freshly written normalized mantissas (spec: it destroys
+ * the abs-max=qMax / var~1 invariants and has its own requantization + output
+ * scale). Lives in LayerNorm.c, NOT arithmetic/: it needs broadcast over
+ * groups (gamma_j shared by all G groups) and the layout-agnostic logical
+ * index map — the flat equal-count arithmetic elementwise ops can express
+ * neither. Scale bookkeeping:
+ *   s_y    = s_norm * s_gamma                  (product idiom, mulSymInt32Tensors)
+ *   seed_j = round(beta_q,j * s_beta / s_y)    (bias-rescale idiom,
+ *            matmulSymInt32TensorsWithBias — a raw beta_q add would silently
+ *            drop beta under dynamic per-tensor scales)
+ *   y_q    = q * gamma_q,j + seed_j            (the product q*gamma_q <= qMax^2
+ *            fits int32, but the rescaled seed is DATA-DEPENDENT and unbounded:
+ *            |seed| ~ |beta| * qMax^2 / (absmax_n * absmax_gamma). The guard
+ *            below fails fast outside the safe envelope instead of casting an
+ *            out-of-range float to int32 (UB). Spec errata: "int32 is safe
+ *            throughout" holds only while the rescaled seed leaves qMax^2 of
+ *            int32 headroom for the gamma-product, i.e. |beta| <~
+ *            absmax_n * absmax_gamma.)
+ * gamma/beta are contiguous default-order rank-D tensors -> flat index j. */
+static void layerNormAffineSymInt32(layerNormConfig_t *cfg, tensor_t *output, float sNorm) {
+    int32_t *out = (int32_t *)output->data;
+    int32_t *gammaQ = (int32_t *)cfg->gamma->param->data;
+    int32_t *betaQ = (int32_t *)cfg->beta->param->data;
+    symInt32QConfig_t *outQC = output->quantization->qConfig;
+    symInt32QConfig_t *gammaQC = cfg->gamma->param->quantization->qConfig;
+    symInt32QConfig_t *betaQC = cfg->beta->param->quantization->qConfig;
+
+    float sY = sNorm * gammaQC->scale;
+    float betaRescale = betaQC->scale / sY;
+
+    size_t G, N;
+    layerNormGroupSizes(output, cfg->numNormDims, &G, &N);
+
+    /* Seed-overflow guard: y_q = q*gamma_q + seed must fit int32. The product
+     * is bounded by qMax^2; the seed is not — fail fast before UB. */
+    const float qMax = powf(2, (float)outQC->qMaxBits - 1) - 1;
+    int32_t maxAbsBetaQ = 0;
+    for (size_t j = 0; j < N; j++) {
+        int32_t a = (betaQ[j] < 0) ? -betaQ[j] : betaQ[j];
+        if (a > maxAbsBetaQ) {
+            maxAbsBetaQ = a;
+        }
+    }
+    /* !(x <= T) instead of (x > T): also catches NaN (0 * inf when sY underflows). */
+    if (!(fabsf((float)maxAbsBetaQ * betaRescale) <= 2147483647.0f - qMax * qMax)) {
+        PRINT_ERROR("LayerNorm SYM_INT32 affine: rescaled beta leaves no int32 headroom for the "
+                    "gamma-product (|beta| exceeds ~absmax(n)*absmax(gamma) — see #189)");
+        exit(1);
+    }
+
+    for (size_t g = 0; g < G; g++) {
+        for (size_t j = 0; j < N; j++) {
+            size_t off = layerNormPhysOffset(output, cfg->numNormDims, g, j);
+            int32_t seed = roundByMode((float)betaQ[j] * betaRescale, outQC->roundingMode);
+            out[off] = out[off] * gammaQ[j] + seed;
+        }
+    }
+    outQC->scale = sY;
+}
+
+/* SYM_INT32 forward (spec 2026-06-05, verified scale-folding scheme):
+ * pass 1: per-group float stats + GLOBAL absmax of the normalized values.
+ *         Multi-group REQUIRES the per-group 1/sigma_g to hit the DATA — one
+ *         per-tensor scale cannot encode G different sigmas; only the global
+ *         stretch lives in the scale.
+ * pass 2: recompute stats per group (recompute-over-store: no scratch at all,
+ *         not even G floats — stateless and MCU-friendly), normalize, stretch
+ *         by K = qMax/absmax, round-clamp.
+ * Output scale s_norm = 1/K. Per-group reconstructed variance of the output is
+ * var/(var+eps) — exactly PyTorch's eps behavior. The affine stage follows
+ * separately (Task 3). */
+static void layerNormForwardSymInt32(layerNormConfig_t *cfg, tensor_t *input, tensor_t *output) {
+    layerNormValidateSymTensor(input, "input");
+    layerNormValidateSymTensor(output, "output");
+    layerNormValidateSymTensor(cfg->gamma->param, "gamma");
+    layerNormValidateSymTensor(cfg->beta->param, "beta");
+
+    symInt32QConfig_t *inQC = input->quantization->qConfig;
+    symInt32QConfig_t *outQC = output->quantization->qConfig;
+    int32_t *in = (int32_t *)input->data;
+    int32_t *out = (int32_t *)output->data;
+    float inScale = inQC->scale;
+    const float qMax = powf(2, (float)outQC->qMaxBits - 1) - 1;
+    const float qMin = -powf(2, (float)outQC->qMaxBits - 1);
+
+    size_t G, N;
+    layerNormGroupSizes(input, cfg->numNormDims, &G, &N);
+
+    if (G == 0 || N == 0) {
+        outQC->scale = 1.0f; /* nothing to normalize; neutral scale (cf. #160) */
+        return;
+    }
+
+    /* Integer range pre-check: if every mantissa is identical (global int32 min
+     * == max), every group's centered value is exactly zero in integer space.
+     * A float absMax==0.0f check alone is fragile here: gcc's default
+     * -ffp-contract=fast may fuse (float)in[off]*inScale - mean into an fma,
+     * so the product is not rounded before the subtraction and the cancellation
+     * x*s - mean is NOT guaranteed to be exactly 0 even when all mantissas are
+     * equal. The integer check is portable and catches this common case. */
+    int32_t intMin = in[layerNormPhysOffset(input, cfg->numNormDims, 0, 0)];
+    int32_t intMax = intMin;
+    bool allConstant = true;
+    for (size_t g = 0; g < G; g++) {
+        for (size_t j = 0; j < N; j++) {
+            int32_t v = in[layerNormPhysOffset(input, cfg->numNormDims, g, j)];
+            if (v < intMin) {
+                intMin = v;
+                allConstant = false;
+            }
+            if (v > intMax) {
+                intMax = v;
+                allConstant = false;
+            }
+        }
+    }
+
+    /* Pass 1: global absmax of n = (x_q*s_x - mu)/sigma over all groups.
+     * Skipped when allConstant — absMax stays 0.0f, caught by the unified guard
+     * below. */
+    float absMax = 0.0f;
+    if (!allConstant) {
+        for (size_t g = 0; g < G; g++) {
+            float mean;
+            float invSigma;
+            layerNormGroupStatsSymInt32(input, cfg->numNormDims, g, N, cfg->eps, inScale, &mean,
+                                        &invSigma);
+            for (size_t j = 0; j < N; j++) {
+                size_t off = layerNormPhysOffset(input, cfg->numNormDims, g, j);
+                float a = fabsf(((float)in[off] * inScale - mean) * invSigma);
+                if (a > absMax) {
+                    absMax = a;
+                }
+            }
+        }
+    }
+
+    float sNorm;
+    if (allConstant || absMax == 0.0f) {
+        /* Constant input (integer fast-path) OR exact float cancellation
+         * (groups internally constant, products exactly representable):
+         * emit all-zero mantissas with scale 1.0 — mirrors the absMax==0
+         * idiom in convertFloatTensorToSymInt32Tensor. */
+        sNorm = 1.0f;
+        for (size_t g = 0; g < G; g++) {
+            for (size_t j = 0; j < N; j++) {
+                out[layerNormPhysOffset(output, cfg->numNormDims, g, j)] = 0;
+            }
+        }
+    } else {
+        float K = qMax / absMax;
+        sNorm = 1.0f / K;
+
+        /* Pass 2: recompute stats, normalize, quantize. */
+        for (size_t g = 0; g < G; g++) {
+            float mean;
+            float invSigma;
+            layerNormGroupStatsSymInt32(input, cfg->numNormDims, g, N, cfg->eps, inScale, &mean,
+                                        &invSigma);
+            for (size_t j = 0; j < N; j++) {
+                size_t inOff = layerNormPhysOffset(input, cfg->numNormDims, g, j);
+                float n = ((float)in[inOff] * inScale - mean) * invSigma;
+                size_t outOff = layerNormPhysOffset(output, cfg->numNormDims, g, j);
+                out[outOff] = roundByMode(clamp(n * K, qMin, qMax), outQC->roundingMode);
+            }
+        }
+    }
+
+    layerNormAffineSymInt32(cfg, output, sNorm);
+}
+
 static void layerNormForwardFloat(layerNormConfig_t *cfg, tensor_t *input, tensor_t *output) {
     float *in = (float *)input->data;
     float *out = (float *)output->data;
@@ -143,8 +364,12 @@ void layerNormForward(layer_t *layer, tensor_t *input, tensor_t *output) {
     case FLOAT32:
         layerNormForwardFloat(cfg, input, output);
         break;
+    case SYM_INT32:
+        layerNormForwardSymInt32(cfg, input, output);
+        break;
     default:
-        PRINT_ERROR("LayerNorm forward: quantization type not implemented (FLOAT32 only in PR-1)");
+        PRINT_ERROR(
+            "LayerNorm forward: quantization type not implemented (FLOAT32/SYM_INT32 only)");
         exit(1);
     }
 }
@@ -203,10 +428,21 @@ void layerNormBackward(layer_t *layer, tensor_t *forwardInput, tensor_t *loss, t
     layerNormValidateInputShape(cfg, forwardInput);
     switch (cfg->backwardQ->type) {
     case FLOAT32:
+        /* PR-2 allows SYM_INT32 forward configs; their backward lands in PR-3
+         * (#187 propLoss dtype asymmetry). Reading a SYM_INT32 forwardInput /
+         * loss / gamma as float* here would be silent garbage — fail fast. */
+        if (forwardInput->quantization->type != FLOAT32 || loss->quantization->type != FLOAT32 ||
+            cfg->gamma->param->quantization->type != FLOAT32) {
+            PRINT_ERROR("LayerNorm backward: FLOAT32 backward requires FLOAT32 tensors "
+                        "(SYM_INT32 backward lands in PR-3, see #187)");
+            exit(1);
+        }
         layerNormBackwardFloat(cfg, forwardInput, loss, propLoss);
         break;
     default:
-        PRINT_ERROR("LayerNorm backward: quantization type not implemented (FLOAT32 only in PR-1)");
+        PRINT_ERROR(
+            "LayerNorm backward: quantization type not implemented (FLOAT32 only until PR-3, see "
+            "#187)");
         exit(1);
     }
 }

--- a/src/userApi/CMakeLists.txt
+++ b/src/userApi/CMakeLists.txt
@@ -54,6 +54,7 @@ target_link_libraries(LayerWeightsApi PRIVATE
         Linear
         Rounding
         Tensor
+        TensorApi
 )
 
 add_library(StateDictApi StateDictApi.c)

--- a/src/userApi/LayerWeightsApi.c
+++ b/src/userApi/LayerWeightsApi.c
@@ -7,6 +7,7 @@
 #include "LayerNorm.h"
 #include "Linear.h"
 #include "Tensor.h"
+#include "TensorApi.h"
 #include <stdlib.h>
 #include <string.h>
 
@@ -77,7 +78,7 @@ void layerLoadWeights(layer_t *layer, float *weightData, float *biasData) {
         }
         tensor_t *gammaTensor = cfg->gamma->param;
         size_t numGamma = calcNumberOfElementsByTensor(gammaTensor);
-        memcpy(gammaTensor->data, weightData, numGamma * sizeof(float));
+        tensorFillFromFloatBuffer(gammaTensor, weightData, numGamma);
 
         if (cfg->beta == NULL) {
             PRINT_ERROR("layerLoadWeights LAYERNORM: layer has no beta parameter");
@@ -89,7 +90,7 @@ void layerLoadWeights(layer_t *layer, float *weightData, float *biasData) {
         }
         tensor_t *betaTensor = cfg->beta->param;
         size_t numBeta = calcNumberOfElementsByTensor(betaTensor);
-        memcpy(betaTensor->data, biasData, numBeta * sizeof(float));
+        tensorFillFromFloatBuffer(betaTensor, biasData, numBeta);
         break;
     }
     case RELU:

--- a/src/userApi/layer/CMakeLists.txt
+++ b/src/userApi/layer/CMakeLists.txt
@@ -137,7 +137,6 @@ target_link_libraries(LayerNormApi PRIVATE
         Layer
         LayerNorm
         LayerQuant
-        Distributions
         Common
         StorageApi
 )

--- a/src/userApi/layer/LayerNormApi.c
+++ b/src/userApi/layer/LayerNormApi.c
@@ -5,7 +5,6 @@
 #include "LayerNormApi.h"
 
 #include "Common.h"
-#include "Distributions.h"
 #include "Layer.h"
 #include "LayerNorm.h"
 #include "LayerQuant.h"
@@ -30,32 +29,42 @@ static shape_t *buildOwnedShape(const size_t *srcDims, size_t numberOfDims) {
     return shape;
 }
 
-/* gamma: shape normalizedShape, init all-ones; grad dtype from gradQ (= the
- * profile's backwardMath; FLOAT32 in PR-1). */
+/* Constant fill via tensorFillFromFloatBuffer: plain memcpy for FLOAT32; for
+ * SYM_INT32 it routes through convertFloatTensorToSymInt32Tensor, which IS
+ * the spec's parameter quantization (all-ones -> mantissa 32767, scale
+ * 1/32767; all-zeros -> mantissa 0, scale 1.0 via the absMax==0 guard).
+ * initDistribution cannot be used here: it is FLOAT32-only by guard, and
+ * extending it is Issue-C scope. */
+static void fillParamTensorWithConstant(tensor_t *paramTensor, float value) {
+    size_t count = calcNumberOfElementsByTensor(paramTensor);
+    float *buf = reserveMemory(count * sizeof(float));
+    for (size_t i = 0; i < count; i++) {
+        buf[i] = value;
+    }
+    tensorFillFromFloatBuffer(paramTensor, buf, count);
+    freeReservedMemory(buf);
+}
+
+/* gamma: shape normalizedShape, init all-ones (FLOAT32: 1.0f each; SYM_INT32:
+ * mantissa 32767, scale 1/32767); grad dtype from gradQ (= the profile's
+ * backwardMath). */
 static parameter_t *allocateLayerNormGamma(const size_t *normalizedShape, size_t numNormDims,
                                            quantization_t *storageQ, quantization_t *gradQ) {
-    if (storageQ->type != FLOAT32) {
-        PRINT_ERROR("layerNormLayerInit: PR-1 supports FLOAT32 gamma storage only");
-        exit(1);
-    }
     shape_t *shape = buildOwnedShape(normalizedShape, numNormDims);
     tensor_t *paramTensor = initTensor(shape, getQLike(storageQ), NULL);
-    distribution_t ones = {.type = ONES};
-    initDistribution(paramTensor, &ones);
+    fillParamTensorWithConstant(paramTensor, 1.0f);
     tensor_t *gradTensor = gradInit(paramTensor, gradQ, NULL);
     return parameterInit(paramTensor, gradTensor);
 }
 
-/* beta: shape normalizedShape, init all-zeros (calloc); grad dtype from gradQ. */
+/* beta: shape normalizedShape, init all-zeros (FLOAT32: 0.0f each; SYM_INT32:
+ * mantissa 0, scale 1.0 — the explicit fill exercises the absMax==0 constant
+ * guard instead of relying on calloc zeros + the default scale). */
 static parameter_t *allocateLayerNormBeta(const size_t *normalizedShape, size_t numNormDims,
                                           quantization_t *storageQ, quantization_t *gradQ) {
-    if (storageQ->type != FLOAT32) {
-        PRINT_ERROR("layerNormLayerInit: PR-1 supports FLOAT32 beta storage only");
-        exit(1);
-    }
     shape_t *shape = buildOwnedShape(normalizedShape, numNormDims);
     tensor_t *paramTensor = initTensor(shape, getQLike(storageQ), NULL);
-    /* zeros already provided by reserveMemory (calloc). */
+    fillParamTensorWithConstant(paramTensor, 0.0f);
     tensor_t *gradTensor = gradInit(paramTensor, gradQ, NULL);
     return parameterInit(paramTensor, gradTensor);
 }
@@ -104,6 +113,21 @@ static void validateLayerQuantForLayerNorm(layerQuant_t *lq) {
     }
     if (lq->biasStorage == NULL) {
         PRINT_ERROR("layerNormLayerInit: layerQuant.biasStorage must be set (beta storage)");
+        exit(1);
+    }
+    if (lq->weightStorage->type != FLOAT32 && lq->weightStorage->type != SYM_INT32) {
+        PRINT_ERROR("layerNormLayerInit: gamma storage must be FLOAT32 or SYM_INT32");
+        exit(1);
+    }
+    if (lq->biasStorage->type != FLOAT32 && lq->biasStorage->type != SYM_INT32) {
+        PRINT_ERROR("layerNormLayerInit: beta storage must be FLOAT32 or SYM_INT32");
+        exit(1);
+    }
+    /* The kernels read gamma/beta in the forward dtype: a FLOAT32 kernel over
+     * SYM mantissas (or vice versa) is silent garbage. Fail at construction. */
+    if (lq->weightStorage->type != lq->forwardMath->type ||
+        lq->biasStorage->type != lq->forwardMath->type) {
+        PRINT_ERROR("layerNormLayerInit: gamma/beta storage type must match forwardMath");
         exit(1);
     }
 }

--- a/test/unit/layer/CMakeLists.txt
+++ b/test/unit/layer/CMakeLists.txt
@@ -209,6 +209,18 @@ add_custom_command(
 add_custom_target(generate_expected_layernorm
         DEPENDS ${GEN_LAYERNORM_HEADER})
 
+set(GEN_LAYERNORM_SYM_HEADER ${CMAKE_CURRENT_BINARY_DIR}/expected_layernorm_sym.h)
+add_custom_command(
+        OUTPUT ${GEN_LAYERNORM_SYM_HEADER}
+        COMMAND uv run ${CMAKE_CURRENT_SOURCE_DIR}/generate_expected_layernorm_sym.py
+                --out ${GEN_LAYERNORM_SYM_HEADER}
+        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/generate_expected_layernorm_sym.py
+        COMMENT "Generating expected_layernorm_sym.h via PyTorch"
+        VERBATIM
+)
+add_custom_target(generate_expected_layernorm_sym
+        DEPENDS ${GEN_LAYERNORM_SYM_HEADER})
+
 add_elastic_ai_unit_test(
         LIB_UNDER_TEST
         LayerNorm
@@ -224,4 +236,5 @@ add_elastic_ai_unit_test(
         StorageApi
 )
 add_dependencies(UnitTestLayerNorm generate_expected_layernorm)
+add_dependencies(UnitTestLayerNorm generate_expected_layernorm_sym)
 target_include_directories(UnitTestLayerNorm PRIVATE ${CMAKE_CURRENT_BINARY_DIR})

--- a/test/unit/layer/UnitTestLayerNorm.c
+++ b/test/unit/layer/UnitTestLayerNorm.c
@@ -1301,6 +1301,87 @@ void testSymForwardTransposedMatchesContiguous(void) {
     }
 }
 
+void testFactorySymInt32StorageQuantizesGammaBeta(void) {
+    size_t normShape[] = {4};
+    layerNormInit_t init = {.normalizedShape = normShape, .numNormDims = 1, .eps = 0.0f};
+
+    quantization_t *symQ = quantizationInitSymInt32(HTE);
+    quantization_t *bwdMath = quantizationInitFloat();
+    layerQuant_t lq = {
+        .forwardMath = symQ, .backwardMath = bwdMath, .weightStorage = symQ, .biasStorage = symQ};
+
+    layer_t *layer = layerNormLayerInit(&init, &lq);
+    layerNormConfig_t *cfg = layer->config->layerNorm;
+
+    int32_t g[4];
+    int32_t b[4];
+    for (size_t i = 0; i < 4; i++) {
+        g[i] = ((int32_t *)cfg->gamma->param->data)[i];
+        b[i] = ((int32_t *)cfg->beta->param->data)[i];
+    }
+    float gScale = symScaleOf(cfg->gamma->param);
+    float bScale = symScaleOf(cfg->beta->param);
+    bool gammaGradFloat = (cfg->gamma->grad->quantization->type == FLOAT32);
+    bool betaGradFloat = (cfg->beta->grad->quantization->type == FLOAT32);
+
+    /* Forward smoke through the vtable on SYM input (factory-built params). */
+    size_t dims[] = {4};
+    tensor_t *in = buildSymInt32TensorND(1, dims, (float[]){1.f, 2.f, 3.f, 4.f});
+    tensor_t *out = buildSymInt32TensorND(1, dims, NULL);
+    layerFunctions[LAYERNORM].forward(layer, in, out);
+    float outScale = symScaleOf(out);
+    float deqMean = 0.f;
+    for (size_t i = 0; i < 4; i++) {
+        deqMean += (float)((int32_t *)out->data)[i] * outScale;
+    }
+    deqMean /= 4.f;
+
+    freeTensor(out);
+    freeTensor(in);
+    freeLayerNormLayer(layer);
+    freeQuantization(bwdMath);
+    freeQuantization(symQ);
+
+    for (size_t i = 0; i < 4; i++) {
+        TEST_ASSERT_EQUAL_INT(32767, g[i]);
+        TEST_ASSERT_EQUAL_INT(0, b[i]);
+    }
+    TEST_ASSERT_FLOAT_WITHIN(1e-9f, 1.0f / 32767.0f, gScale);
+    TEST_ASSERT_FLOAT_WITHIN(1e-9f, 1.0f, bScale);
+    TEST_ASSERT_TRUE(gammaGradFloat);
+    TEST_ASSERT_TRUE(betaGradFloat);
+    TEST_ASSERT_FLOAT_WITHIN(1e-3f, 0.f, deqMean);
+}
+
+void testFactoryOwningSymInt32DeepCopiesQuantizations(void) {
+    size_t normShape[] = {3};
+    layerNormInit_t init = {.normalizedShape = normShape, .numNormDims = 1, .eps = 1e-5f};
+
+    quantization_t *symQ = quantizationInitSymInt32(HTE);
+    quantization_t *bwdMath = quantizationInitFloat();
+    layerQuant_t lq = {
+        .forwardMath = symQ, .backwardMath = bwdMath, .weightStorage = symQ, .biasStorage = symQ};
+
+    layer_t *layer = layerNormLayerInitOwning(&init, &lq);
+    layerNormConfig_t *cfg = layer->config->layerNorm;
+
+    bool fwdIsCopy = (cfg->forwardQ != symQ);
+    bool fwdIsSym = (cfg->forwardQ->type == SYM_INT32);
+    bool fwdCfgIsCopy = (cfg->forwardQ->qConfig != symQ->qConfig);
+    bool owns = cfg->ownsQuantizations;
+
+    /* Caller drops its quants immediately — the layer holds deep copies
+     * (incl. the symInt32QConfig_t; double-free/UAF surfaces under CI ASan). */
+    freeQuantization(bwdMath);
+    freeQuantization(symQ);
+    freeLayerNormLayer(layer);
+
+    TEST_ASSERT_TRUE(fwdIsCopy);
+    TEST_ASSERT_TRUE(fwdIsSym);
+    TEST_ASSERT_TRUE(fwdCfgIsCopy);
+    TEST_ASSERT_TRUE(owns);
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(testConfigStructIsPopulated);
@@ -1334,5 +1415,7 @@ int main(void) {
     RUN_TEST(testSymGoldSigmaRatio10x);
     RUN_TEST(testSymForwardVarNearEpsReconstructsHalf);
     RUN_TEST(testSymForwardTransposedMatchesContiguous);
+    RUN_TEST(testFactorySymInt32StorageQuantizesGammaBeta);
+    RUN_TEST(testFactoryOwningSymInt32DeepCopiesQuantizations);
     return UNITY_END();
 }

--- a/test/unit/layer/UnitTestLayerNorm.c
+++ b/test/unit/layer/UnitTestLayerNorm.c
@@ -17,6 +17,7 @@
 #include "unity.h"
 
 #include "expected_layernorm.h"
+#include "expected_layernorm_sym.h"
 
 void setUp(void) {}
 void tearDown(void) {}
@@ -823,6 +824,118 @@ static void runGoldBackward(size_t numDims, const size_t *dims, const float *xVa
     }
 }
 
+/* SYM gold runner: forward over generated fixtures, then assert
+ * (a) mantissas within +-mantissaTol of the float64 emulation (float32 stats
+ *     noise can flip a rounding boundary; tol = 2*max|gamma_q|+1),
+ * (b) output scale within 1e-4 relative of the emulated s_y,
+ * (c) dequantized output within dequantTol of F.layer_norm on the same
+ *     dequantized inputs,
+ * (d) for gamma=1/beta=0 fixtures: dequant within 3e-5 of PyTorch xhat (the
+ *     spec-verified tolerance; generator guarantees absmax(xhat) <= 1.9), and
+ * (e) per-group dequant variance within 5e-3 of var/(var+eps). */
+static void runSymGoldForward(size_t numDims, const size_t *dims, size_t numNormDims,
+                              const size_t *normShapeIn, const float *xVals, const float *gammaVals,
+                              const float *betaVals, const int32_t *expMantissas, float expScale,
+                              int32_t mantissaTol, const float *expDequant, float dequantTol,
+                              const float *expXhat, const float *expGroupVarRatio, size_t groups,
+                              size_t count) {
+    TEST_ASSERT_TRUE_MESSAGE(count > 0 && count <= 64, "fixture exceeds capture buffer");
+    size_t normCount = count / groups;
+
+    tensor_t *in = buildSymInt32TensorND(numDims, dims, xVals);
+    tensor_t *out = buildSymInt32TensorND(numDims, dims, NULL);
+    parameter_t *gamma = buildSymParam(numNormDims, normShapeIn, gammaVals);
+    parameter_t *beta = buildSymParam(numNormDims, normShapeIn, betaVals);
+    size_t *normShape = reserveMemory(numNormDims * sizeof(size_t));
+    for (size_t i = 0; i < numNormDims; i++) {
+        normShape[i] = normShapeIn[i];
+    }
+    quantization_t *fq = quantizationInitSymInt32(HTE);
+    quantization_t *bq = quantizationInitFloat();
+    layerNormConfig_t cfg;
+    initLayerNormConfig(&cfg, gamma, beta, normShape, numNormDims, 1e-5f, fq, bq);
+    layerConfig_t lcfg;
+    layer_t layer = makeLayerNormLayer(&cfg, &lcfg);
+
+    layerNormForward(&layer, in, out);
+
+    int32_t m[64];
+    for (size_t i = 0; i < count; i++) {
+        m[i] = ((int32_t *)out->data)[i];
+    }
+    float scale = symScaleOf(out);
+
+    freeQuantization(bq);
+    freeQuantization(fq);
+    freeReservedMemory(normShape);
+    freeParameter(beta);
+    freeParameter(gamma);
+    freeTensor(out);
+    freeTensor(in);
+
+    for (size_t i = 0; i < count; i++) {
+        TEST_ASSERT_INT_WITHIN(mantissaTol, expMantissas[i], m[i]);
+    }
+    TEST_ASSERT_FLOAT_WITHIN(expScale * 1e-4f, expScale, scale);
+    for (size_t i = 0; i < count; i++) {
+        float deq = (float)m[i] * scale;
+        TEST_ASSERT_FLOAT_WITHIN(dequantTol, expDequant[i], deq);
+        if (expXhat != NULL) {
+            TEST_ASSERT_FLOAT_WITHIN(3e-5f, expXhat[i], deq);
+        }
+    }
+    if (expGroupVarRatio != NULL) {
+        for (size_t g = 0; g < groups; g++) {
+            float mean = 0.f;
+            for (size_t j = 0; j < normCount; j++) {
+                mean += (float)m[g * normCount + j] * scale;
+            }
+            mean /= (float)normCount;
+            float var = 0.f;
+            for (size_t j = 0; j < normCount; j++) {
+                float d = (float)m[g * normCount + j] * scale - mean;
+                var += d * d;
+            }
+            var /= (float)normCount;
+            TEST_ASSERT_FLOAT_WITHIN(5e-3f, expGroupVarRatio[g], var);
+        }
+    }
+}
+
+void testSymGoldParityMultiGroup(void) {
+    size_t dims[] = {3, 4};
+    size_t ns[] = {4};
+    runSymGoldForward(2, dims, 1, ns, input_layerNormSym_symParity, gamma_layerNormSym_symParity,
+                      beta_layerNormSym_symParity, expectedMantissas_layerNormSym_symParity,
+                      expectedScale_layerNormSym_symParity, mantissaTol_layerNormSym_symParity,
+                      expectedDequant_layerNormSym_symParity, dequantTol_layerNormSym_symParity,
+                      expectedXhat_layerNormSym_symParity,
+                      expectedGroupVarRatio_layerNormSym_symParity, 3,
+                      expectedMantissas_layerNormSym_symParity_len);
+}
+
+void testSymGoldAffine(void) {
+    size_t dims[] = {2, 4};
+    size_t ns[] = {4};
+    runSymGoldForward(2, dims, 1, ns, input_layerNormSym_symAffine, gamma_layerNormSym_symAffine,
+                      beta_layerNormSym_symAffine, expectedMantissas_layerNormSym_symAffine,
+                      expectedScale_layerNormSym_symAffine, mantissaTol_layerNormSym_symAffine,
+                      expectedDequant_layerNormSym_symAffine, dequantTol_layerNormSym_symAffine,
+                      NULL, NULL, 2, expectedMantissas_layerNormSym_symAffine_len);
+}
+
+void testSymGoldSigmaRatio10x(void) {
+    size_t dims[] = {2, 4};
+    size_t ns[] = {4};
+    runSymGoldForward(
+        2, dims, 1, ns, input_layerNormSym_symSigmaRatio, gamma_layerNormSym_symSigmaRatio,
+        beta_layerNormSym_symSigmaRatio, expectedMantissas_layerNormSym_symSigmaRatio,
+        expectedScale_layerNormSym_symSigmaRatio, mantissaTol_layerNormSym_symSigmaRatio,
+        expectedDequant_layerNormSym_symSigmaRatio, dequantTol_layerNormSym_symSigmaRatio,
+        expectedXhat_layerNormSym_symSigmaRatio, expectedGroupVarRatio_layerNormSym_symSigmaRatio,
+        2, expectedMantissas_layerNormSym_symSigmaRatio_len);
+}
+
 /* Small-variance fixture: var (1.25e-6) is comparable to eps (1e-5), so this
  * test distinguishes sqrt(var+eps) from the wrong sqrt(var)+eps — the O(1)-
  * variance fixtures cannot (relative difference ~5e-6, below tolerance).
@@ -1063,6 +1176,131 @@ void testSymForwardConstantInputAppliesBeta(void) {
     }
 }
 
+/* var ~ eps fixture (codebase_eps_mutation_vacuity): with var == eps == 1e-5
+ * the reconstructed output variance is var/(var+eps) == 0.5 — the ONLY regime
+ * where eps placement and the input scale are visible:
+ *   sqrt(var)+eps   -> ratio ~ 0.994 (not 0.5)
+ *   eps omitted     -> ratio ~ 1.0
+ *   s_x dropped     -> standardization is scale-invariant, so this mutation is
+ *                      invisible to every O(1)-variance test; here the
+ *                      mantissa-domain variance (~1.1e4) dwarfs eps -> ~1.0.
+ * d = sqrt(1.5e-5) so var = 2d^2/3 = 1e-5 exactly; N=3 (N=2 would saturate
+ * xhat to +-1 regardless of data). */
+void testSymForwardVarNearEpsReconstructsHalf(void) {
+    float d = 0.0038729833f; /* sqrt(1.5e-5) */
+    size_t dims[] = {3};
+    float vals[] = {1.0f - d, 1.0f, 1.0f + d};
+    tensor_t *in = buildSymInt32TensorND(1, dims, vals);
+    tensor_t *out = buildSymInt32TensorND(1, dims, NULL);
+
+    size_t ns[] = {3};
+    parameter_t *gamma = buildSymParam(1, ns, (float[]){1.f, 1.f, 1.f});
+    parameter_t *beta = buildSymParam(1, ns, (float[]){0.f, 0.f, 0.f});
+    size_t *normShape = reserveMemory(sizeof(size_t));
+    normShape[0] = 3;
+
+    quantization_t *fq = quantizationInitSymInt32(HTE);
+    quantization_t *bq = quantizationInitFloat();
+    layerNormConfig_t cfg;
+    initLayerNormConfig(&cfg, gamma, beta, normShape, 1, 1e-5f, fq, bq);
+    layerConfig_t lcfg;
+    layer_t layer = makeLayerNormLayer(&cfg, &lcfg);
+
+    layerNormForward(&layer, in, out);
+
+    float scale = symScaleOf(out);
+    float deq[3];
+    for (size_t i = 0; i < 3; i++) {
+        deq[i] = (float)((int32_t *)out->data)[i] * scale;
+    }
+
+    freeQuantization(bq);
+    freeQuantization(fq);
+    freeReservedMemory(normShape);
+    freeParameter(beta);
+    freeParameter(gamma);
+    freeTensor(out);
+    freeTensor(in);
+
+    float mean = (deq[0] + deq[1] + deq[2]) / 3.f;
+    float var = 0.f;
+    for (size_t i = 0; i < 3; i++) {
+        float dd = deq[i] - mean;
+        var += dd * dd;
+    }
+    var /= 3.f;
+
+    /* Input quantization perturbs d by <= s_x/2 ~ 1.5e-5 absolute (~0.4%
+     * of d) -> var ratio lands at 0.5 +- ~0.02; 0.05 tolerance is ample. */
+    TEST_ASSERT_FLOAT_WITHIN(0.05f, 0.5f, var);
+}
+
+/* Layout-agnosticism through quantization: same logical [2,4] content,
+ * contiguous vs physically transposed ([4,2] buffer + transposeTensor), must
+ * yield bit-identical mantissas at corresponding LOGICAL positions and the
+ * identical output scale (same float ops in the same order). Physical [4,2]
+ * buffer for logical [2,4]: buf[c*2 + r] = logical(r,c). */
+void testSymForwardTransposedMatchesContiguous(void) {
+    float gammaVals[] = {1.f, -0.5f, 2.f, 0.25f};
+    float betaVals[] = {0.1f, -0.2f, 0.3f, -0.4f};
+
+    size_t dims[] = {2, 4};
+    tensor_t *inC =
+        buildSymInt32TensorND(2, dims, (float[]){1.f, 2.f, 3.f, 4.f, 10.f, 20.f, 30.f, 40.f});
+    tensor_t *outC = buildSymInt32TensorND(2, dims, NULL);
+
+    size_t pdims[] = {4, 2};
+    tensor_t *inT =
+        buildSymInt32TensorND(2, pdims, (float[]){1.f, 10.f, 2.f, 20.f, 3.f, 30.f, 4.f, 40.f});
+    transposeTensor(inT, 0, 1); /* logical [2,4], physical unchanged */
+    tensor_t *outT = buildSymInt32TensorND(2, pdims, NULL);
+    transposeTensor(outT, 0, 1);
+
+    size_t ns[] = {4};
+    parameter_t *gamma = buildSymParam(1, ns, gammaVals);
+    parameter_t *beta = buildSymParam(1, ns, betaVals);
+    size_t *normShape = reserveMemory(sizeof(size_t));
+    normShape[0] = 4;
+
+    quantization_t *fq = quantizationInitSymInt32(HTE);
+    quantization_t *bq = quantizationInitFloat();
+    layerNormConfig_t cfg;
+    initLayerNormConfig(&cfg, gamma, beta, normShape, 1, 1e-5f, fq, bq);
+    layerConfig_t lcfg;
+    layer_t layer = makeLayerNormLayer(&cfg, &lcfg);
+
+    layerNormForward(&layer, inC, outC);
+    layerNormForward(&layer, inT, outT);
+
+    int32_t mC[8];
+    int32_t mT[8];
+    int32_t *ocd = (int32_t *)outC->data;
+    int32_t *otd = (int32_t *)outT->data;
+    for (size_t r = 0; r < 2; r++) {
+        for (size_t c = 0; c < 4; c++) {
+            mC[r * 4 + c] = ocd[r * 4 + c]; /* contiguous: phys == logical */
+            mT[r * 4 + c] = otd[c * 2 + r]; /* transposed: logical (r,c) -> phys c*2+r */
+        }
+    }
+    float scaleC = symScaleOf(outC);
+    float scaleT = symScaleOf(outT);
+
+    freeQuantization(bq);
+    freeQuantization(fq);
+    freeReservedMemory(normShape);
+    freeParameter(beta);
+    freeParameter(gamma);
+    freeTensor(outT);
+    freeTensor(inT);
+    freeTensor(outC);
+    freeTensor(inC);
+
+    TEST_ASSERT_EQUAL_FLOAT(scaleC, scaleT);
+    for (size_t i = 0; i < 8; i++) {
+        TEST_ASSERT_EQUAL_INT(mC[i], mT[i]);
+    }
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(testConfigStructIsPopulated);
@@ -1091,5 +1329,10 @@ int main(void) {
     RUN_TEST(testSymForwardConstantInputEmitsZeros);
     RUN_TEST(testSymForwardMantissaInvariantsViaOnesGamma);
     RUN_TEST(testSymForwardConstantInputAppliesBeta);
+    RUN_TEST(testSymGoldParityMultiGroup);
+    RUN_TEST(testSymGoldAffine);
+    RUN_TEST(testSymGoldSigmaRatio10x);
+    RUN_TEST(testSymForwardVarNearEpsReconstructsHalf);
+    RUN_TEST(testSymForwardTransposedMatchesContiguous);
     return UNITY_END();
 }

--- a/test/unit/layer/UnitTestLayerNorm.c
+++ b/test/unit/layer/UnitTestLayerNorm.c
@@ -2,6 +2,7 @@
 
 #include <math.h>
 #include <stdbool.h>
+#include <stdint.h>
 #include <stdlib.h>
 
 #include "Arithmetic.h"
@@ -45,6 +46,37 @@ static parameter_t *buildFloatParam(size_t numDims, const size_t *dimsIn, const 
     tensor_t *p = buildFloatTensorND(numDims, dimsIn, vals);
     tensor_t *g = gradInitFloat(p, NULL);
     return parameterInit(p, g);
+}
+
+/* Build a SYM_INT32 (HTE, qMaxBits=16) tensor; float vals are quantized via
+ * tensorFillFromFloatBuffer -> convertFloatTensorToSymInt32Tensor (absmax ->
+ * scale, round-clamp; absmax==0 -> scale 1.0). NULL vals -> zero mantissas,
+ * default scale 1.0. Caller frees via freeTensor. */
+static tensor_t *buildSymInt32TensorND(size_t numDims, const size_t *dimsIn, const float *vals) {
+    size_t *dims = reserveMemory(numDims * sizeof(size_t));
+    for (size_t i = 0; i < numDims; i++) {
+        dims[i] = dimsIn[i];
+    }
+    size_t *order = reserveMemory(numDims * sizeof(size_t));
+    setOrderOfDimsForNewTensor(numDims, order);
+    shape_t *shape = reserveMemory(sizeof(shape_t));
+    setShape(shape, dims, numDims, order);
+    tensor_t *t = initTensor(shape, quantizationInitSymInt32(HTE), NULL);
+    if (vals != NULL) {
+        tensorFillFromFloatBuffer(t, vals, calcNumberOfElementsByShape(shape));
+    }
+    return t;
+}
+
+/* SYM_INT32 parameter with SYM_INT32 grad (grads unused in forward-only tests). */
+static parameter_t *buildSymParam(size_t numDims, const size_t *dimsIn, const float *vals) {
+    tensor_t *p = buildSymInt32TensorND(numDims, dimsIn, vals);
+    tensor_t *g = gradInitSymInt32(p, HTE, NULL);
+    return parameterInit(p, g);
+}
+
+static float symScaleOf(tensor_t *t) {
+    return ((symInt32QConfig_t *)t->quantization->qConfig)->scale;
 }
 
 void testConfigStructIsPopulated(void) {
@@ -115,6 +147,66 @@ static layer_t makeLayerNormLayer(layerNormConfig_t *cfg, layerConfig_t *lcfg) {
     lcfg->layerNorm = cfg;
     layer_t layer = {.type = LAYERNORM, .config = lcfg};
     return layer;
+}
+
+/* Dequant-domain invariants (gamma=1, beta=0): per-group dequantized mean ~ 0,
+ * per-group dequantized variance ~ var/(var+eps) (PyTorch eps behavior).
+ * Affine-stable: with gamma=ones the dequantized values are unchanged by the
+ * Task-3 affine stage (mantissa*32767 and scale/32767 cancel). */
+void testSymForwardDequantInvariantsMultiGroup(void) {
+    size_t dims[] = {2, 4};
+    tensor_t *in =
+        buildSymInt32TensorND(2, dims, (float[]){1.f, 2.f, 3.f, 4.f, 10.f, 20.f, 30.f, 40.f});
+    tensor_t *out = buildSymInt32TensorND(2, dims, NULL);
+
+    size_t ns[] = {4};
+    parameter_t *gamma = buildSymParam(1, ns, (float[]){1.f, 1.f, 1.f, 1.f});
+    parameter_t *beta = buildSymParam(1, ns, (float[]){0.f, 0.f, 0.f, 0.f});
+    size_t *normShape = reserveMemory(sizeof(size_t));
+    normShape[0] = 4;
+
+    quantization_t *fq = quantizationInitSymInt32(HTE);
+    quantization_t *bq = quantizationInitFloat();
+    layerNormConfig_t cfg;
+    initLayerNormConfig(&cfg, gamma, beta, normShape, 1, 1e-5f, fq, bq);
+    layerConfig_t lcfg;
+    layer_t layer = makeLayerNormLayer(&cfg, &lcfg);
+
+    layerNormForward(&layer, in, out);
+
+    float scale = symScaleOf(out);
+    int32_t *m = (int32_t *)out->data;
+    float groupMean[2];
+    float groupVar[2];
+    for (size_t g = 0; g < 2; g++) {
+        float mean = 0.f;
+        for (size_t j = 0; j < 4; j++) {
+            mean += (float)m[g * 4 + j] * scale;
+        }
+        mean /= 4.f;
+        float var = 0.f;
+        for (size_t j = 0; j < 4; j++) {
+            float d = (float)m[g * 4 + j] * scale - mean;
+            var += d * d;
+        }
+        groupMean[g] = mean;
+        groupVar[g] = var / 4.f;
+    }
+
+    freeQuantization(bq);
+    freeQuantization(fq);
+    freeReservedMemory(normShape);
+    freeParameter(beta);
+    freeParameter(gamma);
+    freeTensor(out);
+    freeTensor(in);
+
+    /* var/(var+eps): row0 1.25/(1.25+1e-5)=0.999992; row1 125/(125+1e-5)~1.0.
+     * Tolerances absorb input quantization noise (s_x = 40/32767 ~ 1.2e-3). */
+    TEST_ASSERT_FLOAT_WITHIN(1e-3f, 0.f, groupMean[0]);
+    TEST_ASSERT_FLOAT_WITHIN(1e-3f, 0.f, groupMean[1]);
+    TEST_ASSERT_FLOAT_WITHIN(5e-3f, 0.999992f, groupVar[0]);
+    TEST_ASSERT_FLOAT_WITHIN(5e-3f, 1.0f, groupVar[1]);
 }
 
 /* Derivation for testForwardFloatSingleGroup:
@@ -820,6 +912,157 @@ void testGoldBackwardFullRank(void) {
                     gamma_layerNorm_fullRank_len);
 }
 
+/* Constant input -> yhat == 0 exactly in every group (identical mantissas), so
+ * the GLOBAL absmax is 0. Guard: all-zero mantissas, normalization-stage scale
+ * 1.0 (convertFloatTensorToSymInt32Tensor absMax==0 idiom). */
+void testSymForwardConstantInputEmitsZeros(void) {
+    size_t dims[] = {2, 3};
+    tensor_t *in = buildSymInt32TensorND(2, dims, (float[]){7.f, 7.f, 7.f, 7.f, 7.f, 7.f});
+    tensor_t *out = buildSymInt32TensorND(2, dims, NULL);
+
+    size_t ns[] = {3};
+    parameter_t *gamma = buildSymParam(1, ns, (float[]){1.f, 1.f, 1.f});
+    parameter_t *beta = buildSymParam(1, ns, (float[]){0.f, 0.f, 0.f});
+    size_t *normShape = reserveMemory(sizeof(size_t));
+    normShape[0] = 3;
+
+    quantization_t *fq = quantizationInitSymInt32(HTE);
+    quantization_t *bq = quantizationInitFloat();
+    layerNormConfig_t cfg;
+    initLayerNormConfig(&cfg, gamma, beta, normShape, 1, 1e-5f, fq, bq);
+    layerConfig_t lcfg;
+    layer_t layer = makeLayerNormLayer(&cfg, &lcfg);
+
+    layerNormForward(&layer, in, out);
+
+    int32_t mantissas[6];
+    for (size_t i = 0; i < 6; i++) {
+        mantissas[i] = ((int32_t *)out->data)[i];
+    }
+    float scale = symScaleOf(out);
+
+    freeQuantization(bq);
+    freeQuantization(fq);
+    freeReservedMemory(normShape);
+    freeParameter(beta);
+    freeParameter(gamma);
+    freeTensor(out);
+    freeTensor(in);
+
+    for (size_t i = 0; i < 6; i++) {
+        TEST_ASSERT_EQUAL_INT(0, mantissas[i]);
+    }
+    TEST_ASSERT_TRUE(scale > 0.0f);
+}
+
+/* The affine with gamma=ones multiplies every normalized mantissa by exactly
+ * 32767. Recover qNorm = y_q/32767 (remainder must be 0 — pins that the gamma
+ * multiply actually happened) and assert the normalization-stage invariants:
+ * full-range stretch (max |qNorm| == 32767) and near-zero per-group mantissa
+ * sums (Σ n == 0 exactly in real arithmetic; rounding adds <= 0.5/element). */
+void testSymForwardMantissaInvariantsViaOnesGamma(void) {
+    size_t dims[] = {2, 4};
+    tensor_t *in =
+        buildSymInt32TensorND(2, dims, (float[]){1.f, 2.f, 3.f, 4.f, 10.f, 20.f, 30.f, 40.f});
+    tensor_t *out = buildSymInt32TensorND(2, dims, NULL);
+
+    size_t ns[] = {4};
+    parameter_t *gamma = buildSymParam(1, ns, (float[]){1.f, 1.f, 1.f, 1.f});
+    parameter_t *beta = buildSymParam(1, ns, (float[]){0.f, 0.f, 0.f, 0.f});
+    size_t *normShape = reserveMemory(sizeof(size_t));
+    normShape[0] = 4;
+
+    quantization_t *fq = quantizationInitSymInt32(HTE);
+    quantization_t *bq = quantizationInitFloat();
+    layerNormConfig_t cfg;
+    initLayerNormConfig(&cfg, gamma, beta, normShape, 1, 1e-5f, fq, bq);
+    layerConfig_t lcfg;
+    layer_t layer = makeLayerNormLayer(&cfg, &lcfg);
+
+    layerNormForward(&layer, in, out);
+
+    int32_t m[8];
+    for (size_t i = 0; i < 8; i++) {
+        m[i] = ((int32_t *)out->data)[i];
+    }
+
+    freeQuantization(bq);
+    freeQuantization(fq);
+    freeReservedMemory(normShape);
+    freeParameter(beta);
+    freeParameter(gamma);
+    freeTensor(out);
+    freeTensor(in);
+
+    int32_t qNorm[8];
+    int32_t maxAbs = 0;
+    for (size_t i = 0; i < 8; i++) {
+        TEST_ASSERT_EQUAL_INT(0, m[i] % 32767);
+        qNorm[i] = m[i] / 32767;
+        int32_t a = (qNorm[i] < 0) ? -qNorm[i] : qNorm[i];
+        if (a > maxAbs) {
+            maxAbs = a;
+        }
+    }
+    TEST_ASSERT_EQUAL_INT(32767, maxAbs);
+    for (size_t g = 0; g < 2; g++) {
+        int32_t sum = 0;
+        for (size_t j = 0; j < 4; j++) {
+            sum += qNorm[g * 4 + j];
+        }
+        TEST_ASSERT_TRUE(sum >= -4 && sum <= 4);
+    }
+}
+
+/* Constant input + nonzero beta: y = gamma*0 + beta. Pins (a) the affine runs
+ * AFTER the constant guard, (b) the beta-rescale idiom (raw beta_q would
+ * dequantize to 2x the right value here since s_beta = 0.5/32767 != s_y), and
+ * (c) the post-affine output scale s_y = s_norm * s_gamma = 1/32767. */
+void testSymForwardConstantInputAppliesBeta(void) {
+    size_t dims[] = {2, 3};
+    tensor_t *in = buildSymInt32TensorND(2, dims, (float[]){7.f, 7.f, 7.f, 7.f, 7.f, 7.f});
+    tensor_t *out = buildSymInt32TensorND(2, dims, NULL);
+
+    size_t ns[] = {3};
+    parameter_t *gamma = buildSymParam(1, ns, (float[]){1.f, 1.f, 1.f});
+    parameter_t *beta = buildSymParam(1, ns, (float[]){0.5f, -0.25f, 0.125f});
+    size_t *normShape = reserveMemory(sizeof(size_t));
+    normShape[0] = 3;
+
+    quantization_t *fq = quantizationInitSymInt32(HTE);
+    quantization_t *bq = quantizationInitFloat();
+    layerNormConfig_t cfg;
+    initLayerNormConfig(&cfg, gamma, beta, normShape, 1, 1e-5f, fq, bq);
+    layerConfig_t lcfg;
+    layer_t layer = makeLayerNormLayer(&cfg, &lcfg);
+
+    layerNormForward(&layer, in, out);
+
+    float deq[6];
+    float scale = symScaleOf(out);
+    for (size_t i = 0; i < 6; i++) {
+        deq[i] = (float)((int32_t *)out->data)[i] * scale;
+    }
+
+    freeQuantization(bq);
+    freeQuantization(fq);
+    freeReservedMemory(normShape);
+    freeParameter(beta);
+    freeParameter(gamma);
+    freeTensor(out);
+    freeTensor(in);
+
+    float expectedScale = 1.0f / 32767.0f;
+    TEST_ASSERT_FLOAT_WITHIN(expectedScale * 1e-4f, expectedScale, scale);
+    float expBeta[] = {0.5f, -0.25f, 0.125f};
+    for (size_t g = 0; g < 2; g++) {
+        for (size_t j = 0; j < 3; j++) {
+            /* total error <= s_beta/2 (beta storage) + s_y/2 (seed rounding) */
+            TEST_ASSERT_FLOAT_WITHIN(2.0f * expectedScale, expBeta[j], deq[g * 3 + j]);
+        }
+    }
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(testConfigStructIsPopulated);
@@ -844,5 +1087,9 @@ int main(void) {
     RUN_TEST(testGoldBackwardD2MultiGroup);
     RUN_TEST(testGoldForwardFullRank);
     RUN_TEST(testGoldBackwardFullRank);
+    RUN_TEST(testSymForwardDequantInvariantsMultiGroup);
+    RUN_TEST(testSymForwardConstantInputEmitsZeros);
+    RUN_TEST(testSymForwardMantissaInvariantsViaOnesGamma);
+    RUN_TEST(testSymForwardConstantInputAppliesBeta);
     return UNITY_END();
 }

--- a/test/unit/layer/generate_expected_layernorm_sym.py
+++ b/test/unit/layer/generate_expected_layernorm_sym.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""Generate expected_layernorm_sym.h for UnitTestLayerNorm (SYM_INT32 fwd, #148 PR-2).
+
+Emulates the C SYM_INT32 LayerNorm forward end-to-end in float64 (quantize
+inputs -> per-group stats from mantissas -> global absmax stretch -> separate
+affine with beta rescale) and emits the expected output mantissas + scale,
+plus the true PyTorch xhat for dequant-domain parity, per fixture.
+
+Self-checks:
+ - emitted float fixtures are dequantization-STABLE: re-quantizing them
+   reproduces the mantissas bit-exactly (so the C side's
+   tensorFillFromFloatBuffer lands on the same input mantissas);
+ - the emulated dequantized output matches F.layer_norm on the dequantized
+   inputs within the analytic quantization bound;
+ - parity fixtures keep absmax(xhat) <= 1.9, which guarantees the documented
+   3e-5 C-side xhat tolerance (s_norm/2 <= 1.9/65534 ~ 2.9e-5).
+
+Biased variance (/N) via explicit emulation + F.layer_norm; NEVER torch.var
+(ddof=1 default). Rounding: the framework's roundByMode(HTE) is implemented
+as C round() = half-AWAY-from-zero (Rounding.c, despite the HTE name; #188),
+so all rounding here uses round_half_away — NEVER torch.round (true
+half-to-even, which diverges on ties like 16382.5).
+Run via `uv run` (CMake wires this automatically).
+"""
+import argparse
+import sys
+from pathlib import Path
+
+import torch
+import torch.nn.functional as F
+
+QMAX = 32767.0
+QMIN = -32768.0
+
+
+def round_half_away(x: torch.Tensor) -> torch.Tensor:
+    """Match the C kernel: roundByMode(HTE) is C round() = half-away-from-zero
+    (Rounding.c — the HTE name is a misnomer, #188). torch.round would be true
+    half-to-even and silently diverge on .5 ties."""
+    return torch.sign(x) * torch.floor(torch.abs(x) + 0.5)
+
+
+def _format_float_literal(v: float) -> str:
+    s = repr(v)
+    if s in ("inf", "-inf", "nan"):
+        raise ValueError(f"non-finite gold value: {v!r}")
+    return s + "f"
+
+
+def emit_float_array(name: str, tensor: torch.Tensor) -> str:
+    flat = tensor.detach().flatten().tolist()
+    body = ", ".join(_format_float_literal(v) for v in flat)
+    return (
+        f"static const float {name}[] = {{ {body} }};\n"
+        f"static const size_t {name}_len = {len(flat)};\n"
+    )
+
+
+def emit_int32_array(name: str, tensor: torch.Tensor) -> str:
+    flat = [int(v) for v in tensor.detach().flatten().tolist()]
+    body = ", ".join(str(v) for v in flat)
+    return (
+        f"static const int32_t {name}[] = {{ {body} }};\n"
+        f"static const size_t {name}_len = {len(flat)};\n"
+    )
+
+
+def emit_float_scalar(name: str, v: float) -> str:
+    return f"static const float {name} = {_format_float_literal(float(v))};\n"
+
+
+def emit_int32_scalar(name: str, v: int) -> str:
+    return f"static const int32_t {name} = {int(v)};\n"
+
+
+def quantize_sym(x: torch.Tensor):
+    """convertFloatTensorToSymInt32Tensor: absmax -> scale (1.0 if absmax==0),
+    round-clamp with the C rounding (half-away-from-zero)."""
+    absmax = x.abs().max().item()
+    scale = 1.0 if absmax == 0.0 else absmax / QMAX
+    q = round_half_away(torch.clamp(x / scale, QMIN, QMAX))
+    return q.to(torch.int32), scale
+
+
+def stable_dequant(x: torch.Tensor):
+    """Quantize once; return (mantissas, scale, dequantized float32 fixture).
+    The EMITTED float32 fixture is asserted ROUND-TRIP STABLE: re-quantizing
+    it reproduces the same mantissas, so the C side's tensorFillFromFloatBuffer
+    lands on exactly these mantissas."""
+    q, s = quantize_sym(x.to(torch.float64))
+    deq32 = (q.to(torch.float64) * s).to(torch.float32)
+    q2, _ = quantize_sym(deq32.to(torch.float64))
+    assert torch.equal(q, q2), "fixture is not dequantization round-trip stable"
+    return q, s, deq32
+
+
+def emulate_sym_forward(xq, sx, gq, sg, bq, sb, normalized_shape, eps):
+    """Float64 emulation of layerNormForwardSymInt32 + layerNormAffineSymInt32."""
+    n_inner = 1
+    for d in normalized_shape:
+        n_inner *= d
+    groups = xq.numel() // n_inner
+    xqr = xq.reshape(groups, n_inner).to(torch.float64)
+    mean = sx * xqr.sum(dim=1, keepdim=True) / n_inner  # int sum, then scale
+    yhat = xqr * sx - mean
+    var = (yhat ** 2).mean(dim=1, keepdim=True)  # biased /N
+    inv_sigma = 1.0 / torch.sqrt(var + eps)  # eps INSIDE sqrt
+    n = yhat * inv_sigma
+    absmax = n.abs().max().item()
+    if absmax == 0.0:
+        s_norm = 1.0
+        q = torch.zeros_like(n)
+    else:
+        k = QMAX / absmax
+        s_norm = 1.0 / k
+        q = round_half_away(torch.clamp(n * k, QMIN, QMAX))
+    s_y = s_norm * sg
+    seed = round_half_away(bq.to(torch.float64) * (sb / s_y)).reshape(1, n_inner)
+    yq = q * gq.reshape(1, n_inner).to(torch.float64) + seed
+    var_ratio = (var / (var + eps)).flatten()
+    return yq.to(torch.int32).reshape(xq.shape), s_y, s_norm, var_ratio
+
+
+def _run_fixture(name, x, gamma, beta, normalized_shape, *, eps=1e-5,
+                 require_parity=False):
+    xq, sx, x_deq = stable_dequant(x)
+    gq, sg, g_deq = stable_dequant(gamma)
+    bq, sb, b_deq = stable_dequant(beta)
+
+    yq, s_y, s_norm, var_ratio = emulate_sym_forward(
+        xq, sx, gq, sg, bq, sb, normalized_shape, eps)
+
+    # True PyTorch reference ON THE DEQUANTIZED inputs (removes input-quant
+    # error from the comparison entirely).
+    ref = F.layer_norm(x_deq.to(torch.float64), normalized_shape,
+                       weight=g_deq.to(torch.float64),
+                       bias=b_deq.to(torch.float64), eps=eps)
+    xhat = F.layer_norm(x_deq.to(torch.float64), normalized_shape, eps=eps)
+
+    # Self-check: emulated dequant vs F.layer_norm within the analytic bound
+    # (n rounding <= 0.5 LSB * |gamma|, seed rounding <= 0.5 LSB; 1.5x margin).
+    gmax = g_deq.abs().max().item()
+    bound = (0.5 * s_norm * gmax + 0.5 * s_y) * 1.5 + 1e-7
+    err = (yq.to(torch.float64) * s_y - ref).abs().max().item()
+    assert err <= bound, f"{name}: emulation vs F.layer_norm {err} > {bound}"
+
+    if require_parity:
+        a = xhat.abs().max().item()
+        assert a <= 1.9, f"{name}: absmax(xhat)={a} > 1.9 breaks the 3e-5 tol"
+
+    # C-vs-emulation: float32 stats noise can flip a rounding boundary by
+    # +-2 LSB of q, scaled by gamma_q, +-1 on the seed.
+    mantissa_tol = 2 * int(gq.abs().max().item()) + 1
+    dequant_tol = bound + mantissa_tol * s_y
+
+    return {
+        "name": name,
+        "x": x_deq, "gamma": g_deq, "beta": b_deq,
+        "mantissas": yq, "scale": s_y,
+        "mantissa_tol": mantissa_tol, "dequant_tol": dequant_tol,
+        "dequant": ref.to(torch.float32),
+        "xhat": xhat.to(torch.float32) if require_parity else None,
+        "var_ratio": var_ratio.to(torch.float32),
+    }
+
+
+def fixture_sym_parity():
+    # [3,4], D=1, G=3, gamma=1/beta=0: pure normalization. N=4 (N>=3: avoids
+    # the N=2 saturation trap). Hand values keep absmax(xhat) <= 1.9.
+    x = torch.tensor([[0.1, -0.4, 0.7, 1.2],
+                      [2.0, 1.0, -1.5, 0.5],
+                      [-0.3, -0.8, 0.2, 0.9]], dtype=torch.float64)
+    return _run_fixture("symParity", x, torch.ones(4, dtype=torch.float64),
+                        torch.zeros(4, dtype=torch.float64), [4],
+                        require_parity=True)
+
+
+def fixture_sym_affine():
+    # [2,4], non-trivial gamma/beta with deliberately different scales:
+    # s_gamma = 2/32767, s_beta = 0.05/32767 — the beta rescale MUST matter.
+    x = torch.tensor([[0.2, -1.0, 0.6, 1.4],
+                      [1.0, 3.0, -2.0, 0.0]], dtype=torch.float64)
+    gamma = torch.tensor([1.5, -0.5, 2.0, 0.25], dtype=torch.float64)
+    beta = torch.tensor([0.05, -0.0125, 0.025, -0.05], dtype=torch.float64)
+    return _run_fixture("symAffine", x, gamma, beta, [4])
+
+
+def fixture_sym_sigma_ratio():
+    # [2,4], per-group sigma differs ~22x (0.354 vs 7.9): pins that the
+    # per-group 1/sigma_g hits the DATA — a single folded sigma is ~20x off
+    # for one of the groups. Values are x10 the obvious choice so the low-var
+    # group keeps var = 0.125 >> eps: eps mutations stay INVISIBLE here
+    # (division of labor — Task 6 owns eps visibility). gamma=1/beta=0.
+    x = torch.tensor([[4.5, 5.0, 5.5, 5.0],
+                      [-10.0, 10.0, 5.0, -5.0]], dtype=torch.float64)
+    return _run_fixture("symSigmaRatio", x, torch.ones(4, dtype=torch.float64),
+                        torch.zeros(4, dtype=torch.float64), [4],
+                        require_parity=True)
+
+
+def emit_fixture(parts, fx):
+    pre = f"layerNormSym_{fx['name']}"
+    parts.append(emit_float_array(f"input_{pre}", fx["x"]))
+    parts.append(emit_float_array(f"gamma_{pre}", fx["gamma"]))
+    parts.append(emit_float_array(f"beta_{pre}", fx["beta"]))
+    parts.append(emit_int32_array(f"expectedMantissas_{pre}", fx["mantissas"]))
+    parts.append(emit_float_scalar(f"expectedScale_{pre}", fx["scale"]))
+    parts.append(emit_int32_scalar(f"mantissaTol_{pre}", fx["mantissa_tol"]))
+    parts.append(emit_float_array(f"expectedDequant_{pre}", fx["dequant"]))
+    parts.append(emit_float_scalar(f"dequantTol_{pre}", fx["dequant_tol"]))
+    if fx["xhat"] is not None:
+        parts.append(emit_float_array(f"expectedXhat_{pre}", fx["xhat"]))
+    parts.append(emit_float_array(f"expectedGroupVarRatio_{pre}", fx["var_ratio"]))
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out", required=True, type=Path)
+    args = ap.parse_args()
+
+    parts = [
+        "// AUTOGENERATED by generate_expected_layernorm_sym.py — DO NOT EDIT\n",
+        "#ifndef ODT_EXPECTED_LAYERNORM_SYM_H\n",
+        "#define ODT_EXPECTED_LAYERNORM_SYM_H\n",
+        "#include <stdint.h>\n",
+        "#include <stdlib.h>\n\n",
+    ]
+
+    for fx in [fixture_sym_parity(), fixture_sym_affine(), fixture_sym_sigma_ratio()]:
+        emit_fixture(parts, fx)
+
+    parts.append("\n#endif // ODT_EXPECTED_LAYERNORM_SYM_H\n")
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text("".join(parts))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/unit/userAPI/CMakeLists.txt
+++ b/test/unit/userAPI/CMakeLists.txt
@@ -66,6 +66,10 @@ add_elastic_ai_unit_test(
         TensorApi
         LinearApi
         ReluApi
+        LayerNormApi
+        LayerNorm
+        LayerQuant
+        Quantization
         QuantizationApi
         LossFunction
         DataLoader

--- a/test/unit/userAPI/UnitTestInferenceApi.c
+++ b/test/unit/userAPI/UnitTestInferenceApi.c
@@ -1,7 +1,13 @@
+#include <stdbool.h>
+#include <stdint.h>
+
 #include "InferenceApi.h"
 #include "Layer.h"
+#include "LayerNormApi.h"
+#include "LayerQuant.h"
 #include "LinearApi.h"
 #include "LossFunction.h"
+#include "Quantization.h"
 #include "QuantizationApi.h"
 #include "ReluApi.h"
 #include "StorageApi.h"
@@ -251,6 +257,52 @@ void testInferenceWithLossLinearReluFloat() {
     TEST_ASSERT_EQUAL_FLOAT_ARRAY(expectedOutput, capturedOutput, 2);
 }
 
+void testInferenceLayerNormSymInt32(void) {
+    size_t normShape[] = {4};
+    layerNormInit_t init = {.normalizedShape = normShape, .numNormDims = 1, .eps = 1e-5f};
+
+    quantization_t *symQ = quantizationInitSymInt32(HTE);
+    quantization_t *bwd = quantizationInitFloat();
+    layerQuant_t lq = {
+        .forwardMath = symQ, .backwardMath = bwd, .weightStorage = symQ, .biasStorage = symQ};
+    layer_t *ln = layerNormLayerInitOwning(&init, &lq);
+    freeQuantization(bwd);
+    freeQuantization(symQ);
+    layer_t *model[] = {ln};
+
+    /* [2,4] SYM input — int16-range mantissas by construction (NOT a Linear
+     * output; Linear SYM outputs are accumulator-range and would violate the
+     * LayerNorm input contract — open inter-layer requantization question
+     * for the quantized-training epic, #137). */
+    size_t *inDims = reserveMemory(2 * sizeof(size_t));
+    inDims[0] = 2;
+    inDims[1] = 4;
+    size_t *inOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, inOrder);
+    shape_t *inShape = reserveMemory(sizeof(shape_t));
+    setShape(inShape, inDims, 2, inOrder);
+    tensor_t *input = initTensor(inShape, quantizationInitSymInt32(HTE), NULL);
+    tensorFillFromFloatBuffer(input, (float[]){1.f, 2.f, 3.f, 4.f, 10.f, 20.f, 30.f, 40.f}, 8);
+
+    tensor_t *output = inference(model, 1, input);
+
+    bool typeOk = (output->quantization->type == SYM_INT32);
+    float scale = ((symInt32QConfig_t *)output->quantization->qConfig)->scale;
+    float deqMean = 0.f;
+    for (size_t i = 0; i < 8; i++) {
+        deqMean += (float)((int32_t *)output->data)[i] * scale;
+    }
+    deqMean /= 8.f;
+
+    freeTensor(output); /* inference() returns a heap tensor — caller owns. */
+    freeTensor(input);
+    freeLayerNormLayer(ln);
+
+    TEST_ASSERT_TRUE(typeOk);
+    TEST_ASSERT_TRUE(scale > 0.0f && scale < 1e-3f);
+    TEST_ASSERT_FLOAT_WITHIN(1e-3f, 0.f, deqMean);
+}
+
 void setUp() {}
 void tearDown() {}
 
@@ -258,6 +310,7 @@ int main(void) {
     UNITY_BEGIN();
     RUN_TEST(testInferenceLinearReluFloat);
     RUN_TEST(testInferenceLinearReluSymInt32);
+    RUN_TEST(testInferenceLayerNormSymInt32);
 
     RUN_TEST(testInferenceWithLossLinearReluFloat);
     return UNITY_END();

--- a/test/unit/userAPI/UnitTestLayerWeightsApi.c
+++ b/test/unit/userAPI/UnitTestLayerWeightsApi.c
@@ -191,6 +191,51 @@ void testLayerLoadWeightsLayerNormOverwritesGammaAndBeta(void) {
     freeQuantization(q);
 }
 
+void testLayerLoadWeightsLayerNormQuantizesForSymStorage(void) {
+    size_t normShape[] = {3};
+    layerNormInit_t init = {.normalizedShape = normShape, .numNormDims = 1, .eps = 1e-5f};
+
+    quantization_t *symQ = quantizationInitSymInt32(HTE);
+    quantization_t *bwd = quantizationInitFloat();
+    layerQuant_t lq = {
+        .forwardMath = symQ, .backwardMath = bwd, .weightStorage = symQ, .biasStorage = symQ};
+    layer_t *layer = layerNormLayerInit(&init, &lq);
+
+    float gammaData[3] = {2.f, 3.f, 4.f};
+    float betaData[3] = {-1.f, -2.f, -3.f};
+    layerLoadWeights(layer, gammaData, betaData);
+
+    layerNormConfig_t *cfg = layer->config->layerNorm;
+    int32_t g[3];
+    int32_t b[3];
+    for (size_t i = 0; i < 3; i++) {
+        g[i] = ((int32_t *)cfg->gamma->param->data)[i];
+        b[i] = ((int32_t *)cfg->beta->param->data)[i];
+    }
+    float gScale = ((symInt32QConfig_t *)cfg->gamma->param->quantization->qConfig)->scale;
+    float bScale = ((symInt32QConfig_t *)cfg->beta->param->quantization->qConfig)->scale;
+
+    freeLayerNormLayer(layer);
+    freeQuantization(bwd);
+    freeQuantization(symQ);
+
+    /* gamma absmax 4 -> scale 4/32767; mantissas round(v*32767/4):
+     * 16383.5 -> 16384 (half-away-from-zero: the framework's roundHTE is C
+     * round() — see #188), 24575.25 -> 24575, 32767 exact. INT_WITHIN(1)
+     * on the non-absmax elements (float division may land a hair off the
+     * exact midpoint); exact on the absmax element. */
+    TEST_ASSERT_FLOAT_WITHIN(1e-9f, 4.0f / 32767.0f, gScale);
+    TEST_ASSERT_INT_WITHIN(1, 16384, g[0]);
+    TEST_ASSERT_INT_WITHIN(1, 24575, g[1]);
+    TEST_ASSERT_EQUAL_INT(32767, g[2]);
+    /* beta absmax 3 -> scale 3/32767; round(-10922.33) = -10922,
+     * round(-21844.67) = -21845, -32767 exact. */
+    TEST_ASSERT_FLOAT_WITHIN(1e-9f, 3.0f / 32767.0f, bScale);
+    TEST_ASSERT_INT_WITHIN(1, -10922, b[0]);
+    TEST_ASSERT_INT_WITHIN(1, -21845, b[1]);
+    TEST_ASSERT_EQUAL_INT(-32767, b[2]);
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(testLayerLoadWeightsLinearOverwritesWeightAndBiasTensors);
@@ -199,5 +244,6 @@ int main(void) {
     RUN_TEST(testLayerLoadWeightsConv1dNoBiasAcceptsNullBiasData);
     RUN_TEST(testLayerLoadWeightsConv1dTransposedOverwritesWeightAndBiasTensors);
     RUN_TEST(testLayerLoadWeightsLayerNormOverwritesGammaAndBeta);
+    RUN_TEST(testLayerLoadWeightsLayerNormQuantizesForSymStorage);
     return UNITY_END();
 }


### PR DESCRIPTION
Part 2 of 3 for #148 (PR-1: #185, FLOAT32 — merged). Implements the spec-verified **SYM_INT32 LayerNorm forward** (native quantized path, not Softmax's convert-to-float shortcut). SYM_INT32 backward is PR-3 (depends on #187).

## The scheme (verified scale-folding)

Per group: float μ/σ from **int32 mantissa sums** (int16-range contract, `qMaxBits ≤ 16` guards; no int64). Normalize in float, then **one GLOBAL absmax stretch** to ±32767 with a single per-tensor output scale `s_norm = 1/K` — multi-group requires the per-group `1/σ_g` to hit the *data*, only the global stretch lives in the scale. Per-group reconstructed variance is `var/(var+eps)` — exactly PyTorch's eps behavior. The affine `γ·n+β` is a **separate in-place quantized stage**: `s_y = s_norm·s_γ`, β rescaled into `s_y` (matmul bias-seed idiom), with a NaN-robust fail-fast guard against the data-dependent seed overflow (#189). Two-pass, recompute-over-store — the kernel allocates nothing.

## Contents

- **Kernel** (`src/layer/LayerNorm.c`): SYM stats helper (PR-3's backward must recompute through it), forward kernel, constant-input guard (integer all-constant fast-path — FP contraction makes exact float cancellation unreliable — plus float `absMax==0` backstop), affine stage, FLOAT32-backward fail-fast against SYM tensors (until PR-3, #187).
- **Factories** (`LayerNormApi.c`): SYM_INT32 γ/β storage (γ=1 → mantissa 32767, scale 1/32767; β=0 → mantissa 0, scale 1.0); constant init via `tensorFillFromFloatBuffer` (replaces FLOAT32-only `initDistribution`); new validation: storage dtypes must match `forwardMath`.
- **`layerLoadWeights`**: LAYERNORM case routes through `tensorFillFromFloatBuffer` — the raw `memcpy` silently reinterpreted float bits as mantissas under SYM storage (memcpy-equivalent for FLOAT32).
- **Tests** (10 new): PyTorch **pipeline emulator** (`generate_expected_layernorm_sym.py`, self-checking, half-away-from-zero rounding matching the actual `roundByMode(HTE)` implementation — see #188) with mantissa-exact gold parity and **3e-5 xhat parity vs PyTorch**; var≈eps fixture (the only regime where eps placement and input-scale handling are visible); transposed-layout bit-identity; factory/loadweights/InferenceApi integration. Every behavioral test mutation-verified (16 distinct mutations across the suite, each killed by a named assertion).

## Verification

- 59/59 ctest, 22/22 pytest, `clang-format --dry-run --Werror` clean; all three commits build and pass individually (bisect-safe).
- ASan/UBSan deferred to Linux CI (macOS ASan init hang on the dev host).

## Known residual edge (documented, fails loudly)

A per-GROUP-constant but globally non-constant input under FMA contraction (ARM target) leaves `absMax` at noise level instead of exactly 0; with β≠0 the seed-overflow guard then **aborts loudly** on a mathematically valid input. A per-group integer-constancy check would close this exactly — flagged for PR-3 planning alongside #189. Also out of scope here: inter-layer requantization (Linear SYM outputs are accumulator-range, outside LayerNorm's int16-range input contract — tracked under the #137 epic discussion).

## References

#148 (part 2 of 3) · #187 (backward guard) · #188 (rounding emulation) · #189 (seed-overflow guard; filed from this work) — intentionally no `Closes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
