### PR TITLE
feat(arithmetic): shared SYM_INT32 seed-rescale helper + ODT_SEED_GUARD (#189)

### DIFF
--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -372,3 +372,33 @@ This is a research framework: deliberate scheme differences like this one
 MUST be documented here, so experimental design stays separable from
 accidental inconsistency. LayerNorm uses strategy A for BOTH gamma and beta
 per the 2026-06-05 LayerNorm spec.
+
+## SYM_INT32 seed-rescale + the #189 guard
+
+A SYM_INT32 parameter that must enter an integer accumulator at a *different*
+scale — the forward bias seed (Matmul today; Conv when #45 lands) and the
+LayerNorm affine beta seed — is converted via `rescaleIntoAccumulatorScale`
+(`src/arithmetic/Rounding.c`): `seed = round(param_q * param_scale /
+accumulator_scale)`. The `float -> int32` cast is data-dependent and is UB on
+overflow (#189); the helper guards it NaN-robustly (`!(x <= T)`, reserving one
+worst-case int16 product `32768*32767` of headroom) under `-DODT_SEED_GUARD`
+(default ON; a future MCU/release build disables it, with UBSan #204 covering
+occurrences). All seed-rescale sites route through this one helper.
+
+This refold is deliberate, not a wart: it holds the real-valued bias **constant**
+under ODT's dynamic per-input activation scaling. A fixed integer added raw
+(`seed = b_int`, ignoring the bias scale) would apply the bias at
+`s_acc / s_bias` of its value (≈0.01-0.05% on real layers — effectively deleting
+it) and make it co-scale with input magnitude; the refold recomputes the seed
+each forward (`∝ 1/s_acc`) so the bias stays a constant offset. The bias stays
+SYM_INT32 (never a float master — the optimizer is single-dtype); a wide
+raw-integer bias (qMaxBits=32, scale=1) would need a structurally different
+scheme and is out of scope.
+
+## Vision: memory over float accuracy
+
+ODT is a memory-light on-device-training research framework. SYM_INT32 paths
+may be deliberately inaccurate with no float-matching — that is by design, not
+a defect. FLOAT32-twin comparisons are a **ballpark sanity check**, not a tight
+acceptance gate; SYM acceptance is "trains and converges to a useful model".
+This does not license UB — overflow/garbage is still a bug (hence the #189 guard).

--- a/src/arithmetic/CMakeLists.txt
+++ b/src/arithmetic/CMakeLists.txt
@@ -73,7 +73,7 @@ target_link_libraries(Matmul PRIVATE
         Tensor
         DTypes
         Mul
-        Common
+        Rounding
 )
 
 add_library(Mul Mul.c)

--- a/src/arithmetic/Matmul.c
+++ b/src/arithmetic/Matmul.c
@@ -10,7 +10,6 @@
 #define MATMUL_FUNC_SYM_INT32 matmulSymIntTensors
 #endif
 
-#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -19,6 +18,7 @@
 #include "DTypes.h"
 #include "Matmul.h"
 #include "Mul.h"
+#include "Rounding.h"
 #include "Tensor.h"
 
 size_t matmulInstructionCounter = 0;
@@ -247,17 +247,19 @@ void matmulSymInt32TensorsWithBias(tensor_t *aTensor, tensor_t *bTensor, tensor_
             exit(1);
         }
 
+        symInt32QConfig_t *biasQC = (symInt32QConfig_t *)bias->quantization->qConfig;
         float aScale = ((symInt32QConfig_t *)aTensor->quantization->qConfig)->scale;
         float bScale = ((symInt32QConfig_t *)bTensor->quantization->qConfig)->scale;
-        float biasScale = ((symInt32QConfig_t *)bias->quantization->qConfig)->scale;
+        float biasScale = biasQC->scale;
         float outputScale = aScale * bScale;
 
-        /* Rescale the bias into the accumulator's scale: one fixed-point op per
-         * output column (small: == outFeatures), outside the MAC loop. */
+        /* Rescale the bias into the accumulator's scale via the shared #189 helper
+         * (guarded float->int32 cast): one fixed-point op per output column. */
         int32_t seed[bColumns];
         for (size_t c = 0; c < bColumns; c++) {
             int32_t biasIntC = readBytesAsInt32(&bias->data[c * sizeof(int32_t)]);
-            seed[c] = (int32_t)roundf((float)biasIntC * biasScale / outputScale);
+            seed[c] =
+                rescaleIntoAccumulatorScale(biasIntC, biasScale, outputScale, biasQC->roundingMode);
         }
         matmulIntCore(aTensor, bTensor, outputTensor, seed);
     }

--- a/src/arithmetic/Rounding.c
+++ b/src/arithmetic/Rounding.c
@@ -2,7 +2,9 @@
 
 #include <math.h>
 #include <stdio.h>
+#include <stdlib.h>
 
+#include "Common.h"
 #include "RNG.h"
 #include "Rounding.h"
 
@@ -27,6 +29,22 @@ int32_t roundByMode(const float input, const roundingMode_t roundingMode) {
         return roundSRHalfAway(input);
     }
     return 0;
+}
+
+int32_t rescaleIntoAccumulatorScale(int32_t paramQ, float paramScale, float accumulatorScale,
+                                    roundingMode_t roundingMode) {
+    float rescaled = (float)paramQ * paramScale / accumulatorScale;
+#ifdef ODT_SEED_GUARD
+    /* !(x <= T), NOT (x > T): also catches NaN (0*inf when accumulatorScale
+     * underflows to 0). Reserve the real worst int16 product 32768*32767
+     * (the -32768 case), not qMax*qMax. */
+    if (!(fabsf(rescaled) <= 2147483647.0f - 32768.0f * 32767.0f)) {
+        PRINT_ERROR("rescaleIntoAccumulatorScale: param scale incompatible with accumulator "
+                    "scale — seed overflows int32 (#189)");
+        exit(1);
+    }
+#endif
+    return roundByMode(rescaled, roundingMode);
 }
 
 float clamp(float input, float min, float max) {

--- a/src/arithmetic/include/Rounding.h
+++ b/src/arithmetic/include/Rounding.h
@@ -11,6 +11,21 @@ typedef enum roundingMode { HALF_AWAY, SR_HALF_AWAY } roundingMode_t;
 
 int32_t roundByMode(float input, roundingMode_t roundingMode);
 
+/*! @brief Rescale a SYM_INT32 parameter mantissa from its own scale into an
+ * accumulator's product-scale, returning the int32 seed to add into the
+ * integer accumulator (forward bias seed for Matmul/Conv, LayerNorm affine
+ * beta seed).
+ *
+ * The float->int32 cast is data-dependent and is UB on overflow
+ * (C17 6.3.1.4, #189). When compiled with -DODT_SEED_GUARD (unit-test/CI
+ * builds; off for release/MCU) the cast is guarded: it fails fast when the
+ * rescaled value leaves no int32 headroom for one worst-case int16xint16
+ * product (32768*32767). NaN-robust via !(x <= T): a 0*inf=NaN from an
+ * underflowed accumulator scale is caught, not bypassed. Release builds run
+ * the raw cast (UBSan #204 covers occurrences there). */
+int32_t rescaleIntoAccumulatorScale(int32_t paramQ, float paramScale, float accumulatorScale,
+                                    roundingMode_t roundingMode);
+
 float clamp(float input, float min, float max);
 
 #endif // ROUNDING_H

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -17,3 +17,12 @@ if(DEBUG_MODE_DEBUG)
     target_compile_definitions(Common__hdrs INTERFACE DEBUG_MODE_DEBUG=true)
 endif()
 
+# ODT_SEED_GUARD: guard the SYM_INT32 seed-rescale casts (Matmul/Conv bias seed,
+# LayerNorm affine seed) against the data-dependent float->int32 overflow (#189).
+# Default ON (debug/CI), mirroring DEBUG_MODE_ERROR; a future MCU/release preset
+# disables it with -DODT_SEED_GUARD=OFF (UBSan #204 still covers occurrences).
+option(ODT_SEED_GUARD "Guard SYM_INT32 seed-rescale casts against int32 overflow" ON)
+if(ODT_SEED_GUARD)
+    target_compile_definitions(Common__hdrs INTERFACE ODT_SEED_GUARD=true)
+endif()
+

--- a/src/layer/LayerNorm.c
+++ b/src/layer/LayerNorm.c
@@ -177,12 +177,13 @@ static void layerNormGroupStatsSymInt32(tensor_t *t, size_t numNormDims, size_t 
  *            drop beta under dynamic per-tensor scales)
  *   y_q    = q * gamma_q,j + seed_j            (the product q*gamma_q <= qMax^2
  *            fits int32, but the rescaled seed is DATA-DEPENDENT and unbounded:
- *            |seed| ~ |beta| * qMax^2 / (absmax_n * absmax_gamma). The guard
- *            below fails fast outside the safe envelope instead of casting an
+ *            |seed| ~ |beta| * qMax^2 / (absmax_n * absmax_gamma). The shared
+ *            rescaleIntoAccumulatorScale helper (#189) fails fast (under
+ *            -DODT_SEED_GUARD) outside the safe envelope instead of casting an
  *            out-of-range float to int32 (UB). Spec errata: "int32 is safe
- *            throughout" holds only while the rescaled seed leaves qMax^2 of
- *            int32 headroom for the gamma-product, i.e. |beta| <~
- *            absmax_n * absmax_gamma.)
+ *            throughout" holds only while the rescaled seed leaves one worst-case
+ *            int16xint16 product (32768*32767) of int32 headroom for the
+ *            gamma-product, i.e. |beta| <~ absmax_n * absmax_gamma.)
  * gamma/beta are contiguous default-order rank-D tensors -> flat index j. */
 static void layerNormAffineSymInt32(layerNormConfig_t *cfg, tensor_t *output, float sNorm) {
     int32_t *out = (int32_t *)output->data;
@@ -193,32 +194,18 @@ static void layerNormAffineSymInt32(layerNormConfig_t *cfg, tensor_t *output, fl
     symInt32QConfig_t *betaQC = cfg->beta->param->quantization->qConfig;
 
     float sY = sNorm * gammaQC->scale;
-    float betaRescale = betaQC->scale / sY;
 
     size_t G, N;
     layerNormGroupSizes(output, cfg->numNormDims, &G, &N);
 
-    /* Seed-overflow guard: y_q = q*gamma_q + seed must fit int32. The product
-     * is bounded by qMax^2; the seed is not — fail fast before UB. */
-    const float qMax = powf(2, (float)outQC->qMaxBits - 1) - 1;
-    int32_t maxAbsBetaQ = 0;
-    for (size_t j = 0; j < N; j++) {
-        int32_t a = (betaQ[j] < 0) ? -betaQ[j] : betaQ[j];
-        if (a > maxAbsBetaQ) {
-            maxAbsBetaQ = a;
-        }
-    }
-    /* !(x <= T) instead of (x > T): also catches NaN (0 * inf when sY underflows). */
-    if (!(fabsf((float)maxAbsBetaQ * betaRescale) <= 2147483647.0f - qMax * qMax)) {
-        PRINT_ERROR("LayerNorm SYM_INT32 affine: rescaled beta leaves no int32 headroom for the "
-                    "gamma-product (|beta| exceeds ~absmax(n)*absmax(gamma) — see #189)");
-        exit(1);
-    }
-
+    /* Seed-rescale + flag-gated int32-overflow guard live in the shared #189 helper
+     * (rescaleIntoAccumulatorScale): beta is refolded from its own scale into the
+     * output (gamma-product) scale sY per element. */
     for (size_t g = 0; g < G; g++) {
         for (size_t j = 0; j < N; j++) {
             size_t off = layerNormPhysOffset(output, cfg->numNormDims, g, j);
-            int32_t seed = roundByMode((float)betaQ[j] * betaRescale, outQC->roundingMode);
+            int32_t seed =
+                rescaleIntoAccumulatorScale(betaQ[j], betaQC->scale, sY, outQC->roundingMode);
             out[off] = out[off] * gammaQ[j] + seed;
         }
     }

--- a/test/unit/arithmetic/UnitTestRounding.c
+++ b/test/unit/arithmetic/UnitTestRounding.c
@@ -1,6 +1,21 @@
 #include "Rounding.h"
 #include "unity.h"
 
+void testRescaleIntoAccumulatorScale() {
+    /* 100 * 4.0 / 0.5 = 800 (exact) */
+    TEST_ASSERT_EQUAL_INT32(800, rescaleIntoAccumulatorScale(100, 4.0f, 0.5f, HALF_AWAY));
+
+    /* small accumulator scale -> large seed: 1 / 2^-10 = 1024 (exact) */
+    TEST_ASSERT_EQUAL_INT32(1024, rescaleIntoAccumulatorScale(1, 1.0f, 0.0009765625f, HALF_AWAY));
+
+    /* half-away rounding: 3 * 1.0 / 2.0 = 1.5 -> 2 ; -3 -> -1.5 -> -2 */
+    TEST_ASSERT_EQUAL_INT32(2, rescaleIntoAccumulatorScale(3, 1.0f, 2.0f, HALF_AWAY));
+    TEST_ASSERT_EQUAL_INT32(-2, rescaleIntoAccumulatorScale(-3, 1.0f, 2.0f, HALF_AWAY));
+
+    /* identical scales -> identity (ratio exactly 1.0) */
+    TEST_ASSERT_EQUAL_INT32(12345, rescaleIntoAccumulatorScale(12345, 0.25f, 0.25f, HALF_AWAY));
+}
+
 void testRoundHalfAway() {
     float input = 1.7f;
     int32_t actual = roundByMode(input, HALF_AWAY);
@@ -39,6 +54,7 @@ void tearDown() {}
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(testRoundHalfAway);
+    RUN_TEST(testRescaleIntoAccumulatorScale);
 
     return UNITY_END();
 }


### PR DESCRIPTION
## Summary
Prerequisite (M2 step 1) for the Conv1d/Conv1dTransposed SYM_INT32 work (#45). Centralizes the SYM_INT32 "refold a parameter mantissa into an accumulator's product-scale" cast — previously inlined and UB-on-overflow at two sites — into one guarded helper.

- **`rescaleIntoAccumulatorScale`** (`src/arithmetic/Rounding.c`): `seed = round(param_q * param_scale / accumulator_scale)` with a NaN-robust (`!(x <= T)`) int32-overflow guard reserving one worst-case int16 product (`32768*32767`) of headroom. The `float->int32` cast is UB on overflow (C17 6.3.1.4); the guard fails fast.
- **`ODT_SEED_GUARD`** compile flag (default ON, mirroring `DEBUG_MODE_ERROR`): disable for release/MCU via `-DODT_SEED_GUARD=OFF`; UBSan (#204) covers occurrences when the guard is off.
- **Migrations:** the Matmul forward bias seed and the LayerNorm affine β seed now route through the one helper; LayerNorm's inline unconditional guard is removed (its headroom tightened from `qMax^2` to the real worst product).
- **Docs:** `docs/CONVENTIONS.md` records the helper rationale (the refold holds the bias constant under dynamic per-tensor scaling) and the memory-over-accuracy framework vision (SYM accuracy divergence is by-design; float-twin parity is a sanity check, not a gate).

Out of scope (deferred): the `qMaxBits>16 => scale==1` invariant guard (no wide tensor exists yet; placement is the TensorConversion scale-derivation sites, not config init).

## Test plan
- [x] Full unit suite green (62/62, `unit_test_debug`)
- [x] `clang-format` clean on all touched C
- [x] Behavior preserved: `roundByMode(.,HALF_AWAY)` is bit-identical to the old `roundf` at the Matmul site; LayerNorm seed value algebraically identical; SYM gold/parity tests unchanged
- [x] CI UBSan (#204): no new signed-integer / float-cast overflow at the seed sites

Closes #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)