### PR TITLE
ci: UBSan job (signed-integer-overflow, float-cast-overflow) for the SYM integer paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,33 @@ jobs:
       - name: Test
         run: ctest --preset unit_test_asan
 
+  c-ubsan-build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y cmake ninja-build gcc
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Sync Python deps for build-time generators
+        run: uv sync
+
+      - name: Configure
+        run: CC=gcc cmake --preset unit_test_ubsan
+
+      - name: Build
+        run: cmake --build --preset unit_test_ubsan
+
+      - name: Test
+        run: ctest --preset unit_test_ubsan
+
   c-bit-parity:
     runs-on: ubuntu-latest
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -56,6 +56,15 @@
       }
     },
     {
+      "name": "unit_test_ubsan",
+      "displayName": "Unit-Test-UBSan",
+      "inherits": "unit_test_debug",
+      "cacheVariables": {
+        "CMAKE_C_FLAGS": "-fsanitize=signed-integer-overflow,float-cast-overflow -fno-sanitize-recover=all -g -O1",
+        "CMAKE_EXE_LINKER_FLAGS": "-fsanitize=signed-integer-overflow,float-cast-overflow"
+      }
+    },
+    {
       "name": "examples",
       "displayName": "Examples (BUILD_EXAMPLES=ON)",
       "inherits": "host",
@@ -99,6 +108,12 @@
       "name": "unit_test_asan",
       "inherits": "host",
       "configurePreset": "unit_test_asan",
+      "targets": "all_unit_tests"
+    },
+    {
+      "name": "unit_test_ubsan",
+      "inherits": "host",
+      "configurePreset": "unit_test_ubsan",
       "targets": "all_unit_tests"
     },
     {
@@ -178,6 +193,23 @@
       },
       "environment": {
         "ASAN_OPTIONS": "detect_leaks=0:abort_on_error=1:halt_on_error=1:strict_string_checks=1:check_initialization_order=1",
+        "UBSAN_OPTIONS": "print_stacktrace=1:halt_on_error=1"
+      }
+    },
+    {
+      "name": "unit_test_ubsan",
+      "displayName": "Unit Tests (UBSan overflow)",
+      "configurePreset": "unit_test_ubsan",
+      "output": {
+        "outputJUnitFile": "unit-test-ubsan.junit",
+        "outputOnFailure": true
+      },
+      "filter": {
+        "include": {
+          "label": "unit"
+        }
+      },
+      "environment": {
         "UBSAN_OPTIONS": "print_stacktrace=1:halt_on_error=1"
       }
     }


### PR DESCRIPTION
## Summary

- New CMake presets `unit_test_ubsan` (configure/build/test): the `unit_test_debug` configuration plus `-fsanitize=signed-integer-overflow,float-cast-overflow -fno-sanitize-recover=all` on compile and link lines (pattern follows the existing `unit_test_asan` preset).
- New CI job `c-ubsan-build-and-test` (ubuntu, gcc, `CC=gcc` explicit): configure/build/ctest with the new presets, mirroring `c-build-and-test`.
- Policy (spec D6): release/MCU builds stay unchecked by design — overflow there is accepted. This job is the debug-side net for the SYM integer paths: MAC accumulation in `matmulIntCore` (int16×int16 products, unchecked int32 sums) and the #189 float→int cast UB class, framework-wide, with zero framework-code changes. Precedent: UBSan already caught the PR #168 underflow.
- Overlap, stated honestly: `c-asan-build-and-test` (clang `address,undefined`) already includes both checks, so this job starts green. Its distinct value: overflow-only failure signal, `DEBUG_MODE_DEBUG` configuration, gcc codegen (same toolchain the primary build ships), and local runnability on hosts where ASan hangs.
- NOT marked as a required check. Branch protection is updated manually AFTER this job exists on the default branch (adding a Required Check before the job exists locks all open PRs).
- Local smoke ran successfully (UBSan runtime is distinct from ASan; no hang): 59/59 tests passed with zero `runtime error:` reports.

Spec: docs/superpowers/specs/2026-06-11-sym-program-requant-design.md (D6).

Closes #204

<!-- Manual close note: develop-merges do not auto-close issues; run `gh issue close 204 --comment "Shipped in PR 214 (develop)"` after merge. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
