### PR TITLE
feat(tensor): SYM_INT32 requant primitives — dynamic absmax + fixed-scale, in-place capable (#192 PR-1)

### DIFF
--- a/src/tensor/TensorConversion.c
+++ b/src/tensor/TensorConversion.c
@@ -208,6 +208,76 @@ void convertSymInt32TensorToFloat32Tensor(tensor_t *inputTensor, tensor_t *outpu
     memcpy(outputTensor->data, output, numberOfValues * bytesPerOutputElement);
 }
 
+void requantSymInt32Tensor(tensor_t *inputTensor, tensor_t *outputTensor) {
+    size_t numberOfElements = calcNumberOfElementsByTensor(inputTensor);
+
+    symInt32QConfig_t *inputSymInt32QC = inputTensor->quantization->qConfig;
+    symInt32QConfig_t *outputSymInt32QC = outputTensor->quantization->qConfig;
+    /* latch BEFORE writing outputSymInt32QC->scale: when called in-place
+     * (inputTensor == outputTensor) both pointers alias the same config */
+    float inScale = inputSymInt32QC->scale;
+
+    const float qMax = powf(2, (float)outputSymInt32QC->qMaxBits - 1) - 1;
+    const float qMin = -powf(2, (float)outputSymInt32QC->qMaxBits - 1);
+
+    int32_t *inputInt32 = (int32_t *)inputTensor->data;
+    int32_t *outputInt32 = (int32_t *)outputTensor->data;
+
+    /* pass A: absmax over dequantized values — reads only (alias-safe) */
+    float absMax = 0.f;
+    for (size_t i = 0; i < numberOfElements; i++) {
+        float dequant = fabsf((float)inputInt32[i] * inScale);
+        if (dequant > absMax) {
+            absMax = dequant;
+        }
+    }
+
+    float scale;
+    if (absMax == 0.f) {
+        scale = 1.f;
+    } else {
+        scale = absMax / qMax;
+    }
+    outputSymInt32QC->scale = scale;
+
+    /* pass B: same-index read-then-write — in-place safe (int32 both sides) */
+    for (size_t i = 0; i < numberOfElements; i++) {
+        outputInt32[i] = roundByMode(clamp(((float)inputInt32[i] * inScale) / scale, qMin, qMax),
+                                     outputSymInt32QC->roundingMode);
+    }
+}
+
+void requantSymInt32TensorToScale(tensor_t *inputTensor, tensor_t *outputTensor) {
+    size_t numberOfElements = calcNumberOfElementsByTensor(inputTensor);
+
+    symInt32QConfig_t *inputSymInt32QC = inputTensor->quantization->qConfig;
+    symInt32QConfig_t *outputSymInt32QC = outputTensor->quantization->qConfig;
+    float inScale = inputSymInt32QC->scale;
+    float targetScale = outputSymInt32QC->scale;
+
+    /* NaN-robust: !(x > 0.f) is also true for NaN, unlike (x <= 0.f) */
+    if (!(targetScale > 0.f)) {
+        PRINT_ERROR("requantSymInt32TensorToScale: target scale must be pre-set and > 0 on "
+                    "the output qConfig, got %f",
+                    targetScale);
+        exit(1);
+    }
+
+    const float qMax = powf(2, (float)outputSymInt32QC->qMaxBits - 1) - 1;
+    const float qMin = -powf(2, (float)outputSymInt32QC->qMaxBits - 1);
+
+    int32_t *inputInt32 = (int32_t *)inputTensor->data;
+    int32_t *outputInt32 = (int32_t *)outputTensor->data;
+
+    /* single same-index read-then-write pass — shared-buffer in-place safe;
+     * clamp saturates at qMin/qMax BY DESIGN (Deutel Eq. 4 analog) */
+    for (size_t i = 0; i < numberOfElements; i++) {
+        outputInt32[i] =
+            roundByMode(clamp(((float)inputInt32[i] * inScale) / targetScale, qMin, qMax),
+                        outputSymInt32QC->roundingMode);
+    }
+}
+
 void convertSymInt32TensorToAsymTensor(tensor_t *inputTensor, tensor_t *outputTensor) {
     size_t numberOfValues = calcNumberOfElementsByTensor(inputTensor);
 
@@ -349,7 +419,7 @@ conversionFunction_t conversionMatrix[6][6] = {
                  [BOOL] = unsupportedConversionTypes},
     [SYM_INT32] = {[INT32] = extractInt32TensorFromSymInt32Tensor,
                    [FLOAT32] = convertSymInt32TensorToFloat32Tensor,
-                   [SYM_INT32] = NULL,
+                   [SYM_INT32] = requantSymInt32Tensor,
                    [SYM] = unsupportedConversionTypes,
                    [ASYM] = convertSymInt32TensorToAsymTensor,
                    [BOOL] = unsupportedConversionTypes},

--- a/src/tensor/include/TensorConversion.h
+++ b/src/tensor/include/TensorConversion.h
@@ -6,6 +6,48 @@
 typedef void (*conversionFunction_t)(tensor_t *inputTensor, tensor_t *outputTensor);
 
 void convertTensor(tensor_t *inputTensor, tensor_t *outputTensor);
+/*! @brief SYM_INT32 -> SYM_INT32 requantization with a FRESH dynamic scale.
+ *
+ * Pass A (reads only): absMax = max_i |mantissa_i * inScale|.
+ * scale = (absMax == 0) ? 1.0f : absMax / qMax, with qMax = 2^(qMaxBits-1)-1
+ * and qMin = -2^(qMaxBits-1) taken from the OUTPUT tensor's
+ * symInt32QConfig_t. Pass B: out_i = roundByMode(clamp((mantissa_i *
+ * inScale) / scale, qMin, qMax), outQConfig->roundingMode). Writes the fresh
+ * scale to the output qConfig. Never saturates by construction: absMax maps
+ * exactly to +-qMax. (Deutel, IEEE TCAD 44(4) 2025, Eqs. 5-7 idiom: observe
+ * range -> fresh scale -> requantize.)
+ *
+ * IN-PLACE CAPABLE: inputTensor == outputTensor is allowed. Pass A only
+ * reads; pass B is a same-index read-then-write over int32 storage on both
+ * sides. When aliased, the single qConfig carries the input scale on entry
+ * and the fresh scale on exit.
+ *
+ * Elements are processed in flat storage order; orderOfDimensions is ignored
+ * (matches every converter in this file). Shape/sparsity are not touched.
+ * Wired into conversionMatrix[SYM_INT32][SYM_INT32]; convertTensor's
+ * same-type branch short-circuits BEFORE the matrix, so this is reachable
+ * only via direct matrix dispatch. */
+void requantSymInt32Tensor(tensor_t *inputTensor, tensor_t *outputTensor);
+/*! @brief SYM_INT32 -> SYM_INT32 requantization into a PRE-SET target scale.
+ *
+ * The target scale is the OUTPUT tensor's symInt32QConfig_t->scale and must
+ * be set by the caller BEFORE the call; it is never modified. Guard:
+ * !(scale > 0.0f) (NaN-robust) -> PRINT_ERROR + exit(1).
+ * out_i = roundByMode(clamp((mantissa_i * inScale) / targetScale, qMin,
+ * qMax), outQConfig->roundingMode) with qMin/qMax from the output qConfig.
+ *
+ * SATURATES BY DESIGN: values outside the representable range clamp to
+ * qMin/qMax — this is the Deutel (IEEE TCAD 44(4) 2025) Eq. 4 analog
+ * (layer-epilogue requant of errors/activations into a known target scale);
+ * clamping IS the intended semantics, not an error. Covers the #187-deferred
+ * symmetric scratch+convert propLoss case.
+ *
+ * IN-PLACE CAPABLE via a shared data buffer (two tensor_t views with their
+ * own qConfigs): single same-index read-then-write pass over int32 storage.
+ * Flat storage order; orderOfDimensions is ignored; shape/sparsity are not
+ * touched. NOT wired into conversionMatrix (the dynamic variant owns the
+ * diagonal). */
+void requantSymInt32TensorToScale(tensor_t *inputTensor, tensor_t *outputTensor);
 char *quantTypeToString(qtype_t t);
 
 extern conversionFunction_t conversionMatrix[6][6];

--- a/test/unit/goldgen/sym_gold.py
+++ b/test/unit/goldgen/sym_gold.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Shared SYM_INT32 gold-value helpers for unit-test gold generators (spec D7, #192).
+
+Extracted verbatim from test/unit/layer/generate_expected_layernorm_sym_bwd.py
+(the LayerNorm generators keep their private copies for now and migrate
+opportunistically — do NOT import this module from them yet).
+
+Rounding: the framework's roundByMode(HALF_AWAY) is C round() =
+half-away-from-zero — emulate with sign(x)*floor(|x|+0.5), NEVER torch.round
+(true half-to-even, silently diverges on ties).
+
+Generators import via a sys.path bootstrap relative to the script:
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "goldgen"))
+"""
+import torch
+
+QMAX = 32767.0
+QMIN = -32768.0
+
+
+def round_half_away(x: torch.Tensor) -> torch.Tensor:
+    """Match the C kernel: roundByMode(HALF_AWAY) is C round() = half-away-from-zero
+    (Rounding.c)."""
+    return torch.sign(x) * torch.floor(torch.abs(x) + 0.5)
+
+
+def _format_float_literal(v: float) -> str:
+    s = repr(v)
+    if s in ("inf", "-inf", "nan"):
+        raise ValueError(f"non-finite gold value: {v!r}")
+    return s + "f"
+
+
+def emit_float_array(name: str, tensor: torch.Tensor) -> str:
+    flat = tensor.detach().flatten().tolist()
+    body = ", ".join(_format_float_literal(v) for v in flat)
+    return (
+        f"static const float {name}[] = {{ {body} }};\n"
+        f"static const size_t {name}_len = {len(flat)};\n"
+    )
+
+
+def emit_int32_array(name: str, tensor: torch.Tensor) -> str:
+    flat = [int(v) for v in tensor.detach().flatten().tolist()]
+    body = ", ".join(str(v) for v in flat)
+    return (
+        f"static const int32_t {name}[] = {{ {body} }};\n"
+        f"static const size_t {name}_len = {len(flat)};\n"
+    )
+
+
+def emit_float_scalar(name: str, v: float) -> str:
+    return f"static const float {name} = {_format_float_literal(float(v))};\n"
+
+
+def emit_int32_scalar(name: str, v: int) -> str:
+    return f"static const int32_t {name} = {int(v)};\n"
+
+
+def quantize_sym(x: torch.Tensor):
+    """convertFloatTensorToSymInt32Tensor: absmax -> scale (1.0 if absmax==0),
+    round-clamp with the C rounding (half-away-from-zero)."""
+    absmax = x.abs().max().item()
+    scale = 1.0 if absmax == 0.0 else absmax / QMAX
+    q = round_half_away(torch.clamp(x / scale, QMIN, QMAX))
+    return q.to(torch.int32), scale
+
+
+def stable_dequant(x: torch.Tensor):
+    """Quantize once; return (mantissas, scale, dequantized float32 fixture).
+    The EMITTED float32 fixture is asserted ROUND-TRIP STABLE so the C side's
+    tensorFillFromFloatBuffer lands on exactly these mantissas."""
+    q, s = quantize_sym(x.to(torch.float64))
+    deq32 = (q.to(torch.float64) * s).to(torch.float32)
+    q2, _ = quantize_sym(deq32.to(torch.float64))
+    assert torch.equal(q, q2), "fixture is not dequantization round-trip stable"
+    return q, s, deq32

--- a/test/unit/tensor/CMakeLists.txt
+++ b/test/unit/tensor/CMakeLists.txt
@@ -24,6 +24,20 @@ add_elastic_ai_unit_test(
         TensorApi
         StorageApi
 )
+set(GEN_REQUANT_HEADER ${CMAKE_CURRENT_BINARY_DIR}/expected_requant.h)
+add_custom_command(
+        OUTPUT ${GEN_REQUANT_HEADER}
+        COMMAND uv run ${CMAKE_CURRENT_SOURCE_DIR}/generate_expected_requant.py
+                --out ${GEN_REQUANT_HEADER}
+        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/generate_expected_requant.py
+                ${CMAKE_CURRENT_SOURCE_DIR}/../goldgen/sym_gold.py
+        COMMENT "Generating expected_requant.h via PyTorch"
+        VERBATIM
+)
+add_custom_target(generate_expected_requant
+        DEPENDS ${GEN_REQUANT_HEADER})
+add_dependencies(UnitTestTensorConversion generate_expected_requant)
+target_include_directories(UnitTestTensorConversion PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 add_elastic_ai_unit_test(
         LIB_UNDER_TEST
         TensorApi

--- a/test/unit/tensor/UnitTestTensorConversion.c
+++ b/test/unit/tensor/UnitTestTensorConversion.c
@@ -4,6 +4,7 @@
 #include "Tensor.h"
 #include "TensorApi.h"
 #include "TensorConversion.h"
+#include "expected_requant.h"
 #include "unity.h"
 
 #include <stdbool.h>
@@ -541,6 +542,345 @@ void testConversionSymInt32SameTypeCopyPropagatesScale() {
     TEST_ASSERT_EQUAL_FLOAT(0.03125f, outQC.scale);
 }
 
+void testRequantDynamicAccumulatorRangeMatchesGold() {
+    size_t dims[] = {input_requant_f1AccumRange_len};
+    size_t orderOfDims[] = {0};
+    shape_t shape = {.dimensions = dims, .numberOfDimensions = 1, .orderOfDimensions = orderOfDims};
+
+    symInt32QConfig_t inQc;
+    initSymInt32QConfigWithQMaxBits(HALF_AWAY, &inQc, (uint8_t)qMaxBits_requant);
+    inQc.scale = inputScale_requant_f1AccumRange;
+    quantization_t inQ;
+    initSymInt32Quantization(&inQc, &inQ);
+    int32_t inData[input_requant_f1AccumRange_len];
+    memcpy(inData, input_requant_f1AccumRange, sizeof(inData));
+    tensor_t inTensor;
+    setTensorValues(&inTensor, (uint8_t *)inData, &shape, &inQ, NULL);
+
+    symInt32QConfig_t outQc;
+    initSymInt32QConfigWithQMaxBits(HALF_AWAY, &outQc, (uint8_t)qMaxBits_requant);
+    quantization_t outQ;
+    initSymInt32Quantization(&outQc, &outQ);
+    int32_t outData[input_requant_f1AccumRange_len];
+    tensor_t outTensor;
+    setTensorValues(&outTensor, (uint8_t *)outData, &shape, &outQ, NULL);
+
+    requantSymInt32Tensor(&inTensor, &outTensor);
+
+    TEST_ASSERT_EQUAL_INT32_ARRAY(expected_requant_f1AccumRange, outData,
+                                  expected_requant_f1AccumRange_len);
+    TEST_ASSERT_FLOAT_WITHIN(scaleTol_requant_f1AccumRange, expectedScale_requant_f1AccumRange,
+                             outQc.scale);
+    // out-of-place: the input tensor must be untouched (pass A reads only)
+    TEST_ASSERT_EQUAL_INT32_ARRAY(input_requant_f1AccumRange, inData,
+                                  input_requant_f1AccumRange_len);
+    TEST_ASSERT_EQUAL_FLOAT(inputScale_requant_f1AccumRange, inQc.scale);
+}
+
+void testRequantDynamicAbsmaxZeroGivesZerosScaleOne() {
+    size_t dims[] = {input_requant_f2AbsmaxZero_len};
+    size_t orderOfDims[] = {0};
+    shape_t shape = {.dimensions = dims, .numberOfDimensions = 1, .orderOfDimensions = orderOfDims};
+
+    symInt32QConfig_t inQc;
+    initSymInt32QConfigWithQMaxBits(HALF_AWAY, &inQc, (uint8_t)qMaxBits_requant);
+    inQc.scale = inputScale_requant_f2AbsmaxZero;
+    quantization_t inQ;
+    initSymInt32Quantization(&inQc, &inQ);
+    int32_t inData[input_requant_f2AbsmaxZero_len];
+    memcpy(inData, input_requant_f2AbsmaxZero, sizeof(inData));
+    tensor_t inTensor;
+    setTensorValues(&inTensor, (uint8_t *)inData, &shape, &inQ, NULL);
+
+    symInt32QConfig_t outQc;
+    initSymInt32QConfigWithQMaxBits(HALF_AWAY, &outQc, (uint8_t)qMaxBits_requant);
+    quantization_t outQ;
+    initSymInt32Quantization(&outQc, &outQ);
+    int32_t outData[input_requant_f2AbsmaxZero_len];
+    tensor_t outTensor;
+    setTensorValues(&outTensor, (uint8_t *)outData, &shape, &outQ, NULL);
+
+    requantSymInt32Tensor(&inTensor, &outTensor);
+
+    TEST_ASSERT_EQUAL_INT32_ARRAY(expected_requant_f2AbsmaxZero, outData,
+                                  expected_requant_f2AbsmaxZero_len);
+    TEST_ASSERT_FLOAT_WITHIN(scaleTol_requant_f2AbsmaxZero, expectedScale_requant_f2AbsmaxZero,
+                             outQc.scale);
+}
+
+void testRequantDynamicScaleTracksInputRescale() {
+    // ONE output tensor + qConfig reused across BOTH calls (no re-init):
+    // a kernel that fails to recompute/write the scale per call keeps the
+    // stale value and fails the second assert (freeze-the-scale class).
+    size_t dims[] = {input_requant_f3Rescale_len};
+    size_t orderOfDims[] = {0};
+    shape_t shape = {.dimensions = dims, .numberOfDimensions = 1, .orderOfDimensions = orderOfDims};
+
+    symInt32QConfig_t inQc;
+    initSymInt32QConfigWithQMaxBits(HALF_AWAY, &inQc, (uint8_t)qMaxBits_requant);
+    inQc.scale = inputScaleA_requant_f3Rescale;
+    quantization_t inQ;
+    initSymInt32Quantization(&inQc, &inQ);
+    int32_t inData[input_requant_f3Rescale_len];
+    memcpy(inData, input_requant_f3Rescale, sizeof(inData));
+    tensor_t inTensor;
+    setTensorValues(&inTensor, (uint8_t *)inData, &shape, &inQ, NULL);
+
+    symInt32QConfig_t outQc;
+    initSymInt32QConfigWithQMaxBits(HALF_AWAY, &outQc, (uint8_t)qMaxBits_requant);
+    quantization_t outQ;
+    initSymInt32Quantization(&outQc, &outQ);
+    int32_t outData[input_requant_f3Rescale_len];
+    tensor_t outTensor;
+    setTensorValues(&outTensor, (uint8_t *)outData, &shape, &outQ, NULL);
+
+    requantSymInt32Tensor(&inTensor, &outTensor);
+    TEST_ASSERT_EQUAL_INT32_ARRAY(expectedA_requant_f3Rescale, outData,
+                                  expectedA_requant_f3Rescale_len);
+    TEST_ASSERT_FLOAT_WITHIN(scaleTolA_requant_f3Rescale, expectedScaleA_requant_f3Rescale,
+                             outQc.scale);
+
+    // same mantissas, input scale x10 -> fresh scale must track ~x10
+    inQc.scale = inputScaleB_requant_f3Rescale;
+    requantSymInt32Tensor(&inTensor, &outTensor);
+    TEST_ASSERT_EQUAL_INT32_ARRAY(expectedB_requant_f3Rescale, outData,
+                                  expectedB_requant_f3Rescale_len);
+    TEST_ASSERT_FLOAT_WITHIN(scaleTolB_requant_f3Rescale, expectedScaleB_requant_f3Rescale,
+                             outQc.scale);
+}
+
+void testRequantDynamicTieRoundsHalfAwayFromZero() {
+    // quotients land on exact .5 ties (gold construction: scale == 4.0f);
+    // half-to-even AND floor/trunc casts produce different mantissas.
+    size_t dims[] = {input_requant_f4Tie_len};
+    size_t orderOfDims[] = {0};
+    shape_t shape = {.dimensions = dims, .numberOfDimensions = 1, .orderOfDimensions = orderOfDims};
+
+    symInt32QConfig_t inQc;
+    initSymInt32QConfigWithQMaxBits(HALF_AWAY, &inQc, (uint8_t)qMaxBits_requant);
+    inQc.scale = inputScale_requant_f4Tie;
+    quantization_t inQ;
+    initSymInt32Quantization(&inQc, &inQ);
+    int32_t inData[input_requant_f4Tie_len];
+    memcpy(inData, input_requant_f4Tie, sizeof(inData));
+    tensor_t inTensor;
+    setTensorValues(&inTensor, (uint8_t *)inData, &shape, &inQ, NULL);
+
+    symInt32QConfig_t outQc;
+    initSymInt32QConfigWithQMaxBits(HALF_AWAY, &outQc, (uint8_t)qMaxBits_requant);
+    quantization_t outQ;
+    initSymInt32Quantization(&outQc, &outQ);
+    int32_t outData[input_requant_f4Tie_len];
+    tensor_t outTensor;
+    setTensorValues(&outTensor, (uint8_t *)outData, &shape, &outQ, NULL);
+
+    requantSymInt32Tensor(&inTensor, &outTensor);
+
+    TEST_ASSERT_EQUAL_INT32_ARRAY(expected_requant_f4Tie, outData, expected_requant_f4Tie_len);
+    TEST_ASSERT_FLOAT_WITHIN(scaleTol_requant_f4Tie, expectedScale_requant_f4Tie, outQc.scale);
+}
+
+void testRequantDynamicInPlaceAliasMatchesGold() {
+    // In-place contract: ONE tensor_t passed as input AND output. Its single
+    // qConfig is read in the input role (scale on entry) and written in the
+    // output role (fresh scale on exit); qMaxBits/roundingMode of that same
+    // config define the target. Pass B rewrites the mantissas index-by-index.
+    // Result must be bit-identical to the out-of-place gold.
+    size_t dims[] = {input_requant_f1AccumRange_len};
+    size_t orderOfDims[] = {0};
+    shape_t shape = {.dimensions = dims, .numberOfDimensions = 1, .orderOfDimensions = orderOfDims};
+
+    symInt32QConfig_t qc;
+    initSymInt32QConfigWithQMaxBits(HALF_AWAY, &qc, (uint8_t)qMaxBits_requant);
+    qc.scale = inputScale_requant_f1AccumRange;
+    quantization_t q;
+    initSymInt32Quantization(&qc, &q);
+    int32_t data[input_requant_f1AccumRange_len];
+    memcpy(data, input_requant_f1AccumRange, sizeof(data));
+    tensor_t tensor;
+    setTensorValues(&tensor, (uint8_t *)data, &shape, &q, NULL);
+
+    requantSymInt32Tensor(&tensor, &tensor);
+
+    TEST_ASSERT_EQUAL_INT32_ARRAY(expected_requant_f1AccumRange, data,
+                                  expected_requant_f1AccumRange_len);
+    TEST_ASSERT_FLOAT_WITHIN(scaleTol_requant_f1AccumRange, expectedScale_requant_f1AccumRange,
+                             qc.scale);
+}
+
+void testRequantDynamicViaConversionMatrixDiagonal() {
+    // The Quant layer (PR D) dispatches directly over the matrix; pin the
+    // diagonal wiring and that it behaves identically to a direct call.
+    conversionFunction_t conversionFn = conversionMatrix[SYM_INT32][SYM_INT32];
+    TEST_ASSERT_NOT_NULL(conversionFn);
+
+    size_t dims[] = {input_requant_f1AccumRange_len};
+    size_t orderOfDims[] = {0};
+    shape_t shape = {.dimensions = dims, .numberOfDimensions = 1, .orderOfDimensions = orderOfDims};
+
+    symInt32QConfig_t inQc;
+    initSymInt32QConfigWithQMaxBits(HALF_AWAY, &inQc, (uint8_t)qMaxBits_requant);
+    inQc.scale = inputScale_requant_f1AccumRange;
+    quantization_t inQ;
+    initSymInt32Quantization(&inQc, &inQ);
+    int32_t inData[input_requant_f1AccumRange_len];
+    memcpy(inData, input_requant_f1AccumRange, sizeof(inData));
+    tensor_t inTensor;
+    setTensorValues(&inTensor, (uint8_t *)inData, &shape, &inQ, NULL);
+
+    symInt32QConfig_t outQc;
+    initSymInt32QConfigWithQMaxBits(HALF_AWAY, &outQc, (uint8_t)qMaxBits_requant);
+    quantization_t outQ;
+    initSymInt32Quantization(&outQc, &outQ);
+    int32_t outData[input_requant_f1AccumRange_len];
+    tensor_t outTensor;
+    setTensorValues(&outTensor, (uint8_t *)outData, &shape, &outQ, NULL);
+
+    conversionFn(&inTensor, &outTensor);
+
+    TEST_ASSERT_EQUAL_INT32_ARRAY(expected_requant_f1AccumRange, outData,
+                                  expected_requant_f1AccumRange_len);
+    TEST_ASSERT_FLOAT_WITHIN(scaleTol_requant_f1AccumRange, expectedScale_requant_f1AccumRange,
+                             outQc.scale);
+}
+
+void testConvertTensorSymInt32SameTypeKeepsCopySemantics() {
+    // Pins the spec-D1 invariant the PR-D Quant layer relies on:
+    // convertTensor's same-type branch short-circuits BEFORE the matrix
+    // lookup and stays memmove + scale copy — wiring the diagonal must NOT
+    // change it. A requant here would yield {10922, -21845, 32767} with a
+    // fresh scale 150/32767 instead of the copied mantissas + scale 0.5f.
+    size_t dims[] = {3};
+    size_t orderOfDims[] = {0};
+    shape_t shape = {.dimensions = dims, .numberOfDimensions = 1, .orderOfDimensions = orderOfDims};
+
+    symInt32QConfig_t inQc;
+    initSymInt32QConfigWithQMaxBits(HALF_AWAY, &inQc, 16);
+    inQc.scale = 0.5f;
+    quantization_t inQ;
+    initSymInt32Quantization(&inQc, &inQ);
+    int32_t inData[] = {100, -200, 300};
+    tensor_t inTensor;
+    setTensorValues(&inTensor, (uint8_t *)inData, &shape, &inQ, NULL);
+
+    symInt32QConfig_t outQc;
+    initSymInt32QConfigWithQMaxBits(HALF_AWAY, &outQc, 16);
+    outQc.scale = 999.f;
+    quantization_t outQ;
+    initSymInt32Quantization(&outQc, &outQ);
+    int32_t outData[3];
+    tensor_t outTensor;
+    setTensorValues(&outTensor, (uint8_t *)outData, &shape, &outQ, NULL);
+
+    convertTensor(&inTensor, &outTensor);
+
+    int32_t expectedCopy[] = {100, -200, 300};
+    TEST_ASSERT_EQUAL_INT32_ARRAY(expectedCopy, outData, 3);
+    TEST_ASSERT_EQUAL_FLOAT(0.5f, outQc.scale);
+}
+
+void testRequantToScaleNonSaturatingMatchesGold() {
+    size_t dims[] = {input_requant_f5ToScaleFit_len};
+    size_t orderOfDims[] = {0};
+    shape_t shape = {.dimensions = dims, .numberOfDimensions = 1, .orderOfDimensions = orderOfDims};
+
+    symInt32QConfig_t inQc;
+    initSymInt32QConfigWithQMaxBits(HALF_AWAY, &inQc, (uint8_t)qMaxBits_requant);
+    inQc.scale = inputScale_requant_f5ToScaleFit;
+    quantization_t inQ;
+    initSymInt32Quantization(&inQc, &inQ);
+    int32_t inData[input_requant_f5ToScaleFit_len];
+    memcpy(inData, input_requant_f5ToScaleFit, sizeof(inData));
+    tensor_t inTensor;
+    setTensorValues(&inTensor, (uint8_t *)inData, &shape, &inQ, NULL);
+
+    symInt32QConfig_t outQc;
+    initSymInt32QConfigWithQMaxBits(HALF_AWAY, &outQc, (uint8_t)qMaxBits_requant);
+    outQc.scale = targetScale_requant_f5ToScaleFit; // pre-set target (fixed-scale contract)
+    quantization_t outQ;
+    initSymInt32Quantization(&outQc, &outQ);
+    int32_t outData[input_requant_f5ToScaleFit_len];
+    tensor_t outTensor;
+    setTensorValues(&outTensor, (uint8_t *)outData, &shape, &outQ, NULL);
+
+    requantSymInt32TensorToScale(&inTensor, &outTensor);
+
+    TEST_ASSERT_EQUAL_INT32_ARRAY(expected_requant_f5ToScaleFit, outData,
+                                  expected_requant_f5ToScaleFit_len);
+    // fixed-scale contract: the pre-set target scale is NEVER modified
+    TEST_ASSERT_EQUAL_FLOAT(targetScale_requant_f5ToScaleFit, outQc.scale);
+}
+
+void testRequantToScaleSaturatesAtQMinQMax() {
+    // target scale deliberately too small: quotients overshoot BOTH bounds;
+    // clamping at qMin/qMax is the documented Deutel-Eq.4 semantics.
+    size_t dims[] = {input_requant_f6ToScaleSat_len};
+    size_t orderOfDims[] = {0};
+    shape_t shape = {.dimensions = dims, .numberOfDimensions = 1, .orderOfDimensions = orderOfDims};
+
+    symInt32QConfig_t inQc;
+    initSymInt32QConfigWithQMaxBits(HALF_AWAY, &inQc, (uint8_t)qMaxBits_requant);
+    inQc.scale = inputScale_requant_f6ToScaleSat;
+    quantization_t inQ;
+    initSymInt32Quantization(&inQc, &inQ);
+    int32_t inData[input_requant_f6ToScaleSat_len];
+    memcpy(inData, input_requant_f6ToScaleSat, sizeof(inData));
+    tensor_t inTensor;
+    setTensorValues(&inTensor, (uint8_t *)inData, &shape, &inQ, NULL);
+
+    symInt32QConfig_t outQc;
+    initSymInt32QConfigWithQMaxBits(HALF_AWAY, &outQc, (uint8_t)qMaxBits_requant);
+    outQc.scale = targetScale_requant_f6ToScaleSat;
+    quantization_t outQ;
+    initSymInt32Quantization(&outQc, &outQ);
+    int32_t outData[input_requant_f6ToScaleSat_len];
+    tensor_t outTensor;
+    setTensorValues(&outTensor, (uint8_t *)outData, &shape, &outQ, NULL);
+
+    requantSymInt32TensorToScale(&inTensor, &outTensor);
+
+    TEST_ASSERT_EQUAL_INT32_ARRAY(expected_requant_f6ToScaleSat, outData,
+                                  expected_requant_f6ToScaleSat_len);
+    TEST_ASSERT_EQUAL_FLOAT(targetScale_requant_f6ToScaleSat, outQc.scale);
+}
+
+void testRequantToScaleSharedBufferAliasMatchesGold() {
+    // In-place for the fixed-scale variant = SHARED DATA BUFFER with two
+    // tensor_t views, each with its OWN qConfig (input scale vs pre-set
+    // target). Passing one tensor_t twice would force inScale == targetScale
+    // (both roles share a single scale field) — a no-op requant — so the
+    // two-view setup is the realistic aliasing mode. Pins the single
+    // same-index read-then-write pass.
+    size_t dims[] = {input_requant_f6ToScaleSat_len};
+    size_t orderOfDims[] = {0};
+    shape_t shape = {.dimensions = dims, .numberOfDimensions = 1, .orderOfDimensions = orderOfDims};
+
+    int32_t data[input_requant_f6ToScaleSat_len];
+    memcpy(data, input_requant_f6ToScaleSat, sizeof(data));
+
+    symInt32QConfig_t inQc;
+    initSymInt32QConfigWithQMaxBits(HALF_AWAY, &inQc, (uint8_t)qMaxBits_requant);
+    inQc.scale = inputScale_requant_f6ToScaleSat;
+    quantization_t inQ;
+    initSymInt32Quantization(&inQc, &inQ);
+    tensor_t inView;
+    setTensorValues(&inView, (uint8_t *)data, &shape, &inQ, NULL);
+
+    symInt32QConfig_t outQc;
+    initSymInt32QConfigWithQMaxBits(HALF_AWAY, &outQc, (uint8_t)qMaxBits_requant);
+    outQc.scale = targetScale_requant_f6ToScaleSat;
+    quantization_t outQ;
+    initSymInt32Quantization(&outQc, &outQ);
+    tensor_t outView;
+    setTensorValues(&outView, (uint8_t *)data, &shape, &outQ, NULL);
+
+    requantSymInt32TensorToScale(&inView, &outView);
+
+    TEST_ASSERT_EQUAL_INT32_ARRAY(expected_requant_f6ToScaleSat, data,
+                                  expected_requant_f6ToScaleSat_len);
+    TEST_ASSERT_EQUAL_FLOAT(targetScale_requant_f6ToScaleSat, outQc.scale);
+}
+
 void setUp() {}
 void tearDown() {}
 
@@ -562,6 +902,16 @@ int main(void) {
     RUN_TEST(testConversionAsymInt);
     RUN_TEST(testConversionAsymFloat);
     RUN_TEST(testConversionAsymSymInt32);
+    RUN_TEST(testRequantDynamicAccumulatorRangeMatchesGold);
+    RUN_TEST(testRequantDynamicAbsmaxZeroGivesZerosScaleOne);
+    RUN_TEST(testRequantDynamicScaleTracksInputRescale);
+    RUN_TEST(testRequantDynamicTieRoundsHalfAwayFromZero);
+    RUN_TEST(testRequantDynamicInPlaceAliasMatchesGold);
+    RUN_TEST(testRequantDynamicViaConversionMatrixDiagonal);
+    RUN_TEST(testConvertTensorSymInt32SameTypeKeepsCopySemantics);
+    RUN_TEST(testRequantToScaleNonSaturatingMatchesGold);
+    RUN_TEST(testRequantToScaleSaturatesAtQMinQMax);
+    RUN_TEST(testRequantToScaleSharedBufferAliasMatchesGold);
     RUN_TEST(testConversionBoolBoolCopiesOnlyPackedBytes);
     RUN_TEST(testConversionSymInt32SameTypeCopyPropagatesScale);
     RUN_TEST(testQuantTypeToStringBool);

--- a/test/unit/tensor/generate_expected_requant.py
+++ b/test/unit/tensor/generate_expected_requant.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""Generate expected_requant.h for UnitTestTensorConversion (#192 PR-1, spec D1/D7).
+
+Emulates the two C SYM_INT32 -> SYM_INT32 requant kernels BIT-EXACTLY:
+the C kernels do all per-element arithmetic in float32 (int->float cast,
+multiply by inScale, divide by scale, clamp), so the emulator mirrors every
+op in torch.float32 and applies the half-away rounding on the float64-exact
+image of the float32 quotient (C round() operates on the double-promoted
+float — identical). Expected MANTISSAS are therefore exact integers;
+expected SCALES carry a 2-ulp analytic tolerance (>= 2 ulp32 for any
+magnitude: |s| * 2^-22).
+
+Fixtures (qMaxBits = 16, qMax = 32767, qMin = -32768 throughout):
+  f1AccumRange  dynamic; +-2e9 accumulator-range mantissas, inScale 3.05e-5;
+                pins scale-blindness (pass A must dequantize) and the exact
+                absmax -> qMax mapping (max|out| == 32767).
+  f2AbsmaxZero  dynamic; all-zero mantissas -> zero mantissas, scale 1.0.
+  f3Rescale     dynamic; same mantissas at inScale s and 10*s; the C test
+                reuses ONE output qConfig across both calls -> pins
+                freeze-the-scale (scale must track the input rescale ~10x).
+  f4Tie         dynamic; scale lands on exactly 4.0, quotients exactly
+                k + 0.5 -> pins half-away-from-zero vs half-to-even AND vs
+                floor/trunc casts (positive and negative ties).
+  f5ToScaleFit  fixed-scale; target > absmax/qMax -> no clamping; kernel
+                must NOT touch the pre-set scale.
+  f6ToScaleSat  fixed-scale; target too small -> mantissas CLAMP at
+                qMin/qMax (saturation is the documented Deutel-Eq.4
+                semantics, NOT an error).
+
+Self-checks: see asserts inline; the script aborts instead of emitting a
+header that contradicts its own emulation. Run via `uv run` (CMake wires
+this automatically).
+"""
+import argparse
+import sys
+from pathlib import Path
+
+import torch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "goldgen"))
+
+from sym_gold import (QMAX, QMIN, emit_float_scalar, emit_int32_array,
+                      emit_int32_scalar, round_half_away)
+
+QMAX_BITS = 16
+
+
+def _f32(x) -> torch.Tensor:
+    return torch.as_tensor(x, dtype=torch.float32)
+
+
+def scale_tol(scale: float) -> float:
+    """Analytic scale tolerance: >= 2 ulp32 for any magnitude (s in
+    [2^e, 2^(e+1)) has ulp32 = 2^(e-23) <= s * 2^-23)."""
+    return abs(scale) * 2.0 ** -22
+
+
+def emulate_requant_dynamic(mantissas: torch.Tensor, in_scale: float):
+    """requantSymInt32Tensor mirrored in float32: pass A absmax over
+    |(float)m_i * inScale| (reads only), scale = absmax/qMax (1.0 if
+    absmax == 0), pass B round-clamp of ((float)m_i * inScale)/scale."""
+    deq = mantissas.to(torch.float32) * _f32(in_scale)
+    absmax = deq.abs().max()
+    if absmax.item() == 0.0:
+        scale = _f32(1.0)
+    else:
+        scale = absmax / _f32(QMAX)
+    quot = torch.clamp(deq / scale, QMIN, QMAX).to(torch.float64)
+    out = round_half_away(quot).to(torch.int32)
+    return out, float(scale.item())
+
+
+def emulate_requant_to_scale(mantissas: torch.Tensor, in_scale: float,
+                             target_scale: float):
+    """requantSymInt32TensorToScale mirrored in float32: round-clamp of
+    ((float)m_i * inScale)/targetScale; saturates at qMin/qMax; the target
+    scale is pre-set on the output qConfig and never modified."""
+    assert target_scale > 0.0, "fixture bug: guard regime is not unit-testable"
+    deq = mantissas.to(torch.float32) * _f32(in_scale)
+    quot = torch.clamp(deq / _f32(target_scale), QMIN, QMAX).to(torch.float64)
+    return round_half_away(quot).to(torch.int32), deq
+
+
+def _roundtrip_check(name, out, scale, mantissas, in_scale, max_abs_mantissa):
+    """|out_i*scale - m_i*inScale| <= 0.5 LSB (rounding) + ~0.002 LSB
+    (1 ulp32(qMax) float32 division drift) + int->float32 cast error
+    (<= 0.5 ulp of the largest input mantissa, in value space)."""
+    v64 = mantissas.to(torch.float64) * float(_f32(in_scale).item())
+    cast_err = (2.0 ** -24) * 2.0 * max_abs_mantissa * float(_f32(in_scale).item())
+    err = (out.to(torch.float64) * scale - v64).abs().max().item()
+    bound = 0.502 * scale + cast_err
+    assert err <= bound, f"{name}: round-trip err {err} > {bound}"
+
+
+def fixture_f1_accum_range():
+    m = torch.tensor([1999999999, -2000000000, 123456789, -987654321,
+                      31415926, -27182818, 500000000, 0], dtype=torch.int32)
+    in_scale = 3.05e-5
+    out, scale = emulate_requant_dynamic(m, in_scale)
+    assert out.abs().max().item() == int(QMAX), (
+        f"f1AccumRange: absmax must map exactly to qMax, got "
+        f"{out.abs().max().item()}")
+    _roundtrip_check("f1AccumRange", out, scale, m, in_scale, 2.0e9)
+    return {"name": "f1AccumRange", "input": m, "inputScale": in_scale,
+            "expected": out, "expectedScale": scale}
+
+
+def fixture_f2_absmax_zero():
+    m = torch.zeros(6, dtype=torch.int32)
+    in_scale = 0.25
+    out, scale = emulate_requant_dynamic(m, in_scale)
+    assert torch.equal(out, torch.zeros(6, dtype=torch.int32)), "f2: out != 0"
+    assert scale == 1.0, f"f2AbsmaxZero: scale must be exactly 1.0, got {scale}"
+    return {"name": "f2AbsmaxZero", "input": m, "inputScale": in_scale,
+            "expected": out, "expectedScale": scale}
+
+
+def fixture_f3_rescale():
+    m = torch.tensor([1000, -2000, 30, 4500, -16000, 12345], dtype=torch.int32)
+    in_scale_a = 2.0 ** -8     # 0.00390625, exact in float32
+    in_scale_b = 10.0 * in_scale_a  # 0.0390625 = 5*2^-7, ALSO exact in float32
+    out_a, scale_a = emulate_requant_dynamic(m, in_scale_a)
+    out_b, scale_b = emulate_requant_dynamic(m, in_scale_b)
+    # Same mantissas + exactly-10x input scale => identical quotients up to
+    # float32 ulps (no quotient sits near a tie) => identical mantissas.
+    assert torch.equal(out_a, out_b), "f3Rescale: mantissas must be invariant"
+    assert abs(scale_b / scale_a - 10.0) < 1e-6, (
+        f"f3Rescale: scale ratio {scale_b / scale_a} != 10")
+    assert out_a.abs().max().item() == int(QMAX), "f3Rescale: absmax->qMax"
+    _roundtrip_check("f3Rescale/A", out_a, scale_a, m, in_scale_a, 16000.0)
+    _roundtrip_check("f3Rescale/B", out_b, scale_b, m, in_scale_b, 16000.0)
+    return {"name": "f3Rescale", "input": m,
+            "inputScaleA": in_scale_a, "inputScaleB": in_scale_b,
+            "expectedA": out_a, "expectedScaleA": scale_a,
+            "expectedB": out_b, "expectedScaleB": scale_b}
+
+
+def fixture_f4_tie():
+    # absmax mantissa 131068 = 4*32767 with inScale 1.0 => scale exactly 4.0f
+    # => quotients m/4: 10 -> 2.5, 18 -> 4.5, -10 -> -2.5, -26 -> -6.5 are
+    # EXACT float32 ties; 7 -> 1.75 is a non-tie control value.
+    m = torch.tensor([131068, 10, 18, -10, -26, 7], dtype=torch.int32)
+    in_scale = 1.0
+    out, scale = emulate_requant_dynamic(m, in_scale)
+    assert scale == 4.0, f"f4Tie: scale must be exactly 4.0, got {scale}"
+    quot = (m.to(torch.float32) * _f32(in_scale)) / _f32(scale)
+    quot64 = torch.clamp(quot, QMIN, QMAX).to(torch.float64)
+    # the fixture must DIFFER under half-to-even (torch.round) ...
+    assert not torch.equal(out, torch.round(quot64).to(torch.int32)), (
+        "f4Tie: vacuous against half-to-even")
+    # ... and under truncation toward zero ((int32_t) cast in C)
+    assert not torch.equal(out, quot64.trunc().to(torch.int32)), (
+        "f4Tie: vacuous against trunc-cast")
+    expected = torch.tensor([32767, 3, 5, -3, -7, 2], dtype=torch.int32)
+    assert torch.equal(out, expected), f"f4Tie: got {out.tolist()}"
+    return {"name": "f4Tie", "input": m, "inputScale": in_scale,
+            "expected": out, "expectedScale": scale}
+
+
+def fixture_f5_to_scale_fit():
+    # values m * 2^-10, target 2^-4: quotients m/64 stay well inside
+    # [qMin, qMax] => no clamping; all arithmetic float32-exact.
+    m = torch.tensor([12000, -32000, 500, -1, 25000, 0], dtype=torch.int32)
+    in_scale = 2.0 ** -10
+    target = 0.0625  # 2^-4, exact; > absmax/qMax = 31.25/32767 ~ 9.5e-4
+    out, deq = emulate_requant_to_scale(m, in_scale, target)
+    quot = deq.to(torch.float64) / target
+    assert (quot.abs() < QMAX).all(), "f5ToScaleFit: must not saturate"
+    expected = torch.tensor([188, -500, 8, 0, 391, 0], dtype=torch.int32)
+    assert torch.equal(out, expected), f"f5ToScaleFit: got {out.tolist()}"
+    return {"name": "f5ToScaleFit", "input": m, "inputScale": in_scale,
+            "targetScale": target, "expected": out}
+
+
+def fixture_f6_to_scale_sat():
+    # values m * 0.5, target 2^-7: quotients m*64 overshoot BOTH bounds
+    # (600*64 = 38400 > qMax, -600*64 < qMin, 512*64 = 32768 = qMax+1)
+    # => pins saturation semantics at qMin AND qMax.
+    m = torch.tensor([600, -600, 20, -40, 512, -512], dtype=torch.int32)
+    in_scale = 0.5
+    target = 0.0078125  # 2^-7, exact
+    out, deq = emulate_requant_to_scale(m, in_scale, target)
+    quot = deq.to(torch.float64) / target
+    assert (quot > QMAX).any() and (quot < QMIN).any(), (
+        "f6ToScaleSat: vacuous, no saturation on one of the bounds")
+    expected = torch.tensor([32767, -32768, 1280, -2560, 32767, -32768],
+                            dtype=torch.int32)
+    assert torch.equal(out, expected), f"f6ToScaleSat: got {out.tolist()}"
+    assert out.max().item() == int(QMAX) and out.min().item() == int(QMIN)
+    return {"name": "f6ToScaleSat", "input": m, "inputScale": in_scale,
+            "targetScale": target, "expected": out}
+
+
+def emit_dynamic_fixture(parts, fx):
+    pre = f"requant_{fx['name']}"
+    parts.append(emit_int32_array(f"input_{pre}", fx["input"]))
+    parts.append(emit_float_scalar(f"inputScale_{pre}", fx["inputScale"]))
+    parts.append(emit_int32_array(f"expected_{pre}", fx["expected"]))
+    parts.append(emit_float_scalar(f"expectedScale_{pre}", fx["expectedScale"]))
+    parts.append(emit_float_scalar(f"scaleTol_{pre}", scale_tol(fx["expectedScale"])))
+
+
+def emit_rescale_fixture(parts, fx):
+    pre = f"requant_{fx['name']}"
+    parts.append(emit_int32_array(f"input_{pre}", fx["input"]))
+    parts.append(emit_float_scalar(f"inputScaleA_{pre}", fx["inputScaleA"]))
+    parts.append(emit_float_scalar(f"inputScaleB_{pre}", fx["inputScaleB"]))
+    parts.append(emit_int32_array(f"expectedA_{pre}", fx["expectedA"]))
+    parts.append(emit_float_scalar(f"expectedScaleA_{pre}", fx["expectedScaleA"]))
+    parts.append(emit_float_scalar(f"scaleTolA_{pre}", scale_tol(fx["expectedScaleA"])))
+    parts.append(emit_int32_array(f"expectedB_{pre}", fx["expectedB"]))
+    parts.append(emit_float_scalar(f"expectedScaleB_{pre}", fx["expectedScaleB"]))
+    parts.append(emit_float_scalar(f"scaleTolB_{pre}", scale_tol(fx["expectedScaleB"])))
+
+
+def emit_to_scale_fixture(parts, fx):
+    pre = f"requant_{fx['name']}"
+    parts.append(emit_int32_array(f"input_{pre}", fx["input"]))
+    parts.append(emit_float_scalar(f"inputScale_{pre}", fx["inputScale"]))
+    parts.append(emit_float_scalar(f"targetScale_{pre}", fx["targetScale"]))
+    parts.append(emit_int32_array(f"expected_{pre}", fx["expected"]))
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out", required=True, type=Path)
+    args = ap.parse_args()
+
+    parts = [
+        "// AUTOGENERATED by generate_expected_requant.py — DO NOT EDIT\n",
+        "#ifndef ODT_EXPECTED_REQUANT_H\n",
+        "#define ODT_EXPECTED_REQUANT_H\n",
+        "#include <stdint.h>\n",
+        "#include <stdlib.h>\n\n",
+    ]
+    parts.append(emit_int32_scalar("qMaxBits_requant", QMAX_BITS))
+
+    emit_dynamic_fixture(parts, fixture_f1_accum_range())
+    emit_dynamic_fixture(parts, fixture_f2_absmax_zero())
+    emit_rescale_fixture(parts, fixture_f3_rescale())
+    emit_dynamic_fixture(parts, fixture_f4_tie())
+    emit_to_scale_fixture(parts, fixture_f5_to_scale_fit())
+    emit_to_scale_fixture(parts, fixture_f6_to_scale_sat())
+
+    parts.append("\n#endif // ODT_EXPECTED_REQUANT_H\n")
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text("".join(parts))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
First of two #192 PRs (spec D1 + D7, docs/superpowers/specs/2026-06-11-sym-program-requant-design.md). Relates to #192 — does **not** close it; PR-2 (`192-quantization-layer`) ships the Quantization layer, factory, validator and the full-SYM chain test on top of these primitives.

