### PR TITLE
feat: SYM_INT32 LayerNorm backward — recompute + strategy-A grads + dx requant (PR-3 of #148)

### DIFF
--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -338,3 +338,24 @@ grads, block/group scaling, …) → implement or improve a **published** techni
 Tracked as a separate research task. This note is intentionally public (not
 buried in a private spec) so contributors hitting accuracy issues in quantized
 training know this is a known, expected limitation rather than a bug.
+
+### Two accumulation schemes in-tree (both intentional)
+
+- **Strategy A (dynamic-rescale)** — Linear SYM weight grads and LayerNorm
+  gamma/beta grads: per-microbatch `addSymInt32TensorsInplace` (dequantize
+  both operands with their own scales, float-add, requantize the running sum
+  to a fresh absmax scale). Not float-free.
+- **Fixed-scale integer accumulation** — Linear SYM bias grads
+  (`linearCalcBiasGradsSymInt32`): increments are rescaled into the running
+  grad's EXISTING scale and added in integer arithmetic; the scale is never
+  re-derived during accumulation (float-free, following M. Deutel, F. Hannig,
+  C. Mutschler, J. Teich, "On-Device Training of Fully Quantized Deep Neural
+  Networks on Cortex-M Microcontrollers", IEEE TCAD, vol. 44, no. 4,
+  pp. 1250-1261, Apr. 2025, doi:10.1109/TCAD.2024.3484354, arXiv:2407.10734 —
+  the same paper #137 builds on). The coarser resolution (LSB pinned by the
+  running scale) is part of that design.
+
+This is a research framework: deliberate scheme differences like this one
+MUST be documented here, so experimental design stays separable from
+accidental inconsistency. LayerNorm uses strategy A for BOTH gamma and beta
+per the 2026-06-05 LayerNorm spec.

--- a/src/layer/CMakeLists.txt
+++ b/src/layer/CMakeLists.txt
@@ -71,6 +71,9 @@ target_include_directories(LayerNorm PUBLIC include)
 target_link_libraries(LayerNorm PRIVATE
         DTypes
         Tensor
+        TensorConversion
+        Quantization
+        Add
         Arithmetic
         Rounding
         Layer

--- a/src/layer/LayerNorm.c
+++ b/src/layer/LayerNorm.c
@@ -7,12 +7,14 @@
 
 #include "LayerNorm.h"
 
+#include "Add.h"
 #include "Arithmetic.h"
 #include "Common.h"
 #include "Layer.h"
 #include "Quantization.h"
 #include "Rounding.h"
 #include "Tensor.h"
+#include "TensorConversion.h"
 
 void initLayerNormConfig(layerNormConfig_t *cfg, parameter_t *gamma, parameter_t *beta,
                          size_t *normalizedShape, size_t numNormDims, float eps,
@@ -423,26 +425,204 @@ static void layerNormBackwardFloat(layerNormConfig_t *cfg, tensor_t *forwardInpu
     }
 }
 
+/* Quantize an N-element float grad increment into a stack SYM_INT32 scratch
+ * shaped like the grad tensor, then accumulate via addSymInt32TensorsInplace —
+ * Linear's SYM weight-grad idiom (linearCalcWeightGradsSymInt32): the
+ * addSymInt32TensorsInplace stage is the EXACT same strategy-A dynamic-rescale
+ * path (docs/CONVENTIONS.md "Quantized gradient accumulation") — dequantize
+ * both operands with their own scales, float-add, requantize the running sum
+ * to a fresh absmax-derived scale written into the grad's qConfig. The
+ * increment-quantization stage is LayerNorm-specific: Linear's increments are
+ * natively SYM (matmul product scale); ours are float and get a fresh absmax
+ * scale here. Deliberately NOT Linear's bias-grad idiom — that one is an
+ * intentional fixed-scale integer-accumulation research design (Deutel-style
+ * float-free accumulation; see CONVENTIONS.md "Two accumulation schemes
+ * in-tree"), while the LayerNorm spec mandates strategy A for BOTH gamma and
+ * beta grads. The increment
+ * quantization (convertTensor -> convertFloatTensorToSymInt32Tensor: absmax ->
+ * scale, absmax==0 -> 1.0, round-clamp) adds <= 0.5 increment-LSB of noise per
+ * call — same documented strategy-A open problem, no new scheme. */
+static void layerNormAccumulateGradSymInt32(tensor_t *grad, float *inc, size_t N) {
+    quantization_t floatQ;
+    initFloat32Quantization(&floatQ);
+    tensor_t incFloat;
+    setTensorValues(&incFloat, (uint8_t *)inc, grad->shape, &floatQ, grad->sparsity);
+
+    symInt32QConfig_t *gradQC = grad->quantization->qConfig;
+    int32_t incSymData[N];
+    symInt32QConfig_t incSymQC;
+    initSymInt32QConfig(gradQC->roundingMode, &incSymQC);
+    quantization_t incSymQ;
+    initSymInt32Quantization(&incSymQC, &incSymQ);
+    tensor_t incSym;
+    setTensorValues(&incSym, (uint8_t *)incSymData, grad->shape, &incSymQ, grad->sparsity);
+
+    convertTensor(&incFloat, &incSym);
+    addSymInt32TensorsInplace(grad, &incSym);
+}
+
+/* SYM_INT32 backward (spec 2026-06-05, verified scheme). mu/sigma/n are
+ * RECOMPUTED from forwardInput through layerNormGroupStatsSymInt32 — the SAME
+ * helper the forward uses, so backward can never desync from the forward
+ * definition (no cache). dy and gamma are dequantized per element via their
+ * own scales (float math; dy/gamma mantissas are never integer-summed — only
+ * forwardInput is subject to the int32 mantissa-sum bound).
+ * pass A: per-group recompute; grad increments (SUM over groups) + global
+ *         |dx| absmax (recompute-over-store, no scratch).
+ * pass B: recompute stats per group, recompute dx, quantize into propLoss via
+ *         the convertFloatTensorToSymInt32Tensor idiom (scale = absmax/qMax,
+ *         round-clamp; absmax==0 -> zeros, scale 1.0). The propLoss scale is
+ *         data-dependent and REFRESHED ON EVERY CALL. */
+static void layerNormBackwardSymInt32(layerNormConfig_t *cfg, tensor_t *forwardInput,
+                                      tensor_t *loss, tensor_t *propLoss) {
+    layerNormValidateSymTensor(forwardInput, "forwardInput");
+    layerNormValidateSymTensor(loss, "loss");
+    layerNormValidateSymTensor(propLoss, "propLoss");
+    layerNormValidateSymTensor(cfg->gamma->param, "gamma");
+    layerNormValidateSymTensor(cfg->gamma->grad, "gamma grad");
+    layerNormValidateSymTensor(cfg->beta->grad, "beta grad");
+    /* beta->param is never read here (beta does not enter dx; dbeta needs only
+     * dy) — deliberately not validated. */
+
+    int32_t *xq = (int32_t *)forwardInput->data;
+    int32_t *dyq = (int32_t *)loss->data;
+    int32_t *gammaQ = (int32_t *)cfg->gamma->param->data;
+    int32_t *dxq = (int32_t *)propLoss->data;
+    float inScale = ((symInt32QConfig_t *)forwardInput->quantization->qConfig)->scale;
+    float dyScale = ((symInt32QConfig_t *)loss->quantization->qConfig)->scale;
+    float gammaScale = ((symInt32QConfig_t *)cfg->gamma->param->quantization->qConfig)->scale;
+    symInt32QConfig_t *plQC = propLoss->quantization->qConfig;
+    const float qMax = powf(2, (float)plQC->qMaxBits - 1) - 1;
+    const float qMin = -powf(2, (float)plQC->qMaxBits - 1);
+
+    size_t G, N;
+    layerNormGroupSizes(forwardInput, cfg->numNormDims, &G, &N);
+    if (G == 0 || N == 0) {
+        plQC->scale = 1.0f; /* nothing to do; neutral scale (cf. #160, forward) */
+        return;
+    }
+
+    float dgammaInc[N];
+    float dbetaInc[N];
+    for (size_t j = 0; j < N; j++) {
+        dgammaInc[j] = 0.0f;
+        dbetaInc[j] = 0.0f;
+    }
+
+    float absMax = 0.0f;
+    /* Pass A: per-group recompute; grad increments (SUM over groups). */
+    for (size_t g = 0; g < G; g++) {
+        float mean;
+        float invSigma;
+        layerNormGroupStatsSymInt32(forwardInput, cfg->numNormDims, g, N, cfg->eps, inScale, &mean,
+                                    &invSigma);
+        float meanDn = 0.0f;
+        float meanDnN = 0.0f;
+        for (size_t j = 0; j < N; j++) {
+            size_t xoff = layerNormPhysOffset(forwardInput, cfg->numNormDims, g, j);
+            size_t dyoff = layerNormPhysOffset(loss, cfg->numNormDims, g, j);
+            float nval = ((float)xq[xoff] * inScale - mean) * invSigma;
+            float dyv = (float)dyq[dyoff] * dyScale;
+            dbetaInc[j] += dyv;         /* SUM over groups */
+            dgammaInc[j] += dyv * nval; /* SUM over groups */
+            float dn = dyv * ((float)gammaQ[j] * gammaScale);
+            meanDn += dn;
+            meanDnN += dn * nval;
+        }
+        meanDn /= (float)N;
+        meanDnN /= (float)N;
+        for (size_t j = 0; j < N; j++) {
+            size_t xoff = layerNormPhysOffset(forwardInput, cfg->numNormDims, g, j);
+            size_t dyoff = layerNormPhysOffset(loss, cfg->numNormDims, g, j);
+            float nval = ((float)xq[xoff] * inScale - mean) * invSigma;
+            float dn = ((float)dyq[dyoff] * dyScale) * ((float)gammaQ[j] * gammaScale);
+            float a = fabsf(invSigma * (dn - meanDn - nval * meanDnN));
+            if (a > absMax) {
+                absMax = a;
+            }
+        }
+    }
+
+    layerNormAccumulateGradSymInt32(cfg->gamma->grad, dgammaInc, N);
+    layerNormAccumulateGradSymInt32(cfg->beta->grad, dbetaInc, N);
+
+    /* dx requant: convertFloatTensorToSymInt32Tensor idiom (whole-tensor
+     * absmax -> scale -> round-clamp). NO integer dy==0 pre-check is needed
+     * (unlike the forward's constant-input case): the only realistic
+     * absmax==0 source is dy == 0, and zero PROPAGATES exactly through
+     * products and sums even under -ffp-contract=fast, so the float check is
+     * reliable here. */
+    if (absMax == 0.0f) {
+        for (size_t g = 0; g < G; g++) {
+            for (size_t j = 0; j < N; j++) {
+                dxq[layerNormPhysOffset(propLoss, cfg->numNormDims, g, j)] = 0;
+            }
+        }
+        plQC->scale = 1.0f;
+        return;
+    }
+
+    float dxScale = absMax / qMax;
+    /* Pass B: recompute and quantize. The dx expression is textually IDENTICAL
+     * to pass A's absmax expression so gcc's -ffp-contract=fast contracts both
+     * the same way; the clamp absorbs any residual divergence. The propLoss
+     * scale is data-dependent and REFRESHED ON EVERY CALL — a stale scale
+     * silently corrupts the downstream layer. */
+    for (size_t g = 0; g < G; g++) {
+        float mean;
+        float invSigma;
+        layerNormGroupStatsSymInt32(forwardInput, cfg->numNormDims, g, N, cfg->eps, inScale, &mean,
+                                    &invSigma);
+        float meanDn = 0.0f;
+        float meanDnN = 0.0f;
+        for (size_t j = 0; j < N; j++) {
+            size_t xoff = layerNormPhysOffset(forwardInput, cfg->numNormDims, g, j);
+            size_t dyoff = layerNormPhysOffset(loss, cfg->numNormDims, g, j);
+            float nval = ((float)xq[xoff] * inScale - mean) * invSigma;
+            float dyv = (float)dyq[dyoff] * dyScale;
+            float dn = dyv * ((float)gammaQ[j] * gammaScale);
+            meanDn += dn;
+            meanDnN += dn * nval;
+        }
+        meanDn /= (float)N;
+        meanDnN /= (float)N;
+        for (size_t j = 0; j < N; j++) {
+            size_t xoff = layerNormPhysOffset(forwardInput, cfg->numNormDims, g, j);
+            size_t dyoff = layerNormPhysOffset(loss, cfg->numNormDims, g, j);
+            float nval = ((float)xq[xoff] * inScale - mean) * invSigma;
+            float dn = ((float)dyq[dyoff] * dyScale) * ((float)gammaQ[j] * gammaScale);
+            float dxv = invSigma * (dn - meanDn - nval * meanDnN);
+            size_t dxoff = layerNormPhysOffset(propLoss, cfg->numNormDims, g, j);
+            dxq[dxoff] = roundByMode(clamp(dxv / dxScale, qMin, qMax), plQC->roundingMode);
+        }
+    }
+    plQC->scale = dxScale;
+}
+
 void layerNormBackward(layer_t *layer, tensor_t *forwardInput, tensor_t *loss, tensor_t *propLoss) {
     layerNormConfig_t *cfg = layer->config->layerNorm;
     layerNormValidateInputShape(cfg, forwardInput);
     switch (cfg->backwardQ->type) {
     case FLOAT32:
-        /* PR-2 allows SYM_INT32 forward configs; their backward lands in PR-3
-         * (#187 propLoss dtype asymmetry). Reading a SYM_INT32 forwardInput /
-         * loss / gamma as float* here would be silent garbage — fail fast. */
+        /* SYM_INT32 forwardMath + FLOAT32 backwardMath is an inference-only
+         * profile: reading a SYM_INT32 forwardInput / loss / gamma as float*
+         * here would be silent garbage — fail fast. Training a SYM forward
+         * requires backwardMath = SYM_INT32 (factory rule, PR-3). */
         if (forwardInput->quantization->type != FLOAT32 || loss->quantization->type != FLOAT32 ||
             cfg->gamma->param->quantization->type != FLOAT32) {
             PRINT_ERROR("LayerNorm backward: FLOAT32 backward requires FLOAT32 tensors "
-                        "(SYM_INT32 backward lands in PR-3, see #187)");
+                        "(SYM_INT32 forwardMath + FLOAT32 backwardMath is inference-only; "
+                        "use SYM_INT32 backwardMath to train)");
             exit(1);
         }
         layerNormBackwardFloat(cfg, forwardInput, loss, propLoss);
         break;
+    case SYM_INT32:
+        layerNormBackwardSymInt32(cfg, forwardInput, loss, propLoss);
+        break;
     default:
         PRINT_ERROR(
-            "LayerNorm backward: quantization type not implemented (FLOAT32 only until PR-3, see "
-            "#187)");
+            "LayerNorm backward: quantization type not implemented (FLOAT32/SYM_INT32 only)");
         exit(1);
     }
 }

