### PR TITLE
fix: remove NaN-UB source in MSE SYM backward test + dead dequant pass (#215)

### DIFF
--- a/src/loss_functions/MSE.c
+++ b/src/loss_functions/MSE.c
@@ -107,7 +107,6 @@ void mseLossBackwardSymInt32(tensor_t *modelOutput, tensor_t *label, tensor_t *r
     initFloat32Quantization(&resultFloatQ);
     uint8_t resultFloatData[numberOfElements * sizeof(float)];
     setTensorValuesForConversion(resultFloatData, &resultFloatQ, result, &resultFloat);
-    convertTensor(result, &resultFloat);
 
     float *modelOutputArray = (float *)modelOutputFloat.data;
     float *labelArray = (float *)labelFloat.data;

--- a/test/unit/loss_functions/UnitTestMSE.c
+++ b/test/unit/loss_functions/UnitTestMSE.c
@@ -6,6 +6,7 @@
 #include "TensorApi.h"
 #include "TensorConversion.h"
 #include "unity.h"
+#include <string.h>
 
 void testMSEForward_MeanReturnsPerSampleMean() {
     /* Output (1D, 3 elements). Today B=1, so numFeaturesPerSample = 3. */
@@ -149,8 +150,8 @@ void testMSELossBackward_SymInt32WritesRawPerElementGrad() {
     quantization_t resultSymInt32Q;
     initSymInt32Quantization(&resultSymInt32QC, &resultSymInt32Q);
     uint8_t resultSymInt32Data[numberOfElements * sizeof(int32_t)];
+    memset(resultSymInt32Data, 0, numberOfElements * sizeof(int32_t));
     setTensorValuesForConversion(resultSymInt32Data, &resultSymInt32Q, &result, &resultSymInt32);
-    convertTensor(&result, &resultSymInt32);
 
     mseLossBackward(&modelOutputSymInt32, &labelSymInt32, &resultSymInt32);
     convertTensor(&resultSymInt32, &result);


### PR DESCRIPTION
## Root cause

`testMSELossBackward_SymInt32WritesRawPerElementGrad` in `UnitTestMSE.c` declared an uninitialized `float resultData[...]` stack buffer, wrapped it in a FLOAT32 tensor, then immediately called `convertTensor(&result, &resultSymInt32)` — quantizing random garbage floats into `resultSymInt32`. Because `mseLossBackward` fully overwrites `resultSymInt32` before any element is read, the conversion was pure dead ceremony. But UBSan caught the `-nan → int` cast in `Rounding.c:11` when the garbage floats went through the quantizer.

This is a **test-fixture bug only** — not a production bug. Training-loop grad tensors are `calloc`'d, so their contents are defined zero before use.

## Changes

**Commit 1 — `fix(test)`: remove dead garbage-quantizing convertTensor from MSE SYM backward fixture**

- `test/unit/loss_functions/UnitTestMSE.c`: deleted the dead `convertTensor(&result, &resultSymInt32)` call; added `memset(resultSymInt32Data, 0, ...)` so the int32 result buffer has defined contents (scale = 1.0 from `initSymInt32QConfig`, so zeros represent 0.0f). The float `result`/`resultData` are kept — they serve as the output buffer for the final `convertTensor(&resultSymInt32, &result)` dequantizing the grad for assertions.

**Commit 2 — `fix(loss)`: drop dead dequant of prior result contents in MSE SYM backward**

- `src/loss_functions/MSE.c`, `mseLossBackwardSymInt32`: removed the `convertTensor(result, &resultFloat)` call that read the result tensor's prior int32 contents into a scratch float buffer. The gradient loop (`2*(modelOutput[i]-label[i])`) writes every element of `resultFloat.data` before any read — the prior dequantization was a wasted conversion pass that also propagated fixture garbage through UBSan. `setTensorValuesForConversion` (which wires up shape/quantization) and the final `convertTensor(&resultFloat, result)` requant are unchanged.

## Verification

- `ctest --preset unit_test_debug`: **59/59 green** locally
- `UnitTestMSE` binary: **4/4 PASS**
- UBSan proof lands when PR #214's job re-runs on top of this merge; locally all 59 tests green

Closes #215

> **Note:** `Closes #215` fires only on merge to the default branch (main). Close manually after develop-merge with `gh issue close 215`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)