### PR TITLE
fix(tensor): conversionMatrix hygiene — BOOL OOB, NULL-fn guard, fail-fast unsupported, bit-packed same-type copy

### DIFF
--- a/src/tensor/CMakeLists.txt
+++ b/src/tensor/CMakeLists.txt
@@ -30,6 +30,7 @@ target_link_libraries(TensorConversion PRIVATE
         Tensor
         Quantization
         Rounding
+        Common
 )
 
 add_library(Tensor

--- a/src/tensor/TensorConversion.c
+++ b/src/tensor/TensorConversion.c
@@ -404,6 +404,11 @@ void convertTensor(tensor_t *inputTensor, tensor_t *outputTensor) {
         convertTensorsWithSameType(inputTensor, outputTensor, inputDType);
     } else {
         conversionFunction_t conversionFn = conversionMatrix[inputDType][outputDType];
+        if (conversionFn == NULL) {
+            PRINT_ERROR("No conversion function registered for %s to %s",
+                        quantTypeToString(inputDType), quantTypeToString(outputDType));
+            exit(1);
+        }
         conversionFn(inputTensor, outputTensor);
     }
 }

--- a/src/tensor/TensorConversion.c
+++ b/src/tensor/TensorConversion.c
@@ -315,6 +315,8 @@ char *quantTypeToString(qtype_t t) {
         return "SYM";
     case ASYM:
         return "ASYM";
+    case BOOL:
+        return "BOOL";
     default:
         return "UNKNOWN";
     }

--- a/src/tensor/TensorConversion.c
+++ b/src/tensor/TensorConversion.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "Common.h"
 #include "DTypes.h"
 #include "MinMax.h"
 #include "Tensor.h"
@@ -326,8 +327,9 @@ void unsupportedConversionTypes(tensor_t *inputTensor, tensor_t *outputTensor) {
     qtype_t inputQType = inputTensor->quantization->type;
     qtype_t outputQType = outputTensor->quantization->type;
 
-    printf("Error in tensor conversion: Conversion from %s to %s is not supported\n",
-           quantTypeToString(inputQType), quantTypeToString(outputQType));
+    PRINT_ERROR("Conversion from %s to %s is not supported", quantTypeToString(inputQType),
+                quantTypeToString(outputQType));
+    exit(1);
 }
 
 _Static_assert(BOOL + 1 == 6, "extend conversionMatrix when adding qtype_t entries");

