### PR TITLE
fix(loss): fail-fast dtype dispatch for CrossEntropy forward — SYM mantissas were silently reinterpreted as float bits

### DIFF
--- a/src/loss_functions/CrossEntropy.c
+++ b/src/loss_functions/CrossEntropy.c
@@ -36,6 +36,16 @@ float crossEntropyForwardFloat(tensor_t *softmaxOutput, tensor_t *distribution,
     return loss;
 }
 
+float crossEntropyForward(tensor_t *softmaxOutput, tensor_t *distribution, reduction_t reduction) {
+    switch (softmaxOutput->quantization->type) {
+    case FLOAT32:
+        return crossEntropyForwardFloat(softmaxOutput, distribution, reduction);
+    default:
+        PRINT_ERROR("CrossEntropy forward only implemented for FLOAT32!");
+        exit(1);
+    }
+}
+
 /*float crossEntropyForwardFloat(tensor_t *softmaxOutput, tensor_t *distribution) {
     size_t numberOfValues = calcNumberOfElementsByTensor(softmaxOutput);
 

--- a/src/loss_functions/LossFunction.c
+++ b/src/loss_functions/LossFunction.c
@@ -6,7 +6,7 @@
 
 lossFunctions_t lossFunctions[] = {
     [MSE] = {mseLossForward, mseLossBackward, computeMeanScaleMSE},
-    [CROSS_ENTROPY] = {crossEntropyForwardFloat, crossEntropySoftmaxBackward, computeMeanScaleCE},
+    [CROSS_ENTROPY] = {crossEntropyForward, crossEntropySoftmaxBackward, computeMeanScaleCE},
 };
 
 lossConfig_t defaultLossConfig(lossFuncType_t funcType) {

--- a/src/loss_functions/include/CrossEntropy.h
+++ b/src/loss_functions/include/CrossEntropy.h
@@ -7,6 +7,12 @@
 float crossEntropyForwardFloat(tensor_t *softmaxOutput, tensor_t *distribution,
                                reduction_t reduction);
 
+/* Dtype dispatcher registered as lossFunctions[CROSS_ENTROPY].forward.
+ * FLOAT32 -> crossEntropyForwardFloat; any other dtype fails fast — the raw
+ * float impl casts the data buffer to float*, so e.g. SYM_INT32 mantissas
+ * would be silently reinterpreted as float bit patterns. */
+float crossEntropyForward(tensor_t *softmaxOutput, tensor_t *distribution, reduction_t reduction);
+
 void crossEntropySoftmaxBackward(tensor_t *softmaxOutput, tensor_t *distribution, tensor_t *loss);
 
 /* Per-loss MEAN-reduction scale factor (PyTorch parity).

--- a/test/unit/loss_functions/UnitTestCrossEntropy.c
+++ b/test/unit/loss_functions/UnitTestCrossEntropy.c
@@ -223,6 +223,34 @@ void testCrossEntropyForward_Mean1DTensorReturnsSum() {
     TEST_ASSERT_FLOAT_WITHIN(1e-5f, capturedSum, capturedMean);
 }
 
+void testCrossEntropyForward_DispatcherFloat32MatchesFloatImpl() {
+    /* The dispatcher's FLOAT32 arm must be behavior-identical to the direct
+     * float implementation. Synthetic softmax output with B=2 so the MEAN
+     * branch of the float impl is exercised through the dispatcher too. */
+    tensor_t softmaxOutput;
+    float softmaxData[] = {0.6f, 0.4f, 0.7f, 0.3f};
+    size_t dims[] = {2, 2};
+    size_t order[] = {0, 1};
+    shape_t shape;
+    setShape(&shape, dims, 2, order);
+    quantization_t softmaxQ;
+    initFloat32Quantization(&softmaxQ);
+    setTensorValues(&softmaxOutput, (uint8_t *)softmaxData, &shape, &softmaxQ, NULL);
+
+    tensor_t distribution;
+    float distData[] = {1.f, 0.f, 1.f, 0.f};
+    quantization_t distQ;
+    initFloat32Quantization(&distQ);
+    setTensorValues(&distribution, (uint8_t *)distData, &shape, &distQ, NULL);
+
+    float viaDispatcher = crossEntropyForward(&softmaxOutput, &distribution, REDUCTION_MEAN);
+    float viaFloatImpl = crossEntropyForwardFloat(&softmaxOutput, &distribution, REDUCTION_MEAN);
+
+    TEST_ASSERT_EQUAL_FLOAT(viaFloatImpl, viaDispatcher);
+    /* Anchor against both-wrong drift: (-log 0.6 - log 0.7) / 2 (B=2 MEAN). */
+    TEST_ASSERT_FLOAT_WITHIN(1e-5f, (-logf(0.6f) - logf(0.7f)) / 2.0f, viaDispatcher);
+}
+
 void setUp() {}
 void tearDown() {}
 
