### PR TITLE
feat(layer): Quantization layer — generic dtype-boundary + SYM requant, factory, opt-in model validator, full-SYM chain test (#192 PR-2)

### DIFF
--- a/src/layer/CMakeLists.txt
+++ b/src/layer/CMakeLists.txt
@@ -95,6 +95,7 @@ target_link_libraries(Layer PRIVATE
         AdaptiveAvgPool1d
         Softmax
         Flatten
+        QuantizationLayer
         Dropout
         LayerNorm
 )
@@ -114,9 +115,11 @@ target_link_libraries(Linear PRIVATE
 add_library(QuantizationLayer QuantizationLayer.c)
 target_include_directories(QuantizationLayer PUBLIC include)
 target_link_libraries(QuantizationLayer PRIVATE
-        TensorConversion
-        Tensor
+        Common
+        Quantization
         Rounding
+        Tensor
+        TensorConversion
 )
 
 add_library(Relu Relu.c)
@@ -162,6 +165,7 @@ target_link_libraries(CommonLayerLibs INTERFACE
         AdaptiveAvgPool1d
         Softmax
         Flatten
+        QuantizationLayer
         Dropout
         LayerNorm
         Rounding

--- a/src/layer/Layer.c
+++ b/src/layer/Layer.c
@@ -10,6 +10,7 @@
 #include "LayerNorm.h"
 #include "Linear.h"
 #include "MaxPool1d.h"
+#include "QuantizationLayer.h"
 #include "Relu.h"
 #include "Softmax.h"
 
@@ -23,6 +24,7 @@ layerFunctions_t layerFunctions[] = {
     [AVGPOOL1D] = {avgPool1dForward, avgPool1dBackward, avgPool1dCalcOutputShape},
     [SOFTMAX] = {softmaxForward, softmaxBackward, softmaxCalcOutputShape},
     [FLATTEN] = {flattenForward, flattenBackward, flattenCalcOutputShape},
+    [QUANTIZATION] = {quantizationForward, quantizationBackward, quantizationCalcOutputShape},
     [ADAPTIVE_AVGPOOL1D] = {adaptiveAvgPool1dForward, adaptiveAvgPool1dBackward,
                             adaptiveAvgPool1dCalcOutputShape},
     [DROPOUT] = {dropoutForward, dropoutBackward, dropoutCalcOutputShape},

--- a/src/layer/QuantizationLayer.c
+++ b/src/layer/QuantizationLayer.c
@@ -1,11 +1,60 @@
 #define SOURCE_FILE "QUANTIZATION_LAYER"
 
+#include <stdlib.h>
+#include <string.h>
+
+#include "Common.h"
 #include "QuantizationLayer.h"
 #include "TensorConversion.h"
 
-void quantization(tensor_t *input, tensor_t *output) {
-    qtype_t inputQType = input->quantization->type;
-    qtype_t outputQType = output->quantization->type;
-    conversionFunction_t conversion = conversionMatrix[inputQType][outputQType];
-    conversion(input, output);
+/* Dispatch over (input dtype, output dtype) like convertTensor, with ONE
+ * deliberate difference: convertTensor's same-type branch is a memmove +
+ * scale copy (convertTensorsWithSameType, TensorConversion.c), which would
+ * pass accumulator-range mantissas through UNCHANGED. A SYM_INT32->SYM_INT32
+ * Quantization layer must REQUANTIZE instead, so the same-dtype SYM_INT32
+ * case goes through the conversionMatrix diagonal (requantSymInt32Tensor,
+ * wired in PR C). Any other same-dtype pair is a configuration error: a
+ * Quantization layer that neither changes dtype nor requantizes is a
+ * misconfigured no-op. Cross-dtype pairs route through convertTensor, which
+ * carries the NULL-entry guard for unsupported pairs (PR B). */
+static void dispatchQuantization(tensor_t *input, tensor_t *output) {
+    qtype_t inputDType = input->quantization->type;
+    qtype_t outputDType = output->quantization->type;
+
+    if (inputDType == outputDType) {
+        if (inputDType != SYM_INT32) {
+            PRINT_ERROR("Quantization layer: same input/output dtype %d is only supported "
+                        "for SYM_INT32 (requant); other same-dtype pairs are a config error",
+                        (int)inputDType);
+            exit(1);
+        }
+        conversionMatrix[SYM_INT32][SYM_INT32](input, output);
+        return;
+    }
+    convertTensor(input, output);
+}
+
+void quantizationForward(layer_t *layer, tensor_t *inputTensor, tensor_t *outputTensor) {
+    (void)layer; /* dtype dispatch reads the tensors; config->quantization->forwardQ
+                  * already determined outputTensor's dtype at allocation time
+                  * (initLayerOutputs / initBufferOutput). */
+    dispatchQuantization(inputTensor, outputTensor);
+}
+
+void quantizationBackward(layer_t *layer, tensor_t *forwardInput, tensor_t *loss,
+                          tensor_t *propLoss) {
+    (void)layer;
+    (void)forwardInput; /* straight-through: dy does not depend on x. The dynamic
+                         * forward never saturates (absmax maps exactly onto qMax),
+                         * so no STE clipping mask is needed (spec D3). */
+    dispatchQuantization(loss, propLoss);
+}
+
+void quantizationCalcOutputShape(layer_t *layer, shape_t *inputShape, shape_t *outputShape) {
+    (void)layer;
+    memcpy(outputShape->dimensions, inputShape->dimensions,
+           inputShape->numberOfDimensions * sizeof(size_t));
+    memcpy(outputShape->orderOfDimensions, inputShape->orderOfDimensions,
+           inputShape->numberOfDimensions * sizeof(size_t));
+    outputShape->numberOfDimensions = inputShape->numberOfDimensions;
 }

--- a/src/layer/QuantizationLayer.c
+++ b/src/layer/QuantizationLayer.c
@@ -44,9 +44,10 @@ void quantizationForward(layer_t *layer, tensor_t *inputTensor, tensor_t *output
 void quantizationBackward(layer_t *layer, tensor_t *forwardInput, tensor_t *loss,
                           tensor_t *propLoss) {
     (void)layer;
-    (void)forwardInput; /* straight-through: dy does not depend on x. The dynamic
-                         * forward never saturates (absmax maps exactly onto qMax),
-                         * so no STE clipping mask is needed (spec D3). */
+    (void)forwardInput; /* straight-through: dy does not depend on x. Both forward
+                         * and backward requant map their own absmax exactly onto
+                         * qMax, so neither pass saturates and no STE clipping mask
+                         * is needed (spec D3). */
     dispatchQuantization(loss, propLoss);
 }
 

--- a/src/layer/include/Layer.h
+++ b/src/layer/include/Layer.h
@@ -13,6 +13,7 @@ typedef struct avgPool1dConfig avgPool1dConfig_t;
 typedef struct adaptiveAvgPool1dConfig adaptiveAvgPool1dConfig_t;
 typedef struct dropoutConfig dropoutConfig_t;
 typedef struct layerNormConfig layerNormConfig_t;
+typedef struct quantizationConfig quantizationConfig_t;
 
 typedef enum layerType {
     LINEAR,
@@ -42,6 +43,7 @@ typedef union layerConfig {
     adaptiveAvgPool1dConfig_t *adaptiveAvgPool1d;
     dropoutConfig_t *dropout;
     layerNormConfig_t *layerNorm;
+    quantizationConfig_t *quantization;
 } layerConfig_t;
 
 typedef struct layer {

--- a/src/layer/include/QuantizationLayer.h
+++ b/src/layer/include/QuantizationLayer.h
@@ -9,7 +9,12 @@ typedef struct layer layer_t;
 
 typedef struct quantizationConfig {
     quantization_t *forwardQ;  /* forward output target: dtype + qConfig for the layer output */
-    quantization_t *backwardQ; /* backward propLoss target: dtype + qConfig for dy requant */
+    quantization_t *backwardQ; /* Intended backward propLoss target (dtype + qConfig for dy
+                                * requant). NOTE: the training loop currently derives the propLoss
+                                * dtype and roundingMode from the upstream layer's forward output
+                                * (initGradTensor), so backwardQ is only honored when it matches
+                                * that — true for uniform- quantization configs. A per-layer
+                                * backward-dtype override is tracked in #221. */
     bool ownsQuantizations;    /* true → freeQuantLayer tears down forwardQ/backwardQ (Owning
                                 * factory); false → caller owns them (Borrowing). */
 } quantizationConfig_t;

--- a/src/layer/include/QuantizationLayer.h
+++ b/src/layer/include/QuantizationLayer.h
@@ -1,10 +1,24 @@
 #ifndef QUANTIZATIONLAYER_H
 #define QUANTIZATIONLAYER_H
 
+#include <stdbool.h>
+
 #include "Tensor.h"
 
-void quantizationForward(tensor_t *input, tensor_t *output);
+typedef struct layer layer_t;
 
-void quantizationBackward(tensor_t *input, tensor_t *output);
+typedef struct quantizationConfig {
+    quantization_t *forwardQ;  /* forward output target: dtype + qConfig for the layer output */
+    quantization_t *backwardQ; /* backward propLoss target: dtype + qConfig for dy requant */
+    bool ownsQuantizations;    /* true → freeQuantLayer tears down forwardQ/backwardQ (Owning
+                                * factory); false → caller owns them (Borrowing). */
+} quantizationConfig_t;
+
+void quantizationForward(layer_t *layer, tensor_t *inputTensor, tensor_t *outputTensor);
+
+void quantizationBackward(layer_t *layer, tensor_t *forwardInput, tensor_t *loss,
+                          tensor_t *propLoss);
+
+void quantizationCalcOutputShape(layer_t *layer, shape_t *inputShape, shape_t *outputShape);
 
 #endif // QUANTIZATIONLAYER_H

--- a/src/optimizer/Optimizer.c
+++ b/src/optimizer/Optimizer.c
@@ -21,6 +21,7 @@ static size_t calcNumberOfStatesByLayerType(const layerType_t type) {
     case AVGPOOL1D:
     case ADAPTIVE_AVGPOOL1D:
     case DROPOUT:
+    case QUANTIZATION:
         return 0;
     case CONV1D:
     case CONV1D_TRANSPOSED:

--- a/src/userApi/CMakeLists.txt
+++ b/src/userApi/CMakeLists.txt
@@ -21,6 +21,7 @@ target_link_libraries(InferenceApi PRIVATE
         AvgPool1d
         AdaptiveAvgPool1d
         LayerNorm
+        QuantizationLayer
         LossFunction
         Common
         DataLoader

--- a/src/userApi/CMakeLists.txt
+++ b/src/userApi/CMakeLists.txt
@@ -4,7 +4,6 @@ add_subdirectory(optimizer)
 add_subdirectory(tensor)
 add_subdirectory(training_loop)
 
-
 add_library(LayerCommon INTERFACE)
 target_include_directories(LayerCommon INTERFACE include)
 

--- a/src/userApi/CMakeLists.txt
+++ b/src/userApi/CMakeLists.txt
@@ -69,3 +69,15 @@ target_link_libraries(StateDictApi PRIVATE
         Rounding
 )
 
+
+add_library(ModelValidationApi ModelValidationApi.c)
+target_include_directories(ModelValidationApi PUBLIC include)
+target_link_libraries(ModelValidationApi PRIVATE
+        Common
+        Layer
+        LayerNorm
+        Linear
+        Quantization
+        Rounding
+        Tensor
+)

--- a/src/userApi/InferenceApi.c
+++ b/src/userApi/InferenceApi.c
@@ -15,6 +15,7 @@
 #include "LayerNorm.h"
 #include "Linear.h"
 #include "MaxPool1d.h"
+#include "QuantizationLayer.h"
 #include "Relu.h"
 #include "Softmax.h"
 #include "StorageApi.h"
@@ -62,6 +63,9 @@ static void initBufferOutput(tensor_t *buffer, layer_t *currentLayer, shape_t *i
         break;
     case LAYERNORM:
         currentQ = currentLayer->config->layerNorm->forwardQ;
+        break;
+    case QUANTIZATION:
+        currentQ = currentLayer->config->quantization->forwardQ;
         break;
     default:
         PRINT_ERROR("Unknown Layer Type!");

--- a/src/userApi/LayerWeightsApi.c
+++ b/src/userApi/LayerWeightsApi.c
@@ -100,6 +100,7 @@ void layerLoadWeights(layer_t *layer, float *weightData, float *biasData) {
     case AVGPOOL1D:
     case ADAPTIVE_AVGPOOL1D:
     case DROPOUT:
+    case QUANTIZATION:
         PRINT_ERROR("layerLoadWeights: layer type %d has no parameters to load", (int)layer->type);
         exit(1);
     case CONV1D_TRANSPOSED: {

--- a/src/userApi/ModelValidationApi.c
+++ b/src/userApi/ModelValidationApi.c
@@ -1,0 +1,55 @@
+#define SOURCE_FILE "MODEL_VALIDATION_API"
+
+#include <stdbool.h>
+#include <stddef.h>
+
+#include "Common.h"
+#include "Layer.h"
+#include "LayerNorm.h"
+#include "Linear.h"
+#include "ModelValidationApi.h"
+
+/* Returns the forwardQ of accumulator-range producers (layers whose SYM
+ * forward emits raw matmul/post-affine mantissas beyond the int16 norm),
+ * NULL for every other layer type. */
+static quantization_t *producerForwardQ(layer_t *layer) {
+    switch (layer->type) {
+    case LINEAR:
+        return layer->config->linear->forwardQ;
+    case LAYERNORM:
+        return layer->config->layerNorm->forwardQ;
+    default:
+        return NULL;
+    }
+}
+
+bool validateModelQuantization(layer_t **model, size_t modelSize) {
+    if (model == NULL) {
+        PRINT_ERROR("validateModelQuantization: model is NULL");
+        return false;
+    }
+    bool valid = true;
+    for (size_t i = 0; i < modelSize; i++) {
+        if (model[i] == NULL) {
+            PRINT_ERROR("validateModelQuantization: model[%zu] is NULL", i);
+            valid = false;
+            continue;
+        }
+        quantization_t *forwardQ = producerForwardQ(model[i]);
+        if (forwardQ == NULL || forwardQ->type != SYM_INT32) {
+            continue; /* not a SYM accumulator-range producer */
+        }
+        if (i + 1 == modelSize) {
+            continue; /* producer in last position: loss boundary, allowed */
+        }
+        if (model[i + 1] == NULL || model[i + 1]->type != QUANTIZATION) {
+            PRINT_ERROR("validateModelQuantization: layer %zu (type %d) emits SYM_INT32 "
+                        "accumulator-range output but layer %zu (type %d) is not a "
+                        "QUANTIZATION layer — insert a Quant layer to restore the int16 "
+                        "inter-layer contract",
+                        i, (int)model[i]->type, i + 1, model[i + 1] ? (int)model[i + 1]->type : -1);
+            valid = false;
+        }
+    }
+    return valid;
+}

--- a/src/userApi/include/ModelValidationApi.h
+++ b/src/userApi/include/ModelValidationApi.h
@@ -1,0 +1,22 @@
+#ifndef ODT_MODEL_VALIDATION_API_H
+#define ODT_MODEL_VALIDATION_API_H
+
+#include <stdbool.h>
+#include <stddef.h>
+
+#include "Layer.h"
+
+/*! Opt-in model-quantization validator (NOT wired into the training loop).
+ *
+ *  Walks the layer array and checks the int16 inter-layer contract: a layer
+ *  whose forwardQ is SYM_INT32 and whose type is an accumulator-range
+ *  producer (LINEAR, LAYERNORM; Conv joins with #45) must be followed by a
+ *  QUANTIZATION layer that requantizes the raw accumulator mantissas. A
+ *  producer in the last position is allowed (loss boundary).
+ *
+ *  Diagnostics: logs every violation (PRINT_ERROR-style, visible with
+ *  DLEVEL >= 1) and returns false if at least one violation was found.
+ *  NEVER exits — callers decide how to react. */
+bool validateModelQuantization(layer_t **model, size_t modelSize);
+
+#endif // ODT_MODEL_VALIDATION_API_H

--- a/src/userApi/layer/CMakeLists.txt
+++ b/src/userApi/layer/CMakeLists.txt
@@ -140,3 +140,16 @@ target_link_libraries(LayerNormApi PRIVATE
         Common
         StorageApi
 )
+
+add_library(QuantLayerApi QuantLayerApi.c)
+target_include_directories(QuantLayerApi PUBLIC include)
+target_link_libraries(QuantLayerApi PRIVATE
+        Common
+        Layer
+        LayerQuant
+        Quantization
+        QuantizationLayer
+        Rounding
+        StorageApi
+        Tensor
+)

--- a/src/userApi/layer/QuantLayerApi.c
+++ b/src/userApi/layer/QuantLayerApi.c
@@ -1,0 +1,90 @@
+#define SOURCE_FILE "QUANT_LAYER_API"
+
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include "Common.h"
+#include "Layer.h"
+#include "LayerQuant.h"
+#include "QuantLayerApi.h"
+#include "QuantizationLayer.h"
+#include "StorageApi.h"
+
+static void validateLayerQuantForQuantLayer(layerQuant_t *lq) {
+    if (lq == NULL) {
+        PRINT_ERROR("quantLayerInit: lq pointer is NULL");
+        exit(1);
+    }
+    if (lq->forwardMath == NULL) {
+        PRINT_ERROR("quantLayerInit: layerQuant.forwardMath must be set");
+        exit(1);
+    }
+    if (lq->backwardMath == NULL) {
+        PRINT_ERROR("quantLayerInit: layerQuant.backwardMath must be set");
+        exit(1);
+    }
+}
+
+static layer_t *quantLayerInitCommon(void) {
+    layer_t *layer = reserveMemory(sizeof(layer_t));
+    layer->type = QUANTIZATION;
+    layerConfig_t *layerCfg = reserveMemory(sizeof(layerConfig_t));
+    quantizationConfig_t *cfg = reserveMemory(sizeof(quantizationConfig_t));
+    layerCfg->quantization = cfg;
+    layer->config = layerCfg;
+    return layer;
+}
+
+layer_t *quantLayerInit(layerQuant_t *lq) {
+    validateLayerQuantForQuantLayer(lq);
+    layer_t *layer = quantLayerInitCommon();
+    quantizationConfig_t *cfg = layer->config->quantization;
+
+    /* Borrowing: store the two math quant pointers verbatim. The caller owns
+     * forwardMath/backwardMath and frees them; freeQuantLayer leaves them
+     * untouched (ownsQuantizations=false). */
+    cfg->forwardQ = lq->forwardMath;
+    cfg->backwardQ = lq->backwardMath;
+    cfg->ownsQuantizations = false;
+    return layer;
+}
+
+layer_t *quantLayerInitOwning(layerQuant_t *lq) {
+    validateLayerQuantForQuantLayer(lq);
+    layer_t *layer = quantLayerInitCommon();
+    quantizationConfig_t *cfg = layer->config->quantization;
+
+    /* Owning: deep-copy each math quantization so the caller can drop its
+     * pointers immediately. Always two separate copies, even if both lq slots
+     * point at the same instance — keeps freeQuantLayer simple. Mirrors
+     * linearLayerInitOwning / layerNormLayerInitOwning. */
+    cfg->forwardQ = deepCopyQuantization(lq->forwardMath);
+    cfg->backwardQ = deepCopyQuantization(lq->backwardMath);
+    cfg->ownsQuantizations = true;
+    return layer;
+}
+
+void freeQuantLayer(layer_t *quantLayer) {
+    if (quantLayer == NULL) {
+        return;
+    }
+    quantizationConfig_t *cfg = quantLayer->config->quantization;
+
+    /* Owning-variant only — tear down the two math quantization_t (qConfig +
+     * struct). Dedup guard exactly like freeLayerNormLayer: free backwardQ only
+     * if it is a distinct allocation from forwardQ. */
+    if (cfg->ownsQuantizations) {
+        if (cfg->forwardQ != NULL) {
+            freeReservedMemory(cfg->forwardQ->qConfig);
+            freeReservedMemory(cfg->forwardQ);
+        }
+        if (cfg->backwardQ != NULL && cfg->backwardQ != cfg->forwardQ) {
+            freeReservedMemory(cfg->backwardQ->qConfig);
+            freeReservedMemory(cfg->backwardQ);
+        }
+    }
+
+    freeReservedMemory(cfg);
+    freeReservedMemory(quantLayer->config);
+    freeReservedMemory(quantLayer);
+}

--- a/src/userApi/layer/include/QuantLayerApi.h
+++ b/src/userApi/layer/include/QuantLayerApi.h
@@ -1,0 +1,26 @@
+#ifndef ODT_QUANT_LAYER_API_H
+#define ODT_QUANT_LAYER_API_H
+
+#include "Layer.h"
+#include "LayerQuant.h"
+#include "QuantizationLayer.h"
+
+/*! Borrowing variant — factory stores lq->forwardMath / lq->backwardMath
+ *  directly. Caller retains ownership of `lq` and the quantizations;
+ *  `lq` itself can be a compound literal that dies after the call.
+ *  forwardMath = dtype/qConfig target of the forward output; backwardMath =
+ *  dtype/qConfig target of the backward propLoss. weightStorage/biasStorage
+ *  are ignored (the Quantization layer has no parameters). */
+layer_t *quantLayerInit(layerQuant_t *lq);
+
+/*! Owning variant — factory deep-copies forwardMath and backwardMath.
+ *  Caller can free `lq` and both quantization_t* immediately after the
+ *  factory returns. freeQuantLayer will tear down the copies. */
+layer_t *quantLayerInitOwning(layerQuant_t *lq);
+
+/*! Tears down everything the factory allocated (internal config, layer).
+ *  Reads config->ownsQuantizations to decide whether to also tear down the
+ *  two quantization_t* and their qConfigs. */
+void freeQuantLayer(layer_t *quantLayer);
+
+#endif // ODT_QUANT_LAYER_API_H

--- a/src/userApi/optimizer/SgdApi.c
+++ b/src/userApi/optimizer/SgdApi.c
@@ -156,6 +156,7 @@ optimizer_t *sgdMCreateOptim(float learningRate, float momentumFactor, float wei
         case AVGPOOL1D:
         case ADAPTIVE_AVGPOOL1D:
         case DROPOUT:
+        case QUANTIZATION:
             break;
         default:
             PRINT_ERROR("Unknown Layer Type");

--- a/src/userApi/training_loop/calculate_grads/CMakeLists.txt
+++ b/src/userApi/training_loop/calculate_grads/CMakeLists.txt
@@ -13,6 +13,7 @@ target_link_libraries(CalculateGradsSequential PRIVATE
         AvgPool1d
         AdaptiveAvgPool1d
         LayerNorm
+        QuantizationLayer
         Optimizer
         LossFunction
         InferenceApi

--- a/src/userApi/training_loop/calculate_grads/CalculateGradsSequential.c
+++ b/src/userApi/training_loop/calculate_grads/CalculateGradsSequential.c
@@ -17,6 +17,7 @@
 #include "Linear.h"
 #include "LossFunction.h"
 #include "MaxPool1d.h"
+#include "QuantizationLayer.h"
 #include "Relu.h"
 #include "Softmax.h"
 #include "StorageApi.h"
@@ -129,6 +130,9 @@ static void initLayerOutputs(tensor_t **layerOutputs, layer_t **model, size_t si
             break;
         case LAYERNORM:
             currentQ = currentLayer->config->layerNorm->forwardQ;
+            break;
+        case QUANTIZATION:
+            currentQ = currentLayer->config->quantization->forwardQ;
             break;
         default:
             PRINT_ERROR("Unknown Layer Type!");

--- a/test/unit/layer/CMakeLists.txt
+++ b/test/unit/layer/CMakeLists.txt
@@ -261,6 +261,7 @@ add_elastic_ai_unit_test(
         TensorConversion
         QuantizationApi
         LayerQuant
+        QuantLayerApi
         Quantization
         Rounding
         StorageApi

--- a/test/unit/layer/CMakeLists.txt
+++ b/test/unit/layer/CMakeLists.txt
@@ -251,3 +251,17 @@ add_dependencies(UnitTestLayerNorm generate_expected_layernorm)
 add_dependencies(UnitTestLayerNorm generate_expected_layernorm_sym)
 add_dependencies(UnitTestLayerNorm generate_expected_layernorm_sym_bwd)
 target_include_directories(UnitTestLayerNorm PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+
+add_elastic_ai_unit_test(
+        LIB_UNDER_TEST
+        QuantizationLayer
+        MORE_LIBS
+        CommonLayerLibs
+        TensorApi
+        TensorConversion
+        QuantizationApi
+        LayerQuant
+        Quantization
+        Rounding
+        StorageApi
+)

--- a/test/unit/layer/UnitTestQuantizationLayer.c
+++ b/test/unit/layer/UnitTestQuantizationLayer.c
@@ -5,6 +5,8 @@
 #include <string.h>
 
 #include "Layer.h"
+#include "LayerQuant.h"
+#include "QuantLayerApi.h"
 #include "Quantization.h"
 #include "QuantizationApi.h"
 #include "QuantizationLayer.h"
@@ -178,6 +180,60 @@ void testQuantizationConfigUnionMemberRoundTrip(void) {
     freeQuantization(fq);
 }
 
+void testQuantLayerInitBorrowingStoresQuantPointersVerbatim(void) {
+    quantization_t *fq = quantizationInitSymInt32(HALF_AWAY);
+    quantization_t *bq = quantizationInitSymInt32(HALF_AWAY);
+    layerQuant_t lq = {.forwardMath = fq, .backwardMath = bq};
+
+    layer_t *layer = quantLayerInit(&lq);
+
+    TEST_ASSERT_NOT_NULL(layer);
+    TEST_ASSERT_EQUAL_INT(QUANTIZATION, layer->type);
+    quantizationConfig_t *cfg = layer->config->quantization;
+    TEST_ASSERT_NOT_NULL(cfg);
+    TEST_ASSERT_FALSE(cfg->ownsQuantizations);
+    TEST_ASSERT_EQUAL_PTR(fq, cfg->forwardQ);
+    TEST_ASSERT_EQUAL_PTR(bq, cfg->backwardQ);
+
+    freeQuantLayer(layer);
+    /* Borrowing: caller-owned quantizations survive the layer teardown. */
+    TEST_ASSERT_EQUAL_INT(SYM_INT32, fq->type);
+    freeQuantization(bq);
+    freeQuantization(fq);
+}
+
+void testQuantLayerInitOwningDeepCopiesQuantizations(void) {
+    quantization_t *q = quantizationInitSymInt32(HALF_AWAY);
+    layerQuant_t lq = {.forwardMath = q, .backwardMath = q};
+
+    layer_t *layer = quantLayerInitOwning(&lq);
+
+    quantizationConfig_t *cfg = layer->config->quantization;
+    TEST_ASSERT_TRUE(cfg->ownsQuantizations);
+    TEST_ASSERT_NOT_EQUAL(q, cfg->forwardQ);
+    TEST_ASSERT_NOT_EQUAL(q, cfg->backwardQ);
+    TEST_ASSERT_NOT_EQUAL(cfg->forwardQ, cfg->backwardQ); /* two separate copies */
+    TEST_ASSERT_EQUAL_INT(SYM_INT32, cfg->forwardQ->type);
+    TEST_ASSERT_EQUAL_INT(SYM_INT32, cfg->backwardQ->type);
+
+    freeQuantLayer(layer);
+    freeQuantization(q);
+}
+
+void testQuantLayerInitOwningFreesAllAllocationsWithoutLeak(void) {
+    /* Build + free 5 layers — leak-checked by the CI valgrind/LSan sweep
+     * (UnitTestLinear testLinearLayerInitOwningFreesAllAllocationsWithoutLeak
+     * precedent). */
+    for (int i = 0; i < 5; i++) {
+        quantization_t *q = quantizationInitSymInt32(HALF_AWAY);
+        layerQuant_t lq = {.forwardMath = q, .backwardMath = q};
+        layer_t *layer = quantLayerInitOwning(&lq);
+        freeQuantLayer(layer);
+        freeQuantization(q);
+    }
+    TEST_PASS();
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(testQuantizationForwardSymToSymMatchesDirectRequant);
@@ -186,5 +242,8 @@ int main(void) {
     RUN_TEST(testQuantizationCalcOutputShapeIdentityIncludingPermutedOrder);
     RUN_TEST(testLayerFunctionsVtableHasQuantizationRow);
     RUN_TEST(testQuantizationConfigUnionMemberRoundTrip);
+    RUN_TEST(testQuantLayerInitBorrowingStoresQuantPointersVerbatim);
+    RUN_TEST(testQuantLayerInitOwningDeepCopiesQuantizations);
+    RUN_TEST(testQuantLayerInitOwningFreesAllAllocationsWithoutLeak);
     return UNITY_END();
 }

--- a/test/unit/layer/UnitTestQuantizationLayer.c
+++ b/test/unit/layer/UnitTestQuantizationLayer.c
@@ -1,0 +1,190 @@
+#define SOURCE_FILE "UNIT_TEST_QUANTIZATION_LAYER"
+
+#include <math.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "Layer.h"
+#include "Quantization.h"
+#include "QuantizationApi.h"
+#include "QuantizationLayer.h"
+#include "Rounding.h"
+#include "StorageApi.h"
+#include "Tensor.h"
+#include "TensorApi.h"
+#include "TensorConversion.h"
+#include "unity.h"
+
+void setUp(void) {}
+void tearDown(void) {}
+
+/* 2D tensor builders (UnitTestLayerNormIntegration pattern). shape_t backing
+ * arrays come from reserveMemory because shape_t.dimensions is size_t*. */
+static tensor_t *buildSym2D(size_t rows, size_t cols) {
+    size_t *dims = reserveMemory(2 * sizeof(size_t));
+    dims[0] = rows;
+    dims[1] = cols;
+    size_t *order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, order);
+    shape_t *shape = reserveMemory(sizeof(shape_t));
+    setShape(shape, dims, 2, order);
+    return initTensor(shape, quantizationInitSymInt32(HALF_AWAY), NULL);
+}
+
+static tensor_t *buildFloat2D(size_t rows, size_t cols) {
+    size_t *dims = reserveMemory(2 * sizeof(size_t));
+    dims[0] = rows;
+    dims[1] = cols;
+    size_t *order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, order);
+    shape_t *shape = reserveMemory(sizeof(shape_t));
+    setShape(shape, dims, 2, order);
+    return initTensor(shape, quantizationInitFloat(), NULL);
+}
+
+void testQuantizationForwardSymToSymMatchesDirectRequant(void) {
+    /* Linear-SYM-style accumulator-range input: |mantissa| >> 32767. */
+    const int32_t mantissas[6] = {1500000, -730000, 42, 0, 999999, -1500000};
+    tensor_t *input = buildSym2D(2, 3);
+    memcpy(input->data, mantissas, sizeof(mantissas));
+    ((symInt32QConfig_t *)input->quantization->qConfig)->scale = 1e-4f;
+
+    tensor_t *expected = buildSym2D(2, 3);
+    requantSymInt32Tensor(input, expected);
+
+    /* Fixture sanity: the requant must actually change mantissas + scale,
+     * otherwise the differential assert below is vacuous (scale-freeze class). */
+    TEST_ASSERT_TRUE(((int32_t *)expected->data)[0] != 1500000);
+    TEST_ASSERT_TRUE(((symInt32QConfig_t *)expected->quantization->qConfig)->scale != 1e-4f);
+
+    tensor_t *actual = buildSym2D(2, 3);
+    layer_t qLayer = {.type = QUANTIZATION, .config = NULL}; /* kernel reads only tensors */
+    quantizationForward(&qLayer, input, actual);
+
+    int32_t expectedMantissas[6];
+    int32_t actualMantissas[6];
+    memcpy(expectedMantissas, expected->data, sizeof(expectedMantissas));
+    memcpy(actualMantissas, actual->data, sizeof(actualMantissas));
+    float expectedScale = ((symInt32QConfig_t *)expected->quantization->qConfig)->scale;
+    float actualScale = ((symInt32QConfig_t *)actual->quantization->qConfig)->scale;
+
+    freeTensor(actual);
+    freeTensor(expected);
+    freeTensor(input);
+
+    TEST_ASSERT_EQUAL_INT32_ARRAY(expectedMantissas, actualMantissas, 6);
+    TEST_ASSERT_EQUAL_FLOAT(expectedScale, actualScale);
+}
+
+void testQuantizationForwardSymToFloatMatchesConvertTensor(void) {
+    const int32_t mantissas[4] = {12000, -32767, 5, 32767};
+    tensor_t *input = buildSym2D(2, 2);
+    memcpy(input->data, mantissas, sizeof(mantissas));
+    ((symInt32QConfig_t *)input->quantization->qConfig)->scale = 0.5f;
+
+    tensor_t *expected = buildFloat2D(2, 2);
+    convertTensor(input, expected);
+
+    tensor_t *actual = buildFloat2D(2, 2);
+    layer_t qLayer = {.type = QUANTIZATION, .config = NULL};
+    quantizationForward(&qLayer, input, actual);
+
+    float expectedVals[4];
+    float actualVals[4];
+    memcpy(expectedVals, expected->data, sizeof(expectedVals));
+    memcpy(actualVals, actual->data, sizeof(actualVals));
+
+    freeTensor(actual);
+    freeTensor(expected);
+    freeTensor(input);
+
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(expectedVals, actualVals, 4);
+    TEST_ASSERT_EQUAL_FLOAT(6000.0f, actualVals[0]); /* anti-vacuity: 12000 * 0.5 */
+}
+
+void testQuantizationBackwardRequantsDyMantissasLikeDirectRequant(void) {
+    const int32_t dyMantissas[6] = {800000, -123456, 7, -800000, 65536, 0};
+    tensor_t *loss = buildSym2D(2, 3);
+    memcpy(loss->data, dyMantissas, sizeof(dyMantissas));
+    ((symInt32QConfig_t *)loss->quantization->qConfig)->scale = 2e-5f;
+
+    tensor_t *expected = buildSym2D(2, 3);
+    requantSymInt32Tensor(loss, expected);
+
+    tensor_t *forwardInput = buildSym2D(2, 3); /* unused: straight-through backward */
+    tensor_t *propLoss = buildSym2D(2, 3);
+    layer_t qLayer = {.type = QUANTIZATION, .config = NULL};
+    quantizationBackward(&qLayer, forwardInput, loss, propLoss);
+
+    int32_t expectedMantissas[6];
+    int32_t actualMantissas[6];
+    memcpy(expectedMantissas, expected->data, sizeof(expectedMantissas));
+    memcpy(actualMantissas, propLoss->data, sizeof(actualMantissas));
+    float expectedScale = ((symInt32QConfig_t *)expected->quantization->qConfig)->scale;
+    float actualScale = ((symInt32QConfig_t *)propLoss->quantization->qConfig)->scale;
+
+    freeTensor(propLoss);
+    freeTensor(forwardInput);
+    freeTensor(expected);
+    freeTensor(loss);
+
+    TEST_ASSERT_EQUAL_INT32_ARRAY(expectedMantissas, actualMantissas, 6);
+    TEST_ASSERT_EQUAL_FLOAT(expectedScale, actualScale);
+}
+
+void testQuantizationCalcOutputShapeIdentityIncludingPermutedOrder(void) {
+    size_t inDims[2] = {2, 3};
+    size_t inOrder[2] = {1, 0}; /* transposed view */
+    shape_t inputShape = {
+        .dimensions = inDims, .numberOfDimensions = 2, .orderOfDimensions = inOrder};
+
+    size_t outDims[2] = {0, 0};
+    size_t outOrder[2] = {0, 0};
+    shape_t outputShape = {
+        .dimensions = outDims, .numberOfDimensions = 0, .orderOfDimensions = outOrder};
+
+    layer_t qLayer = {.type = QUANTIZATION, .config = NULL};
+    quantizationCalcOutputShape(&qLayer, &inputShape, &outputShape);
+
+    TEST_ASSERT_EQUAL_UINT(2, outputShape.numberOfDimensions);
+    TEST_ASSERT_EQUAL_UINT(2, outputShape.dimensions[0]);
+    TEST_ASSERT_EQUAL_UINT(3, outputShape.dimensions[1]);
+    TEST_ASSERT_EQUAL_UINT(1, outputShape.orderOfDimensions[0]); /* permutation preserved */
+    TEST_ASSERT_EQUAL_UINT(0, outputShape.orderOfDimensions[1]);
+}
+
+void testLayerFunctionsVtableHasQuantizationRow(void) {
+    TEST_ASSERT_EQUAL_PTR((void *)quantizationForward,
+                          (void *)layerFunctions[QUANTIZATION].forward);
+    TEST_ASSERT_EQUAL_PTR((void *)quantizationBackward,
+                          (void *)layerFunctions[QUANTIZATION].backward);
+    TEST_ASSERT_EQUAL_PTR((void *)quantizationCalcOutputShape,
+                          (void *)layerFunctions[QUANTIZATION].calcOutputShape);
+}
+
+void testQuantizationConfigUnionMemberRoundTrip(void) {
+    quantization_t *fq = quantizationInitSymInt32(HALF_AWAY);
+    quantization_t *bq = quantizationInitSymInt32(HALF_AWAY);
+    quantizationConfig_t cfg = {.forwardQ = fq, .backwardQ = bq, .ownsQuantizations = false};
+    layerConfig_t lc = {.quantization = &cfg};
+    layer_t layer;
+    initLayer(&layer, QUANTIZATION, &lc);
+
+    TEST_ASSERT_EQUAL_INT(QUANTIZATION, layer.type);
+    TEST_ASSERT_EQUAL_PTR(fq, layer.config->quantization->forwardQ);
+    TEST_ASSERT_EQUAL_PTR(bq, layer.config->quantization->backwardQ);
+
+    freeQuantization(bq);
+    freeQuantization(fq);
+}
+
+int main(void) {
+    UNITY_BEGIN();
+    RUN_TEST(testQuantizationForwardSymToSymMatchesDirectRequant);
+    RUN_TEST(testQuantizationForwardSymToFloatMatchesConvertTensor);
+    RUN_TEST(testQuantizationBackwardRequantsDyMantissasLikeDirectRequant);
+    RUN_TEST(testQuantizationCalcOutputShapeIdentityIncludingPermutedOrder);
+    RUN_TEST(testLayerFunctionsVtableHasQuantizationRow);
+    RUN_TEST(testQuantizationConfigUnionMemberRoundTrip);
+    return UNITY_END();
+}

--- a/test/unit/userAPI/CMakeLists.txt
+++ b/test/unit/userAPI/CMakeLists.txt
@@ -332,3 +332,19 @@ target_link_libraries(UnitTestQuantLayerIntegration PRIVATE
         StorageApi
 )
 __register_target_as_unit_test(UnitTestQuantLayerIntegration)
+
+add_elastic_ai_unit_test(
+        LIB_UNDER_TEST
+        ModelValidationApi
+        MORE_LIBS
+        CommonLayerLibs
+        QuantizationLayer
+        LinearApi
+        LayerCommon
+        LayerQuant
+        QuantizationApi
+        Quantization
+        Rounding
+        TensorApi
+        StorageApi
+)

--- a/test/unit/userAPI/CMakeLists.txt
+++ b/test/unit/userAPI/CMakeLists.txt
@@ -324,6 +324,8 @@ target_link_libraries(UnitTestQuantLayerIntegration PRIVATE
         LayerQuant
         LayerCommon
         LinearApi
+        QuantLayerApi
+        ModelValidationApi
         TensorApi
         QuantizationApi
         LossFunction

--- a/test/unit/userAPI/CMakeLists.txt
+++ b/test/unit/userAPI/CMakeLists.txt
@@ -309,3 +309,26 @@ target_link_libraries(UnitTestQuantizationApiBitsControl PRIVATE
         Rounding
 )
 __register_target_as_unit_test(UnitTestQuantizationApiBitsControl)
+add_executable(UnitTestQuantLayerIntegration UnitTestQuantLayerIntegration.c)
+target_link_libraries(UnitTestQuantLayerIntegration PRIVATE
+        unity
+        TrainingLoopApi
+        CalculateGradsSequential
+        CommonLayerLibs
+        LayerNormApi
+        LayerNorm
+        QuantizationLayer
+        SgdApi
+        Sgd
+        Optimizer
+        LayerQuant
+        LayerCommon
+        LinearApi
+        TensorApi
+        QuantizationApi
+        LossFunction
+        InferenceApi
+        DataLoader
+        StorageApi
+)
+__register_target_as_unit_test(UnitTestQuantLayerIntegration)

--- a/test/unit/userAPI/UnitTestModelValidationApi.c
+++ b/test/unit/userAPI/UnitTestModelValidationApi.c
@@ -1,0 +1,141 @@
+#define SOURCE_FILE "UNIT_TEST_MODEL_VALIDATION_API"
+
+#include <stdbool.h>
+
+#include "Layer.h"
+#include "LayerNorm.h"
+#include "Linear.h"
+#include "LinearApi.h"
+#include "ModelValidationApi.h"
+#include "QuantizationApi.h"
+#include "QuantizationLayer.h"
+#include "Rounding.h"
+#include "StorageApi.h"
+#include "Tensor.h"
+#include "TensorApi.h"
+#include "unity.h"
+
+void setUp(void) {}
+void tearDown(void) {}
+
+/* The validator reads ONLY layer->type + config->...->forwardQ, so
+ * parameter-free stubs suffice (linearLayerInitLegacy stores forwardQ without
+ * dereferencing weights/bias — UnitTestLinear roundtrip precedent). */
+static layer_t *buildLinearStub(quantization_t *fq) {
+    return linearLayerInitLegacy(NULL, NULL, fq, fq, fq, fq);
+}
+
+static layer_t *buildLayerNormStub(quantization_t *fq) {
+    layerNormConfig_t *cfg = reserveMemory(sizeof(layerNormConfig_t));
+    cfg->gamma = NULL;
+    cfg->beta = NULL;
+    cfg->normalizedShape = NULL;
+    cfg->numNormDims = 0;
+    cfg->eps = 1e-5f;
+    cfg->forwardQ = fq;
+    cfg->backwardQ = fq;
+    cfg->ownsQuantizations = false;
+    layerConfig_t *lc = reserveMemory(sizeof(layerConfig_t));
+    lc->layerNorm = cfg;
+    layer_t *layer = reserveMemory(sizeof(layer_t));
+    initLayer(layer, LAYERNORM, lc);
+    return layer;
+}
+
+static layer_t *buildQuantStub(quantization_t *fq) {
+    quantizationConfig_t *cfg = reserveMemory(sizeof(quantizationConfig_t));
+    cfg->forwardQ = fq;
+    cfg->backwardQ = fq;
+    cfg->ownsQuantizations = false;
+    layerConfig_t *lc = reserveMemory(sizeof(layerConfig_t));
+    lc->quantization = cfg;
+    layer_t *layer = reserveMemory(sizeof(layer_t));
+    initLayer(layer, QUANTIZATION, lc);
+    return layer;
+}
+
+static void freeLayerNormStub(layer_t *layer) {
+    freeReservedMemory(layer->config->layerNorm);
+    freeReservedMemory(layer->config);
+    freeReservedMemory(layer);
+}
+
+static void freeQuantStub(layer_t *layer) {
+    freeReservedMemory(layer->config->quantization);
+    freeReservedMemory(layer->config);
+    freeReservedMemory(layer);
+}
+
+void testValidatorRejectsSymProducerFollowedByNonQuantLayer(void) {
+    quantization_t *symQ = quantizationInitSymInt32(HALF_AWAY);
+    layer_t *linear = buildLinearStub(symQ);
+    layer_t *norm = buildLayerNormStub(symQ);
+    layer_t *model[2] = {linear, norm};
+
+    bool valid = validateModelQuantization(model, 2);
+
+    freeLayerNormStub(norm);
+    freeLinearLayerLegacy(linear);
+    freeQuantization(symQ);
+
+    TEST_ASSERT_FALSE_MESSAGE(valid, "Linear-SYM feeding LayerNorm-SYM without a Quant layer "
+                                     "violates the int16 inter-layer contract");
+}
+
+void testValidatorAcceptsChainWithQuantLayersBetweenProducers(void) {
+    quantization_t *symQ = quantizationInitSymInt32(HALF_AWAY);
+    layer_t *linear0 = buildLinearStub(symQ);
+    layer_t *quant1 = buildQuantStub(symQ);
+    layer_t *norm = buildLayerNormStub(symQ);
+    layer_t *quant2 = buildQuantStub(symQ);
+    layer_t *linear1 = buildLinearStub(symQ); /* producer in last position: allowed */
+    layer_t *model[5] = {linear0, quant1, norm, quant2, linear1};
+
+    bool valid = validateModelQuantization(model, 5);
+
+    freeLinearLayerLegacy(linear1);
+    freeQuantStub(quant2);
+    freeLayerNormStub(norm);
+    freeQuantStub(quant1);
+    freeLinearLayerLegacy(linear0);
+    freeQuantization(symQ);
+
+    TEST_ASSERT_TRUE(valid);
+}
+
+void testValidatorAcceptsSymProducerInLastPosition(void) {
+    quantization_t *symQ = quantizationInitSymInt32(HALF_AWAY);
+    layer_t *linear = buildLinearStub(symQ);
+    layer_t *model[1] = {linear};
+
+    bool valid = validateModelQuantization(model, 1);
+
+    freeLinearLayerLegacy(linear);
+    freeQuantization(symQ);
+
+    TEST_ASSERT_TRUE_MESSAGE(valid, "producer at the loss boundary is allowed");
+}
+
+void testValidatorAcceptsFloatOnlyModel(void) {
+    quantization_t *fQ = quantizationInitFloat();
+    layer_t *linear = buildLinearStub(fQ);
+    layer_t *norm = buildLayerNormStub(fQ);
+    layer_t *model[2] = {linear, norm};
+
+    bool valid = validateModelQuantization(model, 2);
+
+    freeLayerNormStub(norm);
+    freeLinearLayerLegacy(linear);
+    freeQuantization(fQ);
+
+    TEST_ASSERT_TRUE(valid);
+}
+
+int main(void) {
+    UNITY_BEGIN();
+    RUN_TEST(testValidatorRejectsSymProducerFollowedByNonQuantLayer);
+    RUN_TEST(testValidatorAcceptsChainWithQuantLayersBetweenProducers);
+    RUN_TEST(testValidatorAcceptsSymProducerInLastPosition);
+    RUN_TEST(testValidatorAcceptsFloatOnlyModel);
+    return UNITY_END();
+}

--- a/test/unit/userAPI/UnitTestModelValidationApi.c
+++ b/test/unit/userAPI/UnitTestModelValidationApi.c
@@ -66,6 +66,34 @@ static void freeQuantStub(layer_t *layer) {
     freeReservedMemory(layer);
 }
 
+void testValidatorAcceptsEmptyModel(void) {
+    /* modelSize == 0: loop never runs, valid stays true. */
+    layer_t *model[1] = {NULL}; /* pointer needed; element never read */
+    bool valid = validateModelQuantization(model, 0);
+    TEST_ASSERT_TRUE_MESSAGE(valid, "empty model (size 0) should be accepted");
+}
+
+void testValidatorRejectsNullModel(void) {
+    /* model == NULL: guarded at entry, returns false. */
+    bool valid = validateModelQuantization(NULL, 0);
+    TEST_ASSERT_FALSE_MESSAGE(valid, "NULL model pointer should be rejected");
+}
+
+void testValidatorRejectsNullElementMidArray(void) {
+    /* NULL element mid-array: guarded in loop body (model[i]==NULL branch),
+     * sets valid=false and continues without crashing. */
+    quantization_t *symQ = quantizationInitSymInt32(HALF_AWAY);
+    layer_t *linear = buildLinearStub(symQ);
+    layer_t *model[2] = {linear, NULL};
+
+    bool valid = validateModelQuantization(model, 2);
+
+    freeLinearLayerLegacy(linear);
+    freeQuantization(symQ);
+
+    TEST_ASSERT_FALSE_MESSAGE(valid, "NULL element in model array should be rejected");
+}
+
 void testValidatorRejectsSymProducerFollowedByNonQuantLayer(void) {
     quantization_t *symQ = quantizationInitSymInt32(HALF_AWAY);
     layer_t *linear = buildLinearStub(symQ);
@@ -133,6 +161,9 @@ void testValidatorAcceptsFloatOnlyModel(void) {
 
 int main(void) {
     UNITY_BEGIN();
+    RUN_TEST(testValidatorAcceptsEmptyModel);
+    RUN_TEST(testValidatorRejectsNullModel);
+    RUN_TEST(testValidatorRejectsNullElementMidArray);
     RUN_TEST(testValidatorRejectsSymProducerFollowedByNonQuantLayer);
     RUN_TEST(testValidatorAcceptsChainWithQuantLayersBetweenProducers);
     RUN_TEST(testValidatorAcceptsSymProducerInLastPosition);

--- a/test/unit/userAPI/UnitTestQuantLayerIntegration.c
+++ b/test/unit/userAPI/UnitTestQuantLayerIntegration.c
@@ -1,0 +1,214 @@
+#define SOURCE_FILE "UNIT_TEST_QUANT_LAYER_INTEGRATION"
+
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "CalculateGradsSequential.h"
+#include "InferenceApi.h"
+#include "Layer.h"
+#include "LayerNorm.h"
+#include "LayerNormApi.h"
+#include "LayerQuant.h"
+#include "Linear.h"
+#include "LinearApi.h"
+#include "LossFunction.h"
+#include "Optimizer.h"
+#include "Quantization.h"
+#include "QuantizationApi.h"
+#include "QuantizationLayer.h"
+#include "SgdApi.h"
+#include "StorageApi.h"
+#include "Tensor.h"
+#include "TensorApi.h"
+#include "unity.h"
+
+void setUp(void) {}
+void tearDown(void) {}
+
+/* Deterministic fixtures shared by the micro tests (D.4-D.6) and chain test (D.9). */
+static const float W0_VALS[12] = {0.5f,  -0.3f, 0.8f, 0.1f,  -0.7f, 0.4f,
+                                  0.2f,  -0.9f, 0.6f, -0.2f, 0.3f,  0.7f};
+static const float B0_VALS[3] = {0.1f, -0.2f, 0.3f};
+static const float INPUT_VALS[8] = {1.f, 2.f, 3.f, 4.f, 10.f, 20.f, 30.f, 40.f};
+
+static tensor_t *build2DSym(size_t b, size_t f, const float *data, size_t n) {
+    size_t *dims = reserveMemory(2 * sizeof(size_t));
+    dims[0] = b;
+    dims[1] = f;
+    size_t *order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, order);
+    shape_t *shape = reserveMemory(sizeof(shape_t));
+    setShape(shape, dims, 2, order);
+    tensor_t *t = initTensor(shape, quantizationInitSymInt32(HALF_AWAY), NULL);
+    tensorFillFromFloatBuffer(t, (float *)data, n);
+    return t;
+}
+
+/* Trainable Linear with manually built parameters: the new-factory KAIMING
+ * init requires FLOAT32 weight storage (LinearApi.c guard), so SYM Linear
+ * layers use the Legacy factory + explicit parameter_t (UnitTestLinear SYM
+ * precedent), extended with grad tensors for sgdMCreateOptim / sgdStepM. */
+static layer_t *buildTrainableLinear(size_t inF, size_t outF, const float *w, const float *b,
+                                     quantization_t *mathQ, bool sym) {
+    size_t *wDims = reserveMemory(2 * sizeof(size_t));
+    wDims[0] = outF;
+    wDims[1] = inF;
+    size_t *wOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, wOrder);
+    shape_t *wShape = reserveMemory(sizeof(shape_t));
+    setShape(wShape, wDims, 2, wOrder);
+    tensor_t *wParam = initTensor(
+        wShape, sym ? quantizationInitSymInt32(HALF_AWAY) : quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(wParam, (float *)w, outF * inF);
+    parameter_t *weights = parameterInit(wParam, gradInit(wParam, mathQ, NULL));
+
+    size_t *bDims = reserveMemory(1 * sizeof(size_t));
+    bDims[0] = outF;
+    size_t *bOrder = reserveMemory(1 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(1, bOrder);
+    shape_t *bShape = reserveMemory(sizeof(shape_t));
+    setShape(bShape, bDims, 1, bOrder);
+    tensor_t *bParam = initTensor(
+        bShape, sym ? quantizationInitSymInt32(HALF_AWAY) : quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(bParam, (float *)b, outF);
+    parameter_t *bias = parameterInit(bParam, gradInit(bParam, mathQ, NULL));
+
+    return linearLayerInitLegacy(weights, bias, mathQ, mathQ, mathQ, mathQ);
+}
+
+/* Manual Quant-layer builder: documents the quantizationConfig_t contract
+ * without depending on the factory (Task D.7). Borrowed quantizations. */
+static layer_t *buildQuantLayer(quantization_t *forwardQ, quantization_t *backwardQ) {
+    quantizationConfig_t *cfg = reserveMemory(sizeof(quantizationConfig_t));
+    cfg->forwardQ = forwardQ;
+    cfg->backwardQ = backwardQ;
+    cfg->ownsQuantizations = false;
+    layerConfig_t *lc = reserveMemory(sizeof(layerConfig_t));
+    lc->quantization = cfg;
+    layer_t *layer = reserveMemory(sizeof(layer_t));
+    initLayer(layer, QUANTIZATION, lc);
+    return layer;
+}
+
+static void freeQuantLayerShell(layer_t *layer) {
+    freeReservedMemory(layer->config->quantization);
+    freeReservedMemory(layer->config);
+    freeReservedMemory(layer);
+}
+
+/* freeOptimSgdM cascades into freeParameter for every registered parameter_t —
+ * the SAME objects the layers reference; layers are torn down shell-only
+ * afterwards (UnitTestLayerNormIntegration pattern). */
+static void freeLinearLayerShell(layer_t *layer) {
+    freeReservedMemory(layer->config->linear);
+    freeReservedMemory(layer->config);
+    freeReservedMemory(layer);
+}
+
+void testSgdMCreateOptimSkipsQuantizationLayer(void) {
+    quantization_t *symQ = quantizationInitSymInt32(HALF_AWAY);
+    layer_t *linear = buildTrainableLinear(4, 3, W0_VALS, B0_VALS, symQ, true);
+    layer_t *quant = buildQuantLayer(symQ, symQ);
+    layer_t *model[2] = {linear, quant};
+
+    optimizer_t *optim = sgdMCreateOptim(0.1f, 0.0f, 0.0f, model, 2, SYM_INT32);
+    size_t sizeStates = optim->sizeStates;
+
+    freeOptimSgdM(optim); /* frees the Linear weights/bias parameter_t */
+    freeQuantLayerShell(quant);
+    freeLinearLayerShell(linear);
+    freeQuantization(symQ);
+
+    TEST_ASSERT_EQUAL_UINT(2, sizeStates); /* Linear w+b; QUANTIZATION contributes 0 states */
+}
+
+void testTrainingStepLinearSymThenQuantRequantsOutputAndFiniteLoss(void) {
+    quantization_t *symQ = quantizationInitSymInt32(HALF_AWAY);
+    layer_t *linear = buildTrainableLinear(4, 3, W0_VALS, B0_VALS, symQ, true);
+    layer_t *quant = buildQuantLayer(symQ, symQ);
+    layer_t *model[2] = {linear, quant};
+
+    tensor_t *input = build2DSym(2, 4, INPUT_VALS, 8);
+    tensor_t *label = build2DSym(2, 3, (float[]){0.5f, -1.f, 2.f, 1.5f, -0.5f, 1.f}, 6);
+
+    trainingStats_t *stats = calculateGradsSequential(model, 2, defaultLossConfig(MSE),
+                                                      REDUCTION_MEAN, input, label);
+    bool statsNotNull = (stats != NULL);
+    float loss = stats ? stats->loss : NAN;
+
+    int32_t maxAbsMantissa = 0;
+    for (size_t i = 0; statsNotNull && i < 6; i++) {
+        int32_t m = ((int32_t *)stats->output->data)[i];
+        if (m < 0) {
+            m = -m;
+        }
+        if (m > maxAbsMantissa) {
+            maxAbsMantissa = m;
+        }
+    }
+
+    freeTrainingStats(stats);
+    freeTensor(label);
+    freeTensor(input);
+    freeParameter(linear->config->linear->weights); /* no optimizer in this test */
+    freeParameter(linear->config->linear->bias);
+    freeQuantLayerShell(quant);
+    freeLinearLayerShell(linear);
+    freeQuantization(symQ);
+
+    TEST_ASSERT_TRUE(statsNotNull);
+    TEST_ASSERT_TRUE_MESSAGE(isfinite(loss), "loss must be finite after the training step");
+    TEST_ASSERT_TRUE_MESSAGE(maxAbsMantissa > 0, "quant output must be non-trivial");
+    TEST_ASSERT_TRUE_MESSAGE(maxAbsMantissa <= 32767,
+                             "quant layer output must obey the int16 inter-layer contract");
+}
+
+void testInferenceLinearSymThenQuantOutputsInt16RangeMantissas(void) {
+    quantization_t *symQ = quantizationInitSymInt32(HALF_AWAY);
+    layer_t *linear = buildTrainableLinear(4, 3, W0_VALS, B0_VALS, symQ, true);
+    layer_t *quant = buildQuantLayer(symQ, symQ);
+    layer_t *model[2] = {linear, quant};
+
+    tensor_t *input = build2DSym(2, 4, INPUT_VALS, 8);
+    tensor_t *predicted = inference(model, 2, input);
+
+    bool predictedNotNull = (predicted != NULL);
+    bool dequantFinite = true;
+    int32_t maxAbsMantissa = 0;
+    float scale =
+        predictedNotNull ? ((symInt32QConfig_t *)predicted->quantization->qConfig)->scale : NAN;
+    for (size_t i = 0; predictedNotNull && i < 6; i++) {
+        int32_t m = ((int32_t *)predicted->data)[i];
+        dequantFinite = dequantFinite && isfinite((float)m * scale);
+        if (m < 0) {
+            m = -m;
+        }
+        if (m > maxAbsMantissa) {
+            maxAbsMantissa = m;
+        }
+    }
+
+    freeTensor(predicted);
+    freeTensor(input);
+    freeParameter(linear->config->linear->weights);
+    freeParameter(linear->config->linear->bias);
+    freeQuantLayerShell(quant);
+    freeLinearLayerShell(linear);
+    freeQuantization(symQ);
+
+    TEST_ASSERT_TRUE(predictedNotNull);
+    TEST_ASSERT_TRUE_MESSAGE(dequantFinite, "dequantized inference output must be finite");
+    TEST_ASSERT_TRUE_MESSAGE(maxAbsMantissa > 0, "inference output must be non-trivial");
+    TEST_ASSERT_TRUE_MESSAGE(maxAbsMantissa <= 32767,
+                             "quant layer output must obey the int16 inter-layer contract");
+}
+
+int main(void) {
+    UNITY_BEGIN();
+    RUN_TEST(testSgdMCreateOptimSkipsQuantizationLayer);
+    RUN_TEST(testTrainingStepLinearSymThenQuantRequantsOutputAndFiniteLoss);
+    RUN_TEST(testInferenceLinearSymThenQuantOutputsInt16RangeMantissas);
+    return UNITY_END();
+}

--- a/test/unit/userAPI/UnitTestQuantLayerIntegration.c
+++ b/test/unit/userAPI/UnitTestQuantLayerIntegration.c
@@ -14,7 +14,9 @@
 #include "Linear.h"
 #include "LinearApi.h"
 #include "LossFunction.h"
+#include "ModelValidationApi.h"
 #include "Optimizer.h"
+#include "QuantLayerApi.h"
 #include "Quantization.h"
 #include "QuantizationApi.h"
 #include "QuantizationLayer.h"
@@ -28,10 +30,23 @@ void setUp(void) {}
 void tearDown(void) {}
 
 /* Deterministic fixtures shared by the micro tests (D.4-D.6) and chain test (D.9). */
-static const float W0_VALS[12] = {0.5f,  -0.3f, 0.8f, 0.1f,  -0.7f, 0.4f,
-                                  0.2f,  -0.9f, 0.6f, -0.2f, 0.3f,  0.7f};
+static const float W0_VALS[12] = {0.5f, -0.3f, 0.8f, 0.1f,  -0.7f, 0.4f,
+                                  0.2f, -0.9f, 0.6f, -0.2f, 0.3f,  0.7f};
 static const float B0_VALS[3] = {0.1f, -0.2f, 0.3f};
 static const float INPUT_VALS[8] = {1.f, 2.f, 3.f, 4.f, 10.f, 20.f, 30.f, 40.f};
+
+static tensor_t *build2DFloat(size_t b, size_t f, const float *data, size_t n) {
+    size_t *dims = reserveMemory(2 * sizeof(size_t));
+    dims[0] = b;
+    dims[1] = f;
+    size_t *order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, order);
+    shape_t *shape = reserveMemory(sizeof(shape_t));
+    setShape(shape, dims, 2, order);
+    tensor_t *t = initTensor(shape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(t, (float *)data, n);
+    return t;
+}
 
 static tensor_t *build2DSym(size_t b, size_t f, const float *data, size_t n) {
     size_t *dims = reserveMemory(2 * sizeof(size_t));
@@ -107,6 +122,13 @@ static void freeLinearLayerShell(layer_t *layer) {
     freeReservedMemory(layer);
 }
 
+static void freeLayerNormLayerShell(layer_t *layer) {
+    freeReservedMemory(layer->config->layerNorm->normalizedShape);
+    freeReservedMemory(layer->config->layerNorm);
+    freeReservedMemory(layer->config);
+    freeReservedMemory(layer);
+}
+
 void testSgdMCreateOptimSkipsQuantizationLayer(void) {
     quantization_t *symQ = quantizationInitSymInt32(HALF_AWAY);
     layer_t *linear = buildTrainableLinear(4, 3, W0_VALS, B0_VALS, symQ, true);
@@ -133,8 +155,8 @@ void testTrainingStepLinearSymThenQuantRequantsOutputAndFiniteLoss(void) {
     tensor_t *input = build2DSym(2, 4, INPUT_VALS, 8);
     tensor_t *label = build2DSym(2, 3, (float[]){0.5f, -1.f, 2.f, 1.5f, -0.5f, 1.f}, 6);
 
-    trainingStats_t *stats = calculateGradsSequential(model, 2, defaultLossConfig(MSE),
-                                                      REDUCTION_MEAN, input, label);
+    trainingStats_t *stats =
+        calculateGradsSequential(model, 2, defaultLossConfig(MSE), REDUCTION_MEAN, input, label);
     bool statsNotNull = (stats != NULL);
     float loss = stats ? stats->loss : NAN;
 
@@ -205,10 +227,187 @@ void testInferenceLinearSymThenQuantOutputsInt16RangeMantissas(void) {
                              "quant layer output must obey the int16 inter-layer contract");
 }
 
+static const float W1_VALS[6] = {0.6f, -0.4f, 0.2f, -0.5f, 0.3f, 0.9f};
+static const float B1_VALS[2] = {0.05f, -0.1f};
+static const float LABEL_VALS[4] = {1.f, -1.f, 0.5f, 2.f};
+
+/* Acceptance criterion of #192 (spec D3): one full-SYM training step through
+ * Linear(4->3) -> Quant -> LayerNorm([3]) -> Quant -> Linear(3->2) + MSE +
+ * SGD-M, vs a FLOAT32 twin (Linear -> LayerNorm -> Linear; a FLOAT->FLOAT
+ * Quant layer is a config error by design, so the twin omits them) trained
+ * on identical data.
+ *
+ * Tolerance: the single-layer SYM precedent is 5e-3 absolute
+ * (UnitTestLayerNormIntegration PR-0/PR-3). Here error compounds: weight/
+ * input/label quantization (<= absMax/2/32767 ~ 1.5e-5 * absMax per tensor),
+ * TWO dynamic requant hops in forward AND backward (<= scale/2 = 0.5 LSB per
+ * element per hop), LayerNorm strategy-A grads, and two Linear grad paths
+ * consuming requantized dy. Treating each of the ~4 noisy stages as one
+ * 5e-3-class error source in series gives 4 * 5e-3 = 2e-2 as the chain
+ * bound. */
+#define CHAIN_TOL 2e-2f
+
+/* Linear SYM bias grads accumulate at fixed scale (init 1.0); one SGD step
+ * moves them in whole LSBs of size lr, so the worst-case deviation from the
+ * float twin is lr * 0.5 = 0.1 * 0.5 = 0.05. This is the documented Deutel-
+ * style fixed-scale scheme (docs/CONVENTIONS.md "Two accumulation schemes";
+ * scheme choice tracked in #218), NOT a Quantization-layer error — all
+ * weight/gamma/beta paths through both requant hops stay <= CHAIN_TOL. */
+#define BIAS_TOL 5e-2f
+
+static void dequantParam(parameter_t *p, float *out, size_t n, bool sym) {
+    if (sym) {
+        float scale = ((symInt32QConfig_t *)p->param->quantization->qConfig)->scale;
+        for (size_t i = 0; i < n; i++) {
+            out[i] = (float)((int32_t *)p->param->data)[i] * scale;
+        }
+    } else {
+        for (size_t i = 0; i < n; i++) {
+            out[i] = ((float *)p->param->data)[i];
+        }
+    }
+}
+
+void testFullSymChainTrainingStepMatchesFloatTwin(void) {
+    size_t normShape[1] = {3};
+
+    /* ---- SYM model (under test) ---- */
+    quantization_t *symQ = quantizationInitSymInt32(HALF_AWAY);
+    layerQuant_t lqSym = {
+        .forwardMath = symQ, .backwardMath = symQ, .weightStorage = symQ, .biasStorage = symQ};
+    layer_t *lin0S = buildTrainableLinear(4, 3, W0_VALS, B0_VALS, symQ, true);
+    layer_t *quant1 = quantLayerInit(&lqSym);
+    layer_t *lnS = layerNormLayerInit(
+        &(layerNormInit_t){.normalizedShape = normShape, .numNormDims = 1, .eps = 1e-5f}, &lqSym);
+    layer_t *quant2 = quantLayerInit(&lqSym);
+    layer_t *lin1S = buildTrainableLinear(3, 2, W1_VALS, B1_VALS, symQ, true);
+    layer_t *modelSym[5] = {lin0S, quant1, lnS, quant2, lin1S};
+
+    /* Setup assert: the chain satisfies the int16 inter-layer contract. */
+    TEST_ASSERT_TRUE_MESSAGE(validateModelQuantization(modelSym, 5),
+                             "chain with Quant layers must pass the validator");
+
+    tensor_t *inS = build2DSym(2, 4, INPUT_VALS, 8);
+    tensor_t *labelS = build2DSym(2, 2, LABEL_VALS, 4);
+
+    optimizer_t *optimS = sgdMCreateOptim(0.1f, 0.0f, 0.0f, modelSym, 5, SYM_INT32);
+    trainingStats_t *statsS =
+        calculateGradsSequential(modelSym, 5, defaultLossConfig(MSE), REDUCTION_MEAN, inS, labelS);
+    sgdStepM(optimS);
+
+    bool symStatsNotNull = (statsS != NULL);
+    float symLoss = statsS ? statsS->loss : NAN;
+
+    float w0S[12], b0S[3], gammaS[3], betaS[3], w1S[6], b1S[2];
+    dequantParam(lin0S->config->linear->weights, w0S, 12, true);
+    dequantParam(lin0S->config->linear->bias, b0S, 3, true);
+    dequantParam(lnS->config->layerNorm->gamma, gammaS, 3, true);
+    dequantParam(lnS->config->layerNorm->beta, betaS, 3, true);
+    dequantParam(lin1S->config->linear->weights, w1S, 6, true);
+    dequantParam(lin1S->config->linear->bias, b1S, 2, true);
+
+    /* ---- FLOAT32 twin (reference) ---- */
+    quantization_t *fQ = quantizationInitFloat();
+    layerQuant_t lqF;
+    layerQuantInitUniform(&lqF, fQ);
+    layer_t *lin0F = buildTrainableLinear(4, 3, W0_VALS, B0_VALS, fQ, false);
+    layer_t *lnF = layerNormLayerInit(
+        &(layerNormInit_t){.normalizedShape = normShape, .numNormDims = 1, .eps = 1e-5f}, &lqF);
+    layer_t *lin1F = buildTrainableLinear(3, 2, W1_VALS, B1_VALS, fQ, false);
+    layer_t *modelF[3] = {lin0F, lnF, lin1F};
+
+    TEST_ASSERT_TRUE_MESSAGE(validateModelQuantization(modelF, 3),
+                             "FLOAT-only twin must pass the validator");
+
+    tensor_t *inF = build2DFloat(2, 4, INPUT_VALS, 8);
+    tensor_t *labelF = build2DFloat(2, 2, LABEL_VALS, 4);
+
+    optimizer_t *optimF = sgdMCreateOptim(0.1f, 0.0f, 0.0f, modelF, 3, FLOAT32);
+    trainingStats_t *statsF =
+        calculateGradsSequential(modelF, 3, defaultLossConfig(MSE), REDUCTION_MEAN, inF, labelF);
+    sgdStepM(optimF);
+
+    float w0F[12], b0F[3], gammaF[3], betaF[3], w1F[6], b1F[2];
+    dequantParam(lin0F->config->linear->weights, w0F, 12, false);
+    dequantParam(lin0F->config->linear->bias, b0F, 3, false);
+    dequantParam(lnF->config->layerNorm->gamma, gammaF, 3, false);
+    dequantParam(lnF->config->layerNorm->beta, betaF, 3, false);
+    dequantParam(lin1F->config->linear->weights, w1F, 6, false);
+    dequantParam(lin1F->config->linear->bias, b1F, 2, false);
+
+    freeTrainingStats(statsF);
+    freeTrainingStats(statsS);
+    freeTensor(labelF);
+    freeTensor(inF);
+    freeTensor(labelS);
+    freeTensor(inS);
+    freeOptimSgdM(optimF); /* frees w0F/b0F, gammaF/betaF, w1F/b1F parameter_t */
+    freeOptimSgdM(optimS);
+    freeLinearLayerShell(lin1F);
+    freeLayerNormLayerShell(lnF);
+    freeLinearLayerShell(lin0F);
+    freeLinearLayerShell(lin1S);
+    freeQuantLayer(quant2);
+    freeLayerNormLayerShell(lnS);
+    freeQuantLayer(quant1);
+    freeLinearLayerShell(lin0S);
+    freeQuantization(fQ);
+    freeQuantization(symQ);
+
+    TEST_ASSERT_TRUE(symStatsNotNull);
+    TEST_ASSERT_TRUE_MESSAGE(isfinite(symLoss), "SYM chain loss must be finite");
+    for (size_t i = 0; i < 3; i++) {
+        TEST_ASSERT_TRUE_MESSAGE(fabsf(gammaF[i] - 1.0f) > 1e-6f,
+                                 "reference gamma must actually train");
+    }
+    for (size_t i = 0; i < 12; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(CHAIN_TOL, w0F[i], w0S[i]);
+    }
+    for (size_t i = 0; i < 3; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(BIAS_TOL, b0F[i], b0S[i]);
+        TEST_ASSERT_FLOAT_WITHIN(CHAIN_TOL, gammaF[i], gammaS[i]);
+        TEST_ASSERT_FLOAT_WITHIN(CHAIN_TOL, betaF[i], betaS[i]);
+    }
+    for (size_t i = 0; i < 6; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(CHAIN_TOL, w1F[i], w1S[i]);
+    }
+    for (size_t i = 0; i < 2; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(BIAS_TOL, b1F[i], b1S[i]);
+    }
+}
+
+void testValidatorRejectsChainWithoutQuantLayers(void) {
+    quantization_t *symQ = quantizationInitSymInt32(HALF_AWAY);
+    layerQuant_t lqSym = {
+        .forwardMath = symQ, .backwardMath = symQ, .weightStorage = symQ, .biasStorage = symQ};
+    size_t normShape[1] = {3};
+    layer_t *lin0 = buildTrainableLinear(4, 3, W0_VALS, B0_VALS, symQ, true);
+    layer_t *ln = layerNormLayerInit(
+        &(layerNormInit_t){.normalizedShape = normShape, .numNormDims = 1, .eps = 1e-5f}, &lqSym);
+    layer_t *lin1 = buildTrainableLinear(3, 2, W1_VALS, B1_VALS, symQ, true);
+    layer_t *model[3] = {lin0, ln, lin1};
+
+    /* Linear-SYM raw accumulator would feed LayerNorm directly — do NOT train. */
+    bool valid = validateModelQuantization(model, 3);
+
+    freeParameter(lin1->config->linear->weights);
+    freeParameter(lin1->config->linear->bias);
+    freeLinearLayerShell(lin1);
+    freeLayerNormLayer(ln); /* factory free: gamma/beta not registered with any optimizer */
+    freeParameter(lin0->config->linear->weights);
+    freeParameter(lin0->config->linear->bias);
+    freeLinearLayerShell(lin0);
+    freeQuantization(symQ);
+
+    TEST_ASSERT_FALSE_MESSAGE(valid, "missing Quant layers must be rejected by the validator");
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(testSgdMCreateOptimSkipsQuantizationLayer);
     RUN_TEST(testTrainingStepLinearSymThenQuantRequantsOutputAndFiniteLoss);
     RUN_TEST(testInferenceLinearSymThenQuantOutputsInt16RangeMantissas);
+    RUN_TEST(testFullSymChainTrainingStepMatchesFloatTwin);
+    RUN_TEST(testValidatorRejectsChainWithoutQuantLayers);
     return UNITY_END();
 }


### PR DESCRIPTION
Closes #192

## Summary
- `quantizationForward/Backward/CalcOutputShape` kernel: generic dtype-boundary layer dispatching over the conversion matrix; same-dtype SYM_INT32 routes through the `conversionMatrix[SYM_INT32][SYM_INT32]` requant diagonal (PR-1 primitive), cross-dtype through `convertTensor` (PR-1 guards), same-dtype non-SYM is a fail-fast config error; backward is straight-through with dy requant (dynamic targets never saturate -> no STE question, per spec D3)
- `quantizationConfig_t { forwardQ; backwardQ; ownsQuantizations }` as `layerConfig_t` union member `quantization`; vtable row in `Layer.c`
- Dispatch sites: `calcNumberOfStatesByLayerType` (0 states), `sgdMCreateOptim` (skip), `initLayerOutputs` + `initBufferOutput` (output alloc from `forwardQ`), `layerLoadWeights` (no-param guard)
- Factory `quantLayerInit` / `quantLayerInitOwning` / `freeQuantLayer` (QuantLayerApi, borrow/own/free per LinearApi template)
- Opt-in validator `validateModelQuantization` (ModelValidationApi): SYM accumulator-range producers (Linear, LayerNorm) must be followed by a Quantization layer; loss boundary exempt; logs + returns false, never exits, NOT wired into the training loop
- Acceptance test: full-SYM `Linear(4->3) -> Quant -> LayerNorm([3]) -> Quant -> Linear(3->2)` training step (MSE + SGD-M) vs FLOAT32 twin; negative validator companion

## Chain acceptance tolerance
All weight/gamma/beta paths through both requant hops stay <= 4.2e-5, well within the derived `CHAIN_TOL = 2e-2` (derivation in the test comment). The two Linear bias comparisons (b0, b1) use their own analytic `BIAS_TOL = 5e-2`: Linear SYM bias grads accumulate at fixed scale (init 1.0), so one SGD step moves them in whole LSBs of size `lr`, giving worst-case deviation `lr * 0.5 = 0.1 * 0.5 = 0.05`. This is the documented Deutel-style fixed-scale scheme (docs/CONVENTIONS.md "Two accumulation schemes"; scheme choice tracked in #218), NOT a Quantization-layer error.

## 14 wiring sites (spec section 1.3)
- [x] vtable `Layer.c`
- [x] `layerConfig_t` union `Layer.h`
- [x] kernel signatures `QuantizationLayer.{c,h}` (stub rewritten)
- [x] `calcNumberOfStatesByLayerType` `Optimizer.c`
- [x] `initLayerOutputs` `CalculateGradsSequential.c`
- [x] `initBufferOutput` `InferenceApi.c`
- [x] `sgdMCreateOptim` `SgdApi.c`
- [x] `layerLoadWeights` `LayerWeightsApi.c`
- [x] `StateDictApi.c` (`layerHasParameters` — was already correct, returns false)
- [ ] `Serialize.c` — deferred to #186 (third missing case alongside DROPOUT/LAYERNORM)
- [ ] `Deserialize.c` — deferred to #186
- [x] factory (`QuantLayerApi`)
- [x] CMake linkage (`QuantizationLayer` deps, `Layer`, `CommonLayerLibs`, new libs)
- [x] tests (`UnitTestQuantizationLayer`, `UnitTestQuantLayerIntegration`, `UnitTestModelValidationApi`)

Note: develop-merges do not auto-close issues — close #192 manually after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)