--- a/src/tensor/TensorConversion.c
+++ b/src/tensor/TensorConversion.c
@@ -358,9 +358,9 @@ conversionFunction_t conversionMatrix[5][5] = {
 static void convertTensorsWithSameType(tensor_t *inputTensor, tensor_t *outputTensor,
                                        qtype_t qType) {
     size_t numberOfElements = calcNumberOfElementsByTensor(inputTensor);
-    size_t bytesPerElement = calcBytesPerElement(inputTensor->quantization);
+    size_t numberOfBytes = calcNumberOfBytesForData(inputTensor->quantization, numberOfElements);
 
-    memmove(outputTensor->data, inputTensor->data, numberOfElements * bytesPerElement);
+    memmove(outputTensor->data, inputTensor->data, numberOfBytes);
 
     switch (qType) {
     case SYM_INT32:

--- a/src/tensor/TensorConversion.c
+++ b/src/tensor/TensorConversion.c
@@ -330,32 +330,45 @@ void unsupportedConversionTypes(tensor_t *inputTensor, tensor_t *outputTensor) {
            quantTypeToString(inputQType), quantTypeToString(outputQType));
 }
 
-conversionFunction_t conversionMatrix[5][5] = {
+_Static_assert(BOOL + 1 == 6, "extend conversionMatrix when adding qtype_t entries");
+
+conversionFunction_t conversionMatrix[6][6] = {
     [INT32] = {[INT32] = NULL,
                [FLOAT32] = convertInt32TensorToFloatTensor,
                [SYM_INT32] = convertInt32TensorToSymInt32Tensor,
                [SYM] = unsupportedConversionTypes,
-               [ASYM] = convertInt32TensorToAsymTensor},
+               [ASYM] = convertInt32TensorToAsymTensor,
+               [BOOL] = unsupportedConversionTypes},
     [FLOAT32] = {[INT32] = convertFloatTensorToInt32Tensor,
                  [FLOAT32] = NULL,
                  [SYM_INT32] = convertFloatTensorToSymInt32Tensor,
                  [SYM] = unsupportedConversionTypes,
-                 [ASYM] = convertFloatTensorToAsymTensor},
+                 [ASYM] = convertFloatTensorToAsymTensor,
+                 [BOOL] = unsupportedConversionTypes},
     [SYM_INT32] = {[INT32] = extractInt32TensorFromSymInt32Tensor,
                    [FLOAT32] = convertSymInt32TensorToFloat32Tensor,
                    [SYM_INT32] = NULL,
                    [SYM] = unsupportedConversionTypes,
-                   [ASYM] = convertSymInt32TensorToAsymTensor},
+                   [ASYM] = convertSymInt32TensorToAsymTensor,
+                   [BOOL] = unsupportedConversionTypes},
     [SYM] = {[INT32] = unsupportedConversionTypes,
              [FLOAT32] = unsupportedConversionTypes,
              [SYM_INT32] = unsupportedConversionTypes,
              [SYM] = NULL,
-             [ASYM] = unsupportedConversionTypes},
+             [ASYM] = unsupportedConversionTypes,
+             [BOOL] = unsupportedConversionTypes},
     [ASYM] = {[INT32] = convertAsymTensorToInt32Tensor,
               [FLOAT32] = convertAsymTensorToFloatTensor,
               [SYM_INT32] = convertAsymTensorToSymInt32Tensor,
               [SYM] = unsupportedConversionTypes,
-              [ASYM] = NULL}};
+              [ASYM] = NULL,
+              [BOOL] = unsupportedConversionTypes},
+    [BOOL] = {[INT32] = unsupportedConversionTypes,
+              [FLOAT32] = unsupportedConversionTypes,
+              [SYM_INT32] = unsupportedConversionTypes,
+              [SYM] = unsupportedConversionTypes,
+              [ASYM] = unsupportedConversionTypes,
+              [BOOL] = NULL}};
 
 static void convertTensorsWithSameType(tensor_t *inputTensor, tensor_t *outputTensor,
                                        qtype_t qType) {

--- a/src/tensor/include/TensorConversion.h
+++ b/src/tensor/include/TensorConversion.h
@@ -8,6 +8,6 @@ typedef void (*conversionFunction_t)(tensor_t *inputTensor, tensor_t *outputTens
 void convertTensor(tensor_t *inputTensor, tensor_t *outputTensor);
 char *quantTypeToString(qtype_t t);
 
-extern conversionFunction_t conversionMatrix[5][5];
+extern conversionFunction_t conversionMatrix[6][6];
 
 #endif // TENSOR_CONVERSION_H

--- a/src/tensor/include/TensorConversion.h
+++ b/src/tensor/include/TensorConversion.h
@@ -6,6 +6,7 @@
 typedef void (*conversionFunction_t)(tensor_t *inputTensor, tensor_t *outputTensor);
 
 void convertTensor(tensor_t *inputTensor, tensor_t *outputTensor);
+char *quantTypeToString(qtype_t t);
 
 extern conversionFunction_t conversionMatrix[5][5];
 

--- a/src/userApi/tensor/TensorApi.c
+++ b/src/userApi/tensor/TensorApi.c
@@ -98,6 +98,12 @@ void tensorFillFromFloatBuffer(tensor_t *tensor, const float *source, size_t cou
         exit(1);
     }
 
+    if (tensor->quantization->type == BOOL) {
+        PRINT_ERROR("tensorFillFromFloatBuffer does not support BOOL tensors; "
+                    "use tensorFillFromBoolBuffer instead");
+        exit(1);
+    }
+
     if (tensor->quantization->type == FLOAT32) {
         memcpy(tensor->data, source, count * sizeof(float));
         return;

--- a/test/unit/tensor/CMakeLists.txt
+++ b/test/unit/tensor/CMakeLists.txt
@@ -21,6 +21,8 @@ add_elastic_ai_unit_test(
         Tensor
         Rounding
         Quantization
+        TensorApi
+        StorageApi
 )
 add_elastic_ai_unit_test(
         LIB_UNDER_TEST

--- a/test/unit/tensor/UnitTestTensorConversion.c
+++ b/test/unit/tensor/UnitTestTensorConversion.c
@@ -1,11 +1,16 @@
 #include "DTypes.h"
 #include "Quantization.h"
+#include "StorageApi.h"
 #include "Tensor.h"
+#include "TensorApi.h"
 #include "TensorConversion.h"
 #include "unity.h"
 
+#include <stdbool.h>
 #include <stddef.h>
+#include <stdint.h>
 #include <stdlib.h>
+#include <string.h>
 
 void testConversionIntFloat() {
     uint8_t numValues = 6;
@@ -447,6 +452,55 @@ void testConversionAsymSymInt32() {
     TEST_ASSERT_EQUAL_INT32_ARRAY(expectedData, actual, numValues);
 }
 
+void testConversionBoolBoolCopiesOnlyPackedBytes() {
+    /* N=9 BOOL elements occupy (9+7)/8 = 2 packed bytes; the same-type copy
+     * must move exactly 2 bytes. Canary: the output payload sits at the start
+     * of a 16-byte guard allocation whose bytes 2..15 hold sentinel 0xAA.
+     * Before the fix, convertTensor memmoves N * calcBytesPerElement(BOOL)
+     * = 9 bytes and clobbers the sentinels with the input buffer's 0x55
+     * filler. Both buffers are oversized on purpose so the buggy 9-byte
+     * memmove stays inside owned allocations and the RED run is
+     * well-defined. initTensor is not used here because it allocates the
+     * exact packed size (2 bytes), which would make the buggy copy run out
+     * of bounds. */
+    enum { N = 9, GUARD_BYTES = 16, PAYLOAD_BYTES = 2 };
+
+    size_t dims[] = {N};
+    size_t orderOfDims[] = {0};
+    shape_t shape = {.dimensions = dims, .numberOfDimensions = 1, .orderOfDimensions = orderOfDims};
+
+    quantization_t inQ;
+    initBoolQuantization(&inQ);
+    uint8_t *inBuffer = reserveMemory(GUARD_BYTES);
+    memset(inBuffer, 0x55, GUARD_BYTES);
+    tensor_t inTensor;
+    setTensorValues(&inTensor, inBuffer, &shape, &inQ, NULL);
+
+    const bool pattern[N] = {true, false, true, true, false, false, true, false, true};
+    tensorFillFromBoolBuffer(&inTensor, pattern, N);
+
+    quantization_t outQ;
+    initBoolQuantization(&outQ);
+    uint8_t *outBuffer = reserveMemory(GUARD_BYTES);
+    memset(outBuffer, 0xAA, GUARD_BYTES);
+    tensor_t outTensor;
+    setTensorValues(&outTensor, outBuffer, &shape, &outQ, NULL);
+
+    convertTensor(&inTensor, &outTensor);
+
+    /* Under-copy guard: all 9 bits must arrive. */
+    for (size_t i = 0; i < N; i++) {
+        TEST_ASSERT_EQUAL(pattern[i], tensorBoolGet(&outTensor, i));
+    }
+    /* Over-copy guard: every byte after the packed payload is untouched. */
+    for (size_t i = PAYLOAD_BYTES; i < GUARD_BYTES; i++) {
+        TEST_ASSERT_EQUAL_UINT8(0xAA, outBuffer[i]);
+    }
+
+    freeReservedMemory(inBuffer);
+    freeReservedMemory(outBuffer);
+}
+
 void setUp() {}
 void tearDown() {}
 
@@ -468,6 +522,7 @@ int main(void) {
     RUN_TEST(testConversionAsymInt);
     RUN_TEST(testConversionAsymFloat);
     RUN_TEST(testConversionAsymSymInt32);
+    RUN_TEST(testConversionBoolBoolCopiesOnlyPackedBytes);
 
     return UNITY_END();
 }

--- a/test/unit/tensor/UnitTestTensorConversion.c
+++ b/test/unit/tensor/UnitTestTensorConversion.c
@@ -501,6 +501,42 @@ void testConversionBoolBoolCopiesOnlyPackedBytes() {
     freeReservedMemory(outBuffer);
 }
 
+void testConversionSymInt32SameTypeCopyPropagatesScale() {
+    /* Pins the same-type copy semantics PR C builds on: mantissas memmoved,
+     * input scale overwrites any pre-set output scale, NO rescale happens.
+     * symInt32QConfig_t is zero-initialized instead of using
+     * initSymInt32QConfig so this test references no roundingMode_t
+     * enumerator (PR A renames them in parallel); the same-type copy path
+     * never reads roundingMode. */
+    size_t numValues = 4;
+    size_t dims[] = {4};
+    size_t orderOfDims[] = {0};
+    shape_t shape = {.dimensions = dims, .numberOfDimensions = 1, .orderOfDimensions = orderOfDims};
+
+    symInt32QConfig_t inQC = {0};
+    inQC.scale = 0.03125f;
+    inQC.qMaxBits = 16;
+    quantization_t inQ;
+    initSymInt32Quantization(&inQC, &inQ);
+    int32_t inData[] = {100, -200, 300, -400};
+    tensor_t inTensor;
+    setTensorValues(&inTensor, (uint8_t *)inData, &shape, &inQ, NULL);
+
+    symInt32QConfig_t outQC = {0};
+    outQC.scale = 999.0f; /* pre-set garbage; the copy must overwrite it */
+    outQC.qMaxBits = 16;
+    quantization_t outQ;
+    initSymInt32Quantization(&outQC, &outQ);
+    int32_t outData[4] = {0, 0, 0, 0};
+    tensor_t outTensor;
+    setTensorValues(&outTensor, (uint8_t *)outData, &shape, &outQ, NULL);
+
+    convertTensor(&inTensor, &outTensor);
+
+    TEST_ASSERT_EQUAL_INT32_ARRAY(inData, outData, numValues);
+    TEST_ASSERT_EQUAL_FLOAT(0.03125f, outQC.scale);
+}
+
 void setUp() {}
 void tearDown() {}
 
@@ -523,6 +559,7 @@ int main(void) {
     RUN_TEST(testConversionAsymFloat);
     RUN_TEST(testConversionAsymSymInt32);
     RUN_TEST(testConversionBoolBoolCopiesOnlyPackedBytes);
+    RUN_TEST(testConversionSymInt32SameTypeCopyPropagatesScale);
 
     return UNITY_END();
 }

--- a/test/unit/tensor/UnitTestTensorConversion.c
+++ b/test/unit/tensor/UnitTestTensorConversion.c
@@ -501,6 +501,10 @@ void testConversionBoolBoolCopiesOnlyPackedBytes() {
     freeReservedMemory(outBuffer);
 }
 
+void testQuantTypeToStringBool() {
+    TEST_ASSERT_EQUAL_STRING("BOOL", quantTypeToString(BOOL));
+}
+
 void testConversionSymInt32SameTypeCopyPropagatesScale() {
     /* Pins the same-type copy semantics PR C builds on: mantissas memmoved,
      * input scale overwrites any pre-set output scale, NO rescale happens.
@@ -560,6 +564,7 @@ int main(void) {
     RUN_TEST(testConversionAsymSymInt32);
     RUN_TEST(testConversionBoolBoolCopiesOnlyPackedBytes);
     RUN_TEST(testConversionSymInt32SameTypeCopyPropagatesScale);
+    RUN_TEST(testQuantTypeToStringBool);
 
     return UNITY_END();
 }


### PR DESCRIPTION
## Summary

conversionMatrix hygiene sweep (sibling of #171/#172), one commit per fix:

- `conversionMatrix` extended `[5][5]` -> `[6][6]`: BOOL row/column (`unsupportedConversionTypes` off-diagonal, NULL diagonal) + `_Static_assert(BOOL + 1 == 6, ...)` so qtype_t growth breaks the build instead of indexing out of bounds (`conversionMatrix[FLOAT32][BOOL]` used to alias `extractInt32TensorFromSymInt32Tensor` and silently call the wrong converter)
- `convertTensor`: NULL-function guard with both type names (PRINT_ERROR + exit(1)) instead of calling through NULL
- `unsupportedConversionTypes`: printf-and-continue -> PRINT_ERROR + exit(1); silent no-op conversions eliminated
- `convertTensorsWithSameType`: byte count via `calcNumberOfBytesForData` — BOOL same-type copy moved N*1 bytes instead of (N+7)/8 (~8x over-copy past both buffers); guard-buffer canary test included
- `quantTypeToString`: BOOL case + public declaration in TensorConversion.h
- `tensorFillFromFloatBuffer`: BOOL fail-fast guard pointing at `tensorFillFromBoolBuffer`
- new regression test pins SYM_INT32 same-type copy semantics (data + scale propagation) that the upcoming requant-primitive PR builds on

Independent of the #188 rename PR; both are prerequisites for the SYM requant primitives.

Closes #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)