### PR TITLE
refactor(arithmetic): rename roundHTE to roundHalfAway — name was the bug (#188)

### DIFF
--- a/src/arithmetic/Rounding.c
+++ b/src/arithmetic/Rounding.c
@@ -6,8 +6,8 @@
 #include "RNG.h"
 #include "Rounding.h"
 
-// round to even, when fractional is EXACTLY 0.5
-int32_t roundHTE(float input) {
+// C round(): rounds half away from zero (C17 7.12.9.6)
+int32_t roundHalfAway(float input) {
     return round(input);
 }
 
@@ -15,16 +15,16 @@ float randfloat() {
     return rngNextFloat();
 }
 
-int32_t roundSRHTE(const float input) {
-    return roundHTE(input + randfloat() - 0.5f);
+int32_t roundSRHalfAway(const float input) {
+    return roundHalfAway(input + randfloat() - 0.5f);
 }
 
 int32_t roundByMode(const float input, const roundingMode_t roundingMode) {
     switch (roundingMode) {
-    case HTE:
-        return roundHTE(input);
-    case SRHTE:
-        return roundSRHTE(input);
+    case HALF_AWAY:
+        return roundHalfAway(input);
+    case SR_HALF_AWAY:
+        return roundSRHalfAway(input);
     }
     return 0;
 }

--- a/src/arithmetic/include/Rounding.h
+++ b/src/arithmetic/include/Rounding.h
@@ -3,10 +3,11 @@
 #include <stdint.h>
 
 /*! @brief Describes rounding
- * HTE = Half to Even
- * SRHTE = Stochastic Rounding Half to Even
+ * HALF_AWAY = round half away from zero (C round(), C17 7.12.9.6)
+ * SR_HALF_AWAY = stochastic rounding: uniform jitter in [-0.5, 0.5) is added
+ *                before rounding half away from zero
  */
-typedef enum roundingMode { HTE, SRHTE } roundingMode_t;
+typedef enum roundingMode { HALF_AWAY, SR_HALF_AWAY } roundingMode_t;
 
 int32_t roundByMode(float input, roundingMode_t roundingMode);
 

--- a/test/unit/arithmetic/UnitTestAdd.c
+++ b/test/unit/arithmetic/UnitTestAdd.c
@@ -144,7 +144,7 @@ void testAddSymInt32TensorsInplace() {
     size_t numberOfValues = 6;
 
     symInt32QConfig_t aQC;
-    initSymInt32QConfig(HTE, &aQC);
+    initSymInt32QConfig(HALF_AWAY, &aQC);
     aQC.scale = 1.f;
     quantization_t aQ;
     initSymInt32Quantization(&aQC, &aQ);
@@ -162,7 +162,7 @@ void testAddSymInt32TensorsInplace() {
     setTensorValues(&aTensor, aDataBytes, &shape, &aQ, NULL);
 
     symInt32QConfig_t bQC;
-    initSymInt32QConfig(HTE, &bQC);
+    initSymInt32QConfig(HALF_AWAY, &bQC);
     bQC.scale = 2.f;
     quantization_t bQ;
     initSymInt32Quantization(&bQC, &bQ);
@@ -208,7 +208,7 @@ void testAddInt32TensorWithSymInt32TensorInplace() {
     size_t numberOfValues = 6;
 
     symInt32QConfig_t aQC;
-    initSymInt32QConfig(HTE, &aQC);
+    initSymInt32QConfig(HALF_AWAY, &aQC);
     aQC.scale = 100.f;
     quantization_t aQ;
     initSymInt32Quantization(&aQC, &aQ);
@@ -240,7 +240,7 @@ void testAddFloat32TensorToSymInt32TensorInplace() {
     size_t numberOfValues = 6;
 
     symInt32QConfig_t aQC;
-    initSymInt32QConfig(HTE, &aQC);
+    initSymInt32QConfig(HALF_AWAY, &aQC);
     aQC.scale = 100.f;
     quantization_t aQ;
     initSymInt32Quantization(&aQC, &aQ);

--- a/test/unit/arithmetic/UnitTestDiv.c
+++ b/test/unit/arithmetic/UnitTestDiv.c
@@ -62,7 +62,7 @@ void testDivSymInt32TensorsInplace() {
         .dimensions = dims, .orderOfDimensions = orderOfDims, .numberOfDimensions = numberOfDims};
 
     symInt32QConfig_t aSymInt32QC;
-    initSymInt32QConfig(HTE, &aSymInt32QC);
+    initSymInt32QConfig(HALF_AWAY, &aSymInt32QC);
     quantization_t aQ;
     initSymInt32Quantization(&aSymInt32QC, &aQ);
 
@@ -73,7 +73,7 @@ void testDivSymInt32TensorsInplace() {
     uint8_t *bDataBytes = (uint8_t *)bData;
 
     symInt32QConfig_t bSymInt32QC;
-    initSymInt32QConfig(HTE, &bSymInt32QC);
+    initSymInt32QConfig(HALF_AWAY, &bSymInt32QC);
     quantization_t bQ;
     initSymInt32Quantization(&bSymInt32QC, &bQ);
 

--- a/test/unit/arithmetic/UnitTestMatmul.c
+++ b/test/unit/arithmetic/UnitTestMatmul.c
@@ -222,7 +222,7 @@ void testMatmulSymInt32Tensors() {
     shape_t aShape;
     setShape(&aShape, aDims, aNumberOfDims, aOrderOfDims);
     symInt32QConfig_t aSymInt32QC;
-    initSymInt32QConfig(HTE, &aSymInt32QC);
+    initSymInt32QConfig(HALF_AWAY, &aSymInt32QC);
     aSymInt32QC.scale = 2.f;
     quantization_t aQ;
     initSymInt32Quantization(&aSymInt32QC, &aQ);
@@ -236,7 +236,7 @@ void testMatmulSymInt32Tensors() {
     shape_t bShape;
     setShape(&bShape, bDims, bNumberOfDims, bOrderOfDims);
     symInt32QConfig_t bSymInt32QC;
-    initSymInt32QConfig(HTE, &bSymInt32QC);
+    initSymInt32QConfig(HALF_AWAY, &bSymInt32QC);
     quantization_t bQ;
     initSymInt32Quantization(&bSymInt32QC, &bQ);
     setTensorValues(&bTensor, (uint8_t *)bData, &bShape, &bQ, NULL);
@@ -249,7 +249,7 @@ void testMatmulSymInt32Tensors() {
     shape_t outputShape;
     setShape(&outputShape, outputDims, outputNumberOfDims, outputOrderOfDims);
     symInt32QConfig_t outputSymInt32QC;
-    initSymInt32QConfig(HTE, &outputSymInt32QC);
+    initSymInt32QConfig(HALF_AWAY, &outputSymInt32QC);
     quantization_t outputQ;
     initSymInt32Quantization(&outputSymInt32QC, &outputQ);
     setTensorValues(&outputTensor, (uint8_t *)outputData, &outputShape, &outputQ, NULL);
@@ -357,7 +357,7 @@ void testMatmulSymInt32TensorsWithBiasRescalesBias() {
     shape_t aShape;
     setShape(&aShape, aDims, 2, aOrder);
     symInt32QConfig_t aQC;
-    initSymInt32QConfig(HTE, &aQC);
+    initSymInt32QConfig(HALF_AWAY, &aQC);
     aQC.scale = 2.f;
     quantization_t aQ;
     initSymInt32Quantization(&aQC, &aQ);
@@ -370,7 +370,7 @@ void testMatmulSymInt32TensorsWithBiasRescalesBias() {
     shape_t bShape;
     setShape(&bShape, bDims, 2, bOrder);
     symInt32QConfig_t bQC;
-    initSymInt32QConfig(HTE, &bQC);
+    initSymInt32QConfig(HALF_AWAY, &bQC);
     bQC.scale = 1.f;
     quantization_t bQ;
     initSymInt32Quantization(&bQC, &bQ);
@@ -383,7 +383,7 @@ void testMatmulSymInt32TensorsWithBiasRescalesBias() {
     shape_t biasShape;
     setShape(&biasShape, biasDims, 1, biasOrder);
     symInt32QConfig_t biasQC;
-    initSymInt32QConfig(HTE, &biasQC);
+    initSymInt32QConfig(HALF_AWAY, &biasQC);
     biasQC.scale = 4.f;
     quantization_t biasQ;
     initSymInt32Quantization(&biasQC, &biasQ);
@@ -396,7 +396,7 @@ void testMatmulSymInt32TensorsWithBiasRescalesBias() {
     shape_t outputShape;
     setShape(&outputShape, outputDims, 2, outputOrder);
     symInt32QConfig_t outputQC;
-    initSymInt32QConfig(HTE, &outputQC);
+    initSymInt32QConfig(HALF_AWAY, &outputQC);
     quantization_t outputQ;
     initSymInt32Quantization(&outputQC, &outputQ);
     setTensorValues(&outputTensor, (uint8_t *)outputData, &outputShape, &outputQ, NULL);

--- a/test/unit/arithmetic/UnitTestRounding.c
+++ b/test/unit/arithmetic/UnitTestRounding.c
@@ -1,34 +1,34 @@
 #include "Rounding.h"
 #include "unity.h"
 
-void testRoundHTE() {
+void testRoundHalfAway() {
     float input = 1.7f;
-    int32_t actual = roundByMode(input, HTE);
+    int32_t actual = roundByMode(input, HALF_AWAY);
     int32_t expected = 2;
     TEST_ASSERT_EQUAL(expected, actual);
 
     input = 2.3f;
-    actual = roundByMode(input, HTE);
+    actual = roundByMode(input, HALF_AWAY);
     expected = 2;
     TEST_ASSERT_EQUAL(expected, actual);
 
     input = 2.5f;
-    actual = roundByMode(input, HTE);
+    actual = roundByMode(input, HALF_AWAY);
     expected = 3;
     TEST_ASSERT_EQUAL(expected, actual);
 
     input = -1.7f;
-    actual = roundByMode(input, HTE);
+    actual = roundByMode(input, HALF_AWAY);
     expected = -2;
     TEST_ASSERT_EQUAL(expected, actual);
 
     input = -2.3f;
-    actual = roundByMode(input, HTE);
+    actual = roundByMode(input, HALF_AWAY);
     expected = -2;
     TEST_ASSERT_EQUAL(expected, actual);
 
     input = -2.5f;
-    actual = roundByMode(input, HTE);
+    actual = roundByMode(input, HALF_AWAY);
     expected = -3;
     TEST_ASSERT_EQUAL(expected, actual);
 }
@@ -38,7 +38,7 @@ void tearDown() {}
 
 int main(void) {
     UNITY_BEGIN();
-    RUN_TEST(testRoundHTE);
+    RUN_TEST(testRoundHalfAway);
 
     return UNITY_END();
 }

--- a/test/unit/arithmetic/UnitTestSub.c
+++ b/test/unit/arithmetic/UnitTestSub.c
@@ -87,7 +87,7 @@ void testSubSymInt32Tensors() {
                       .orderOfDimensions = aOrderOfDims,
                       .numberOfDimensions = aNumberOfDims};
     symInt32QConfig_t aSymInt32QC;
-    initSymInt32QConfig(HTE, &aSymInt32QC);
+    initSymInt32QConfig(HALF_AWAY, &aSymInt32QC);
     quantization_t aQ;
     initSymInt32Quantization(&aSymInt32QC, &aQ);
 
@@ -105,7 +105,7 @@ void testSubSymInt32Tensors() {
                       .numberOfDimensions = bNumberOfDims};
 
     symInt32QConfig_t bSymInt32QC;
-    initSymInt32QConfig(HTE, &bSymInt32QC);
+    initSymInt32QConfig(HALF_AWAY, &bSymInt32QC);
     quantization_t bQ;
     initSymInt32Quantization(&bSymInt32QC, &bQ);
 

--- a/test/unit/layer/UnitTestDropout.c
+++ b/test/unit/layer/UnitTestDropout.c
@@ -89,7 +89,7 @@ void testForwardEvalIdentitySymInt32(void) {
     setOrderOfDimsForNewTensor(1, order);
     shape_t *shape = reserveMemory(sizeof(shape_t));
     setShape(shape, dims, 1, order);
-    tensor_t *symIn = initTensor(shape, quantizationInitSymInt32(HTE), NULL);
+    tensor_t *symIn = initTensor(shape, quantizationInitSymInt32(HALF_AWAY), NULL);
     int32_t inInts[] = {10, -20, 30, -40};
     for (size_t i = 0; i < n; i++) {
         ((int32_t *)symIn->data)[i] = inInts[i];
@@ -102,11 +102,11 @@ void testForwardEvalIdentitySymInt32(void) {
     setOrderOfDimsForNewTensor(1, oorder);
     shape_t *oshape = reserveMemory(sizeof(shape_t));
     setShape(oshape, odims, 1, oorder);
-    tensor_t *symOut = initTensor(oshape, quantizationInitSymInt32(HTE), NULL);
+    tensor_t *symOut = initTensor(oshape, quantizationInitSymInt32(HALF_AWAY), NULL);
 
     tensor_t *mask = buildBoolMask(n);
-    quantization_t *fq = quantizationInitSymInt32(HTE);
-    quantization_t *bq = quantizationInitSymInt32(HTE);
+    quantization_t *fq = quantizationInitSymInt32(HALF_AWAY);
+    quantization_t *bq = quantizationInitSymInt32(HALF_AWAY);
     dropoutConfig_t dcfg;
     initDropoutConfig(&dcfg, 0.5f, mask, fq, bq); // eval mode
     layerConfig_t lcfg;
@@ -183,7 +183,7 @@ void testForwardTrainingSymInt32ScaleFold(void) {
     setOrderOfDimsForNewTensor(1, order);
     shape_t *shape = reserveMemory(sizeof(shape_t));
     setShape(shape, dims, 1, order);
-    tensor_t *symIn = initTensor(shape, quantizationInitSymInt32(HTE), NULL);
+    tensor_t *symIn = initTensor(shape, quantizationInitSymInt32(HALF_AWAY), NULL);
     int32_t inInts[] = {10, -20, 30, 40};
     for (size_t i = 0; i < n; i++) {
         ((int32_t *)symIn->data)[i] = inInts[i];
@@ -196,11 +196,11 @@ void testForwardTrainingSymInt32ScaleFold(void) {
     setOrderOfDimsForNewTensor(1, oorder);
     shape_t *oshape = reserveMemory(sizeof(shape_t));
     setShape(oshape, odims, 1, oorder);
-    tensor_t *symOut = initTensor(oshape, quantizationInitSymInt32(HTE), NULL);
+    tensor_t *symOut = initTensor(oshape, quantizationInitSymInt32(HALF_AWAY), NULL);
 
     tensor_t *mask = buildBoolMask(n);
-    quantization_t *fq = quantizationInitSymInt32(HTE);
-    quantization_t *bq = quantizationInitSymInt32(HTE);
+    quantization_t *fq = quantizationInitSymInt32(HALF_AWAY);
+    quantization_t *bq = quantizationInitSymInt32(HALF_AWAY);
     dropoutConfig_t dcfg;
     initDropoutConfig(&dcfg, 0.5f, mask, fq, bq);
     dcfg.training = true;
@@ -282,7 +282,7 @@ void testBackwardSymInt32UsesMaskAndScaleFold(void) {
     setOrderOfDimsForNewTensor(1, lorder);
     shape_t *lshape = reserveMemory(sizeof(shape_t));
     setShape(lshape, ldims, 1, lorder);
-    tensor_t *loss = initTensor(lshape, quantizationInitSymInt32(HTE), NULL);
+    tensor_t *loss = initTensor(lshape, quantizationInitSymInt32(HALF_AWAY), NULL);
     int32_t gradInts[] = {5, 6, 7, 8};
     for (size_t i = 0; i < n; i++) {
         ((int32_t *)loss->data)[i] = gradInts[i];
@@ -295,13 +295,13 @@ void testBackwardSymInt32UsesMaskAndScaleFold(void) {
     setOrderOfDimsForNewTensor(1, porder);
     shape_t *pshape = reserveMemory(sizeof(shape_t));
     setShape(pshape, pdims, 1, porder);
-    tensor_t *propLoss = initTensor(pshape, quantizationInitSymInt32(HTE), NULL);
+    tensor_t *propLoss = initTensor(pshape, quantizationInitSymInt32(HALF_AWAY), NULL);
 
     tensor_t *mask = buildBoolMask(n);
     fillMaskKeepEven(mask);
 
-    quantization_t *fq = quantizationInitSymInt32(HTE);
-    quantization_t *bq = quantizationInitSymInt32(HTE);
+    quantization_t *fq = quantizationInitSymInt32(HALF_AWAY);
+    quantization_t *bq = quantizationInitSymInt32(HALF_AWAY);
     dropoutConfig_t dcfg;
     initDropoutConfig(&dcfg, 0.5f, mask, fq, bq);
     dcfg.training = true;

--- a/test/unit/layer/UnitTestFlatten.c
+++ b/test/unit/layer/UnitTestFlatten.c
@@ -125,7 +125,7 @@ void testFlattenForwardSymInt32_PropagatesScaleAndValues(void) {
     setOrderOfDimsForNewTensor(3, inputOrder);
     shape_t *inputShape = reserveMemory(sizeof(shape_t));
     setShape(inputShape, inputDims, 3, inputOrder);
-    tensor_t *input = initTensor(inputShape, quantizationInitSymInt32(HTE), NULL);
+    tensor_t *input = initTensor(inputShape, quantizationInitSymInt32(HALF_AWAY), NULL);
     tensorFillFromFloatBuffer(input, inputFloatData, n);
 
     /* 2. Build heap output tensor (SymInt32, shape 1x6). */
@@ -136,7 +136,7 @@ void testFlattenForwardSymInt32_PropagatesScaleAndValues(void) {
     setOrderOfDimsForNewTensor(2, outputOrder);
     shape_t *outputShape = reserveMemory(sizeof(shape_t));
     setShape(outputShape, outputDims, 2, outputOrder);
-    tensor_t *output = initTensor(outputShape, quantizationInitSymInt32(HTE), NULL);
+    tensor_t *output = initTensor(outputShape, quantizationInitSymInt32(HALF_AWAY), NULL);
 
     /* Clobber the output's scale so we can verify flattenForward writes it. */
     symInt32QConfig_t *outputQC = output->quantization->qConfig;
@@ -250,7 +250,7 @@ void testFlattenBackwardSymInt32_PropagatesScale(void) {
     setOrderOfDimsForNewTensor(3, forwardOrder);
     shape_t *forwardShape = reserveMemory(sizeof(shape_t));
     setShape(forwardShape, forwardDims, 3, forwardOrder);
-    tensor_t *forwardInput = initTensor(forwardShape, quantizationInitSymInt32(HTE), NULL);
+    tensor_t *forwardInput = initTensor(forwardShape, quantizationInitSymInt32(HALF_AWAY), NULL);
     tensorFillFromFloatBuffer(forwardInput, (float[]){-1.f, 0.f, 1.f, 2.f, 5.f, -6.f}, 6);
 
     /* 2. Build heap loss tensor (SymInt32, shape 1x6). */
@@ -261,7 +261,7 @@ void testFlattenBackwardSymInt32_PropagatesScale(void) {
     setOrderOfDimsForNewTensor(2, lossOrder);
     shape_t *lossShape = reserveMemory(sizeof(shape_t));
     setShape(lossShape, lossDims, 2, lossOrder);
-    tensor_t *loss = initTensor(lossShape, quantizationInitSymInt32(HTE), NULL);
+    tensor_t *loss = initTensor(lossShape, quantizationInitSymInt32(HALF_AWAY), NULL);
     tensorFillFromFloatBuffer(loss, lossFloatData, n);
 
     /* 3. Build heap propLoss tensor (SymInt32, shape 1x2x3). */
@@ -273,7 +273,7 @@ void testFlattenBackwardSymInt32_PropagatesScale(void) {
     setOrderOfDimsForNewTensor(3, propLossOrder);
     shape_t *propLossShape = reserveMemory(sizeof(shape_t));
     setShape(propLossShape, propLossDims, 3, propLossOrder);
-    tensor_t *propLoss = initTensor(propLossShape, quantizationInitSymInt32(HTE), NULL);
+    tensor_t *propLoss = initTensor(propLossShape, quantizationInitSymInt32(HALF_AWAY), NULL);
 
     /* Clobber propLoss scale so we can verify flattenBackward writes it. */
     symInt32QConfig_t *propLossQC = propLoss->quantization->qConfig;

--- a/test/unit/layer/UnitTestLayerNorm.c
+++ b/test/unit/layer/UnitTestLayerNorm.c
@@ -50,7 +50,7 @@ static parameter_t *buildFloatParam(size_t numDims, const size_t *dimsIn, const 
     return parameterInit(p, g);
 }
 
-/* Build a SYM_INT32 (HTE, qMaxBits=16) tensor; float vals are quantized via
+/* Build a SYM_INT32 (HALF_AWAY, qMaxBits=16) tensor; float vals are quantized via
  * tensorFillFromFloatBuffer -> convertFloatTensorToSymInt32Tensor (absmax ->
  * scale, round-clamp; absmax==0 -> scale 1.0). NULL vals -> zero mantissas,
  * default scale 1.0. Caller frees via freeTensor. */
@@ -63,7 +63,7 @@ static tensor_t *buildSymInt32TensorND(size_t numDims, const size_t *dimsIn, con
     setOrderOfDimsForNewTensor(numDims, order);
     shape_t *shape = reserveMemory(sizeof(shape_t));
     setShape(shape, dims, numDims, order);
-    tensor_t *t = initTensor(shape, quantizationInitSymInt32(HTE), NULL);
+    tensor_t *t = initTensor(shape, quantizationInitSymInt32(HALF_AWAY), NULL);
     if (vals != NULL) {
         tensorFillFromFloatBuffer(t, vals, calcNumberOfElementsByShape(shape));
     }
@@ -73,7 +73,7 @@ static tensor_t *buildSymInt32TensorND(size_t numDims, const size_t *dimsIn, con
 /* SYM_INT32 parameter with SYM_INT32 grad (grads unused in forward-only tests). */
 static parameter_t *buildSymParam(size_t numDims, const size_t *dimsIn, const float *vals) {
     tensor_t *p = buildSymInt32TensorND(numDims, dimsIn, vals);
-    tensor_t *g = gradInitSymInt32(p, HTE, NULL);
+    tensor_t *g = gradInitSymInt32(p, HALF_AWAY, NULL);
     return parameterInit(p, g);
 }
 
@@ -167,7 +167,7 @@ void testSymForwardDequantInvariantsMultiGroup(void) {
     size_t *normShape = reserveMemory(sizeof(size_t));
     normShape[0] = 4;
 
-    quantization_t *fq = quantizationInitSymInt32(HTE);
+    quantization_t *fq = quantizationInitSymInt32(HALF_AWAY);
     quantization_t *bq = quantizationInitFloat();
     layerNormConfig_t cfg;
     initLayerNormConfig(&cfg, gamma, beta, normShape, 1, 1e-5f, fq, bq);
@@ -851,7 +851,7 @@ static void runSymGoldForward(size_t numDims, const size_t *dims, size_t numNorm
     for (size_t i = 0; i < numNormDims; i++) {
         normShape[i] = normShapeIn[i];
     }
-    quantization_t *fq = quantizationInitSymInt32(HTE);
+    quantization_t *fq = quantizationInitSymInt32(HALF_AWAY);
     quantization_t *bq = quantizationInitFloat();
     layerNormConfig_t cfg;
     initLayerNormConfig(&cfg, gamma, beta, normShape, numNormDims, 1e-5f, fq, bq);
@@ -932,8 +932,8 @@ static void runSymGoldBackward(
     for (size_t i = 0; i < numNormDims; i++) {
         normShape[i] = normShapeIn[i];
     }
-    quantization_t *fq = quantizationInitSymInt32(HTE);
-    quantization_t *bq = quantizationInitSymInt32(HTE);
+    quantization_t *fq = quantizationInitSymInt32(HALF_AWAY);
+    quantization_t *bq = quantizationInitSymInt32(HALF_AWAY);
     layerNormConfig_t cfg;
     initLayerNormConfig(&cfg, gamma, beta, normShape, numNormDims, 1e-5f, fq, bq);
     layerConfig_t lcfg;
@@ -1017,8 +1017,8 @@ void testSymBackwardZeroLossGradEmitsZerosNeutralScale(void) {
     size_t *normShape = reserveMemory(sizeof(size_t));
     normShape[0] = 4;
 
-    quantization_t *fq = quantizationInitSymInt32(HTE);
-    quantization_t *bq = quantizationInitSymInt32(HTE);
+    quantization_t *fq = quantizationInitSymInt32(HALF_AWAY);
+    quantization_t *bq = quantizationInitSymInt32(HALF_AWAY);
     layerNormConfig_t cfg;
     initLayerNormConfig(&cfg, gamma, beta, normShape, 1, 1e-5f, fq, bq);
     layerConfig_t lcfg;
@@ -1196,7 +1196,7 @@ void testSymForwardConstantInputEmitsZeros(void) {
     size_t *normShape = reserveMemory(sizeof(size_t));
     normShape[0] = 3;
 
-    quantization_t *fq = quantizationInitSymInt32(HTE);
+    quantization_t *fq = quantizationInitSymInt32(HALF_AWAY);
     quantization_t *bq = quantizationInitFloat();
     layerNormConfig_t cfg;
     initLayerNormConfig(&cfg, gamma, beta, normShape, 1, 1e-5f, fq, bq);
@@ -1242,7 +1242,7 @@ void testSymForwardMantissaInvariantsViaOnesGamma(void) {
     size_t *normShape = reserveMemory(sizeof(size_t));
     normShape[0] = 4;
 
-    quantization_t *fq = quantizationInitSymInt32(HTE);
+    quantization_t *fq = quantizationInitSymInt32(HALF_AWAY);
     quantization_t *bq = quantizationInitFloat();
     layerNormConfig_t cfg;
     initLayerNormConfig(&cfg, gamma, beta, normShape, 1, 1e-5f, fq, bq);
@@ -1299,7 +1299,7 @@ void testSymForwardConstantInputAppliesBeta(void) {
     size_t *normShape = reserveMemory(sizeof(size_t));
     normShape[0] = 3;
 
-    quantization_t *fq = quantizationInitSymInt32(HTE);
+    quantization_t *fq = quantizationInitSymInt32(HALF_AWAY);
     quantization_t *bq = quantizationInitFloat();
     layerNormConfig_t cfg;
     initLayerNormConfig(&cfg, gamma, beta, normShape, 1, 1e-5f, fq, bq);
@@ -1356,7 +1356,7 @@ void testSymForwardVarNearEpsReconstructsHalf(void) {
     size_t *normShape = reserveMemory(sizeof(size_t));
     normShape[0] = 3;
 
-    quantization_t *fq = quantizationInitSymInt32(HTE);
+    quantization_t *fq = quantizationInitSymInt32(HALF_AWAY);
     quantization_t *bq = quantizationInitFloat();
     layerNormConfig_t cfg;
     initLayerNormConfig(&cfg, gamma, beta, normShape, 1, 1e-5f, fq, bq);
@@ -1419,7 +1419,7 @@ void testSymForwardTransposedMatchesContiguous(void) {
     size_t *normShape = reserveMemory(sizeof(size_t));
     normShape[0] = 4;
 
-    quantization_t *fq = quantizationInitSymInt32(HTE);
+    quantization_t *fq = quantizationInitSymInt32(HALF_AWAY);
     quantization_t *bq = quantizationInitFloat();
     layerNormConfig_t cfg;
     initLayerNormConfig(&cfg, gamma, beta, normShape, 1, 1e-5f, fq, bq);
@@ -1462,7 +1462,7 @@ void testFactorySymInt32StorageQuantizesGammaBeta(void) {
     size_t normShape[] = {4};
     layerNormInit_t init = {.normalizedShape = normShape, .numNormDims = 1, .eps = 0.0f};
 
-    quantization_t *symQ = quantizationInitSymInt32(HTE);
+    quantization_t *symQ = quantizationInitSymInt32(HALF_AWAY);
     quantization_t *bwdMath = quantizationInitFloat();
     layerQuant_t lq = {
         .forwardMath = symQ, .backwardMath = bwdMath, .weightStorage = symQ, .biasStorage = symQ};
@@ -1514,7 +1514,7 @@ void testFactoryOwningSymInt32DeepCopiesQuantizations(void) {
     size_t normShape[] = {3};
     layerNormInit_t init = {.normalizedShape = normShape, .numNormDims = 1, .eps = 1e-5f};
 
-    quantization_t *symQ = quantizationInitSymInt32(HTE);
+    quantization_t *symQ = quantizationInitSymInt32(HALF_AWAY);
     quantization_t *bwdMath = quantizationInitFloat();
     layerQuant_t lq = {
         .forwardMath = symQ, .backwardMath = bwdMath, .weightStorage = symQ, .biasStorage = symQ};
@@ -1555,8 +1555,8 @@ void testSymBackwardPropLossScaleRefreshedEveryCall(void) {
     size_t *normShape = reserveMemory(sizeof(size_t));
     normShape[0] = 4;
 
-    quantization_t *fq = quantizationInitSymInt32(HTE);
-    quantization_t *bq = quantizationInitSymInt32(HTE);
+    quantization_t *fq = quantizationInitSymInt32(HALF_AWAY);
+    quantization_t *bq = quantizationInitSymInt32(HALF_AWAY);
     layerNormConfig_t cfg;
     initLayerNormConfig(&cfg, gamma, beta, normShape, 1, 1e-5f, fq, bq);
     layerConfig_t lcfg;
@@ -1614,8 +1614,8 @@ void testSymBackwardGradsAccumulateAcrossCalls(void) {
     size_t *normShape = reserveMemory(sizeof(size_t));
     normShape[0] = 4;
 
-    quantization_t *fq = quantizationInitSymInt32(HTE);
-    quantization_t *bq = quantizationInitSymInt32(HTE);
+    quantization_t *fq = quantizationInitSymInt32(HALF_AWAY);
+    quantization_t *bq = quantizationInitSymInt32(HALF_AWAY);
     layerNormConfig_t cfg;
     initLayerNormConfig(&cfg, gamma, beta, normShape, 1, 1e-5f, fq, bq);
     layerConfig_t lcfg;
@@ -1700,8 +1700,8 @@ void testSymBackwardDivergentLayoutsBitIdentical(void) {
     parameter_t *betaC = buildSymParam(1, ns, NULL);
     size_t *normShapeC = reserveMemory(sizeof(size_t));
     normShapeC[0] = 4;
-    quantization_t *fqC = quantizationInitSymInt32(HTE);
-    quantization_t *bqC = quantizationInitSymInt32(HTE);
+    quantization_t *fqC = quantizationInitSymInt32(HALF_AWAY);
+    quantization_t *bqC = quantizationInitSymInt32(HALF_AWAY);
     layerNormConfig_t cfgC;
     initLayerNormConfig(&cfgC, gammaC, betaC, normShapeC, 1, 1e-5f, fqC, bqC);
     layerConfig_t lcfgC;
@@ -1725,8 +1725,8 @@ void testSymBackwardDivergentLayoutsBitIdentical(void) {
     parameter_t *betaT = buildSymParam(1, ns, NULL);
     size_t *normShapeT = reserveMemory(sizeof(size_t));
     normShapeT[0] = 4;
-    quantization_t *fqT = quantizationInitSymInt32(HTE);
-    quantization_t *bqT = quantizationInitSymInt32(HTE);
+    quantization_t *fqT = quantizationInitSymInt32(HALF_AWAY);
+    quantization_t *bqT = quantizationInitSymInt32(HALF_AWAY);
     layerNormConfig_t cfgT;
     initLayerNormConfig(&cfgT, gammaT, betaT, normShapeT, 1, 1e-5f, fqT, bqT);
     layerConfig_t lcfgT;
@@ -1790,7 +1790,7 @@ void testFactoryFullSymProfileTrainsSymGrads(void) {
     size_t normShape[] = {4};
     layerNormInit_t init = {.normalizedShape = normShape, .numNormDims = 1, .eps = 1e-5f};
 
-    quantization_t *symQ = quantizationInitSymInt32(HTE);
+    quantization_t *symQ = quantizationInitSymInt32(HALF_AWAY);
     layerQuant_t lq = {
         .forwardMath = symQ, .backwardMath = symQ, .weightStorage = symQ, .biasStorage = symQ};
     layer_t *layer = layerNormLayerInit(&init, &lq);

--- a/test/unit/layer/UnitTestLinear.c
+++ b/test/unit/layer/UnitTestLinear.c
@@ -88,7 +88,7 @@ void testLinearForwardSymInt32Rank1BiasRank2Output() {
     setOrderOfDimsForNewTensor(2, weightOrder);
     shape_t *weightShape = reserveMemory(sizeof(shape_t));
     setShape(weightShape, weightDims, 2, weightOrder);
-    tensor_t *weightsParam = initTensor(weightShape, quantizationInitSymInt32(HTE), NULL);
+    tensor_t *weightsParam = initTensor(weightShape, quantizationInitSymInt32(HALF_AWAY), NULL);
     tensorFillFromFloatBuffer(weightsParam, (float[]){-1.f, 2.f, -3.f, 4.f, 5.f, -6.f}, 6);
     parameter_t *weights = parameterInit(weightsParam, NULL);
 
@@ -99,7 +99,7 @@ void testLinearForwardSymInt32Rank1BiasRank2Output() {
     setOrderOfDimsForNewTensor(1, biasOrder);
     shape_t *biasShape = reserveMemory(sizeof(shape_t));
     setShape(biasShape, biasDims, 1, biasOrder);
-    tensor_t *biasParam = initTensor(biasShape, quantizationInitSymInt32(HTE), NULL);
+    tensor_t *biasParam = initTensor(biasShape, quantizationInitSymInt32(HALF_AWAY), NULL);
     tensorFillFromFloatBuffer(biasParam, (float[]){-1.f, 3.f}, 2);
     parameter_t *bias = parameterInit(biasParam, NULL);
 
@@ -110,7 +110,7 @@ void testLinearForwardSymInt32Rank1BiasRank2Output() {
     setOrderOfDimsForNewTensor(2, inputOrder);
     shape_t *inputShape = reserveMemory(sizeof(shape_t));
     setShape(inputShape, inputDims, 2, inputOrder);
-    tensor_t *input = initTensor(inputShape, quantizationInitSymInt32(HTE), NULL);
+    tensor_t *input = initTensor(inputShape, quantizationInitSymInt32(HALF_AWAY), NULL);
     tensorFillFromFloatBuffer(input, (float[]){0.f, 1.f, 2.f}, 3);
 
     size_t *outputDims = reserveMemory(2 * sizeof(size_t));
@@ -120,9 +120,9 @@ void testLinearForwardSymInt32Rank1BiasRank2Output() {
     setOrderOfDimsForNewTensor(2, outputOrder);
     shape_t *outputShape = reserveMemory(sizeof(shape_t));
     setShape(outputShape, outputDims, 2, outputOrder);
-    tensor_t *output = initTensor(outputShape, quantizationInitSymInt32(HTE), NULL);
+    tensor_t *output = initTensor(outputShape, quantizationInitSymInt32(HALF_AWAY), NULL);
 
-    quantization_t *test = quantizationInitSymInt32(HTE);
+    quantization_t *test = quantizationInitSymInt32(HALF_AWAY);
     layer_t *linearLayer = linearLayerInitLegacy(weights, bias, test, test, test, test);
 
     linearForward(linearLayer, input, output);
@@ -262,9 +262,9 @@ void testLinearBackwardSymInt32Rank1Bias() {
     setOrderOfDimsForNewTensor(2, weightOrder);
     shape_t *weightShape = reserveMemory(sizeof(shape_t));
     setShape(weightShape, weightDims, 2, weightOrder);
-    tensor_t *weightsParam = initTensor(weightShape, quantizationInitSymInt32(HTE), NULL);
+    tensor_t *weightsParam = initTensor(weightShape, quantizationInitSymInt32(HALF_AWAY), NULL);
     tensorFillFromFloatBuffer(weightsParam, (float[]){-1.f, 2.f, -3.f, 4.f, 5.f, -6.f}, 6);
-    tensor_t *weightsGrad = gradInitSymInt32(weightsParam, HTE, NULL);
+    tensor_t *weightsGrad = gradInitSymInt32(weightsParam, HALF_AWAY, NULL);
     parameter_t *weights = parameterInit(weightsParam, weightsGrad);
 
     /* 2. Build heap bias parameter (SymInt32, RANK-1 shape [2]) with grad. */
@@ -274,9 +274,9 @@ void testLinearBackwardSymInt32Rank1Bias() {
     setOrderOfDimsForNewTensor(1, biasOrder);
     shape_t *biasShape = reserveMemory(sizeof(shape_t));
     setShape(biasShape, biasDims, 1, biasOrder);
-    tensor_t *biasParam = initTensor(biasShape, quantizationInitSymInt32(HTE), NULL);
+    tensor_t *biasParam = initTensor(biasShape, quantizationInitSymInt32(HALF_AWAY), NULL);
     tensorFillFromFloatBuffer(biasParam, (float[]){-1.f, 3.f}, 2);
-    tensor_t *biasGrad = gradInitSymInt32(biasParam, HTE, NULL);
+    tensor_t *biasGrad = gradInitSymInt32(biasParam, HALF_AWAY, NULL);
     parameter_t *bias = parameterInit(biasParam, biasGrad);
 
     /* 3. Build heap forwardInput tensor (SymInt32, shape 1x3). */
@@ -287,7 +287,7 @@ void testLinearBackwardSymInt32Rank1Bias() {
     setOrderOfDimsForNewTensor(2, fwdOrder);
     shape_t *fwdShape = reserveMemory(sizeof(shape_t));
     setShape(fwdShape, fwdDims, 2, fwdOrder);
-    tensor_t *forwardInput = initTensor(fwdShape, quantizationInitSymInt32(HTE), NULL);
+    tensor_t *forwardInput = initTensor(fwdShape, quantizationInitSymInt32(HALF_AWAY), NULL);
     tensorFillFromFloatBuffer(forwardInput, (float[]){0.f, 1.f, 2.f}, 3);
 
     /* 4. Build heap loss tensor (SymInt32, shape 1x2). */
@@ -298,7 +298,7 @@ void testLinearBackwardSymInt32Rank1Bias() {
     setOrderOfDimsForNewTensor(2, lossOrder);
     shape_t *lossShape = reserveMemory(sizeof(shape_t));
     setShape(lossShape, lossDims, 2, lossOrder);
-    tensor_t *loss = initTensor(lossShape, quantizationInitSymInt32(HTE), NULL);
+    tensor_t *loss = initTensor(lossShape, quantizationInitSymInt32(HALF_AWAY), NULL);
     tensorFillFromFloatBuffer(loss, (float[]){-4.f, -3.f}, 2);
 
     /* 5. Build heap propLoss tensor (SymInt32, shape (3,)). */
@@ -308,10 +308,10 @@ void testLinearBackwardSymInt32Rank1Bias() {
     setOrderOfDimsForNewTensor(1, propLossOrder);
     shape_t *propLossShape = reserveMemory(sizeof(shape_t));
     setShape(propLossShape, propLossDims, 1, propLossOrder);
-    tensor_t *propLoss = initTensor(propLossShape, quantizationInitSymInt32(HTE), NULL);
+    tensor_t *propLoss = initTensor(propLossShape, quantizationInitSymInt32(HALF_AWAY), NULL);
 
     /* 6. Build layer (shared SymInt32 quantization). */
-    quantization_t *test = quantizationInitSymInt32(HTE);
+    quantization_t *test = quantizationInitSymInt32(HALF_AWAY);
     layer_t *linearLayer = linearLayerInitLegacy(weights, bias, test, test, test, test);
 
     linearBackward(linearLayer, forwardInput, loss, propLoss);
@@ -573,9 +573,9 @@ void testLinearForwardSymInt32() {
     setOrderOfDimsForNewTensor(2, weightOrder);
     shape_t *weightShape = reserveMemory(sizeof(shape_t));
     setShape(weightShape, weightDims, 2, weightOrder);
-    tensor_t *weightsParam = initTensor(weightShape, quantizationInitSymInt32(HTE), NULL);
+    tensor_t *weightsParam = initTensor(weightShape, quantizationInitSymInt32(HALF_AWAY), NULL);
     tensorFillFromFloatBuffer(weightsParam, (float[]){-1.f, 2.f, -3.f, 4.f, 5.f, -6.f}, 6);
-    tensor_t *weightsGrad = gradInitSymInt32(weightsParam, HTE, NULL);
+    tensor_t *weightsGrad = gradInitSymInt32(weightsParam, HALF_AWAY, NULL);
     parameter_t *weights = parameterInit(weightsParam, weightsGrad);
 
     /* 2. Build heap bias parameter (SymInt32, shape 1x2) with grad. */
@@ -586,9 +586,9 @@ void testLinearForwardSymInt32() {
     setOrderOfDimsForNewTensor(2, biasOrder);
     shape_t *biasShape = reserveMemory(sizeof(shape_t));
     setShape(biasShape, biasDims, 2, biasOrder);
-    tensor_t *biasParam = initTensor(biasShape, quantizationInitSymInt32(HTE), NULL);
+    tensor_t *biasParam = initTensor(biasShape, quantizationInitSymInt32(HALF_AWAY), NULL);
     tensorFillFromFloatBuffer(biasParam, (float[]){-1.f, 3.f}, 2);
-    tensor_t *biasGrad = gradInitSymInt32(biasParam, HTE, NULL);
+    tensor_t *biasGrad = gradInitSymInt32(biasParam, HALF_AWAY, NULL);
     parameter_t *bias = parameterInit(biasParam, biasGrad);
 
     /* 3. Build heap input tensor (SymInt32, shape 1x3). */
@@ -599,7 +599,7 @@ void testLinearForwardSymInt32() {
     setOrderOfDimsForNewTensor(2, inputOrder);
     shape_t *inputShape = reserveMemory(sizeof(shape_t));
     setShape(inputShape, inputDims, 2, inputOrder);
-    tensor_t *input = initTensor(inputShape, quantizationInitSymInt32(HTE), NULL);
+    tensor_t *input = initTensor(inputShape, quantizationInitSymInt32(HALF_AWAY), NULL);
     tensorFillFromFloatBuffer(input, (float[]){0.f, 1.f, 2.f}, 3);
 
     /* 4. Build heap output tensor (SymInt32, shape 1x2). */
@@ -610,10 +610,10 @@ void testLinearForwardSymInt32() {
     setOrderOfDimsForNewTensor(2, outputOrder);
     shape_t *outputShape = reserveMemory(sizeof(shape_t));
     setShape(outputShape, outputDims, 2, outputOrder);
-    tensor_t *output = initTensor(outputShape, quantizationInitSymInt32(HTE), NULL);
+    tensor_t *output = initTensor(outputShape, quantizationInitSymInt32(HALF_AWAY), NULL);
 
     /* 5. Build layer (shared SymInt32 quantization). */
-    quantization_t *test = quantizationInitSymInt32(HTE);
+    quantization_t *test = quantizationInitSymInt32(HALF_AWAY);
     layer_t *linearLayer = linearLayerInitLegacy(weights, bias, test, test, test, test);
 
     linearForward(linearLayer, input, output);
@@ -664,9 +664,9 @@ void testLinearBackwardSymInt32() {
     setOrderOfDimsForNewTensor(2, weightOrder);
     shape_t *weightShape = reserveMemory(sizeof(shape_t));
     setShape(weightShape, weightDims, 2, weightOrder);
-    tensor_t *weightsParam = initTensor(weightShape, quantizationInitSymInt32(HTE), NULL);
+    tensor_t *weightsParam = initTensor(weightShape, quantizationInitSymInt32(HALF_AWAY), NULL);
     tensorFillFromFloatBuffer(weightsParam, (float[]){-1.f, 2.f, -3.f, 4.f, 5.f, -6.f}, 6);
-    tensor_t *weightsGrad = gradInitSymInt32(weightsParam, HTE, NULL);
+    tensor_t *weightsGrad = gradInitSymInt32(weightsParam, HALF_AWAY, NULL);
     parameter_t *weights = parameterInit(weightsParam, weightsGrad);
 
     /* 2. Build heap bias parameter (SymInt32, shape 1x2) with grad. */
@@ -677,9 +677,9 @@ void testLinearBackwardSymInt32() {
     setOrderOfDimsForNewTensor(2, biasOrder);
     shape_t *biasShape = reserveMemory(sizeof(shape_t));
     setShape(biasShape, biasDims, 2, biasOrder);
-    tensor_t *biasParam = initTensor(biasShape, quantizationInitSymInt32(HTE), NULL);
+    tensor_t *biasParam = initTensor(biasShape, quantizationInitSymInt32(HALF_AWAY), NULL);
     tensorFillFromFloatBuffer(biasParam, (float[]){-1.f, 3.f}, 2);
-    tensor_t *biasGrad = gradInitSymInt32(biasParam, HTE, NULL);
+    tensor_t *biasGrad = gradInitSymInt32(biasParam, HALF_AWAY, NULL);
     parameter_t *bias = parameterInit(biasParam, biasGrad);
 
     /* 3. Build heap forwardInput tensor (SymInt32, shape 1x3). */
@@ -690,7 +690,7 @@ void testLinearBackwardSymInt32() {
     setOrderOfDimsForNewTensor(2, fwdOrder);
     shape_t *fwdShape = reserveMemory(sizeof(shape_t));
     setShape(fwdShape, fwdDims, 2, fwdOrder);
-    tensor_t *forwardInput = initTensor(fwdShape, quantizationInitSymInt32(HTE), NULL);
+    tensor_t *forwardInput = initTensor(fwdShape, quantizationInitSymInt32(HALF_AWAY), NULL);
     tensorFillFromFloatBuffer(forwardInput, (float[]){0.f, 1.f, 2.f}, 3);
 
     /* 4. Build heap loss tensor (SymInt32, shape 1x2). */
@@ -701,7 +701,7 @@ void testLinearBackwardSymInt32() {
     setOrderOfDimsForNewTensor(2, lossOrder);
     shape_t *lossShape = reserveMemory(sizeof(shape_t));
     setShape(lossShape, lossDims, 2, lossOrder);
-    tensor_t *loss = initTensor(lossShape, quantizationInitSymInt32(HTE), NULL);
+    tensor_t *loss = initTensor(lossShape, quantizationInitSymInt32(HALF_AWAY), NULL);
     tensorFillFromFloatBuffer(loss, (float[]){-4.f, -3.f}, 2);
 
     /* 5. Build heap propLoss tensor (SymInt32, shape (3,)). */
@@ -711,10 +711,10 @@ void testLinearBackwardSymInt32() {
     setOrderOfDimsForNewTensor(1, propLossOrder);
     shape_t *propLossShape = reserveMemory(sizeof(shape_t));
     setShape(propLossShape, propLossDims, 1, propLossOrder);
-    tensor_t *propLoss = initTensor(propLossShape, quantizationInitSymInt32(HTE), NULL);
+    tensor_t *propLoss = initTensor(propLossShape, quantizationInitSymInt32(HALF_AWAY), NULL);
 
     /* 6. Build layer (shared SymInt32 quantization). */
-    quantization_t *test = quantizationInitSymInt32(HTE);
+    quantization_t *test = quantizationInitSymInt32(HALF_AWAY);
     layer_t *linearLayer = linearLayerInitLegacy(weights, bias, test, test, test, test);
 
     linearBackward(linearLayer, forwardInput, loss, propLoss);
@@ -850,7 +850,7 @@ void testLinearBackwardFloatWithMismatchedQuantizations() {
     setOrderOfDimsForNewTensor(2, lossAsymOrder);
     shape_t *lossAsymShape = reserveMemory(sizeof(shape_t));
     setShape(lossAsymShape, lossAsymDims, 2, lossAsymOrder);
-    tensor_t *lossAsym = initTensor(lossAsymShape, quantizationInitAsym(8, HTE), NULL);
+    tensor_t *lossAsym = initTensor(lossAsymShape, quantizationInitAsym(8, HALF_AWAY), NULL);
     tensorFillFromFloatBuffer(lossAsym, (float[]){-4.f, -3.f}, 2);
 
     /* 5. Build heap propLoss tensor (Float, shape 1x3). */
@@ -1116,8 +1116,8 @@ void testLinearLayerInitBorrowingBiasFalseLeavesBiasNull(void) {
 void testLinearLayerInitSymInt32BackwardMathYieldsSymInt32Grad(void) {
     /* Regression for the "config lies" bug: a Linear built with a SYM_INT32
      * backwardMath must store SYM_INT32 parameter gradients, not FLOAT32. */
-    quantization_t *fwd = quantizationInitFloat();       /* FLOAT32 forward + storage */
-    quantization_t *bwd = quantizationInitSymInt32(HTE); /* SYM_INT32 backward */
+    quantization_t *fwd = quantizationInitFloat();             /* FLOAT32 forward + storage */
+    quantization_t *bwd = quantizationInitSymInt32(HALF_AWAY); /* SYM_INT32 backward */
     layerQuant_t lq = {
         .forwardMath = fwd,
         .backwardMath = bwd,
@@ -1243,7 +1243,7 @@ static tensor_t *e2eMakeSym1x3(void) {
     setOrderOfDimsForNewTensor(2, o);
     shape_t *s = reserveMemory(sizeof(shape_t));
     setShape(s, d, 2, o);
-    return initTensor(s, quantizationInitSymInt32(HTE), NULL);
+    return initTensor(s, quantizationInitSymInt32(HALF_AWAY), NULL);
 }
 
 void testLinearSymInt32GradAccumulatesOverTwoMicrobatchesAndSteps(void) {
@@ -1254,7 +1254,7 @@ void testLinearSymInt32GradAccumulatesOverTwoMicrobatchesAndSteps(void) {
 
     /* ---- SYM_INT32-backward layer (under test) ---- */
     quantization_t *fwd = quantizationInitFloat();
-    quantization_t *bwd = quantizationInitSymInt32(HTE);
+    quantization_t *bwd = quantizationInitSymInt32(HALF_AWAY);
     layerQuant_t lqSym = {
         .forwardMath = fwd, .backwardMath = bwd, .weightStorage = fwd, .biasStorage = fwd};
     layer_t *symLayer = linearLayerInit(

--- a/test/unit/layer/UnitTestRelu.c
+++ b/test/unit/layer/UnitTestRelu.c
@@ -68,7 +68,7 @@ void testReluForwardSymInt32() {
     setOrderOfDimsForNewTensor(2, inputOrder);
     shape_t *inputShape = reserveMemory(sizeof(shape_t));
     setShape(inputShape, inputDims, 2, inputOrder);
-    tensor_t *input = initTensor(inputShape, quantizationInitSymInt32(HTE), NULL);
+    tensor_t *input = initTensor(inputShape, quantizationInitSymInt32(HALF_AWAY), NULL);
     tensorFillFromFloatBuffer(input, (float[]){-1.f, 0.f, 1.f, 2.f, 5.f, -6.f}, 6);
 
     /* 2. Build heap output tensor (SymInt32, shape 2x3). */
@@ -79,10 +79,10 @@ void testReluForwardSymInt32() {
     setOrderOfDimsForNewTensor(2, outputOrder);
     shape_t *outputShape = reserveMemory(sizeof(shape_t));
     setShape(outputShape, outputDims, 2, outputOrder);
-    tensor_t *output = initTensor(outputShape, quantizationInitSymInt32(HTE), NULL);
+    tensor_t *output = initTensor(outputShape, quantizationInitSymInt32(HALF_AWAY), NULL);
 
     /* 3. Shared SymInt32 quantization for the layer. */
-    quantization_t *symIntQ = quantizationInitSymInt32(HTE);
+    quantization_t *symIntQ = quantizationInitSymInt32(HALF_AWAY);
     layer_t *reluLayer = reluLayerInitLegacy(symIntQ, symIntQ);
     layerFunctions_t reluFns = layerFunctions[RELU];
     reluFns.forward(reluLayer, input, output);
@@ -185,7 +185,7 @@ void testReluBackwardSymInt32() {
     setOrderOfDimsForNewTensor(1, fwdOrder);
     shape_t *fwdShape = reserveMemory(sizeof(shape_t));
     setShape(fwdShape, fwdDims, 1, fwdOrder);
-    tensor_t *forwardInput = initTensor(fwdShape, quantizationInitSymInt32(HTE), NULL);
+    tensor_t *forwardInput = initTensor(fwdShape, quantizationInitSymInt32(HALF_AWAY), NULL);
     tensorFillFromFloatBuffer(forwardInput, (float[]){-1.f, 0.f, 1.f, 2.f, 5.f, -6.f}, 6);
 
     /* 2. Build heap loss tensor (SymInt32). */
@@ -195,7 +195,7 @@ void testReluBackwardSymInt32() {
     setOrderOfDimsForNewTensor(1, lossOrder);
     shape_t *lossShape = reserveMemory(sizeof(shape_t));
     setShape(lossShape, lossDims, 1, lossOrder);
-    tensor_t *loss = initTensor(lossShape, quantizationInitSymInt32(HTE), NULL);
+    tensor_t *loss = initTensor(lossShape, quantizationInitSymInt32(HALF_AWAY), NULL);
     tensorFillFromFloatBuffer(loss, (float[]){0.f, 2.f, -4.f, 6.f, 3.f, 2.f}, 6);
 
     /* 3. Build heap propLoss tensor (SymInt32). */
@@ -205,10 +205,10 @@ void testReluBackwardSymInt32() {
     setOrderOfDimsForNewTensor(1, propLossOrder);
     shape_t *propLossShape = reserveMemory(sizeof(shape_t));
     setShape(propLossShape, propLossDims, 1, propLossOrder);
-    tensor_t *propLoss = initTensor(propLossShape, quantizationInitSymInt32(HTE), NULL);
+    tensor_t *propLoss = initTensor(propLossShape, quantizationInitSymInt32(HALF_AWAY), NULL);
 
     /* 4. Build layer with shared SymInt32 quantization. */
-    quantization_t *symIntQ = quantizationInitSymInt32(HTE);
+    quantization_t *symIntQ = quantizationInitSymInt32(HALF_AWAY);
     layer_t *reluLayer = reluLayerInitLegacy(symIntQ, symIntQ);
     layerFunctions_t reluFns = layerFunctions[RELU];
     reluFns.backward(reluLayer, forwardInput, loss, propLoss);

--- a/test/unit/layer/UnitTestSoftmax.c
+++ b/test/unit/layer/UnitTestSoftmax.c
@@ -71,7 +71,7 @@ void unitTestSoftmaxForwardSymInt32() {
     setOrderOfDimsForNewTensor(2, inputOrder);
     shape_t *inputShape = reserveMemory(sizeof(shape_t));
     setShape(inputShape, inputDims, 2, inputOrder);
-    tensor_t *input = initTensor(inputShape, quantizationInitSymInt32(HTE), NULL);
+    tensor_t *input = initTensor(inputShape, quantizationInitSymInt32(HALF_AWAY), NULL);
     tensorFillFromFloatBuffer(input, (float[]){-1.f, 0.f, 1.f, 2.f, 5.f, -6.f}, 6);
 
     /* 2. Build heap output tensor (SymInt32, shape 2x3). */
@@ -82,10 +82,10 @@ void unitTestSoftmaxForwardSymInt32() {
     setOrderOfDimsForNewTensor(2, outputOrder);
     shape_t *outputShape = reserveMemory(sizeof(shape_t));
     setShape(outputShape, outputDims, 2, outputOrder);
-    tensor_t *output = initTensor(outputShape, quantizationInitSymInt32(HTE), NULL);
+    tensor_t *output = initTensor(outputShape, quantizationInitSymInt32(HALF_AWAY), NULL);
 
     /* 3. Shared SymInt32 quantization for the layer. */
-    quantization_t *symIntQ = quantizationInitSymInt32(HTE);
+    quantization_t *symIntQ = quantizationInitSymInt32(HALF_AWAY);
     layer_t *softmaxLayer = softmaxLayerInitLegacy(symIntQ, symIntQ);
     layerFunctions_t softmaxFns = layerFunctions[SOFTMAX];
     softmaxFns.forward(softmaxLayer, input, output);
@@ -197,7 +197,7 @@ void unitTestSoftmaxBackwardSymInt32() {
     setOrderOfDimsForNewTensor(2, inputOrder);
     shape_t *inputShape = reserveMemory(sizeof(shape_t));
     setShape(inputShape, inputDims, 2, inputOrder);
-    tensor_t *input = initTensor(inputShape, quantizationInitSymInt32(HTE), NULL);
+    tensor_t *input = initTensor(inputShape, quantizationInitSymInt32(HALF_AWAY), NULL);
     tensorFillFromFloatBuffer(
         input,
         (float[]){2.3008e-03f, 6.2543e-03f, 1.7001e-02f, 4.6213e-02f, 9.2822e-01f, 1.5503e-05f}, 6);
@@ -210,7 +210,7 @@ void unitTestSoftmaxBackwardSymInt32() {
     setOrderOfDimsForNewTensor(2, lossOrder);
     shape_t *lossShape = reserveMemory(sizeof(shape_t));
     setShape(lossShape, lossDims, 2, lossOrder);
-    tensor_t *loss = initTensor(lossShape, quantizationInitSymInt32(HTE), NULL);
+    tensor_t *loss = initTensor(lossShape, quantizationInitSymInt32(HALF_AWAY), NULL);
     tensorFillFromFloatBuffer(loss, (float[]){0.f, 2.f, -4.f, 6.f, 3.f, 2.f}, 6);
 
     /* 3. Build heap propLoss tensor (SymInt32). */
@@ -221,10 +221,10 @@ void unitTestSoftmaxBackwardSymInt32() {
     setOrderOfDimsForNewTensor(2, propLossOrder);
     shape_t *propLossShape = reserveMemory(sizeof(shape_t));
     setShape(propLossShape, propLossDims, 2, propLossOrder);
-    tensor_t *propLoss = initTensor(propLossShape, quantizationInitSymInt32(HTE), NULL);
+    tensor_t *propLoss = initTensor(propLossShape, quantizationInitSymInt32(HALF_AWAY), NULL);
 
     /* 4. Build layer. */
-    quantization_t *symIntQ = quantizationInitSymInt32(HTE);
+    quantization_t *symIntQ = quantizationInitSymInt32(HALF_AWAY);
     layer_t *softmaxLayer = softmaxLayerInitLegacy(symIntQ, symIntQ);
     layerFunctions_t softmaxFns = layerFunctions[SOFTMAX];
     softmaxFns.backward(softmaxLayer, input, loss, propLoss);

--- a/test/unit/layer/generate_expected_layernorm_sym.py
+++ b/test/unit/layer/generate_expected_layernorm_sym.py
@@ -16,8 +16,8 @@ Self-checks:
    3e-5 C-side xhat tolerance (s_norm/2 <= 1.9/65534 ~ 2.9e-5).
 
 Biased variance (/N) via explicit emulation + F.layer_norm; NEVER torch.var
-(ddof=1 default). Rounding: the framework's roundByMode(HTE) is implemented
-as C round() = half-AWAY-from-zero (Rounding.c, despite the HTE name; #188),
+(ddof=1 default). Rounding: the framework's roundByMode(HALF_AWAY) is C
+round() = half-AWAY-from-zero (Rounding.c, roundHalfAway; renamed in #188),
 so all rounding here uses round_half_away — NEVER torch.round (true
 half-to-even, which diverges on ties like 16382.5).
 Run via `uv run` (CMake wires this automatically).
@@ -34,9 +34,9 @@ QMIN = -32768.0
 
 
 def round_half_away(x: torch.Tensor) -> torch.Tensor:
-    """Match the C kernel: roundByMode(HTE) is C round() = half-away-from-zero
-    (Rounding.c — the HTE name is a misnomer, #188). torch.round would be true
-    half-to-even and silently diverge on .5 ties."""
+    """Match the C kernel: roundByMode(HALF_AWAY) is C round() =
+    half-away-from-zero (Rounding.c, roundHalfAway; renamed in #188).
+    torch.round would be true half-to-even and silently diverge on .5 ties."""
     return torch.sign(x) * torch.floor(torch.abs(x) + 0.5)
 
 

--- a/test/unit/layer/generate_expected_layernorm_sym_bwd.py
+++ b/test/unit/layer/generate_expected_layernorm_sym_bwd.py
@@ -22,9 +22,10 @@ Self-checks:
    within analytic quantization bounds;
  - the var~eps fixture really sits in the eps-visible regime (0.5 < var/eps < 2).
 
-Rounding: the framework's roundByMode(HTE) is C round() = half-AWAY-from-zero
-(Rounding.c, #188 misnomer) — emulate with sign(x)*floor(|x|+0.5), NEVER
-torch.round (true half-to-even, silently diverges on ties).
+Rounding: the framework's roundByMode(HALF_AWAY) is C round() =
+half-AWAY-from-zero (Rounding.c, roundHalfAway; renamed in #188) — emulate
+with sign(x)*floor(|x|+0.5), NEVER torch.round (true half-to-even, silently
+diverges on ties).
 Run via `uv run` (CMake wires this automatically).
 """
 import argparse
@@ -39,8 +40,8 @@ QMIN = -32768.0
 
 
 def round_half_away(x: torch.Tensor) -> torch.Tensor:
-    """Match the C kernel: roundByMode(HTE) is C round() = half-away-from-zero
-    (Rounding.c — the HTE name is a misnomer, #188)."""
+    """Match the C kernel: roundByMode(HALF_AWAY) is C round() =
+    half-away-from-zero (Rounding.c, roundHalfAway; renamed in #188)."""
     return torch.sign(x) * torch.floor(torch.abs(x) + 0.5)
 
 

--- a/test/unit/loss_functions/UnitTestMSE.c
+++ b/test/unit/loss_functions/UnitTestMSE.c
@@ -114,7 +114,7 @@ void testMSELossBackward_SymInt32WritesRawPerElementGrad() {
 
     tensor_t modelOutputSymInt32;
     symInt32QConfig_t modelOutputSymInt32QC;
-    initSymInt32QConfig(HTE, &modelOutputSymInt32QC);
+    initSymInt32QConfig(HALF_AWAY, &modelOutputSymInt32QC);
     quantization_t modelOutputSymInt32Q;
     initSymInt32Quantization(&modelOutputSymInt32QC, &modelOutputSymInt32Q);
     uint8_t modelOutputSymInt32Data[numberOfElements * sizeof(int32_t)];
@@ -130,7 +130,7 @@ void testMSELossBackward_SymInt32WritesRawPerElementGrad() {
 
     tensor_t labelSymInt32;
     symInt32QConfig_t labelSymInt32QC;
-    initSymInt32QConfig(HTE, &labelSymInt32QC);
+    initSymInt32QConfig(HALF_AWAY, &labelSymInt32QC);
     quantization_t labelSymInt32Q;
     initSymInt32Quantization(&labelSymInt32QC, &labelSymInt32Q);
     uint8_t labelSymInt32Data[numberOfElements * sizeof(int32_t)];
@@ -145,7 +145,7 @@ void testMSELossBackward_SymInt32WritesRawPerElementGrad() {
 
     tensor_t resultSymInt32;
     symInt32QConfig_t resultSymInt32QC;
-    initSymInt32QConfig(HTE, &resultSymInt32QC);
+    initSymInt32QConfig(HALF_AWAY, &resultSymInt32QC);
     quantization_t resultSymInt32Q;
     initSymInt32Quantization(&resultSymInt32QC, &resultSymInt32Q);
     uint8_t resultSymInt32Data[numberOfElements * sizeof(int32_t)];

--- a/test/unit/optimizer/UnitTestSgd.c
+++ b/test/unit/optimizer/UnitTestSgd.c
@@ -329,7 +329,7 @@ void testSGDZeroGrad() {
 
 void testSgdZeroGradOnSymInt32GradZeroesMantissasAndResetsScale(void) {
     quantization_t *fwd = quantizationInitFloat();
-    quantization_t *bwd = quantizationInitSymInt32(HTE);
+    quantization_t *bwd = quantizationInitSymInt32(HALF_AWAY);
     layerQuant_t lq = {
         .forwardMath = fwd, .backwardMath = bwd, .weightStorage = fwd, .biasStorage = fwd};
     layer_t *layer =

--- a/test/unit/tensor/UnitTestTensor.c
+++ b/test/unit/tensor/UnitTestTensor.c
@@ -235,14 +235,14 @@ void testCopyTensor() {
 }
 
 void test_calcBitsPerElement_Sym_qBits3() {
-    symQConfig_t cfg = {.scale = 1.0f, .qBits = 3, .roundingMode = HTE};
+    symQConfig_t cfg = {.scale = 1.0f, .qBits = 3, .roundingMode = HALF_AWAY};
     quantization_t q;
     initSymQuantization(&cfg, &q);
     TEST_ASSERT_EQUAL_size_t(3, calcBitsPerElement(&q));
 }
 
 void test_calcBytesPerElement_Sym_qBits3() {
-    symQConfig_t cfg = {.scale = 1.0f, .qBits = 3, .roundingMode = HTE};
+    symQConfig_t cfg = {.scale = 1.0f, .qBits = 3, .roundingMode = HALF_AWAY};
     quantization_t q;
     initSymQuantization(&cfg, &q);
     /* ceil(3/8) = 1 */
@@ -250,7 +250,7 @@ void test_calcBytesPerElement_Sym_qBits3() {
 }
 
 void test_calcNumberOfBytesForData_Sym_qBits3_N10() {
-    symQConfig_t cfg = {.scale = 1.0f, .qBits = 3, .roundingMode = HTE};
+    symQConfig_t cfg = {.scale = 1.0f, .qBits = 3, .roundingMode = HALF_AWAY};
     quantization_t q;
     initSymQuantization(&cfg, &q);
     /* ceil(3*10 / 8) = ceil(30/8) = 4 */
@@ -258,7 +258,7 @@ void test_calcNumberOfBytesForData_Sym_qBits3_N10() {
 }
 
 void test_calcNumberOfBytesForData_Sym_qBits5_N4() {
-    symQConfig_t cfg = {.scale = 1.0f, .qBits = 5, .roundingMode = HTE};
+    symQConfig_t cfg = {.scale = 1.0f, .qBits = 5, .roundingMode = HALF_AWAY};
     quantization_t q;
     initSymQuantization(&cfg, &q);
     /* ceil(5*4 / 8) = ceil(20/8) = 3 */

--- a/test/unit/tensor/UnitTestTensorApi.c
+++ b/test/unit/tensor/UnitTestTensorApi.c
@@ -475,8 +475,8 @@ void testGradInitSymInt32_DoesNotAliasParentShape(void) {
     shape_t *shape = reserveMemory(sizeof(shape_t));
     setShape(shape, dims, 2, order);
 
-    tensor_t *param = initTensor(shape, quantizationInitSymInt32(HTE), NULL);
-    tensor_t *grad = gradInitSymInt32(param, HTE, NULL);
+    tensor_t *param = initTensor(shape, quantizationInitSymInt32(HALF_AWAY), NULL);
+    tensor_t *grad = gradInitSymInt32(param, HALF_AWAY, NULL);
 
     TEST_ASSERT_TRUE_MESSAGE(grad->shape != param->shape,
                              "gradInitSymInt32 aliases parent shape (H2 hazard)");
@@ -494,8 +494,8 @@ void testGradInitAsym_DoesNotAliasParentShape(void) {
     shape_t *shape = reserveMemory(sizeof(shape_t));
     setShape(shape, dims, 2, order);
 
-    tensor_t *param = initTensor(shape, quantizationInitAsym(8, HTE), NULL);
-    tensor_t *grad = gradInitAsym(param, 8, HTE, NULL);
+    tensor_t *param = initTensor(shape, quantizationInitAsym(8, HALF_AWAY), NULL);
+    tensor_t *grad = gradInitAsym(param, 8, HALF_AWAY, NULL);
 
     TEST_ASSERT_TRUE_MESSAGE(grad->shape != param->shape,
                              "gradInitAsym aliases parent shape (H2 hazard)");
@@ -509,7 +509,7 @@ void testGradInitAsym_DoesNotAliasParentShape(void) {
  * on the already-truncated result — under-allocating by one byte whenever the
  * total bit count was not a multiple of 8. */
 void testCalcNumberOfBytesForData_AsymSubByte_RoundsUpInsteadOfTruncating(void) {
-    quantization_t *q = quantizationInitAsym(3, HTE);
+    quantization_t *q = quantizationInitAsym(3, HALF_AWAY);
     /* 10 elements * 3 bits = 30 bits => ceil(30/8) = 4 bytes. */
     size_t bytes = calcNumberOfBytesForData(q, 10);
     freeQuantization(q);
@@ -522,7 +522,7 @@ void testCalcNumberOfBytesForData_AsymSubByte_RoundsUpInsteadOfTruncating(void) 
  * trips heap-buffer-overflow; the value-assertion test above catches the
  * arithmetic itself. */
 void testGetDataLike_AsymSubByte_AllocatesCeilingOfBits(void) {
-    quantization_t *q = quantizationInitAsym(3, HTE);
+    quantization_t *q = quantizationInitAsym(3, HALF_AWAY);
     uint8_t *data = getDataLike(q, 10);
     /* 30 bits => 4 bytes; pre-fix only 3 are allocated. */
     for (size_t i = 0; i < 4; ++i) {
@@ -634,7 +634,7 @@ void testGradInit_SymInt32_MatchesParamShapeAndDtype(void) {
     /* Param can stay FLOAT32; grad dtype is driven solely by gradQ. */
     tensor_t *param = initTensor(shape, quantizationInitFloat(), NULL);
 
-    quantization_t *gradQ = quantizationInitSymInt32(HTE);
+    quantization_t *gradQ = quantizationInitSymInt32(HALF_AWAY);
     tensor_t *grad = gradInit(param, gradQ, NULL);
 
     int gradTypeMatches = (grad->quantization->type == SYM_INT32);

--- a/test/unit/tensor/UnitTestTensorConversion.c
+++ b/test/unit/tensor/UnitTestTensorConversion.c
@@ -55,7 +55,7 @@ void testConversionIntSymInt32() {
     setTensorValues(&intTensor, (uint8_t *)intData, &shape, &intQ, NULL);
 
     symInt32QConfig_t symInt32QConfig;
-    initSymInt32QConfig(HTE, &symInt32QConfig);
+    initSymInt32QConfig(HALF_AWAY, &symInt32QConfig);
     quantization_t symInt32Q;
     initSymInt32Quantization(&symInt32QConfig, &symInt32Q);
 
@@ -85,7 +85,7 @@ void testConversionIntAsym() {
     setTensorValues(&intTensor, (uint8_t *)intData, &shape, &intQ, NULL);
 
     asymQConfig_t asymQConfig;
-    initAsymQConfig(5, HTE, &asymQConfig);
+    initAsymQConfig(5, HALF_AWAY, &asymQConfig);
     quantization_t asymQ;
     initAsymQuantization(&asymQConfig, &asymQ);
     uint8_t asymData[numValues * calcBytesPerElement(&asymQ)];
@@ -158,7 +158,7 @@ void testConversionFloatSymInt32() {
     setTensorValues(&floatTensor, (uint8_t *)floatData, &shape, &floatQ, NULL);
 
     symInt32QConfig_t symInt32QConfig;
-    initSymInt32QConfig(HTE, &symInt32QConfig);
+    initSymInt32QConfig(HALF_AWAY, &symInt32QConfig);
     quantization_t symInt32Q;
     initSymInt32Quantization(&symInt32QConfig, &symInt32Q);
 
@@ -198,7 +198,7 @@ void testConversionFloatAsym() {
     setTensorValues(&floatTensor, (uint8_t *)floatData, &shape, &floatQ, NULL);
 
     asymQConfig_t asymQConfig;
-    initAsymQConfig(5, HTE, &asymQConfig);
+    initAsymQConfig(5, HALF_AWAY, &asymQConfig);
     quantization_t asymQ;
     initAsymQuantization(&asymQConfig, &asymQ);
 
@@ -231,7 +231,7 @@ void testConversionSymInt32Int() {
         .dimensions = dims, .numberOfDimensions = numberOfDims, .orderOfDimensions = orderOfDims};
 
     symInt32QConfig_t symInt32QConfig;
-    initSymInt32QConfig(HTE, &symInt32QConfig);
+    initSymInt32QConfig(HALF_AWAY, &symInt32QConfig);
     quantization_t symInt32Q;
     initSymInt32Quantization(&symInt32QConfig, &symInt32Q);
 
@@ -262,7 +262,7 @@ void testConversionSymInt32Float() {
         .dimensions = dims, .numberOfDimensions = numberOfDims, .orderOfDimensions = orderOfDims};
 
     symInt32QConfig_t symInt32QConfig;
-    initSymInt32QConfig(HTE, &symInt32QConfig);
+    initSymInt32QConfig(HALF_AWAY, &symInt32QConfig);
     symInt32QConfig.scale = 1.f;
     quantization_t symInt32Q;
     initSymInt32Quantization(&symInt32QConfig, &symInt32Q);
@@ -302,7 +302,7 @@ void testConversionSymInt32Asym() {
         .dimensions = dims, .numberOfDimensions = numberOfDims, .orderOfDimensions = orderOfDims};
 
     symInt32QConfig_t symInt32QConfig;
-    initSymInt32QConfig(HTE, &symInt32QConfig);
+    initSymInt32QConfig(HALF_AWAY, &symInt32QConfig);
     symInt32QConfig.scale = 1.f;
     quantization_t symInt32Q;
     initSymInt32Quantization(&symInt32QConfig, &symInt32Q);
@@ -312,7 +312,7 @@ void testConversionSymInt32Asym() {
     setTensorValues(&symInt32Tensor, (uint8_t *)symInt32Data, &shape, &symInt32Q, NULL);
 
     asymQConfig_t asymQConfig;
-    initAsymQConfig(5, HTE, &asymQConfig);
+    initAsymQConfig(5, HALF_AWAY, &asymQConfig);
     quantization_t asymQ;
     initAsymQuantization(&asymQConfig, &asymQ);
 
@@ -347,7 +347,7 @@ void testConversionAsymInt() {
         .dimensions = dims, .numberOfDimensions = numberOfDims, .orderOfDimensions = orderOfDims};
 
     asymQConfig_t asymQConfig;
-    initAsymQConfig(5, HTE, &asymQConfig);
+    initAsymQConfig(5, HALF_AWAY, &asymQConfig);
     asymQConfig.scale = 0.1875f;
     asymQConfig.zeroPoint = -11;
 
@@ -382,7 +382,7 @@ void testConversionAsymFloat() {
         .dimensions = dims, .numberOfDimensions = numberOfDims, .orderOfDimensions = orderOfDims};
 
     asymQConfig_t asymQConfig;
-    initAsymQConfig(5, HTE, &asymQConfig);
+    initAsymQConfig(5, HALF_AWAY, &asymQConfig);
     asymQConfig.scale = 0.1875f;
     asymQConfig.zeroPoint = -11;
     quantization_t asymQ;
@@ -417,7 +417,7 @@ void testConversionAsymSymInt32() {
         .dimensions = dims, .numberOfDimensions = numberOfDims, .orderOfDimensions = orderOfDims};
 
     asymQConfig_t asymQConfig;
-    initAsymQConfig(5, HTE, &asymQConfig);
+    initAsymQConfig(5, HALF_AWAY, &asymQConfig);
     asymQConfig.scale = 0.1875f;
     asymQConfig.zeroPoint = -11;
     quantization_t asymQ;
@@ -429,7 +429,7 @@ void testConversionAsymSymInt32() {
     setTensorValues(&asymTensor, asymData, &shape, &asymQ, NULL);
 
     symInt32QConfig_t symInt32QConfig;
-    initSymInt32QConfig(HTE, &symInt32QConfig);
+    initSymInt32QConfig(HALF_AWAY, &symInt32QConfig);
     quantization_t symInt32Q;
     initSymInt32Quantization(&symInt32QConfig, &symInt32Q);
     int32_t symInt32Data[numValues];

--- a/test/unit/userAPI/UnitTestConv1dApi.c
+++ b/test/unit/userAPI/UnitTestConv1dApi.c
@@ -200,7 +200,7 @@ void testConv1dLayerInitKeepsFloat32GradEvenWithSymInt32BackwardMath(void) {
     /* Conv1d backward is FLOAT32-only; its grad must stay FLOAT32 regardless of
      * backwardMath, so the gradInit plumbing defaults Conv1d to FLOAT32. */
     quantization_t *fwd = quantizationInitFloat();
-    quantization_t *bwd = quantizationInitSymInt32(HTE);
+    quantization_t *bwd = quantizationInitSymInt32(HALF_AWAY);
     layerQuant_t lq = {
         .forwardMath = fwd,
         .backwardMath = bwd,

--- a/test/unit/userAPI/UnitTestConv1dTransposedApi.c
+++ b/test/unit/userAPI/UnitTestConv1dTransposedApi.c
@@ -168,7 +168,7 @@ void testConv1dTransposedLayerInitOwningFreesAllAllocationsWithoutLeak(void) {
 
 void testConv1dTransposedLayerInitKeepsFloat32Grad(void) {
     quantization_t *fwd = quantizationInitFloat();
-    quantization_t *bwd = quantizationInitSymInt32(HTE);
+    quantization_t *bwd = quantizationInitSymInt32(HALF_AWAY);
     layerQuant_t lq = {
         .forwardMath = fwd,
         .backwardMath = bwd,

--- a/test/unit/userAPI/UnitTestInferenceApi.c
+++ b/test/unit/userAPI/UnitTestInferenceApi.c
@@ -92,7 +92,7 @@ void testInferenceLinearReluSymInt32() {
     size_t numberOfOutputs = 2;
 
     /* Shared SymInt32 quantization for layers. */
-    quantization_t *q = quantizationInitSymInt32(HTE);
+    quantization_t *q = quantizationInitSymInt32(HALF_AWAY);
 
     /* Weights (2x3). */
     size_t *weightDims = reserveMemory(2 * sizeof(size_t));
@@ -102,9 +102,9 @@ void testInferenceLinearReluSymInt32() {
     setOrderOfDimsForNewTensor(2, weightOrder);
     shape_t *weightShape = reserveMemory(sizeof(shape_t));
     setShape(weightShape, weightDims, 2, weightOrder);
-    tensor_t *weightsParam = initTensor(weightShape, quantizationInitSymInt32(HTE), NULL);
+    tensor_t *weightsParam = initTensor(weightShape, quantizationInitSymInt32(HALF_AWAY), NULL);
     tensorFillFromFloatBuffer(weightsParam, (float[]){-1.f, 2.f, -3.f, 4.f, 5.f, 6.f}, 6);
-    tensor_t *weightGrad = gradInitSymInt32(weightsParam, HTE, NULL);
+    tensor_t *weightGrad = gradInitSymInt32(weightsParam, HALF_AWAY, NULL);
     parameter_t *weights = parameterInit(weightsParam, weightGrad);
 
     /* Bias (1x2). */
@@ -115,9 +115,9 @@ void testInferenceLinearReluSymInt32() {
     setOrderOfDimsForNewTensor(2, biasOrder);
     shape_t *biasShape = reserveMemory(sizeof(shape_t));
     setShape(biasShape, biasDims, 2, biasOrder);
-    tensor_t *biasParam = initTensor(biasShape, quantizationInitSymInt32(HTE), NULL);
+    tensor_t *biasParam = initTensor(biasShape, quantizationInitSymInt32(HALF_AWAY), NULL);
     tensorFillFromFloatBuffer(biasParam, (float[]){-1.f, 3.f}, 2);
-    tensor_t *biasGrad = gradInitSymInt32(biasParam, HTE, NULL);
+    tensor_t *biasGrad = gradInitSymInt32(biasParam, HALF_AWAY, NULL);
     parameter_t *bias = parameterInit(biasParam, biasGrad);
 
     /* Input (1x3). */
@@ -128,7 +128,7 @@ void testInferenceLinearReluSymInt32() {
     setOrderOfDimsForNewTensor(2, inputOrder);
     shape_t *inputShape = reserveMemory(sizeof(shape_t));
     setShape(inputShape, inputDims, 2, inputOrder);
-    tensor_t *input = initTensor(inputShape, quantizationInitSymInt32(HTE), NULL);
+    tensor_t *input = initTensor(inputShape, quantizationInitSymInt32(HALF_AWAY), NULL);
     tensorFillFromFloatBuffer(input, (float[]){0.f, 1.f, 2.f}, 3);
 
     /* Layers. */
@@ -261,7 +261,7 @@ void testInferenceLayerNormSymInt32(void) {
     size_t normShape[] = {4};
     layerNormInit_t init = {.normalizedShape = normShape, .numNormDims = 1, .eps = 1e-5f};
 
-    quantization_t *symQ = quantizationInitSymInt32(HTE);
+    quantization_t *symQ = quantizationInitSymInt32(HALF_AWAY);
     quantization_t *bwd = quantizationInitFloat();
     layerQuant_t lq = {
         .forwardMath = symQ, .backwardMath = bwd, .weightStorage = symQ, .biasStorage = symQ};
@@ -281,7 +281,7 @@ void testInferenceLayerNormSymInt32(void) {
     setOrderOfDimsForNewTensor(2, inOrder);
     shape_t *inShape = reserveMemory(sizeof(shape_t));
     setShape(inShape, inDims, 2, inOrder);
-    tensor_t *input = initTensor(inShape, quantizationInitSymInt32(HTE), NULL);
+    tensor_t *input = initTensor(inShape, quantizationInitSymInt32(HALF_AWAY), NULL);
     tensorFillFromFloatBuffer(input, (float[]){1.f, 2.f, 3.f, 4.f, 10.f, 20.f, 30.f, 40.f}, 8);
 
     tensor_t *output = inference(model, 1, input);

--- a/test/unit/userAPI/UnitTestLayerNormIntegration.c
+++ b/test/unit/userAPI/UnitTestLayerNormIntegration.c
@@ -47,7 +47,7 @@ static tensor_t *build2DSym(size_t b, size_t f, const float *data, size_t n) {
     setOrderOfDimsForNewTensor(2, order);
     shape_t *shape = reserveMemory(sizeof(shape_t));
     setShape(shape, dims, 2, order);
-    tensor_t *t = initTensor(shape, quantizationInitSymInt32(HTE), NULL);
+    tensor_t *t = initTensor(shape, quantizationInitSymInt32(HALF_AWAY), NULL);
     tensorFillFromFloatBuffer(t, (float *)data, n);
     return t;
 }
@@ -158,7 +158,7 @@ void testLayerNormSymInt32SingleLayerTrainingStep(void) {
 
     /* ---- SYM model (under test) ---- */
     layerNormInit_t initSym = {.normalizedShape = normShape, .numNormDims = 1, .eps = 1e-5f};
-    quantization_t *symQ = quantizationInitSymInt32(HTE);
+    quantization_t *symQ = quantizationInitSymInt32(HALF_AWAY);
     layerQuant_t lqSym = {
         .forwardMath = symQ, .backwardMath = symQ, .weightStorage = symQ, .biasStorage = symQ};
     layer_t *lnSym = layerNormLayerInit(&initSym, &lqSym);

--- a/test/unit/userAPI/UnitTestLayerQuant.c
+++ b/test/unit/userAPI/UnitTestLayerQuant.c
@@ -50,7 +50,7 @@ void testDeepCopyQuantizationFloat32ReturnsFreshAllocationWithNullQConfig(void) 
 }
 
 void testDeepCopyQuantizationSymInt32DuplicatesQConfigBytes(void) {
-    quantization_t *src = quantizationInitSymInt32(HTE);
+    quantization_t *src = quantizationInitSymInt32(HALF_AWAY);
     quantization_t *dst = deepCopyQuantization(src);
 
     TEST_ASSERT_NOT_NULL(dst);

--- a/test/unit/userAPI/UnitTestLayerWeightsApi.c
+++ b/test/unit/userAPI/UnitTestLayerWeightsApi.c
@@ -195,7 +195,7 @@ void testLayerLoadWeightsLayerNormQuantizesForSymStorage(void) {
     size_t normShape[] = {3};
     layerNormInit_t init = {.normalizedShape = normShape, .numNormDims = 1, .eps = 1e-5f};
 
-    quantization_t *symQ = quantizationInitSymInt32(HTE);
+    quantization_t *symQ = quantizationInitSymInt32(HALF_AWAY);
     quantization_t *bwd = quantizationInitFloat();
     layerQuant_t lq = {
         .forwardMath = symQ, .backwardMath = bwd, .weightStorage = symQ, .biasStorage = symQ};
@@ -220,7 +220,7 @@ void testLayerLoadWeightsLayerNormQuantizesForSymStorage(void) {
     freeQuantization(symQ);
 
     /* gamma absmax 4 -> scale 4/32767; mantissas round(v*32767/4):
-     * 16383.5 -> 16384 (half-away-from-zero: the framework's roundHTE is C
+     * 16383.5 -> 16384 (half-away-from-zero: the framework's roundHalfAway is C
      * round() — see #188), 24575.25 -> 24575, 32767 exact. INT_WITHIN(1)
      * on the non-absmax elements (float division may land a hair off the
      * exact midpoint); exact on the absmax element. */

--- a/test/unit/userAPI/UnitTestOptimizerScaling.c
+++ b/test/unit/userAPI/UnitTestOptimizerScaling.c
@@ -179,9 +179,9 @@ static optimizer_t *buildSymInt32OneLayerOptim(layer_t **modelOut, parameter_t *
         setOrderOfDimsForNewTensor(2, order);
         shape_t *shape = reserveMemory(sizeof(shape_t));
         setShape(shape, dims, 2, order);
-        wParam = initTensor(shape, quantizationInitSymInt32(HTE), NULL);
+        wParam = initTensor(shape, quantizationInitSymInt32(HALF_AWAY), NULL);
     }
-    tensor_t *wGrad = gradInitSymInt32(wParam, HTE, NULL);
+    tensor_t *wGrad = gradInitSymInt32(wParam, HALF_AWAY, NULL);
     {
         int32_t *gradData = (int32_t *)wGrad->data;
         memcpy(gradData, wInitialGradInt32, 6 * sizeof(int32_t));
@@ -200,9 +200,9 @@ static optimizer_t *buildSymInt32OneLayerOptim(layer_t **modelOut, parameter_t *
         setOrderOfDimsForNewTensor(2, order);
         shape_t *shape = reserveMemory(sizeof(shape_t));
         setShape(shape, dims, 2, order);
-        bParam = initTensor(shape, quantizationInitSymInt32(HTE), NULL);
+        bParam = initTensor(shape, quantizationInitSymInt32(HALF_AWAY), NULL);
     }
-    tensor_t *bGrad = gradInitSymInt32(bParam, HTE, NULL);
+    tensor_t *bGrad = gradInitSymInt32(bParam, HALF_AWAY, NULL);
     {
         int32_t *gradData = (int32_t *)bGrad->data;
         memcpy(gradData, bInitialGradInt32, 2 * sizeof(int32_t));
@@ -211,7 +211,7 @@ static optimizer_t *buildSymInt32OneLayerOptim(layer_t **modelOut, parameter_t *
     }
     parameter_t *b = parameterInit(bParam, bGrad);
 
-    quantization_t *layerQ = quantizationInitSymInt32(HTE);
+    quantization_t *layerQ = quantizationInitSymInt32(HALF_AWAY);
     layer_t *linear = linearLayerInitLegacy(w, b, layerQ, layerQ, layerQ, layerQ);
     modelOut[0] = linear;
     *wOut = w;

--- a/test/unit/userAPI/UnitTestQuantizationApiBitsControl.c
+++ b/test/unit/userAPI/UnitTestQuantizationApiBitsControl.c
@@ -9,32 +9,32 @@ void setUp() {}
 void tearDown() {}
 
 void testQuantizationInitSymInt32WithBitsSetsBitsAndRoundingMode(void) {
-    quantization_t *q = quantizationInitSymInt32WithBits(SRHTE, 12);
+    quantization_t *q = quantizationInitSymInt32WithBits(SR_HALF_AWAY, 12);
 
     TEST_ASSERT_EQUAL_INT(SYM_INT32, q->type);
     TEST_ASSERT_NOT_NULL(q->qConfig);
 
     symInt32QConfig_t *cfg = (symInt32QConfig_t *)q->qConfig;
     TEST_ASSERT_EQUAL_UINT8(12, cfg->qMaxBits);
-    TEST_ASSERT_EQUAL_INT(SRHTE, cfg->roundingMode);
+    TEST_ASSERT_EQUAL_INT(SR_HALF_AWAY, cfg->roundingMode);
 }
 
 void testQuantizationInitSymInt32WithBitsAcceptsMaxBits32(void) {
-    quantization_t *q = quantizationInitSymInt32WithBits(HTE, 32);
+    quantization_t *q = quantizationInitSymInt32WithBits(HALF_AWAY, 32);
 
     symInt32QConfig_t *cfg = (symInt32QConfig_t *)q->qConfig;
     TEST_ASSERT_EQUAL_UINT8(32, cfg->qMaxBits);
 }
 
 void testQuantizationInitSymBuildsQConfigWithSpecifiedBitsAndRounding(void) {
-    quantization_t *q = quantizationInitSym(4, HTE);
+    quantization_t *q = quantizationInitSym(4, HALF_AWAY);
 
     TEST_ASSERT_EQUAL_INT(SYM, q->type);
     TEST_ASSERT_NOT_NULL(q->qConfig);
 
     symQConfig_t *cfg = (symQConfig_t *)q->qConfig;
     TEST_ASSERT_EQUAL_UINT8(4, cfg->qBits);
-    TEST_ASSERT_EQUAL_INT(HTE, cfg->roundingMode);
+    TEST_ASSERT_EQUAL_INT(HALF_AWAY, cfg->roundingMode);
 }
 
 int main(void) {


### PR DESCRIPTION
Mechanical rename, zero behavior change. The implementation was always C `round()` = round-half-away-from-zero (C17 7.12.9.6); only the names and doc comments claimed half-to-even.

- `roundingMode_t`: `HTE` -> `HALF_AWAY`, `SRHTE` -> `SR_HALF_AWAY`
- functions: `roundHTE` -> `roundHalfAway`, `roundSRHTE` -> `roundSRHalfAway`
- fixed the false "Half to Even" doc comments in `Rounding.h` / `Rounding.c`
- token rename across all 24 C unit-test files (qConfig initializers, pinned rounding test); `testRoundHTE` -> `testRoundHalfAway` with byte-identical assertions — the +/-2.5 -> +/-3 cases pin half-away behavior
- reworded the misnomer notes in the two LayerNorm gold generators (`generate_expected_layernorm_sym*.py`); their `round_half_away` emulation is unchanged
- grep-gated: zero `HTE`/`SRHTE` tokens remain in `*.c`/`*.h`/`*.py`/`*.md`

Closes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)