@@ -233,5 +261,6 @@ int main() {
     RUN_TEST(testCrossEntropyForward_SumReturnsRawSum);
     RUN_TEST(testCrossEntropyForward_MeanDividesByMicrobatch);
     RUN_TEST(testCrossEntropyForward_Mean1DTensorReturnsSum);
+    RUN_TEST(testCrossEntropyForward_DispatcherFloat32MatchesFloatImpl);
     return UNITY_END();
 }

--- a/test/unit/loss_functions/UnitTestLossFunction.c
+++ b/test/unit/loss_functions/UnitTestLossFunction.c
@@ -73,6 +73,13 @@ void testLossFunctionsVtable_ComputeMeanScaleDispatchesToFamilyImpl() {
     TEST_ASSERT_FLOAT_WITHIN(1e-7f, 0.5f, ceScale);
 }
 
+void testLossFunctionsVtable_ForwardSlotBindsCrossEntropyDispatcher() {
+    /* The vtable must route through the dtype dispatcher, not the raw float
+     * impl — otherwise SYM_INT32 mantissas reaching CE forward are silently
+     * reinterpreted as float bit patterns (no error, garbage loss). */
+    TEST_ASSERT_TRUE(lossFunctions[CROSS_ENTROPY].forward == crossEntropyForward);
+}
+
 /* === defaultLossConfig === */
 
 void testDefaultLossConfig_MSE() {
@@ -96,6 +103,7 @@ int main(void) {
     RUN_TEST(testComputeMeanScaleCE_ScaleIsOneOverN);
     RUN_TEST(testComputeMeanScaleCE_FeatureCountDoesNotAffectScale);
     RUN_TEST(testLossFunctionsVtable_ComputeMeanScaleDispatchesToFamilyImpl);
+    RUN_TEST(testLossFunctionsVtable_ForwardSlotBindsCrossEntropyDispatcher);
     RUN_TEST(testDefaultLossConfig_MSE);
     RUN_TEST(testDefaultLossConfig_CrossEntropy);
     return UNITY_END();


### PR DESCRIPTION
## Summary

- `lossFunctions[CROSS_ENTROPY].forward` was bound directly to `crossEntropyForwardFloat` (LossFunction.c:9), which unconditionally casts `softmaxOutput->data` to `float *` — a SYM_INT32 model output reaching CE forward had its int32 mantissas silently reinterpreted as float bit patterns (garbage loss, no error). CE was the only loss with a raw impl in the vtable; MSE already registers a dispatcher.
- New dispatcher `crossEntropyForward` mirrors `mseLossForward` (MSE.c) exactly: FLOAT32 routes to the unchanged float impl; every other dtype fails fast with `PRINT_ERROR` + `exit(1)`.
- Dispatcher exported in `CrossEntropy.h` (MSE.h precedent) and pinned by a registry-binding test (`lossFunctions[CROSS_ENTROPY].forward == crossEntropyForward`); the FLOAT32 arm is pinned behavior-identical to the direct impl with a known-value anchor.
- Until the CE SYM arm lands (M5 of the SYM completeness program), classification on SYM models uses the mixed-precision head (… Conv-SYM → Quant(SYM→FLOAT) → Linear-FLOAT → Softmax → CE).

Closes #200

Note: develop-merges do not auto-close issues — close #200 manually after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)