- `requantSymInt32Tensor`: SYM_INT32 -> SYM_INT32 requant with a fresh dynamic scale (pass A: absmax over dequantized mantissas, reads only; pass B: round-clamp; absmax==0 -> scale 1.0 + zeros; never saturates — absmax maps exactly to qMax). Wired into `conversionMatrix[SYM_INT32][SYM_INT32]`; `convertTensor`'s same-type copy semantics are untouched (pin test included).
- `requantSymInt32TensorToScale`: requant into a pre-set target scale; NaN-robust `!(scale > 0)` fail-fast guard; **saturates at qMin/qMax by design**; never modifies the target scale. Covers the #187-deferred symmetric scratch+convert case.
- Deutel mapping (IEEE TCAD 44(4) 2025, arXiv:2407.10734, spec section 2): the fixed-scale variant is the Eq. 4 analog (layer-epilogue error/activation requant into a known scale, clamping intended); the dynamic variant is the Eqs. 5-7 idiom (observe range -> fresh scale -> requantize). Documented deviations: half-away-from-zero rounding instead of literal floor, symmetric int16 norm instead of asymmetric uint8.
- Both kernels are in-place capable (alias tests: same `tensor_t` for the dynamic variant; shared data buffer with two views for the fixed-scale variant), allocation-free, VLA-free, flat-storage-order (documented).
- New shared gold module `test/unit/goldgen/sym_gold.py` (extracted from the LayerNorm SYM generator; LayerNorm generators not migrated yet) + self-checking float64/float32-exact gold generator with 6 fixtures: accumulator range, absmax==0, freeze-the-scale, exact .5 ties (half-away vs half-even vs trunc), non-saturating and saturating fixed-scale. Expected mantissas are bit-exact; scales carry emitted 2-ulp analytic tolerances. 10 new Unity tests, each mutation-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)