--- a/src/userApi/layer/LayerNormApi.c
+++ b/src/userApi/layer/LayerNormApi.c
@@ -130,6 +130,19 @@ static void validateLayerQuantForLayerNorm(layerQuant_t *lq) {
         PRINT_ERROR("layerNormLayerInit: gamma/beta storage type must match forwardMath");
         exit(1);
     }
+    if (lq->backwardMath->type != FLOAT32 && lq->backwardMath->type != SYM_INT32) {
+        PRINT_ERROR("layerNormLayerInit: backwardMath must be FLOAT32 or SYM_INT32");
+        exit(1);
+    }
+    /* The SYM_INT32 backward recomputes group stats from forwardInput's int32
+     * mantissas and reads gamma mantissas; with a FLOAT32 forward those
+     * buffers hold float bits — silent garbage. The REVERSE (SYM forwardMath +
+     * FLOAT32 backwardMath) stays constructible: it is the inference-only
+     * profile, and the runtime backward guard rejects training it. */
+    if (lq->backwardMath->type == SYM_INT32 && lq->forwardMath->type != SYM_INT32) {
+        PRINT_ERROR("layerNormLayerInit: SYM_INT32 backwardMath requires SYM_INT32 forwardMath");
+        exit(1);
+    }
 }
 
 /* Shared scaffolding for both factories: validate, allocate the layer/config

--- a/test/unit/layer/CMakeLists.txt
+++ b/test/unit/layer/CMakeLists.txt
@@ -221,6 +221,18 @@ add_custom_command(
 add_custom_target(generate_expected_layernorm_sym
         DEPENDS ${GEN_LAYERNORM_SYM_HEADER})
 
+set(GEN_LAYERNORM_SYM_BWD_HEADER ${CMAKE_CURRENT_BINARY_DIR}/expected_layernorm_sym_bwd.h)
+add_custom_command(
+        OUTPUT ${GEN_LAYERNORM_SYM_BWD_HEADER}
+        COMMAND uv run ${CMAKE_CURRENT_SOURCE_DIR}/generate_expected_layernorm_sym_bwd.py
+                --out ${GEN_LAYERNORM_SYM_BWD_HEADER}
+        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/generate_expected_layernorm_sym_bwd.py
+        COMMENT "Generating expected_layernorm_sym_bwd.h via PyTorch"
+        VERBATIM
+)
+add_custom_target(generate_expected_layernorm_sym_bwd
+        DEPENDS ${GEN_LAYERNORM_SYM_BWD_HEADER})
+
 add_elastic_ai_unit_test(
         LIB_UNDER_TEST
         LayerNorm
@@ -237,4 +249,5 @@ add_elastic_ai_unit_test(
 )
 add_dependencies(UnitTestLayerNorm generate_expected_layernorm)
 add_dependencies(UnitTestLayerNorm generate_expected_layernorm_sym)
+add_dependencies(UnitTestLayerNorm generate_expected_layernorm_sym_bwd)
 target_include_directories(UnitTestLayerNorm PRIVATE ${CMAKE_CURRENT_BINARY_DIR})

--- a/test/unit/layer/UnitTestLayerNorm.c
+++ b/test/unit/layer/UnitTestLayerNorm.c
@@ -18,6 +18,7 @@
 
 #include "expected_layernorm.h"
 #include "expected_layernorm_sym.h"
+#include "expected_layernorm_sym_bwd.h"
 
 void setUp(void) {}
 void tearDown(void) {}
@@ -902,6 +903,162 @@ static void runSymGoldForward(size_t numDims, const size_t *dims, size_t numNorm
     }
 }
 
+/* SYM backward gold runner: hand-built layer with backwardQ = SYM_INT32, fresh
+ * (zero, scale-1.0) grads, backward through the vtable. Asserts:
+ * (a) dgamma/dbeta grad mantissas within gradMantissaTol of the float64
+ *     emulation (quantize-increment + addSymInt32TensorsInplace),
+ * (b) grad scales within 1e-4 relative of the emulated scales,
+ * (c) dequantized grads within gradDequantTol of float64 torch-autograd,
+ * (d) when expDx != NULL: dx mantissas/scale/dequant likewise (dequant asserts
+ *     are the scale-blindness catchers: a dropped s_dy/s_gamma/s_x leaves
+ *     mantissas IDENTICAL and shows up only in the scale).
+ * Fixtures are contiguous default-order: physical offset == g*N + j. */
+static void runSymGoldBackward(
+    size_t numDims, const size_t *dims, size_t numNormDims, const size_t *normShapeIn,
+    const float *xVals, const float *gammaVals, const float *lossGradVals, const int32_t *expDx,
+    float expDxScale, int32_t dxMantissaTol, const float *expDxDequant, float dxDequantTol,
+    const int32_t *expDgamma, float expDgammaScale, const int32_t *expDbeta, float expDbetaScale,
+    int32_t gradMantissaTol, const float *expDgammaDequant, const float *expDbetaDequant,
+    float gradDequantTol, size_t count, size_t normCount) {
+    TEST_ASSERT_TRUE_MESSAGE(count > 0 && count <= 64, "fixture exceeds capture buffer");
+    TEST_ASSERT_TRUE_MESSAGE(normCount > 0 && normCount <= 64, "fixture exceeds capture buffer");
+
+    tensor_t *fwdIn = buildSymInt32TensorND(numDims, dims, xVals);
+    tensor_t *loss = buildSymInt32TensorND(numDims, dims, lossGradVals);
+    tensor_t *propLoss = buildSymInt32TensorND(numDims, dims, NULL);
+    parameter_t *gamma = buildSymParam(numNormDims, normShapeIn, gammaVals);
+    parameter_t *beta = buildSymParam(numNormDims, normShapeIn, NULL); /* zeros; unused in bwd */
+    size_t *normShape = reserveMemory(numNormDims * sizeof(size_t));
+    for (size_t i = 0; i < numNormDims; i++) {
+        normShape[i] = normShapeIn[i];
+    }
+    quantization_t *fq = quantizationInitSymInt32(HTE);
+    quantization_t *bq = quantizationInitSymInt32(HTE);
+    layerNormConfig_t cfg;
+    initLayerNormConfig(&cfg, gamma, beta, normShape, numNormDims, 1e-5f, fq, bq);
+    layerConfig_t lcfg;
+    layer_t layer = makeLayerNormLayer(&cfg, &lcfg);
+
+    layerFunctions[LAYERNORM].backward(&layer, fwdIn, loss, propLoss);
+
+    int32_t dgm[64], dbm[64], dxm[64];
+    for (size_t i = 0; i < normCount; i++) {
+        dgm[i] = ((int32_t *)gamma->grad->data)[i];
+        dbm[i] = ((int32_t *)beta->grad->data)[i];
+    }
+    for (size_t i = 0; i < count; i++) {
+        dxm[i] = ((int32_t *)propLoss->data)[i];
+    }
+    float dgScale = symScaleOf(gamma->grad);
+    float dbScale = symScaleOf(beta->grad);
+    float dxScale = symScaleOf(propLoss);
+
+    freeQuantization(bq);
+    freeQuantization(fq);
+    freeReservedMemory(normShape);
+    freeParameter(beta);
+    freeParameter(gamma);
+    freeTensor(propLoss);
+    freeTensor(loss);
+    freeTensor(fwdIn);
+
+    for (size_t i = 0; i < normCount; i++) {
+        TEST_ASSERT_INT_WITHIN(gradMantissaTol, expDgamma[i], dgm[i]);
+        TEST_ASSERT_INT_WITHIN(gradMantissaTol, expDbeta[i], dbm[i]);
+    }
+    TEST_ASSERT_FLOAT_WITHIN(expDgammaScale * 1e-4f, expDgammaScale, dgScale);
+    TEST_ASSERT_FLOAT_WITHIN(expDbetaScale * 1e-4f, expDbetaScale, dbScale);
+    for (size_t i = 0; i < normCount; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(gradDequantTol, expDgammaDequant[i], (float)dgm[i] * dgScale);
+        TEST_ASSERT_FLOAT_WITHIN(gradDequantTol, expDbetaDequant[i], (float)dbm[i] * dbScale);
+    }
+    if (expDx != NULL) {
+        for (size_t i = 0; i < count; i++) {
+            TEST_ASSERT_INT_WITHIN(dxMantissaTol, expDx[i], dxm[i]);
+        }
+        TEST_ASSERT_FLOAT_WITHIN(expDxScale * 1e-4f, expDxScale, dxScale);
+        for (size_t i = 0; i < count; i++) {
+            TEST_ASSERT_FLOAT_WITHIN(dxDequantTol, expDxDequant[i], (float)dxm[i] * dxScale);
+        }
+    }
+}
+
+void testSymBackwardGoldMultiGroup(void) {
+    size_t dims[] = {3, 4};
+    size_t ns[] = {4};
+    runSymGoldBackward(
+        2, dims, 1, ns, input_layerNormSymBwd_bwdBase, gamma_layerNormSymBwd_bwdBase,
+        lossGrad_layerNormSymBwd_bwdBase, expectedDx_layerNormSymBwd_bwdBase,
+        expectedDxScale_layerNormSymBwd_bwdBase, dxMantissaTol_layerNormSymBwd_bwdBase,
+        expectedDxDequant_layerNormSymBwd_bwdBase, dxDequantTol_layerNormSymBwd_bwdBase,
+        expectedDgamma_layerNormSymBwd_bwdBase, expectedDgammaScale_layerNormSymBwd_bwdBase,
+        expectedDbeta_layerNormSymBwd_bwdBase, expectedDbetaScale_layerNormSymBwd_bwdBase,
+        gradMantissaTol_layerNormSymBwd_bwdBase, expectedDgammaDequant_layerNormSymBwd_bwdBase,
+        expectedDbetaDequant_layerNormSymBwd_bwdBase, gradDequantTol_layerNormSymBwd_bwdBase, 12,
+        4);
+}
+
+/* dy == 0: dx must be all-zero mantissas with the NEUTRAL scale 1.0 (the
+ * absmax==0 idiom), and the fresh zero grads must stay EXACTLY zero with
+ * scale 1.0 (zero increments quantize to zeros/scale-1.0 and 0+0 == 0 through
+ * the strategy-A add). Zero propagates exactly through float products/sums
+ * even under -ffp-contract=fast — no integer pre-check needed (unlike the
+ * forward's constant-input cancellation). */
+void testSymBackwardZeroLossGradEmitsZerosNeutralScale(void) {
+    size_t dims[] = {2, 4};
+    tensor_t *fwdIn =
+        buildSymInt32TensorND(2, dims, (float[]){1.f, 2.f, 3.f, 4.f, 10.f, 20.f, 30.f, 40.f});
+    tensor_t *loss = buildSymInt32TensorND(2, dims, NULL); /* zero mantissas, scale 1.0 */
+    tensor_t *propLoss = buildSymInt32TensorND(2, dims, NULL);
+
+    size_t ns[] = {4};
+    parameter_t *gamma = buildSymParam(1, ns, (float[]){2.f, 1.f, -1.f, 0.5f});
+    parameter_t *beta = buildSymParam(1, ns, NULL);
+    size_t *normShape = reserveMemory(sizeof(size_t));
+    normShape[0] = 4;
+
+    quantization_t *fq = quantizationInitSymInt32(HTE);
+    quantization_t *bq = quantizationInitSymInt32(HTE);
+    layerNormConfig_t cfg;
+    initLayerNormConfig(&cfg, gamma, beta, normShape, 1, 1e-5f, fq, bq);
+    layerConfig_t lcfg;
+    layer_t layer = makeLayerNormLayer(&cfg, &lcfg);
+
+    layerNormBackward(&layer, fwdIn, loss, propLoss);
+
+    int32_t dxm[8], dgm[4], dbm[4];
+    for (size_t i = 0; i < 8; i++) {
+        dxm[i] = ((int32_t *)propLoss->data)[i];
+    }
+    for (size_t i = 0; i < 4; i++) {
+        dgm[i] = ((int32_t *)gamma->grad->data)[i];
+        dbm[i] = ((int32_t *)beta->grad->data)[i];
+    }
+    float dxScale = symScaleOf(propLoss);
+    float dgScale = symScaleOf(gamma->grad);
+    float dbScale = symScaleOf(beta->grad);
+
+    freeQuantization(bq);
+    freeQuantization(fq);
+    freeReservedMemory(normShape);
+    freeParameter(beta);
+    freeParameter(gamma);
+    freeTensor(propLoss);
+    freeTensor(loss);
+    freeTensor(fwdIn);
+
+    for (size_t i = 0; i < 8; i++) {
+        TEST_ASSERT_EQUAL_INT(0, dxm[i]);
+    }
+    TEST_ASSERT_EQUAL_FLOAT(1.0f, dxScale);
+    for (size_t i = 0; i < 4; i++) {
+        TEST_ASSERT_EQUAL_INT(0, dgm[i]);
+        TEST_ASSERT_EQUAL_INT(0, dbm[i]);
+    }
+    TEST_ASSERT_EQUAL_FLOAT(1.0f, dgScale);
+    TEST_ASSERT_EQUAL_FLOAT(1.0f, dbScale);
+}
+
 void testSymGoldParityMultiGroup(void) {
     size_t dims[] = {3, 4};
     size_t ns[] = {4};
@@ -1382,6 +1539,293 @@ void testFactoryOwningSymInt32DeepCopiesQuantizations(void) {
     TEST_ASSERT_TRUE(owns);
 }
 
+/* Spec-mandated freeze-the-scale test: the propLoss scale is data-dependent
+ * and must be RE-derived on every call. Two backwards with dy2 = 10x dy1 on
+ * the same layer/propLoss; each call must match its own golds. */
+void testSymBackwardPropLossScaleRefreshedEveryCall(void) {
+    size_t dims[] = {2, 4};
+    tensor_t *fwdIn = buildSymInt32TensorND(2, dims, input_layerNormSymBwd_bwdTwoCalls);
+    tensor_t *loss1 = buildSymInt32TensorND(2, dims, lossGrad_layerNormSymBwd_bwdTwoCalls);
+    tensor_t *loss2 = buildSymInt32TensorND(2, dims, lossGrad2_layerNormSymBwd_bwdTwoCalls);
+    tensor_t *propLoss = buildSymInt32TensorND(2, dims, NULL);
+
+    size_t ns[] = {4};
+    parameter_t *gamma = buildSymParam(1, ns, gamma_layerNormSymBwd_bwdTwoCalls);
+    parameter_t *beta = buildSymParam(1, ns, NULL);
+    size_t *normShape = reserveMemory(sizeof(size_t));
+    normShape[0] = 4;
+
+    quantization_t *fq = quantizationInitSymInt32(HTE);
+    quantization_t *bq = quantizationInitSymInt32(HTE);
+    layerNormConfig_t cfg;
+    initLayerNormConfig(&cfg, gamma, beta, normShape, 1, 1e-5f, fq, bq);
+    layerConfig_t lcfg;
+    layer_t layer = makeLayerNormLayer(&cfg, &lcfg);
+
+    layerNormBackward(&layer, fwdIn, loss1, propLoss);
+    int32_t dx1[8];
+    for (size_t i = 0; i < 8; i++) {
+        dx1[i] = ((int32_t *)propLoss->data)[i];
+    }
+    float s1 = symScaleOf(propLoss);
+
+    layerNormBackward(&layer, fwdIn, loss2, propLoss);
+    int32_t dx2[8];
+    for (size_t i = 0; i < 8; i++) {
+        dx2[i] = ((int32_t *)propLoss->data)[i];
+    }
+    float s2 = symScaleOf(propLoss);
+
+    freeQuantization(bq);
+    freeQuantization(fq);
+    freeReservedMemory(normShape);
+    freeParameter(beta);
+    freeParameter(gamma);
+    freeTensor(propLoss);
+    freeTensor(loss2);
+    freeTensor(loss1);
+    freeTensor(fwdIn);
+
+    for (size_t i = 0; i < 8; i++) {
+        TEST_ASSERT_INT_WITHIN(dxMantissaTol_layerNormSymBwd_bwdTwoCalls,
+                               expectedDx_layerNormSymBwd_bwdTwoCalls[i], dx1[i]);
+        TEST_ASSERT_INT_WITHIN(dxMantissaTol_layerNormSymBwd_bwdTwoCalls,
+                               expectedDx2_layerNormSymBwd_bwdTwoCalls[i], dx2[i]);
+    }
+    TEST_ASSERT_FLOAT_WITHIN(expectedDxScale_layerNormSymBwd_bwdTwoCalls * 1e-4f,
+                             expectedDxScale_layerNormSymBwd_bwdTwoCalls, s1);
+    TEST_ASSERT_FLOAT_WITHIN(expectedDxScale2_layerNormSymBwd_bwdTwoCalls * 1e-4f,
+                             expectedDxScale2_layerNormSymBwd_bwdTwoCalls, s2);
+}
+
+/* Strategy-A accumulation across microbatch calls: grads after two backwards
+ * must match the emulated two-call accumulation (incl. the intermediate
+ * requant) and stay within the analytic dequant bound of autograd's sum. */
+void testSymBackwardGradsAccumulateAcrossCalls(void) {
+    size_t dims[] = {2, 4};
+    tensor_t *fwdIn = buildSymInt32TensorND(2, dims, input_layerNormSymBwd_bwdTwoCalls);
+    tensor_t *loss1 = buildSymInt32TensorND(2, dims, lossGrad_layerNormSymBwd_bwdTwoCalls);
+    tensor_t *loss2 = buildSymInt32TensorND(2, dims, lossGrad2_layerNormSymBwd_bwdTwoCalls);
+    tensor_t *propLoss = buildSymInt32TensorND(2, dims, NULL);
+
+    size_t ns[] = {4};
+    parameter_t *gamma = buildSymParam(1, ns, gamma_layerNormSymBwd_bwdTwoCalls);
+    parameter_t *beta = buildSymParam(1, ns, NULL);
+    size_t *normShape = reserveMemory(sizeof(size_t));
+    normShape[0] = 4;
+
+    quantization_t *fq = quantizationInitSymInt32(HTE);
+    quantization_t *bq = quantizationInitSymInt32(HTE);
+    layerNormConfig_t cfg;
+    initLayerNormConfig(&cfg, gamma, beta, normShape, 1, 1e-5f, fq, bq);
+    layerConfig_t lcfg;
+    layer_t layer = makeLayerNormLayer(&cfg, &lcfg);
+
+    layerNormBackward(&layer, fwdIn, loss1, propLoss);
+    layerNormBackward(&layer, fwdIn, loss2, propLoss);
+
+    int32_t dgm[4], dbm[4];
+    for (size_t i = 0; i < 4; i++) {
+        dgm[i] = ((int32_t *)gamma->grad->data)[i];
+        dbm[i] = ((int32_t *)beta->grad->data)[i];
+    }
+    float dgScale = symScaleOf(gamma->grad);
+    float dbScale = symScaleOf(beta->grad);
+
+    freeQuantization(bq);
+    freeQuantization(fq);
+    freeReservedMemory(normShape);
+    freeParameter(beta);
+    freeParameter(gamma);
+    freeTensor(propLoss);
+    freeTensor(loss2);
+    freeTensor(loss1);
+    freeTensor(fwdIn);
+
+    for (size_t i = 0; i < 4; i++) {
+        TEST_ASSERT_INT_WITHIN(gradMantissaTol_layerNormSymBwd_bwdTwoCalls,
+                               expectedDgammaAfter2_layerNormSymBwd_bwdTwoCalls[i], dgm[i]);
+        TEST_ASSERT_INT_WITHIN(gradMantissaTol_layerNormSymBwd_bwdTwoCalls,
+                               expectedDbetaAfter2_layerNormSymBwd_bwdTwoCalls[i], dbm[i]);
+    }
+    TEST_ASSERT_FLOAT_WITHIN(expectedDgammaScaleAfter2_layerNormSymBwd_bwdTwoCalls * 1e-4f,
+                             expectedDgammaScaleAfter2_layerNormSymBwd_bwdTwoCalls, dgScale);
+    TEST_ASSERT_FLOAT_WITHIN(expectedDbetaScaleAfter2_layerNormSymBwd_bwdTwoCalls * 1e-4f,
+                             expectedDbetaScaleAfter2_layerNormSymBwd_bwdTwoCalls, dbScale);
+    for (size_t i = 0; i < 4; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(gradDequantTol2_layerNormSymBwd_bwdTwoCalls,
+                                 expectedDgammaDequant2_layerNormSymBwd_bwdTwoCalls[i],
+                                 (float)dgm[i] * dgScale);
+        TEST_ASSERT_FLOAT_WITHIN(gradDequantTol2_layerNormSymBwd_bwdTwoCalls,
+                                 expectedDbetaDequant2_layerNormSymBwd_bwdTwoCalls[i],
+                                 (float)dbm[i] * dbScale);
+    }
+}
+
+/* var == eps == 1e-5 (codebase memory eps-mutation vacuity): the ONLY regime
+ * where eps placement inside the backward's recomputed invSigma is visible —
+ * O(1)-variance fixtures see a ~5e-6 relative shift (far below 1 dx-LSB).
+ * Here sqrt(var)+eps vs sqrt(var+eps) shifts invSigma ~41%. */
+void testSymBackwardVarNearEpsGold(void) {
+    size_t dims[] = {3};
+    size_t ns[] = {3};
+    runSymGoldBackward(
+        1, dims, 1, ns, input_layerNormSymBwd_bwdVarEps, gamma_layerNormSymBwd_bwdVarEps,
+        lossGrad_layerNormSymBwd_bwdVarEps, expectedDx_layerNormSymBwd_bwdVarEps,
+        expectedDxScale_layerNormSymBwd_bwdVarEps, dxMantissaTol_layerNormSymBwd_bwdVarEps,
+        expectedDxDequant_layerNormSymBwd_bwdVarEps, dxDequantTol_layerNormSymBwd_bwdVarEps,
+        expectedDgamma_layerNormSymBwd_bwdVarEps, expectedDgammaScale_layerNormSymBwd_bwdVarEps,
+        expectedDbeta_layerNormSymBwd_bwdVarEps, expectedDbetaScale_layerNormSymBwd_bwdVarEps,
+        gradMantissaTol_layerNormSymBwd_bwdVarEps, expectedDgammaDequant_layerNormSymBwd_bwdVarEps,
+        expectedDbetaDequant_layerNormSymBwd_bwdVarEps, gradDequantTol_layerNormSymBwd_bwdVarEps, 3,
+        3);
+}
+
+/* Layout-agnosticism: run bwdBase contiguous, then with forwardInput AND
+ * propLoss physically transposed ([4,3] buffers + transposeTensor) while dy
+ * stays natural — three DIVERGENT maps. Same logical iteration order => same
+ * float ops => mantissas (at logical positions), scales, and grads must be
+ * BIT-identical. Catches: x read through the wrong map, dy read through x's
+ * map, dx scattered row-major instead of through propLoss's map.
+ * (PR-1's testBackwardFloatDivergentLayouts is the float precedent.) */
+void testSymBackwardDivergentLayoutsBitIdentical(void) {
+    size_t dims[] = {3, 4};
+    size_t ns[] = {4};
+
+    /* --- contiguous run --- */
+    tensor_t *fwdC = buildSymInt32TensorND(2, dims, input_layerNormSymBwd_bwdBase);
+    tensor_t *lossC = buildSymInt32TensorND(2, dims, lossGrad_layerNormSymBwd_bwdBase);
+    tensor_t *propC = buildSymInt32TensorND(2, dims, NULL);
+    parameter_t *gammaC = buildSymParam(1, ns, gamma_layerNormSymBwd_bwdBase);
+    parameter_t *betaC = buildSymParam(1, ns, NULL);
+    size_t *normShapeC = reserveMemory(sizeof(size_t));
+    normShapeC[0] = 4;
+    quantization_t *fqC = quantizationInitSymInt32(HTE);
+    quantization_t *bqC = quantizationInitSymInt32(HTE);
+    layerNormConfig_t cfgC;
+    initLayerNormConfig(&cfgC, gammaC, betaC, normShapeC, 1, 1e-5f, fqC, bqC);
+    layerConfig_t lcfgC;
+    layer_t layerC = makeLayerNormLayer(&cfgC, &lcfgC);
+    layerNormBackward(&layerC, fwdC, lossC, propC);
+
+    /* --- divergent run: x and propLoss physical [4,3], logical [3,4] --- */
+    float xT[12];
+    for (size_t r = 0; r < 3; r++) {
+        for (size_t c = 0; c < 4; c++) {
+            xT[c * 3 + r] = input_layerNormSymBwd_bwdBase[r * 4 + c];
+        }
+    }
+    size_t pdims[] = {4, 3};
+    tensor_t *fwdT = buildSymInt32TensorND(2, pdims, xT);
+    transposeTensor(fwdT, 0, 1); /* logical [3,4], physical unchanged */
+    tensor_t *lossT = buildSymInt32TensorND(2, dims, lossGrad_layerNormSymBwd_bwdBase);
+    tensor_t *propT = buildSymInt32TensorND(2, pdims, NULL);
+    transposeTensor(propT, 0, 1);
+    parameter_t *gammaT = buildSymParam(1, ns, gamma_layerNormSymBwd_bwdBase);
+    parameter_t *betaT = buildSymParam(1, ns, NULL);
+    size_t *normShapeT = reserveMemory(sizeof(size_t));
+    normShapeT[0] = 4;
+    quantization_t *fqT = quantizationInitSymInt32(HTE);
+    quantization_t *bqT = quantizationInitSymInt32(HTE);
+    layerNormConfig_t cfgT;
+    initLayerNormConfig(&cfgT, gammaT, betaT, normShapeT, 1, 1e-5f, fqT, bqT);
+    layerConfig_t lcfgT;
+    layer_t layerT = makeLayerNormLayer(&cfgT, &lcfgT);
+    layerNormBackward(&layerT, fwdT, lossT, propT);
+
+    int32_t dxC[12], dxT[12], dgC[4], dgT[4], dbC[4], dbT[4];
+    int32_t *pcd = (int32_t *)propC->data;
+    int32_t *ptd = (int32_t *)propT->data;
+    for (size_t r = 0; r < 3; r++) {
+        for (size_t c = 0; c < 4; c++) {
+            dxC[r * 4 + c] = pcd[r * 4 + c]; /* contiguous: phys == logical */
+            dxT[r * 4 + c] = ptd[c * 3 + r]; /* transposed: logical (r,c) -> phys c*3+r */
+        }
+    }
+    for (size_t i = 0; i < 4; i++) {
+        dgC[i] = ((int32_t *)gammaC->grad->data)[i];
+        dgT[i] = ((int32_t *)gammaT->grad->data)[i];
+        dbC[i] = ((int32_t *)betaC->grad->data)[i];
+        dbT[i] = ((int32_t *)betaT->grad->data)[i];
+    }
+    float sC = symScaleOf(propC);
+    float sT = symScaleOf(propT);
+    float dgsC = symScaleOf(gammaC->grad);
+    float dgsT = symScaleOf(gammaT->grad);
+
+    freeQuantization(bqT);
+    freeQuantization(fqT);
+    freeReservedMemory(normShapeT);
+    freeParameter(betaT);
+    freeParameter(gammaT);
+    freeTensor(propT);
+    freeTensor(lossT);
+    freeTensor(fwdT);
+    freeQuantization(bqC);
+    freeQuantization(fqC);
+    freeReservedMemory(normShapeC);
+    freeParameter(betaC);
+    freeParameter(gammaC);
+    freeTensor(propC);
+    freeTensor(lossC);
+    freeTensor(fwdC);
+
+    TEST_ASSERT_EQUAL_FLOAT(sC, sT);
+    TEST_ASSERT_EQUAL_FLOAT(dgsC, dgsT);
+    for (size_t i = 0; i < 12; i++) {
+        TEST_ASSERT_EQUAL_INT(dxC[i], dxT[i]);
+    }
+    for (size_t i = 0; i < 4; i++) {
+        TEST_ASSERT_EQUAL_INT(dgC[i], dgT[i]);
+        TEST_ASSERT_EQUAL_INT(dbC[i], dbT[i]);
+    }
+}
+
+/* Full-SYM profile (forwardMath = backwardMath = storage = SYM_INT32) through
+ * the Borrowing factory: gradInit must yield SYM_INT32 grads (PR-0 plumbing),
+ * and a vtable backward on factory-built params must accumulate into them.
+ * (The new validation rules are death paths — liveness-checked in this task's
+ * inversion step, not Unity-testable.) */
+void testFactoryFullSymProfileTrainsSymGrads(void) {
+    size_t normShape[] = {4};
+    layerNormInit_t init = {.normalizedShape = normShape, .numNormDims = 1, .eps = 1e-5f};
+
+    quantization_t *symQ = quantizationInitSymInt32(HTE);
+    layerQuant_t lq = {
+        .forwardMath = symQ, .backwardMath = symQ, .weightStorage = symQ, .biasStorage = symQ};
+    layer_t *layer = layerNormLayerInit(&init, &lq);
+    layerNormConfig_t *cfg = layer->config->layerNorm;
+
+    bool gradsSym = (cfg->gamma->grad->quantization->type == SYM_INT32) &&
+                    (cfg->beta->grad->quantization->type == SYM_INT32);
+
+    size_t dims[] = {2, 4};
+    tensor_t *fwdIn =
+        buildSymInt32TensorND(2, dims, (float[]){1.f, 2.f, 3.f, 4.f, 10.f, 20.f, 30.f, 40.f});
+    tensor_t *loss = buildSymInt32TensorND(
+        2, dims, (float[]){0.5f, -1.f, 0.25f, 0.75f, -0.5f, 1.5f, -0.25f, 1.f});
+    tensor_t *propLoss = buildSymInt32TensorND(2, dims, NULL);
+
+    layerFunctions[LAYERNORM].backward(layer, fwdIn, loss, propLoss);
+
+    int32_t dbSum = 0;
+    for (size_t i = 0; i < 4; i++) {
+        int32_t v = ((int32_t *)cfg->beta->grad->data)[i];
+        dbSum += (v < 0) ? -v : v;
+    }
+    float dxScale = symScaleOf(propLoss);
+
+    freeTensor(propLoss);
+    freeTensor(loss);
+    freeTensor(fwdIn);
+    freeLayerNormLayer(layer);
+    freeQuantization(symQ);
+
+    TEST_ASSERT_TRUE(gradsSym);
+    TEST_ASSERT_TRUE_MESSAGE(dbSum > 0, "backward must accumulate into the factory SYM grads");
+    TEST_ASSERT_TRUE(dxScale > 0.0f && dxScale != 1.0f);
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(testConfigStructIsPopulated);
@@ -1417,5 +1861,12 @@ int main(void) {
     RUN_TEST(testSymForwardTransposedMatchesContiguous);
     RUN_TEST(testFactorySymInt32StorageQuantizesGammaBeta);
     RUN_TEST(testFactoryOwningSymInt32DeepCopiesQuantizations);
+    RUN_TEST(testSymBackwardGoldMultiGroup);
+    RUN_TEST(testSymBackwardZeroLossGradEmitsZerosNeutralScale);
+    RUN_TEST(testSymBackwardPropLossScaleRefreshedEveryCall);
+    RUN_TEST(testSymBackwardGradsAccumulateAcrossCalls);
+    RUN_TEST(testSymBackwardVarNearEpsGold);
+    RUN_TEST(testSymBackwardDivergentLayoutsBitIdentical);
+    RUN_TEST(testFactoryFullSymProfileTrainsSymGrads);
     return UNITY_END();
 }

--- a/test/unit/layer/generate_expected_layernorm_sym_bwd.py
+++ b/test/unit/layer/generate_expected_layernorm_sym_bwd.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python3
+"""Generate expected_layernorm_sym_bwd.h for UnitTestLayerNorm (SYM_INT32 bwd, #148 PR-3).
+
+Emulates the C SYM_INT32 LayerNorm backward end-to-end in float64:
+  quantize x/gamma/dy -> recompute group stats from x mantissas (int sum, then
+  scale; biased /N; eps INSIDE sqrt) -> per-element dy dequant -> dgamma/dbeta
+  increments summed over groups -> dx reduction -> whole-tensor absmax requant
+  (absmax==0 -> zeros, scale 1.0) -> grad accumulation exactly as the C does it
+  (quantize increment, then addSymInt32TensorsInplace: dequant both, float add,
+  requant to a fresh absmax/QMAX scale).
+
+Self-checks:
+ - emitted float fixtures are dequantization-STABLE (re-quantizing reproduces
+   the mantissas bit-exactly), pinning the C input mantissas to this emulation;
+ - every dy fixture is per-group NON-uniform (with the default constant gamma,
+   uniform dy degenerates dx to float rounding noise — vacuous for
+   scatter/reduction mutations; enforced unconditionally as the stronger
+   fixture property — codebase memory);
+ - emulated dequantized dx/dgamma/dbeta match float64 torch-autograd on the
+   EXACT float64 dequants (q*s; NOT the float32-rounded emitted fixtures —
+   those differ by ~0.5 ulp_f32 and would trip the 1e-9 increment bound)
+   within analytic quantization bounds;
+ - the var~eps fixture really sits in the eps-visible regime (0.5 < var/eps < 2).
+
+Rounding: the framework's roundByMode(HTE) is C round() = half-AWAY-from-zero
+(Rounding.c, #188 misnomer) — emulate with sign(x)*floor(|x|+0.5), NEVER
+torch.round (true half-to-even, silently diverges on ties).
+Run via `uv run` (CMake wires this automatically).
+"""
+import argparse
+import sys
+from pathlib import Path
+
+import torch
+import torch.nn.functional as F
+
+QMAX = 32767.0
+QMIN = -32768.0
+
+
+def round_half_away(x: torch.Tensor) -> torch.Tensor:
+    """Match the C kernel: roundByMode(HTE) is C round() = half-away-from-zero
+    (Rounding.c — the HTE name is a misnomer, #188)."""
+    return torch.sign(x) * torch.floor(torch.abs(x) + 0.5)
+
+
+def _format_float_literal(v: float) -> str:
+    s = repr(v)
+    if s in ("inf", "-inf", "nan"):
+        raise ValueError(f"non-finite gold value: {v!r}")
+    return s + "f"
+
+
+def emit_float_array(name: str, tensor: torch.Tensor) -> str:
+    flat = tensor.detach().flatten().tolist()
+    body = ", ".join(_format_float_literal(v) for v in flat)
+    return (
+        f"static const float {name}[] = {{ {body} }};\n"
+        f"static const size_t {name}_len = {len(flat)};\n"
+    )
+
+
+def emit_int32_array(name: str, tensor: torch.Tensor) -> str:
+    flat = [int(v) for v in tensor.detach().flatten().tolist()]
+    body = ", ".join(str(v) for v in flat)
+    return (
+        f"static const int32_t {name}[] = {{ {body} }};\n"
+        f"static const size_t {name}_len = {len(flat)};\n"
+    )
+
+
+def emit_float_scalar(name: str, v: float) -> str:
+    return f"static const float {name} = {_format_float_literal(float(v))};\n"
+
+
+def emit_int32_scalar(name: str, v: int) -> str:
+    return f"static const int32_t {name} = {int(v)};\n"
+
+
+def quantize_sym(x: torch.Tensor):
+    """convertFloatTensorToSymInt32Tensor: absmax -> scale (1.0 if absmax==0),
+    round-clamp with the C rounding (half-away-from-zero)."""
+    absmax = x.abs().max().item()
+    scale = 1.0 if absmax == 0.0 else absmax / QMAX
+    q = round_half_away(torch.clamp(x / scale, QMIN, QMAX))
+    return q.to(torch.int32), scale
+
+
+def stable_dequant(x: torch.Tensor):
+    """Quantize once; return (mantissas, scale, dequantized float32 fixture).
+    The EMITTED float32 fixture is asserted ROUND-TRIP STABLE so the C side's
+    tensorFillFromFloatBuffer lands on exactly these mantissas."""
+    q, s = quantize_sym(x.to(torch.float64))
+    deq32 = (q.to(torch.float64) * s).to(torch.float32)
+    q2, _ = quantize_sym(deq32.to(torch.float64))
+    assert torch.equal(q, q2), "fixture is not dequantization round-trip stable"
+    return q, s, deq32
+
+
+def emulate_group_stats(xq, sx, n_inner, eps):
+    """layerNormGroupStatsSymInt32 in float64: int mantissa sum then scale;
+    biased variance /N; eps INSIDE sqrt. Returns (n, inv_sigma) per group."""
+    xqr = xq.reshape(-1, n_inner).to(torch.float64)
+    mean = sx * xqr.sum(dim=1, keepdim=True) / n_inner
+    yhat = xqr * sx - mean
+    var = (yhat ** 2).mean(dim=1, keepdim=True)
+    inv_sigma = 1.0 / torch.sqrt(var + eps)
+    return yhat * inv_sigma, inv_sigma, var
+
+
+def emulate_sym_backward(xq, sx, gq, sg, dyq, sdy, n_inner, eps):
+    """layerNormBackwardSymInt32's math in float64. Returns
+    (dx_mantissas int32 [G,N], s_dx, dgamma_inc float64 [N], dbeta_inc float64 [N])."""
+    n, inv_sigma, _ = emulate_group_stats(xq, sx, n_inner, eps)
+    dy = dyq.reshape(-1, n_inner).to(torch.float64) * sdy
+    g = (gq.to(torch.float64) * sg).reshape(1, n_inner)
+    dbeta_inc = dy.sum(dim=0)
+    dgamma_inc = (dy * n).sum(dim=0)
+    dn = dy * g
+    mean_dn = dn.mean(dim=1, keepdim=True)
+    mean_dnn = (dn * n).mean(dim=1, keepdim=True)
+    dx = inv_sigma * (dn - mean_dn - n * mean_dnn)
+    absmax = dx.abs().max().item()
+    if absmax == 0.0:
+        s_dx = 1.0
+        dxq = torch.zeros_like(dx)
+    else:
+        s_dx = absmax / QMAX
+        dxq = round_half_away(torch.clamp(dx / s_dx, QMIN, QMAX))
+    return dxq.to(torch.int32), s_dx, dgamma_inc, dbeta_inc
+
+
+def emulate_accumulate(grad_q, grad_s, inc):
+    """Strategy-A grad accumulation exactly as the C does it:
+    (1) convertFloatTensorToSymInt32Tensor on the float increment (fresh
+        absmax scale, absmax==0 -> 1.0, round-clamp);
+    (2) addSymInt32TensorsInplace: dequantize BOTH with their own scales,
+        float-add, requantize the sum with a fresh absmax/QMAX scale.
+    Returns ((mantissas, scale) after accumulation, increment scale)."""
+    inc_q, inc_s = quantize_sym(inc)
+    total = grad_q.to(torch.float64) * grad_s + inc_q.to(torch.float64) * inc_s
+    out_q, out_s = quantize_sym(total)
+    return (out_q, out_s), inc_s
+
+
+def autograd_reference(x64, g64, dy64, normalized_shape, eps):
+    """float64 torch-autograd on the EXACT float64 dequants (q*s in float64) —
+    the SAME inputs the emulator uses, so the increment self-checks hold to
+    ~machine eps. Do NOT feed the emitted float32 fixtures here: they are
+    rounded by ~0.5 ulp_f32 per element, which shifts dgamma by ~1e-8 (and
+    ~6e-7 in the var~eps fixture, where cancellation amplifies it) and trips
+    the 1e-9 bound. The C kernel sees identical MANTISSAS either way, so the
+    emitted golds are unaffected by this choice."""
+    x_in = x64.clone().detach().requires_grad_(True)
+    g_in = g64.clone().detach().requires_grad_(True)
+    b_in = torch.zeros(normalized_shape, dtype=torch.float64, requires_grad=True)
+    y = F.layer_norm(x_in, normalized_shape, weight=g_in, bias=b_in, eps=eps)
+    y.backward(dy64)
+    return x_in.grad, g_in.grad, b_in.grad
+
+
+def _check_dy_nonuniform(name, dy_deq, n_inner):
+    per_group = dy_deq.reshape(-1, n_inner).to(torch.float64)
+    spread = per_group.max(dim=1).values - per_group.min(dim=1).values
+    assert (spread > 1e-6).all(), (
+        f"{name}: a dy group is uniform — degenerate/vacuous fixture (see docstring)"
+    )
+
+
+def _run_bwd_fixture(name, x, gamma, dy, normalized_shape, *, eps=1e-5,
+                     dy2=None, var_near_eps=False):
+    n_inner = 1
+    for d in normalized_shape:
+        n_inner *= d
+
+    xq, sx, x_deq = stable_dequant(x)
+    gq, sg, g_deq = stable_dequant(gamma)
+    dyq, sdy, dy_deq = stable_dequant(dy)
+    _check_dy_nonuniform(name, dy_deq, n_inner)
+
+    if var_near_eps:
+        _, _, var = emulate_group_stats(xq, sx, n_inner, eps)
+        ratio = (var / eps).flatten()
+        assert ((ratio > 0.5) & (ratio < 2.0)).all(), (
+            f"{name}: var/eps = {ratio.tolist()} outside the eps-visible regime"
+        )
+
+    dx_q, s_dx, dg_inc, db_inc = emulate_sym_backward(xq, sx, gq, sg, dyq, sdy,
+                                                      n_inner, eps)
+    # EXACT float64 dequants for the autograd reference (see autograd_reference).
+    x64 = xq.to(torch.float64) * sx
+    g64 = gq.to(torch.float64) * sg
+    dy64 = dyq.to(torch.float64) * sdy
+    ref_dx, ref_dg, ref_db = autograd_reference(x64, g64, dy64, normalized_shape, eps)
+
+    # Self-check: emulated dequant dx vs autograd. The emulation IS the math
+    # (sympy-verified equal to the Jacobian) in float64; the only difference is
+    # the dx output quantization (<= 0.5 LSB). 1.5x margin.
+    err = (dx_q.to(torch.float64).reshape(-1) * s_dx
+           - ref_dx.reshape(-1)).abs().max().item()
+    assert err <= 0.5 * s_dx * 1.5 + 1e-12, f"{name}: dx emulation err {err}"
+    # Increments are pure float64 math — must match autograd to ~machine eps.
+    assert (dg_inc - ref_dg.reshape(-1)).abs().max().item() <= 1e-9, name
+    assert (db_inc - ref_db.reshape(-1)).abs().max().item() <= 1e-9, name
+
+    # Grad accumulation from FRESH zero grads (scale 1.0, sgdZeroGrad state).
+    zeros = torch.zeros(n_inner, dtype=torch.int32)
+    (dg_q, dg_s), dg_inc_s = emulate_accumulate(zeros, 1.0, dg_inc)
+    (db_q, db_s), db_inc_s = emulate_accumulate(zeros, 1.0, db_inc)
+
+    # Analytic dequant tolerance for the C-vs-autograd grad assert:
+    # increment quant (0.5*s_inc) + running-sum requant (0.5*s_final)
+    # + +-2 LSB float32-vs-float64 mantissa drift (2*s_final); 1.5x margin.
+    dg_tol = (0.5 * dg_inc_s + 2.5 * dg_s) * 1.5
+    db_tol = (0.5 * db_inc_s + 2.5 * db_s) * 1.5
+    err_g = (dg_q.to(torch.float64) * dg_s - ref_dg.reshape(-1)).abs().max().item()
+    err_b = (db_q.to(torch.float64) * db_s - ref_db.reshape(-1)).abs().max().item()
+    assert err_g <= dg_tol, f"{name}: dgamma accum err {err_g} > {dg_tol}"
+    assert err_b <= db_tol, f"{name}: dbeta accum err {err_b} > {db_tol}"
+
+    fx = {
+        "name": name, "x": x_deq, "gamma": g_deq, "dy": dy_deq,
+        "dx_q": dx_q, "s_dx": s_dx,
+        "dx_dequant": ref_dx.to(torch.float32),
+        "dx_dequant_tol": 3.0 * s_dx,  # +-2 LSB drift + 0.5 LSB rounding + margin
+        "dg_q": dg_q, "dg_s": dg_s, "db_q": db_q, "db_s": db_s,
+        "dg_dequant": ref_dg.to(torch.float32),
+        "db_dequant": ref_db.to(torch.float32),
+        "grad_dequant_tol": max(dg_tol, db_tol),
+    }
+
+    if dy2 is not None:
+        dy2q, sdy2, dy2_deq = stable_dequant(dy2)
+        _check_dy_nonuniform(name + "/dy2", dy2_deq, n_inner)
+        dx2_q, s_dx2, dg_inc2, db_inc2 = emulate_sym_backward(
+            xq, sx, gq, sg, dy2q, sdy2, n_inner, eps)
+        dy2_64 = dy2q.to(torch.float64) * sdy2
+        ref_dx2, ref_dg2, ref_db2 = autograd_reference(
+            x64, g64, dy2_64, normalized_shape, eps)
+        (dg2_q, dg2_s), dg2_inc_s = emulate_accumulate(dg_q, dg_s, dg_inc2)
+        (db2_q, db2_s), db2_inc_s = emulate_accumulate(db_q, db_s, db_inc2)
+        ref_dg_sum = (ref_dg + ref_dg2).reshape(-1)
+        ref_db_sum = (ref_db + ref_db2).reshape(-1)
+        dg2_tol = (0.5 * dg_inc_s + 0.5 * dg_s + 0.5 * dg2_inc_s + 2.5 * dg2_s) * 1.5
+        db2_tol = (0.5 * db_inc_s + 0.5 * db_s + 0.5 * db2_inc_s + 2.5 * db2_s) * 1.5
+        err_g2 = (dg2_q.to(torch.float64) * dg2_s - ref_dg_sum).abs().max().item()
+        err_b2 = (db2_q.to(torch.float64) * db2_s - ref_db_sum).abs().max().item()
+        assert err_g2 <= dg2_tol, f"{name}: 2-call dgamma err {err_g2} > {dg2_tol}"
+        assert err_b2 <= db2_tol, f"{name}: 2-call dbeta err {err_b2} > {db2_tol}"
+        fx.update({
+            "dy2": dy2_deq, "dx2_q": dx2_q, "s_dx2": s_dx2,
+            "dg2_q": dg2_q, "dg2_s": dg2_s, "db2_q": db2_q, "db2_s": db2_s,
+            "dg2_dequant": ref_dg_sum.to(torch.float32),
+            "db2_dequant": ref_db_sum.to(torch.float32),
+            "grad_dequant_tol2": max(dg2_tol, db2_tol),
+        })
+    return fx
+
+
+def fixture_bwd_base():
+    # [3,4], D=1, G=3, N=4 (N>=3). Per-group variance ratio ~445x (row1) pins
+    # per-group invSigma in dx. Non-uniform dy with sign/magnitude structure
+    # per group; gamma non-trivial with s_gamma = 2/32767 (scale-blindness
+    # mutations must show up in the dequant/scale asserts).
+    x = torch.tensor([[0.1, -0.4, 0.7, 1.2],
+                      [20.0, 10.0, -15.0, 5.0],
+                      [-0.3, -0.8, 0.2, 0.9]], dtype=torch.float64)
+    gamma = torch.tensor([1.5, -0.5, 2.0, 0.25], dtype=torch.float64)
+    dy = torch.tensor([[1.0, -2.0, 0.5, 1.5],
+                       [-0.25, 0.75, 1.25, -1.0],
+                       [2.0, 0.5, -1.5, -0.75]], dtype=torch.float64)
+    return _run_bwd_fixture("bwdBase", x, gamma, dy, [4])
+
+
+def fixture_bwd_var_eps():
+    # var == eps == 1e-5 (d = sqrt(1.5e-5), var = 2d^2/3): the ONLY regime
+    # where eps placement in the backward is visible (codebase memory:
+    # O(1)-variance fixtures are blind). N=3, G=1, gamma=ones.
+    d = 0.0038729833
+    x = torch.tensor([1.0 - d, 1.0, 1.0 + d], dtype=torch.float64)
+    gamma = torch.ones(3, dtype=torch.float64)
+    dy = torch.tensor([0.5, -1.0, 0.25], dtype=torch.float64)
+    return _run_bwd_fixture("bwdVarEps", x, gamma, dy, [3], var_near_eps=True)
+
+
+def fixture_bwd_two_calls():
+    # [2,4]; dy2 = 10x dy1 -> s_dx must refresh ~10x on call 2 (freeze-scale
+    # test) and grads must accumulate per strategy A across calls.
+    x = torch.tensor([[1.0, 2.0, 3.0, 4.0],
+                      [10.0, 20.0, 30.0, 40.0]], dtype=torch.float64)
+    gamma = torch.tensor([2.0, 1.0, -1.0, 0.5], dtype=torch.float64)
+    dy1 = torch.tensor([[0.5, -1.0, 0.25, 0.75],
+                        [-0.5, 1.5, -0.25, 1.0]], dtype=torch.float64)
+    dy2 = torch.tensor([[5.0, -10.0, 2.5, 7.5],
+                        [-5.0, 15.0, -2.5, 10.0]], dtype=torch.float64)
+    return _run_bwd_fixture("bwdTwoCalls", x, gamma, dy1, [4], dy2=dy2)
+
+
+def emit_fixture(parts, fx):
+    pre = f"layerNormSymBwd_{fx['name']}"
+    parts.append(emit_float_array(f"input_{pre}", fx["x"]))
+    parts.append(emit_float_array(f"gamma_{pre}", fx["gamma"]))
+    parts.append(emit_float_array(f"lossGrad_{pre}", fx["dy"]))
+    parts.append(emit_int32_array(f"expectedDx_{pre}", fx["dx_q"]))
+    parts.append(emit_float_scalar(f"expectedDxScale_{pre}", fx["s_dx"]))
+    parts.append(emit_int32_scalar(f"dxMantissaTol_{pre}", 2))
+    parts.append(emit_float_array(f"expectedDxDequant_{pre}", fx["dx_dequant"]))
+    parts.append(emit_float_scalar(f"dxDequantTol_{pre}", fx["dx_dequant_tol"]))
+    parts.append(emit_int32_array(f"expectedDgamma_{pre}", fx["dg_q"]))
+    parts.append(emit_float_scalar(f"expectedDgammaScale_{pre}", fx["dg_s"]))
+    parts.append(emit_int32_array(f"expectedDbeta_{pre}", fx["db_q"]))
+    parts.append(emit_float_scalar(f"expectedDbetaScale_{pre}", fx["db_s"]))
+    parts.append(emit_int32_scalar(f"gradMantissaTol_{pre}", 2))
+    parts.append(emit_float_array(f"expectedDgammaDequant_{pre}", fx["dg_dequant"]))
+    parts.append(emit_float_array(f"expectedDbetaDequant_{pre}", fx["db_dequant"]))
+    parts.append(emit_float_scalar(f"gradDequantTol_{pre}", fx["grad_dequant_tol"]))
+    if "dy2" in fx:
+        parts.append(emit_float_array(f"lossGrad2_{pre}", fx["dy2"]))
+        parts.append(emit_int32_array(f"expectedDx2_{pre}", fx["dx2_q"]))
+        parts.append(emit_float_scalar(f"expectedDxScale2_{pre}", fx["s_dx2"]))
+        parts.append(emit_int32_array(f"expectedDgammaAfter2_{pre}", fx["dg2_q"]))
+        parts.append(emit_float_scalar(f"expectedDgammaScaleAfter2_{pre}", fx["dg2_s"]))
+        parts.append(emit_int32_array(f"expectedDbetaAfter2_{pre}", fx["db2_q"]))
+        parts.append(emit_float_scalar(f"expectedDbetaScaleAfter2_{pre}", fx["db2_s"]))
+        parts.append(emit_float_array(f"expectedDgammaDequant2_{pre}", fx["dg2_dequant"]))
+        parts.append(emit_float_array(f"expectedDbetaDequant2_{pre}", fx["db2_dequant"]))
+        parts.append(emit_float_scalar(f"gradDequantTol2_{pre}", fx["grad_dequant_tol2"]))
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out", required=True, type=Path)
+    args = ap.parse_args()
+
+    parts = [
+        "// AUTOGENERATED by generate_expected_layernorm_sym_bwd.py — DO NOT EDIT\n",
+        "#ifndef ODT_EXPECTED_LAYERNORM_SYM_BWD_H\n",
+        "#define ODT_EXPECTED_LAYERNORM_SYM_BWD_H\n",
+        "#include <stdint.h>\n",
+        "#include <stdlib.h>\n\n",
+    ]
+
+    for fx in [fixture_bwd_base(), fixture_bwd_var_eps(), fixture_bwd_two_calls()]:
+        emit_fixture(parts, fx)
+
+    parts.append("\n#endif // ODT_EXPECTED_LAYERNORM_SYM_BWD_H\n")
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text("".join(parts))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/unit/userAPI/UnitTestLayerNormIntegration.c
+++ b/test/unit/userAPI/UnitTestLayerNormIntegration.c
@@ -2,6 +2,7 @@
 
 #include <math.h>
 #include <stdbool.h>
+#include <stdint.h>
 #include <stdlib.h>
 
 #include "CalculateGradsSequential.h"
@@ -14,6 +15,7 @@
 #include "LinearApi.h"
 #include "LossFunction.h"
 #include "Optimizer.h"
+#include "Quantization.h"
 #include "QuantizationApi.h"
 #include "SgdApi.h"
 #include "StorageApi.h"
@@ -33,6 +35,19 @@ static tensor_t *build2DFloat(size_t b, size_t f, const float *data, size_t n) {
     shape_t *shape = reserveMemory(sizeof(shape_t));
     setShape(shape, dims, 2, order);
     tensor_t *t = initTensor(shape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(t, (float *)data, n);
+    return t;
+}
+
+static tensor_t *build2DSym(size_t b, size_t f, const float *data, size_t n) {
+    size_t *dims = reserveMemory(2 * sizeof(size_t));
+    dims[0] = b;
+    dims[1] = f;
+    size_t *order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, order);
+    shape_t *shape = reserveMemory(sizeof(shape_t));
+    setShape(shape, dims, 2, order);
+    tensor_t *t = initTensor(shape, quantizationInitSymInt32(HTE), NULL);
     tensorFillFromFloatBuffer(t, (float *)data, n);
     return t;
 }
@@ -125,8 +140,104 @@ void testLinearLayerNormLinearOneTrainingStep(void) {
     TEST_ASSERT_TRUE_MESSAGE(predictedFinite, "inference output must be finite");
 }
 
+/* Full-SYM single-LayerNorm training step through the public training APIs:
+ * calculateGradsSequential (MSE — the only SYM-capable loss backward) + SGD-M
+ * step on SYM gamma/beta with SYM grads. Single-layer BY DESIGN: direct SYM
+ * Linear->LayerNorm chaining is not intended to work (Linear SYM outputs are
+ * accumulator-range mantissas, violating LayerNorm's int16-range input
+ * contract); the designed composition inserts explicit Quantization (requant)
+ * layers — Linear -> Quant -> LayerNorm -> Quant -> Linear — a follow-up
+ * feature (#192; the accumulator-range contract itself is #137).
+ * A FLOAT32 twin trained on the same data is the reference; 5e-3 absolute
+ * dequant tolerance absorbs input quantization + strategy-A grad noise
+ * (PR-0 E2E precedent tolerance). */
+void testLayerNormSymInt32SingleLayerTrainingStep(void) {
+    const float inputVals[8] = {1.f, 2.f, 3.f, 4.f, 10.f, 20.f, 30.f, 40.f};
+    const float labelVals[8] = {0.5f, -1.f, 2.f, 1.5f, -0.5f, 1.f, -2.f, 0.25f};
+    size_t normShape[] = {4};
+
+    /* ---- SYM model (under test) ---- */
+    layerNormInit_t initSym = {.normalizedShape = normShape, .numNormDims = 1, .eps = 1e-5f};
+    quantization_t *symQ = quantizationInitSymInt32(HTE);
+    layerQuant_t lqSym = {
+        .forwardMath = symQ, .backwardMath = symQ, .weightStorage = symQ, .biasStorage = symQ};
+    layer_t *lnSym = layerNormLayerInit(&initSym, &lqSym);
+    layer_t *modelSym[1] = {lnSym};
+
+    tensor_t *inSym = build2DSym(2, 4, inputVals, 8);
+    tensor_t *labelSym = build2DSym(2, 4, labelVals, 8);
+
+    bool gradSymDtype = (lnSym->config->layerNorm->gamma->grad->quantization->type == SYM_INT32);
+
+    optimizer_t *optimSym = sgdMCreateOptim(0.1f, 0.0f, 0.0f, modelSym, 1, SYM_INT32);
+    trainingStats_t *statsSym = calculateGradsSequential(modelSym, 1, defaultLossConfig(MSE),
+                                                         REDUCTION_MEAN, inSym, labelSym);
+    sgdStepM(optimSym);
+
+    float gammaSym[4], betaSym[4];
+    {
+        layerNormConfig_t *cfg = lnSym->config->layerNorm;
+        float gs = ((symInt32QConfig_t *)cfg->gamma->param->quantization->qConfig)->scale;
+        float bs = ((symInt32QConfig_t *)cfg->beta->param->quantization->qConfig)->scale;
+        for (size_t i = 0; i < 4; i++) {
+            gammaSym[i] = (float)((int32_t *)cfg->gamma->param->data)[i] * gs;
+            betaSym[i] = (float)((int32_t *)cfg->beta->param->data)[i] * bs;
+        }
+    }
+    bool symStatsNotNull = (statsSym != NULL);
+    float symLoss = statsSym ? statsSym->loss : NAN;
+
+    /* ---- FLOAT32 twin (reference) ---- */
+    layerNormInit_t initF = {.normalizedShape = normShape, .numNormDims = 1, .eps = 1e-5f};
+    quantization_t *fQ = quantizationInitFloat();
+    layerQuant_t lqF;
+    layerQuantInitUniform(&lqF, fQ);
+    layer_t *lnF = layerNormLayerInit(&initF, &lqF);
+    layer_t *modelF[1] = {lnF};
+
+    tensor_t *inF = build2DFloat(2, 4, inputVals, 8);
+    tensor_t *labelF = build2DFloat(2, 4, labelVals, 8);
+
+    optimizer_t *optimF = sgdMCreateOptim(0.1f, 0.0f, 0.0f, modelF, 1, FLOAT32);
+    trainingStats_t *statsF =
+        calculateGradsSequential(modelF, 1, defaultLossConfig(MSE), REDUCTION_MEAN, inF, labelF);
+    sgdStepM(optimF);
+
+    float gammaF[4], betaF[4];
+    for (size_t i = 0; i < 4; i++) {
+        gammaF[i] = ((float *)lnF->config->layerNorm->gamma->param->data)[i];
+        betaF[i] = ((float *)lnF->config->layerNorm->beta->param->data)[i];
+    }
+
+    freeTrainingStats(statsF);
+    freeTrainingStats(statsSym);
+    freeTensor(labelF);
+    freeTensor(inF);
+    freeTensor(labelSym);
+    freeTensor(inSym);
+    freeOptimSgdM(optimF); /* frees gamma/beta parameter_t of the float twin */
+    freeOptimSgdM(optimSym);
+    freeLayerNormLayerShell(lnF);
+    freeLayerNormLayerShell(lnSym);
+    freeQuantization(fQ);
+    freeQuantization(symQ);
+
+    TEST_ASSERT_TRUE(symStatsNotNull);
+    TEST_ASSERT_TRUE_MESSAGE(isfinite(symLoss), "SYM loss must be finite");
+    TEST_ASSERT_TRUE_MESSAGE(gradSymDtype, "factory must produce SYM_INT32 grads");
+    for (size_t i = 0; i < 4; i++) {
+        /* gamma init 1.0 / beta init 0.0: both twins must move, and the SYM
+         * twin must land near the float twin. */
+        TEST_ASSERT_TRUE_MESSAGE(fabsf(gammaF[i] - 1.0f) > 1e-6f,
+                                 "reference gamma must actually train");
+        TEST_ASSERT_FLOAT_WITHIN(5e-3f, gammaF[i], gammaSym[i]);
+        TEST_ASSERT_FLOAT_WITHIN(5e-3f, betaF[i], betaSym[i]);
+    }
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(testLinearLayerNormLinearOneTrainingStep);
+    RUN_TEST(testLayerNormSymInt32SingleLayerTrainingStep);
     return UNITY_END();
 }


### PR DESCRIPTION
PR-3 of 3 for #148 (after #185 / #190). Implements the spec-verified SYM_INT32 backward:

- **Kernel** (`layerNormBackwardSymInt32`): mu/sigma/n recomputed from `forwardInput` through `layerNormGroupStatsSymInt32` (the same helper the forward uses — no desync possible); dy/gamma dequantized per element via their own scales; dgamma/dbeta float increments summed over groups, then accumulated via Linear's SYM weight-grad idiom (quantize increment → `addSymInt32TensorsInplace`, strategy-A dynamic rescale per docs/CONVENTIONS.md); dx two-pass recompute-over-store with whole-tensor absmax requant (`convertFloatTensorToSymInt32Tensor` idiom, absmax==0 → zeros/scale 1.0), propLoss scale refreshed on every call.
- **Tests**: float64 pipeline emulator (`generate_expected_layernorm_sym_bwd.py`, half-away-from-zero rounding per #188, dequantization-stable fixtures, per-group non-uniform dy enforced) + gold suites: multi-group base (~445x per-group variance ratio, ~21x sigma), var≈eps backward fixture, two-call scale-refresh + cross-call accumulation, dy==0 guard, divergent-layout bit-identity. Every behavioral test mutation-verified (evidence in the commit bodies).
- **Factory**: backwardMath validated; SYM_INT32 backwardMath requires SYM_INT32 forwardMath; SYM forward + FLOAT32 backwardMath stays constructible as the inference-only profile.
- **Integration**: full-SYM single-LayerNorm training step (`calculateGradsSequential` + MSE + `sgdStepM` on SYM grads) vs a FLOAT32 twin. Single-layer by design: direct SYM Linear→LayerNorm chaining is not intended; the designed composition (explicit Quantization/requant layers: Linear→Quant→LayerNorm→Quant→Linear) is the follow-up Quantization-layer feature (#192, accumulator-range contract: #137).

Depends on #187 (propLoss dtype guards, separate PR #191 — merged). Part 3 of 3 for #148 — do NOT auto-close (develop-merge): close #148 manually after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
