### PR TITLE
ci: cache raw dataset downloads in c-bit-parity job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,19 @@ jobs:
       - name: Sync Python deps
         run: uv sync
 
+      # Cache the raw dataset downloads (zip + extracted files). The flaky
+      # external hosts (timeseriesclassification.com, archive.ics.uci.edu) are
+      # only hit on a cache miss; _download_if_missing() skips the network call
+      # when the zip is already present. Keyed on the prep scripts so a URL or
+      # download-logic change invalidates the cache and forces a fresh fetch.
+      - name: Cache raw datasets
+        uses: actions/cache@v4
+        with:
+          path: |
+            examples/har_classifier/data/raw
+            examples/ecg_anomaly_ae/data/raw
+          key: datasets-raw-${{ hashFiles('examples/har_classifier/prepare_data.py', 'examples/ecg_anomaly_ae/prepare_data.py') }}
+
       - name: Prepare HAR data
         run: uv run examples/har_classifier/prepare_data.py
 


### PR DESCRIPTION
## What

Add an `actions/cache@v4` step to the `c-bit-parity` job that caches the raw
dataset downloads for both examples:

- `examples/har_classifier/data/raw`
- `examples/ecg_anomaly_ae/data/raw`

Keyed on a hash of the two `prepare_data.py` scripts, so a URL or
download-logic change invalidates the cache and forces a fresh fetch.

## Why

The `c-bit-parity` job downloads ECG5000 (from `timeseriesclassification.com`)
and UCI-HAR (from `archive.ics.uci.edu`) on **every** run. These academic
hosts are flaky. On 2026-06-15 the ECG download returned `HTTP 401`, failing
the job on `main` (run [27553117883](https://github.com/es-ude/OnDeviceTraining/actions/runs/27553117883)) — while the **identical commit** (`fe6a6e9`) had
passed on `develop` minutes earlier. No code changed; only the upstream
server's response did. Probing the host afterward showed sporadic `401`/`502`
interleaved with `200` — classic gateway flakiness.

`_download_if_missing()` in both scripts already skips the network call when
the zip is present, so a cache hit bypasses the flaky hosts entirely.

## Caveat

Caching does not protect the **first** run after a cache miss (initial run, or
any edit to a `prepare_data.py`) — that still hits the network. A download
retry would close that gap; it was intentionally not added here to keep the
change scoped to caching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)