### PR TITLE
docs(conventions): refine Deutel attribution — static-scale forward bias, no bias-grad scheme (refs #218)

### DIFF
--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -351,15 +351,20 @@ quantized training know this is a known, expected limitation rather than a bug.
   re-derived during accumulation. The coarser resolution (LSB pinned by the
   running scale, which inits to 1.0) is inherent to the scheme.
 
-  **Attribution note (corrected 2026-06-15):** this is ODT's own float-free
-  extension, NOT prescribed by Deutel et al. (arXiv:2407.10734). Verified
-  against the v2 full text: the paper has no bias term, performs gradient
-  descent in floating-point space ("we omit the re-quantization of grad_W
-  since we perform gradient descent locally in floating-point space",
-  Sec. III-A), and re-derives scale/zero-point every update (Eqs. 6-7) — the
-  opposite of fixed-scale integer accumulation. What ODT *does* follow from
-  Deutel: per-layer error requant (~Eq. 4) and the float-space SGD step
-  (~Eqs. 5-7). Scheme choice + the init-scale resolution limit: #218.
+  **Attribution note (corrected 2026-06-15):** this fixed-scale integer
+  bias-GRADIENT accumulation is ODT's own construction. Deutel et al.
+  (arXiv:2407.10734) DO use a bias — the forward QGEMM/QConv (Fig. 2) adds an
+  int32 bias onto the int32 MAC accumulator at a STATIC scale (s_w*s_x, fixed
+  offline); the bias/forward scales are not dynamic. The paper's dynamic scale
+  re-derivation (Eqs. 6-7) applies only to *weight* tensors during the SGD
+  update, which itself runs in floating-point space. The paper describes NO
+  bias-*gradient* accumulation scheme (its gradient formalization, Eq. 3-4,
+  omits the bias). So our bias-grad accumulation is *consistent with* Deutel's
+  static-scale bias philosophy but is not prescribed by the paper for
+  gradients — do not cite it as "following Deutel" without this nuance. What
+  ODT clearly DOES follow: per-layer error requant (~Eq. 4) and the
+  float-space SGD step (~Eqs. 5-7). Scheme choice + the init-scale resolution
+  limit: #218.
 
 This is a research framework: deliberate scheme differences like this one
 MUST be documented here, so experimental design stays separable from


### PR DESCRIPTION
Refines the #219 attribution note after a closer reading of the paper (per Leo, 2026-06-15).

The #219 note overstated the correction. The accurate picture:

- Deutel et al. **do** use a bias — the forward QGEMM/QConv (Fig. 2) adds an int32 bias onto the int32 MAC accumulator at a **static** scale `s_w*s_x` (fixed offline). The bias/forward scales are **not** dynamic.
- The paper's dynamic scale re-derivation (Eqs. 6-7) applies only to **weight** tensors during the SGD update, which itself runs in floating-point space.
- The paper describes **no bias-gradient accumulation scheme** (its gradient formalization, Eq. 3-4, omits the bias).

So ODT's fixed-scale integer bias-gradient accumulation (`linearCalcBiasGradsSymInt32`) is its own construction — **consistent with** Deutel's static-scale bias philosophy, not "the opposite of fixed-scale" as #219 wrongly stated. Scheme choice still tracked in #218.

Docs-only; no code change.

Refs #218.

🤖 Generated with [Claude Code](https://claude.com/claude-code)