### PR TITLE
feat(conv1d): SYM_INT32 forward + backward, int12 operands (#45 PR2)

### DIFF
--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -395,6 +395,69 @@ SYM_INT32 (never a float master — the optimizer is single-dtype); a wide
 raw-integer bias (qMaxBits=32, scale=1) would need a structurally different
 scheme and is out of scope.
 
+## Conv1d / Conv1dTransposed SYM_INT32 (#45)
+
+Two integer sliding-window cores live in `src/arithmetic/`, siblings of the
+FLOAT kernels with identical loop nest + `SlidingWindow1d` geometry:
+
+- `conv1dKernelSymInt32` — gather forward; Conv1d forward, and Conv1dTransposed's
+  `dx` adjoint in PR3.
+- `convTranspose1dKernelSymInt32` — scatter forward; Conv1d's `dx` adjoint, and
+  Conv1dTransposed's forward in PR3.
+
+Both emit **raw accumulator-range int32 mantissas** at output scale `s_in·s_w`
+(NOT range-restored). An explicitly-chained Quantization layer (#192) restores
+the operand width downstream — the same contract as Linear/LayerNorm. Per-output-
+channel bias is refolded into the product scale via `rescaleIntoAccumulatorScale`
+(the #189 guarded helper); never raw-added.
+
+Conv1d backward dispatches on **three independent qConfigs** (`weightGradQ`,
+`biasGradQ`, `propLossQ`), like `linearBackward`:
+
+- **weightGrad (SYM)** = strategy A: integer gather into a fresh `reserveMemory`
+  intermediate at scale `s_loss·s_in`, then `addSymInt32TensorsInplace` into the
+  SYM grad accumulator (fresh absmax scale).
+- **biasGrad (SYM)** = an int32 `(batch × outputLength)` accumulator per output
+  channel, then `rescaleIntoAccumulatorScale(sum, s_loss, s_bg, mode)` at the
+  bias-grad's fixed scale (the #218 scheme).
+- **dx / propLoss (SYM)** = `convTranspose1dKernelSymInt32(lossGrad, weights)`,
+  scale `s_loss·s_w`, guarded by the #187 fail-fast if `propLoss` is not SYM.
+
+### Operand bit-width: int12, not int16 (int32-accumulator soundness)
+
+SYM kernels accumulate **products** of operands in an **int32** accumulator (no
+int64 — hard rule). For symmetric `b`-bit operands each product is ≤ 2^(2b−2),
+so an int32 accumulator (~2^31) holds only ~2^(33−2b) worst-case product terms
+before signed overflow (UB):
+
+| operand width | max product | int32 product-terms before overflow |
+|---|---|---|
+| int16 (qMaxBits=16) | 2^30 | 2 |
+| int12 (qMaxBits=12) | 2^22 | 512 |
+| int8  (qMaxBits=8)  | 2^14 | 131072 |
+
+int16×int16→int32 is **unsound for product-accumulation** (forward, dx,
+weightGrad) — it overflows after ~2 full-scale terms; it is sound only for
+*value* sums (biasGrad). Conv SYM therefore uses **int12 operands**
+(`quantizationInitSymInt32WithBits(rm, 12)`): products ≤ 2047² ≈ 4.2e6, ~512-term
+int32 headroom — ample for the batch=1 MCU regime ODT targets, matching the
+low-bit×low-bit→int32 arithmetic of the Deutel FQT paper (arXiv:2407.10734) /
+TFLite. The **grad accumulators stay int16** (wider accumulator, free since SYM
+stores int32 regardless of qMaxBits). The **kernels are bit-width-agnostic** —
+only the quantization configs change; the int32 accumulator (no int64) is kept.
+
+> **Framework-wide follow-up:** Linear's `matmulIntCore` and LayerNorm accumulate
+> int16 products in int32 with the identical 2-term ceiling and have not yet moved
+> to int12 — tracked in a follow-up issue. The #189 policy (release runs free, CI
+> UBSan #204 traps occurrences) backstops any residual overflow beyond int12's
+> headroom.
+
+The training loop (`CalculateGradsSequential.c`) allocates grad/activation
+tensors from the **forward** qConfig, not the backward qConfigs — so a full-SYM
+chain needs each layer's `propLossQ` to agree with the forward-derived grad dtype
+(else the #187 guard fires), exactly as for Linear. The Conv→Quant→…→MSE chain
+wiring + FLOAT32-twin convergence check is PR3.
+
 ## Vision: memory over float accuracy
 
 ODT is a memory-light on-device-training research framework. SYM_INT32 paths

--- a/src/arithmetic/CMakeLists.txt
+++ b/src/arithmetic/CMakeLists.txt
@@ -147,6 +147,8 @@ target_link_libraries(Conv1dKernel PRIVATE
         Tensor
         Kernel
         SlidingWindow1d
+        Mul
+        Rounding
         Common
 )
 
@@ -156,5 +158,7 @@ target_link_libraries(ConvTranspose1dKernel PRIVATE
         Tensor
         Kernel
         SlidingWindow1d
+        Mul
+        Rounding
         Common
 )

--- a/src/arithmetic/Conv1dKernel.c
+++ b/src/arithmetic/Conv1dKernel.c
@@ -3,6 +3,8 @@
 #include "Conv1dKernel.h"
 
 #include "Common.h"
+#include "Mul.h"
+#include "Rounding.h"
 #include "SlidingWindow1d.h"
 
 void conv1dKernelFloat32(tensor_t const *input, tensor_t const *weight, tensor_t const *bias,
@@ -66,4 +68,93 @@ void conv1dKernelFloat32(tensor_t const *input, tensor_t const *weight, tensor_t
             }
         }
     }
+}
+
+void conv1dKernelSymInt32(tensor_t const *input, tensor_t const *weight, tensor_t const *bias,
+                          kernel_t const *kernel, size_t groups, tensor_t *output) {
+    size_t batch = input->shape->dimensions[0];
+    size_t inChannels = input->shape->dimensions[1];
+    size_t inputLength = input->shape->dimensions[2];
+    size_t outChannels = output->shape->dimensions[1];
+    size_t outputLength = output->shape->dimensions[2];
+    size_t kernelSize = weight->shape->dimensions[2];
+
+    if (inChannels % groups != 0 || outChannels % groups != 0) {
+        PRINT_ERROR("conv1dKernelSymInt32: groups (%zu) must divide in_channels "
+                    "(%zu) and out_channels (%zu)",
+                    groups, inChannels, outChannels);
+        exit(1);
+    }
+
+    size_t inChPerGroup = inChannels / groups;
+    size_t outChPerGroup = outChannels / groups;
+
+    windowGeometry1d_t geom = windowGeometry1dCalc(inputLength, kernel);
+    if (geom.outputLength != outputLength) {
+        PRINT_ERROR("conv1dKernelSymInt32: output_length mismatch "
+                    "(geometry=%zu, output tensor=%zu)",
+                    geom.outputLength, outputLength);
+        exit(1);
+    }
+
+    int32_t const *xArr = (int32_t const *)input->data;
+    int32_t const *wArr = (int32_t const *)weight->data;
+    int32_t *yArr = (int32_t *)output->data;
+
+    float inScale = ((symInt32QConfig_t *)input->quantization->qConfig)->scale;
+    float wScale = ((symInt32QConfig_t *)weight->quantization->qConfig)->scale;
+    float outputScale = inScale * wScale;
+
+    /* Per-output-channel bias seed, refolded into the accumulator product scale
+     * via the #189 guarded helper (NULL bias -> all zero). VLA over channels
+     * (topology-bounded), mirroring matmulSymInt32TensorsWithBias's seed[bColumns]. */
+    int32_t seed[outChannels];
+    if (bias != NULL) {
+        int32_t const *bArr = (int32_t const *)bias->data;
+        symInt32QConfig_t *biasQC = (symInt32QConfig_t *)bias->quantization->qConfig;
+        for (size_t oc = 0; oc < outChannels; oc++) {
+            seed[oc] = rescaleIntoAccumulatorScale(bArr[oc], biasQC->scale, outputScale,
+                                                   biasQC->roundingMode);
+        }
+    } else {
+        for (size_t oc = 0; oc < outChannels; oc++) {
+            seed[oc] = 0;
+        }
+    }
+
+    for (size_t b = 0; b < batch; b++) {
+        for (size_t g = 0; g < groups; g++) {
+            size_t inLo = g * inChPerGroup;
+            size_t outLo = g * outChPerGroup;
+
+            for (size_t ocOffset = 0; ocOffset < outChPerGroup; ocOffset++) {
+                size_t oc = outLo + ocOffset;
+                for (size_t outPos = 0; outPos < outputLength; outPos++) {
+                    windowSlice1d_t slice = windowSlice1dAt(&geom, outPos);
+                    int32_t sum = seed[oc];
+
+                    for (size_t icOffset = 0; icOffset < inChPerGroup; icOffset++) {
+                        size_t ic = inLo + icOffset;
+                        for (size_t i = 0; i < slice.validCount; i++) {
+                            size_t inputIdx = slice.firstValidInputIdx + i * geom.dilation;
+                            size_t kernelIdx = slice.firstValidKernelOffset + i;
+
+                            int32_t xv = xArr[(b * inChannels + ic) * inputLength + inputIdx];
+                            int32_t wv =
+                                wArr[(oc * inChPerGroup + icOffset) * kernelSize + kernelIdx];
+                            sum += mulInt32s(xv, wv);
+                        }
+                    }
+
+                    yArr[(b * outChannels + oc) * outputLength + outPos] = sum;
+                }
+            }
+        }
+    }
+
+    if (output->quantization->qConfig == NULL) {
+        PRINT_ERROR("conv1dKernelSymInt32: output qConfig is NULL but SYM_INT32 expected (#187)");
+        exit(1);
+    }
+    ((symInt32QConfig_t *)output->quantization->qConfig)->scale = outputScale;
 }

--- a/src/arithmetic/ConvTranspose1dKernel.c
+++ b/src/arithmetic/ConvTranspose1dKernel.c
@@ -3,6 +3,8 @@
 #include "ConvTranspose1dKernel.h"
 
 #include "Common.h"
+#include "Mul.h"
+#include "Rounding.h"
 #include "SlidingWindow1d.h"
 
 void convTranspose1dKernelFloat32(tensor_t const *input, tensor_t const *weight,
@@ -134,4 +136,134 @@ void convTranspose1dKernelFloat32(tensor_t const *input, tensor_t const *weight,
             }
         }
     }
+}
+
+void convTranspose1dKernelSymInt32(tensor_t const *input, tensor_t const *weight,
+                                   tensor_t const *bias, kernel_t const *kernel, size_t groups,
+                                   size_t outputPadding, tensor_t *output) {
+    size_t batch = input->shape->dimensions[0];
+    size_t inChannels = input->shape->dimensions[1];
+    size_t inputLength = input->shape->dimensions[2];
+    size_t outChannels = output->shape->dimensions[1];
+    size_t outputLength = output->shape->dimensions[2];
+    size_t kernelSize = weight->shape->dimensions[2];
+
+    if (inChannels % groups != 0 || outChannels % groups != 0) {
+        PRINT_ERROR("convTranspose1dKernelSymInt32: groups (%zu) must divide "
+                    "in_channels (%zu) and out_channels (%zu)",
+                    groups, inChannels, outChannels);
+        exit(1);
+    }
+
+    size_t padLeft = 0;
+
+    if (kernel->paddingType == VALID) {
+        size_t expectedOutLen = (inputLength - 1) * kernel->stride +
+                                kernel->dilation * (kernelSize - 1) + outputPadding + 1;
+        if (expectedOutLen != outputLength) {
+            PRINT_ERROR("convTranspose1dKernelSymInt32: VALID output_length mismatch "
+                        "(expected=%zu, got=%zu)",
+                        expectedOutLen, outputLength);
+            exit(1);
+        }
+        if (outputPadding != 0 &&
+            outputPadding >=
+                ((kernel->stride > kernel->dilation) ? kernel->stride : kernel->dilation)) {
+            PRINT_ERROR("convTranspose1dKernelSymInt32: outputPadding (%zu) must be "
+                        "< max(stride=%zu, dilation=%zu)",
+                        outputPadding, kernel->stride, kernel->dilation);
+            exit(1);
+        }
+    } else if (kernel->paddingType == SAME || kernel->paddingType == EXPLICIT) {
+        if (outputPadding != 0) {
+            PRINT_ERROR("convTranspose1dKernelSymInt32: outputPadding must be 0 in "
+                        "SAME/EXPLICIT mode (was %zu)",
+                        outputPadding);
+            exit(1);
+        }
+        windowGeometry1d_t fwdGeom = windowGeometry1dCalc(outputLength, kernel);
+        if (fwdGeom.outputLength != inputLength) {
+            PRINT_ERROR("convTranspose1dKernelSymInt32: SAME/EXPLICIT adjoint input length "
+                        "(%zu) does not match forward conv1d output length on the "
+                        "given output shape (%zu, fwd-out=%zu)",
+                        inputLength, outputLength, fwdGeom.outputLength);
+            exit(1);
+        }
+        padLeft = fwdGeom.padLeft;
+    } else {
+        PRINT_ERROR("convTranspose1dKernelSymInt32: unsupported paddingType %d",
+                    (int)kernel->paddingType);
+        exit(1);
+    }
+
+    size_t inChPerGroup = inChannels / groups;
+    size_t outChPerGroup = outChannels / groups;
+
+    int32_t const *xArr = (int32_t const *)input->data;
+    int32_t const *wArr = (int32_t const *)weight->data;
+    int32_t *yArr = (int32_t *)output->data;
+
+    float inScale = ((symInt32QConfig_t *)input->quantization->qConfig)->scale;
+    float wScale = ((symInt32QConfig_t *)weight->quantization->qConfig)->scale;
+    float outputScale = inScale * wScale;
+
+    size_t totalOut = batch * outChannels * outputLength;
+    for (size_t i = 0; i < totalOut; i++) {
+        yArr[i] = 0;
+    }
+
+    long long padLeftSigned = (long long)padLeft;
+    long long outputLengthSigned = (long long)outputLength;
+    long long dilation = (long long)kernel->dilation;
+
+    for (size_t b = 0; b < batch; b++) {
+        for (size_t g = 0; g < groups; g++) {
+            size_t inLo = g * inChPerGroup;
+            size_t outLo = g * outChPerGroup;
+
+            for (size_t icOffset = 0; icOffset < inChPerGroup; icOffset++) {
+                size_t ic = inLo + icOffset;
+                for (size_t inPos = 0; inPos < inputLength; inPos++) {
+                    int32_t xv = xArr[(b * inChannels + ic) * inputLength + inPos];
+                    long long outBase = (long long)(inPos * kernel->stride) - padLeftSigned;
+
+                    for (size_t ocOffset = 0; ocOffset < outChPerGroup; ocOffset++) {
+                        size_t oc = outLo + ocOffset;
+                        for (size_t k = 0; k < kernelSize; k++) {
+                            long long outIdx = outBase + (long long)k * dilation;
+                            if (outIdx < 0 || outIdx >= outputLengthSigned) {
+                                continue;
+                            }
+                            int32_t wv = wArr[(ic * outChPerGroup + ocOffset) * kernelSize + k];
+                            yArr[(b * outChannels + oc) * outputLength + (size_t)outIdx] +=
+                                mulInt32s(xv, wv);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /* Bias seed pass (refold), separate from the pure-+= scatter. NULL for Conv1d dx;
+     * exercised by Conv1dTransposed forward in PR3. */
+    if (bias != NULL) {
+        int32_t const *bArr = (int32_t const *)bias->data;
+        symInt32QConfig_t *biasQC = (symInt32QConfig_t *)bias->quantization->qConfig;
+        for (size_t oc = 0; oc < outChannels; oc++) {
+            int32_t seed = rescaleIntoAccumulatorScale(bArr[oc], biasQC->scale, outputScale,
+                                                       biasQC->roundingMode);
+            for (size_t b = 0; b < batch; b++) {
+                for (size_t l = 0; l < outputLength; l++) {
+                    yArr[(b * outChannels + oc) * outputLength + l] += seed;
+                }
+            }
+        }
+    }
+
+    if (output->quantization->qConfig == NULL) {
+        PRINT_ERROR("convTranspose1dKernelSymInt32: output qConfig is NULL but SYM_INT32 "
+                    "expected (#187)");
+        exit(1);
+    }
+    ((symInt32QConfig_t *)output->quantization->qConfig)->scale = outputScale;
 }

--- a/src/arithmetic/include/Conv1dKernel.h
+++ b/src/arithmetic/include/Conv1dKernel.h
@@ -18,4 +18,19 @@
 void conv1dKernelFloat32(tensor_t const *input, tensor_t const *weight, tensor_t const *bias,
                          kernel_t const *kernel, size_t groups, tensor_t *output);
 
+/*! 1D convolution forward (SYM_INT32). Integer correlation: int32 accumulator,
+ *  mulInt32s per MAC, per-output-channel bias seed refolded into the product
+ *  scale via rescaleIntoAccumulatorScale. Output mantissas are raw accumulator
+ *  range at scale s_in*s_w (a downstream Quantization layer restores int16).
+ *
+ *  @param input  [batch, in_channels, input_length], SYM_INT32
+ *  @param weight [out_channels, in_channels/groups, kernel_size], SYM_INT32
+ *  @param bias   [out_channels] or NULL, SYM_INT32
+ *  @param kernel kernel_t with size/stride/dilation/paddingType
+ *  @param groups must divide in_channels and out_channels
+ *  @param output [batch, out_channels, output_length], SYM_INT32, pre-allocated
+ */
+void conv1dKernelSymInt32(tensor_t const *input, tensor_t const *weight, tensor_t const *bias,
+                          kernel_t const *kernel, size_t groups, tensor_t *output);
+
 #endif // ODT_CONV1D_KERNEL_H

--- a/src/arithmetic/include/ConvTranspose1dKernel.h
+++ b/src/arithmetic/include/ConvTranspose1dKernel.h
@@ -37,4 +37,19 @@ void convTranspose1dKernelFloat32(tensor_t const *input, tensor_t const *weight,
                                   tensor_t const *bias, kernel_t const *kernel, size_t groups,
                                   size_t outputPadding, tensor_t *output);
 
+/*! Transposed 1D convolution forward (SYM_INT32). Integer scatter sibling of
+ *  convTranspose1dKernelFloat32: int32 accumulator, mulInt32s, per-output-channel
+ *  bias seed (refold) added in a separate pass. Output mantissas are raw
+ *  accumulator range at scale s_in*s_w. Same VALID/SAME/EXPLICIT geometry; used
+ *  as Conv1d's dx adjoint with bias==NULL (SAME/EXPLICIT branch), and as
+ *  Conv1dTransposed's forward in PR3.
+ *
+ *  @param input  [batch, in_channels, input_length], SYM_INT32
+ *  @param weight [in_channels, out_channels/groups, kernel_size], SYM_INT32
+ *  @param bias   [out_channels] or NULL, SYM_INT32
+ */
+void convTranspose1dKernelSymInt32(tensor_t const *input, tensor_t const *weight,
+                                   tensor_t const *bias, kernel_t const *kernel, size_t groups,
+                                   size_t outputPadding, tensor_t *output);
+
 #endif // ODT_CONV_TRANSPOSE_1D_KERNEL_H

--- a/src/layer/CMakeLists.txt
+++ b/src/layer/CMakeLists.txt
@@ -4,6 +4,11 @@ target_link_libraries(Conv1d PRIVATE
         DTypes
         Tensor
         Arithmetic
+        Add
+        Mul
+        Quantization
+        Rounding
+        StorageApi
         Common
         Kernel
         SlidingWindow1d

--- a/src/layer/Conv1d.c
+++ b/src/layer/Conv1d.c
@@ -2,11 +2,16 @@
 
 #include "Conv1d.h"
 
+#include "Add.h"
 #include "Common.h"
 #include "Conv1dKernel.h"
 #include "ConvTranspose1dKernel.h"
 #include "Layer.h"
+#include "Mul.h"
+#include "Quantization.h"
+#include "Rounding.h"
 #include "SlidingWindow1d.h"
+#include "StorageApi.h"
 #include "Tensor.h"
 
 void initConv1dConfigWithWeightsAndBias(conv1dConfig_t *conv1dConfig, kernel_t *kernel,
@@ -35,11 +40,22 @@ void conv1dForwardFloat(layer_t *conv1dLayer, tensor_t *input, tensor_t *output)
     conv1dKernelFloat32(input, weightTensor, biasTensor, cfg->kernel, cfg->groups, output);
 }
 
+void conv1dForwardSymInt32(layer_t *conv1dLayer, tensor_t *input, tensor_t *output) {
+    conv1dConfig_t *cfg = conv1dLayer->config->conv1d;
+    tensor_t *weightTensor = cfg->weights->param;
+    tensor_t *biasTensor = cfg->bias ? cfg->bias->param : NULL;
+
+    conv1dKernelSymInt32(input, weightTensor, biasTensor, cfg->kernel, cfg->groups, output);
+}
+
 void conv1dForward(layer_t *layer, tensor_t *input, tensor_t *output) {
     conv1dConfig_t *cfg = layer->config->conv1d;
     switch (cfg->forwardQ->type) {
     case FLOAT32:
         conv1dForwardFloat(layer, input, output);
+        break;
+    case SYM_INT32:
+        conv1dForwardSymInt32(layer, input, output);
         break;
     default:
         PRINT_ERROR("Conv1d forward: quantization type not implemented");
@@ -119,6 +135,106 @@ static void conv1dCalcBiasGradsFloat32(conv1dConfig_t *cfg, tensor_t *lossGrad) 
     }
 }
 
+void conv1dCalcWeightGradsSymInt32(conv1dConfig_t *cfg, tensor_t *forwardInput,
+                                   tensor_t *lossGrad) {
+    size_t batch = forwardInput->shape->dimensions[0];
+    size_t inChannels = forwardInput->shape->dimensions[1];
+    size_t inputLength = forwardInput->shape->dimensions[2];
+    size_t outChannels = lossGrad->shape->dimensions[1];
+    size_t outputLength = lossGrad->shape->dimensions[2];
+    size_t kernelSize = cfg->weights->param->shape->dimensions[2];
+
+    size_t groups = cfg->groups;
+    size_t inChPerGroup = inChannels / groups;
+    size_t outChPerGroup = outChannels / groups;
+
+    windowGeometry1d_t geom = windowGeometry1dCalc(inputLength, cfg->kernel);
+    if (geom.outputLength != outputLength) {
+        PRINT_ERROR("Conv1d backward (SYM weightGrad): lossGrad outputLength (%zu) does not "
+                    "match geometry derived from forwardInput (%zu)",
+                    outputLength, geom.outputLength);
+        exit(1);
+    }
+
+    float inScale = ((symInt32QConfig_t *)forwardInput->quantization->qConfig)->scale;
+    float lossScale = ((symInt32QConfig_t *)lossGrad->quantization->qConfig)->scale;
+
+    tensor_t *weightGrad = cfg->weights->grad;
+    size_t numberOfWeights = calcNumberOfElementsByTensor(weightGrad);
+
+    /* Fresh int32 intermediate at scale s_in*s_loss, allocated via reserveMemory
+     * (allocation-locality rule — NOT a stack VLA). reserveMemory zero-inits. */
+    int32_t *interData = reserveMemory(numberOfWeights * sizeof(int32_t));
+
+    symInt32QConfig_t interQC;
+    initSymInt32QConfig(((symInt32QConfig_t *)weightGrad->quantization->qConfig)->roundingMode,
+                        &interQC);
+    interQC.scale = inScale * lossScale;
+    quantization_t interQ;
+    initSymInt32Quantization(&interQC, &interQ);
+    tensor_t intermediate;
+    setTensorValues(&intermediate, (uint8_t *)interData, weightGrad->shape, &interQ, NULL);
+
+    int32_t const *xArr = (int32_t const *)forwardInput->data;
+    int32_t const *gyArr = (int32_t const *)lossGrad->data;
+
+    for (size_t b = 0; b < batch; b++) {
+        for (size_t g = 0; g < groups; g++) {
+            size_t inLo = g * inChPerGroup;
+            size_t outLo = g * outChPerGroup;
+
+            for (size_t ocOffset = 0; ocOffset < outChPerGroup; ocOffset++) {
+                size_t oc = outLo + ocOffset;
+                for (size_t outPos = 0; outPos < outputLength; outPos++) {
+                    windowSlice1d_t slice = windowSlice1dAt(&geom, outPos);
+                    int32_t gy = gyArr[(b * outChannels + oc) * outputLength + outPos];
+
+                    for (size_t icOffset = 0; icOffset < inChPerGroup; icOffset++) {
+                        size_t ic = inLo + icOffset;
+                        for (size_t i = 0; i < slice.validCount; i++) {
+                            size_t inputIdx = slice.firstValidInputIdx + i * geom.dilation;
+                            size_t kernelIdx = slice.firstValidKernelOffset + i;
+
+                            int32_t xv = xArr[(b * inChannels + ic) * inputLength + inputIdx];
+                            interData[(oc * inChPerGroup + icOffset) * kernelSize + kernelIdx] +=
+                                mulInt32s(xv, gy);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    addSymInt32TensorsInplace(weightGrad, &intermediate);
+    freeReservedMemory(interData);
+}
+
+void conv1dCalcBiasGradsSymInt32(conv1dConfig_t *cfg, tensor_t *lossGrad) {
+    size_t batch = lossGrad->shape->dimensions[0];
+    size_t outChannels = lossGrad->shape->dimensions[1];
+    size_t outputLength = lossGrad->shape->dimensions[2];
+
+    int32_t const *gyArr = (int32_t const *)lossGrad->data;
+    tensor_t *biasGrad = cfg->bias->grad;
+    int32_t *gbArr = (int32_t *)biasGrad->data;
+
+    float lossScale = ((symInt32QConfig_t *)lossGrad->quantization->qConfig)->scale;
+    symInt32QConfig_t *bgQC = (symInt32QConfig_t *)biasGrad->quantization->qConfig;
+    float bgScale = bgQC->scale;
+
+    for (size_t oc = 0; oc < outChannels; oc++) {
+        /* int32 accumulator (NO int64): loss mantissas are int16-range per the
+         * qMaxBits<=16 contract, so the batch*outputLength sum stays within int32. */
+        int32_t sum = 0;
+        for (size_t b = 0; b < batch; b++) {
+            for (size_t outPos = 0; outPos < outputLength; outPos++) {
+                sum += gyArr[(b * outChannels + oc) * outputLength + outPos];
+            }
+        }
+        gbArr[oc] += rescaleIntoAccumulatorScale(sum, lossScale, bgScale, bgQC->roundingMode);
+    }
+}
+
 void conv1dBackwardFloat(layer_t *layer, tensor_t *forwardInput, tensor_t *lossGrad,
                          tensor_t *propLoss) {
     conv1dConfig_t *cfg = layer->config->conv1d;
@@ -136,12 +252,51 @@ void conv1dBackwardFloat(layer_t *layer, tensor_t *forwardInput, tensor_t *lossG
 void conv1dBackward(layer_t *layer, tensor_t *forwardInput, tensor_t *lossGrad,
                     tensor_t *propLoss) {
     conv1dConfig_t *cfg = layer->config->conv1d;
+
     switch (cfg->weightGradQ->type) {
     case FLOAT32:
-        conv1dBackwardFloat(layer, forwardInput, lossGrad, propLoss);
+        conv1dCalcWeightGradsFloat32(cfg, forwardInput, lossGrad);
+        break;
+    case SYM_INT32:
+        conv1dCalcWeightGradsSymInt32(cfg, forwardInput, lossGrad);
         break;
     default:
-        PRINT_ERROR("Conv1d backward: quantization type not implemented");
+        PRINT_ERROR("Conv1d backward (weightGrad): quantization type not implemented");
+        exit(1);
+    }
+
+    switch (cfg->biasGradQ->type) {
+    case FLOAT32:
+        if (cfg->bias) {
+            conv1dCalcBiasGradsFloat32(cfg, lossGrad);
+        }
+        break;
+    case SYM_INT32:
+        if (cfg->bias) {
+            conv1dCalcBiasGradsSymInt32(cfg, lossGrad);
+        }
+        break;
+    default:
+        PRINT_ERROR("Conv1d backward (biasGrad): quantization type not implemented");
+        exit(1);
+    }
+
+    switch (cfg->propLossQ->type) {
+    case FLOAT32:
+        convTranspose1dKernelFloat32(lossGrad, cfg->weights->param, NULL, cfg->kernel, cfg->groups,
+                                     0u, propLoss);
+        break;
+    case SYM_INT32:
+        if (propLoss->quantization->type != SYM_INT32) {
+            PRINT_ERROR("Conv1d backward: propLossQ is SYM_INT32 but the propLoss tensor is "
+                        "not (#187)");
+            exit(1);
+        }
+        convTranspose1dKernelSymInt32(lossGrad, cfg->weights->param, NULL, cfg->kernel, cfg->groups,
+                                      0u, propLoss);
+        break;
+    default:
+        PRINT_ERROR("Conv1d backward (propLoss): quantization type not implemented");
         exit(1);
     }
 }

--- a/src/layer/Conv1d.c
+++ b/src/layer/Conv1d.c
@@ -173,6 +173,8 @@ void conv1dCalcWeightGradsSymInt32(conv1dConfig_t *cfg, tensor_t *forwardInput,
     quantization_t interQ;
     initSymInt32Quantization(&interQC, &interQ);
     tensor_t intermediate;
+    /* intermediate borrows weightGrad->shape read-only (addSymInt32TensorsInplace
+     * only reads shapes); mirrors Linear.c backwardSymInt32. */
     setTensorValues(&intermediate, (uint8_t *)interData, weightGrad->shape, &interQ, NULL);
 
     int32_t const *xArr = (int32_t const *)forwardInput->data;
@@ -223,8 +225,9 @@ void conv1dCalcBiasGradsSymInt32(conv1dConfig_t *cfg, tensor_t *lossGrad) {
     float bgScale = bgQC->scale;
 
     for (size_t oc = 0; oc < outChannels; oc++) {
-        /* int32 accumulator (NO int64): loss mantissas are int16-range per the
-         * qMaxBits<=16 contract, so the batch*outputLength sum stays within int32. */
+        /* int32 accumulator (NO int64): loss mantissas are int12-range per the
+         * qMaxBits=12 operand contract, so the batch*outputLength sum stays
+         * well within int32 (even more headroom than the old int16 path). */
         int32_t sum = 0;
         for (size_t b = 0; b < batch; b++) {
             for (size_t outPos = 0; outPos < outputLength; outPos++) {

--- a/src/layer/include/Conv1d.h
+++ b/src/layer/include/Conv1d.h
@@ -27,10 +27,14 @@ void initConv1dConfigWithWeightsAndBias(conv1dConfig_t *conv1dConfig, kernel_t *
 
 void conv1dForward(layer_t *layer, tensor_t *input, tensor_t *output);
 void conv1dForwardFloat(layer_t *layer, tensor_t *input, tensor_t *output);
+void conv1dForwardSymInt32(layer_t *layer, tensor_t *input, tensor_t *output);
 
 void conv1dBackward(layer_t *layer, tensor_t *forwardInput, tensor_t *lossGrad, tensor_t *propLoss);
 void conv1dBackwardFloat(layer_t *layer, tensor_t *forwardInput, tensor_t *lossGrad,
                          tensor_t *propLoss);
+
+void conv1dCalcWeightGradsSymInt32(conv1dConfig_t *cfg, tensor_t *forwardInput, tensor_t *lossGrad);
+void conv1dCalcBiasGradsSymInt32(conv1dConfig_t *cfg, tensor_t *lossGrad);
 
 void conv1dCalcOutputShape(layer_t *layer, shape_t *inputShape, shape_t *outputShape);
 

--- a/test/unit/layer/CMakeLists.txt
+++ b/test/unit/layer/CMakeLists.txt
@@ -6,6 +6,7 @@ add_custom_command(
         COMMAND uv run ${CMAKE_CURRENT_SOURCE_DIR}/generate_expected_conv1d.py
                 --out ${GEN_CONV1D_HEADER}
         DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/generate_expected_conv1d.py
+                ${CMAKE_CURRENT_SOURCE_DIR}/../goldgen/sym_gold.py
         COMMENT "Generating expected_conv1d.h via PyTorch"
         VERBATIM
 )
@@ -56,8 +57,9 @@ add_elastic_ai_unit_test(
         TensorApi
         QuantizationApi
         Conv1dApi
+        Conv1dKernel
+        ConvTranspose1dKernel
         Kernel
-        QuantizationApi
         StorageApi
 )
 add_dependencies(UnitTestConv1d generate_expected_conv1d)

--- a/test/unit/layer/UnitTestConv1d.c
+++ b/test/unit/layer/UnitTestConv1d.c
@@ -2,8 +2,11 @@
 
 #include "Conv1d.h"
 #include "Conv1dApi.h"
+#include "ConvTranspose1dKernel.h"
 #include "Layer.h"
 #include "QuantizationApi.h"
+#include "StorageApi.h"
+#include "Tensor.h"
 #include "TensorApi.h"
 #include "expected_conv1d.h"
 #include "unity.h"
@@ -91,6 +94,36 @@ static conv1dRunResult_t conv1dRunForward(conv1dFixtureSetup_t s, float *outputB
     conv1dForward(r.layer, r.input, r.output);
 
     return r;
+}
+
+/* Build a SYM_INT32 (HALF_AWAY, qMaxBits=16) tensor from a float fixture: values
+ * are quantized via tensorFillFromFloatBuffer (absmax->scale, round-clamp). The
+ * fixtures are dequant-round-trip-stable (sym_gold.stable_dequant) so the C side
+ * lands on exactly the gold mantissas+scale. NULL vals -> zero mantissas, scale 1.0. */
+static tensor_t *buildSymTensor(size_t numDims, const size_t *dimsIn, const float *vals) {
+    size_t *dims = reserveMemory(numDims * sizeof(size_t));
+    for (size_t i = 0; i < numDims; i++) {
+        dims[i] = dimsIn[i];
+    }
+    size_t *order = reserveMemory(numDims * sizeof(size_t));
+    setOrderOfDimsForNewTensor(numDims, order);
+    shape_t *shape = reserveMemory(sizeof(shape_t));
+    setShape(shape, dims, numDims, order);
+    tensor_t *t = initTensor(shape, quantizationInitSymInt32WithBits(HALF_AWAY, 12), NULL);
+    if (vals != NULL) {
+        tensorFillFromFloatBuffer(t, vals, calcNumberOfElementsByShape(shape));
+    }
+    return t;
+}
+
+static parameter_t *buildSymParam(size_t numDims, const size_t *dimsIn, const float *vals) {
+    tensor_t *p = buildSymTensor(numDims, dimsIn, vals);
+    tensor_t *g = gradInitSymInt32(p, HALF_AWAY, NULL);
+    return parameterInit(p, g);
+}
+
+static float symScaleOf(tensor_t *t) {
+    return ((symInt32QConfig_t *)t->quantization->qConfig)->scale;
 }
 
 void testConv1dForwardMultiChannelWithBias() {
@@ -756,6 +789,403 @@ void testConv1dBackwardExplicitPadding() {
     }
 }
 
+void testConv1dForwardSymSingleChannelSingleBatch() {
+    size_t weightDims[] = {1, 1, 2};
+    size_t inputDims[] = {1, 1, 4};
+    size_t outputDims[] = {1, 1, 3};
+
+    parameter_t *weights = buildSymParam(3, weightDims, weight_conv1dSym_singleChannelSingleBatch);
+    tensor_t *input = buildSymTensor(3, inputDims, input_conv1dSym_singleChannelSingleBatch);
+    tensor_t *output = buildSymTensor(3, outputDims, NULL);
+
+    kernel_t kernel;
+    initKernel(&kernel, 2, VALID, 1, 1);
+    quantization_t *sq = quantizationInitSymInt32(HALF_AWAY);
+    layer_t *conv1d = conv1dLayerInitLegacy(weights, NULL, &kernel, sq, sq, sq, sq);
+
+    conv1dForward(conv1d, input, output);
+
+    int32_t *m = (int32_t *)output->data;
+    for (size_t i = 0; i < expectedForward_conv1dSym_singleChannelSingleBatch_len; i++) {
+        TEST_ASSERT_INT_WITHIN(forwardMantissaTol_conv1dSym_singleChannelSingleBatch,
+                               expectedForward_conv1dSym_singleChannelSingleBatch[i], m[i]);
+    }
+    float scale = symScaleOf(output);
+    TEST_ASSERT_FLOAT_WITHIN(expectedForwardScale_conv1dSym_singleChannelSingleBatch * 1e-4f,
+                             expectedForwardScale_conv1dSym_singleChannelSingleBatch, scale);
+    for (size_t i = 0; i < expectedForwardDequant_conv1dSym_singleChannelSingleBatch_len; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(forwardDequantTol_conv1dSym_singleChannelSingleBatch,
+                                 expectedForwardDequant_conv1dSym_singleChannelSingleBatch[i],
+                                 (float)m[i] * scale);
+    }
+}
+
+void testConv1dForwardSymSingleChannelWithBias() {
+    size_t weightDims[] = {1, 1, 2};
+    size_t biasDims[] = {1};
+    size_t inputDims[] = {1, 1, 4};
+    size_t outputDims[] = {1, 1, 3};
+
+    parameter_t *weights = buildSymParam(3, weightDims, weight_conv1dSym_singleChannelWithBias);
+    parameter_t *bias = buildSymParam(1, biasDims, bias_conv1dSym_singleChannelWithBias);
+    tensor_t *input = buildSymTensor(3, inputDims, input_conv1dSym_singleChannelWithBias);
+    tensor_t *output = buildSymTensor(3, outputDims, NULL);
+
+    kernel_t kernel;
+    initKernel(&kernel, 2, VALID, 1, 1);
+    quantization_t *sq = quantizationInitSymInt32(HALF_AWAY);
+    layer_t *conv1d = conv1dLayerInitLegacy(weights, bias, &kernel, sq, sq, sq, sq);
+
+    conv1dForward(conv1d, input, output);
+
+    int32_t *m = (int32_t *)output->data;
+    for (size_t i = 0; i < expectedForward_conv1dSym_singleChannelWithBias_len; i++) {
+        TEST_ASSERT_INT_WITHIN(forwardMantissaTol_conv1dSym_singleChannelWithBias,
+                               expectedForward_conv1dSym_singleChannelWithBias[i], m[i]);
+    }
+    float scale = symScaleOf(output);
+    TEST_ASSERT_FLOAT_WITHIN(expectedForwardScale_conv1dSym_singleChannelWithBias * 1e-4f,
+                             expectedForwardScale_conv1dSym_singleChannelWithBias, scale);
+    for (size_t i = 0; i < expectedForwardDequant_conv1dSym_singleChannelWithBias_len; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(forwardDequantTol_conv1dSym_singleChannelWithBias,
+                                 expectedForwardDequant_conv1dSym_singleChannelWithBias[i],
+                                 (float)m[i] * scale);
+    }
+}
+
+void testConv1dForwardSymPointwise() {
+    size_t weightDims[] = {4, 3, 1};
+    size_t biasDims[] = {4};
+    size_t inputDims[] = {2, 3, 5};
+    size_t outputDims[] = {2, 4, 5};
+
+    parameter_t *weights = buildSymParam(3, weightDims, weight_conv1dSym_pointwise);
+    parameter_t *bias = buildSymParam(1, biasDims, bias_conv1dSym_pointwise);
+    tensor_t *input = buildSymTensor(3, inputDims, input_conv1dSym_pointwise);
+    tensor_t *output = buildSymTensor(3, outputDims, NULL);
+
+    kernel_t kernel;
+    initKernel(&kernel, 1, VALID, 1, 1);
+    quantization_t *sq = quantizationInitSymInt32(HALF_AWAY);
+    layer_t *conv1d = conv1dLayerInitLegacy(weights, bias, &kernel, sq, sq, sq, sq);
+
+    conv1dForward(conv1d, input, output);
+
+    int32_t *m = (int32_t *)output->data;
+    for (size_t i = 0; i < expectedForward_conv1dSym_pointwise_len; i++) {
+        TEST_ASSERT_INT_WITHIN(forwardMantissaTol_conv1dSym_pointwise,
+                               expectedForward_conv1dSym_pointwise[i], m[i]);
+    }
+    float scale = symScaleOf(output);
+    TEST_ASSERT_FLOAT_WITHIN(expectedForwardScale_conv1dSym_pointwise * 1e-4f,
+                             expectedForwardScale_conv1dSym_pointwise, scale);
+    for (size_t i = 0; i < expectedForwardDequant_conv1dSym_pointwise_len; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(forwardDequantTol_conv1dSym_pointwise,
+                                 expectedForwardDequant_conv1dSym_pointwise[i],
+                                 (float)m[i] * scale);
+    }
+}
+
+void testConv1dForwardSymExplicitPadding() {
+    size_t weightDims[] = {3, 2, 7};
+    size_t biasDims[] = {3};
+    size_t inputDims[] = {1, 2, 10};
+    size_t outputDims[] = {1, 3, 5};
+
+    parameter_t *weights = buildSymParam(3, weightDims, weight_conv1dSym_explicitPadding);
+    parameter_t *bias = buildSymParam(1, biasDims, bias_conv1dSym_explicitPadding);
+    tensor_t *input = buildSymTensor(3, inputDims, input_conv1dSym_explicitPadding);
+    tensor_t *output = buildSymTensor(3, outputDims, NULL);
+
+    kernel_t kernel;
+    initKernelExplicit(&kernel, 7, 3, 1, 2);
+    quantization_t *sq = quantizationInitSymInt32(HALF_AWAY);
+    layer_t *conv1d = conv1dLayerInitLegacy(weights, bias, &kernel, sq, sq, sq, sq);
+
+    conv1dForward(conv1d, input, output);
+
+    int32_t *m = (int32_t *)output->data;
+    for (size_t i = 0; i < expectedForward_conv1dSym_explicitPadding_len; i++) {
+        TEST_ASSERT_INT_WITHIN(forwardMantissaTol_conv1dSym_explicitPadding,
+                               expectedForward_conv1dSym_explicitPadding[i], m[i]);
+    }
+    float scale = symScaleOf(output);
+    TEST_ASSERT_FLOAT_WITHIN(expectedForwardScale_conv1dSym_explicitPadding * 1e-4f,
+                             expectedForwardScale_conv1dSym_explicitPadding, scale);
+    for (size_t i = 0; i < expectedForwardDequant_conv1dSym_explicitPadding_len; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(forwardDequantTol_conv1dSym_explicitPadding,
+                                 expectedForwardDequant_conv1dSym_explicitPadding[i],
+                                 (float)m[i] * scale);
+    }
+}
+
+void testConv1dCalcWeightGradsSymGroupsGrouped() {
+    size_t weightDims[] = {8, 2, 2};
+    size_t biasDims[] = {8};
+    size_t inputDims[] = {1, 4, 5};
+    size_t lossDims[] = {1, 8, 4};
+
+    parameter_t *weights = buildSymParam(3, weightDims, weight_conv1dSym_groupsGroupedSym);
+    parameter_t *bias = buildSymParam(1, biasDims, bias_conv1dSym_groupsGroupedSym);
+    tensor_t *input = buildSymTensor(3, inputDims, input_conv1dSym_groupsGroupedSym);
+    tensor_t *lossGrad = buildSymTensor(3, lossDims, lossGrad_conv1dSym_groupsGroupedSym);
+
+    kernel_t kernel;
+    initKernel(&kernel, 2, VALID, 1, 1);
+    conv1dConfig_t cfg;
+    quantization_t *sq = quantizationInitSymInt32(HALF_AWAY);
+    initConv1dConfigWithWeightsAndBias(&cfg, &kernel, weights, bias, 2, sq, sq, sq, sq);
+
+    conv1dCalcWeightGradsSymInt32(&cfg, input, lossGrad);
+
+    int32_t *m = (int32_t *)weights->grad->data;
+    for (size_t i = 0; i < expectedWeightGrad_conv1dSym_groupsGroupedSym_len; i++) {
+        TEST_ASSERT_INT_WITHIN(weightGradMantissaTol_conv1dSym_groupsGroupedSym,
+                               expectedWeightGrad_conv1dSym_groupsGroupedSym[i], m[i]);
+    }
+    float scale = symScaleOf(weights->grad);
+    TEST_ASSERT_FLOAT_WITHIN(expectedWeightGradScale_conv1dSym_groupsGroupedSym * 1e-4f,
+                             expectedWeightGradScale_conv1dSym_groupsGroupedSym, scale);
+    for (size_t i = 0; i < expectedWeightGradDequant_conv1dSym_groupsGroupedSym_len; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(weightGradDequantTol_conv1dSym_groupsGroupedSym,
+                                 expectedWeightGradDequant_conv1dSym_groupsGroupedSym[i],
+                                 (float)m[i] * scale);
+    }
+}
+
+void testConv1dKernelSymScatterStrideDilation() {
+    size_t weightDims[] = {1, 1, 2};
+    size_t lossDims[] = {1, 1, 3};
+    size_t propDims[] = {1, 1, 9};
+
+    tensor_t *weight = buildSymTensor(3, weightDims, weight_conv1dSym_strideDilationSym);
+    tensor_t *lossGrad = buildSymTensor(3, lossDims, lossGrad_conv1dSym_strideDilationSym);
+    tensor_t *propLoss = buildSymTensor(3, propDims, NULL);
+
+    kernel_t kernel;
+    initKernel(&kernel, 2, VALID, 2, 3); /* size=2, VALID, dilation=2, stride=3 */
+
+    convTranspose1dKernelSymInt32(lossGrad, weight, NULL, &kernel, 1, 0, propLoss);
+
+    int32_t *m = (int32_t *)propLoss->data;
+    for (size_t i = 0; i < expectedPropLoss_conv1dSym_strideDilationSym_len; i++) {
+        TEST_ASSERT_INT_WITHIN(propLossMantissaTol_conv1dSym_strideDilationSym,
+                               expectedPropLoss_conv1dSym_strideDilationSym[i], m[i]);
+    }
+    float scale = symScaleOf(propLoss);
+    TEST_ASSERT_FLOAT_WITHIN(expectedPropLossScale_conv1dSym_strideDilationSym * 1e-4f,
+                             expectedPropLossScale_conv1dSym_strideDilationSym, scale);
+    for (size_t i = 0; i < expectedPropLossDequant_conv1dSym_strideDilationSym_len; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(propLossDequantTol_conv1dSym_strideDilationSym,
+                                 expectedPropLossDequant_conv1dSym_strideDilationSym[i],
+                                 (float)m[i] * scale);
+    }
+}
+
+void testConv1dCalcBiasGradsSymPointwise() {
+    size_t weightDims[] = {4, 3, 1};
+    size_t biasDims[] = {4};
+    size_t lossDims[] = {2, 4, 5};
+
+    parameter_t *weights = buildSymParam(3, weightDims, weight_conv1dSym_pointwise);
+    parameter_t *bias = buildSymParam(1, biasDims, bias_conv1dSym_pointwise);
+    tensor_t *lossGrad = buildSymTensor(3, lossDims, lossGrad_conv1dSym_pointwise);
+
+    kernel_t kernel;
+    initKernel(&kernel, 1, VALID, 1, 1);
+    conv1dConfig_t cfg;
+    quantization_t *sq = quantizationInitSymInt32(HALF_AWAY);
+    initConv1dConfigWithWeightsAndBias(&cfg, &kernel, weights, bias, 1, sq, sq, sq, sq);
+
+    conv1dCalcBiasGradsSymInt32(&cfg, lossGrad);
+
+    int32_t *m = (int32_t *)bias->grad->data;
+    for (size_t i = 0; i < expectedBiasGrad_conv1dSym_pointwise_len; i++) {
+        TEST_ASSERT_INT_WITHIN(biasGradMantissaTol_conv1dSym_pointwise,
+                               expectedBiasGrad_conv1dSym_pointwise[i], m[i]);
+    }
+    float scale = symScaleOf(bias->grad);
+    TEST_ASSERT_FLOAT_WITHIN(expectedBiasGradScale_conv1dSym_pointwise * 1e-4f,
+                             expectedBiasGradScale_conv1dSym_pointwise, scale);
+    for (size_t i = 0; i < expectedBiasGradDequant_conv1dSym_pointwise_len; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(biasGradDequantTol_conv1dSym_pointwise,
+                                 expectedBiasGradDequant_conv1dSym_pointwise[i],
+                                 (float)m[i] * scale);
+    }
+}
+
+void testConv1dBackwardSymExplicitPadding() {
+    size_t weightDims[] = {3, 2, 7};
+    size_t biasDims[] = {3};
+    size_t inputDims[] = {1, 2, 10};
+    size_t outputDims[] = {1, 3, 5};
+
+    parameter_t *weights = buildSymParam(3, weightDims, weight_conv1dSym_explicitPadding);
+    parameter_t *bias = buildSymParam(1, biasDims, bias_conv1dSym_explicitPadding);
+    tensor_t *input = buildSymTensor(3, inputDims, input_conv1dSym_explicitPadding);
+    tensor_t *lossGrad = buildSymTensor(3, outputDims, lossGrad_conv1dSym_explicitPadding);
+    tensor_t *propLoss = buildSymTensor(3, inputDims, NULL);
+
+    kernel_t kernel;
+    initKernelExplicit(&kernel, 7, 3, 1, 2); /* K=7, pad=3, dilation=1, stride=2 */
+    conv1dConfig_t cfg;
+    quantization_t *sq = quantizationInitSymInt32(HALF_AWAY);
+    static layerConfig_t lc;
+    static layer_t layer;
+    initConv1dConfigWithWeightsAndBias(&cfg, &kernel, weights, bias, 1, sq, sq, sq, sq);
+    layer.type = CONV1D;
+    lc.conv1d = &cfg;
+    layer.config = &lc;
+
+    conv1dBackward(&layer, input, lossGrad, propLoss);
+
+    /* propLoss (dx) */
+    int32_t *dx = (int32_t *)propLoss->data;
+    for (size_t i = 0; i < expectedPropLoss_conv1dSym_explicitPadding_len; i++) {
+        TEST_ASSERT_INT_WITHIN(propLossMantissaTol_conv1dSym_explicitPadding,
+                               expectedPropLoss_conv1dSym_explicitPadding[i], dx[i]);
+    }
+    float dxScale = symScaleOf(propLoss);
+    TEST_ASSERT_FLOAT_WITHIN(expectedPropLossScale_conv1dSym_explicitPadding * 1e-4f,
+                             expectedPropLossScale_conv1dSym_explicitPadding, dxScale);
+    for (size_t i = 0; i < expectedPropLossDequant_conv1dSym_explicitPadding_len; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(propLossDequantTol_conv1dSym_explicitPadding,
+                                 expectedPropLossDequant_conv1dSym_explicitPadding[i],
+                                 (float)dx[i] * dxScale);
+    }
+    /* weightGrad */
+    int32_t *dw = (int32_t *)weights->grad->data;
+    float dwScale = symScaleOf(weights->grad);
+    for (size_t i = 0; i < expectedWeightGrad_conv1dSym_explicitPadding_len; i++) {
+        TEST_ASSERT_INT_WITHIN(weightGradMantissaTol_conv1dSym_explicitPadding,
+                               expectedWeightGrad_conv1dSym_explicitPadding[i], dw[i]);
+        TEST_ASSERT_FLOAT_WITHIN(weightGradDequantTol_conv1dSym_explicitPadding,
+                                 expectedWeightGradDequant_conv1dSym_explicitPadding[i],
+                                 (float)dw[i] * dwScale);
+    }
+    /* biasGrad */
+    int32_t *db = (int32_t *)bias->grad->data;
+    float dbScale = symScaleOf(bias->grad);
+    for (size_t i = 0; i < expectedBiasGrad_conv1dSym_explicitPadding_len; i++) {
+        TEST_ASSERT_INT_WITHIN(biasGradMantissaTol_conv1dSym_explicitPadding,
+                               expectedBiasGrad_conv1dSym_explicitPadding[i], db[i]);
+        TEST_ASSERT_FLOAT_WITHIN(biasGradDequantTol_conv1dSym_explicitPadding,
+                                 expectedBiasGradDequant_conv1dSym_explicitPadding[i],
+                                 (float)db[i] * dbScale);
+    }
+}
+
+void testConv1dBackwardSymGroupsGrouped() {
+    size_t weightDims[] = {8, 2, 2};
+    size_t biasDims[] = {8};
+    size_t inputDims[] = {1, 4, 5};
+    size_t outputDims[] = {1, 8, 4};
+
+    parameter_t *weights = buildSymParam(3, weightDims, weight_conv1dSym_groupsGroupedSym);
+    parameter_t *bias = buildSymParam(1, biasDims, bias_conv1dSym_groupsGroupedSym);
+    tensor_t *input = buildSymTensor(3, inputDims, input_conv1dSym_groupsGroupedSym);
+    tensor_t *lossGrad = buildSymTensor(3, outputDims, lossGrad_conv1dSym_groupsGroupedSym);
+    tensor_t *propLoss = buildSymTensor(3, inputDims, NULL);
+
+    kernel_t kernel;
+    initKernel(&kernel, 2, VALID, 1, 1);
+    conv1dConfig_t cfg;
+    quantization_t *sq = quantizationInitSymInt32(HALF_AWAY);
+    static layerConfig_t lc;
+    static layer_t layer;
+    initConv1dConfigWithWeightsAndBias(&cfg, &kernel, weights, bias, 2, sq, sq, sq, sq);
+    layer.type = CONV1D;
+    lc.conv1d = &cfg;
+    layer.config = &lc;
+
+    conv1dBackward(&layer, input, lossGrad, propLoss);
+
+    /* propLoss (dx) */
+    int32_t *dx = (int32_t *)propLoss->data;
+    for (size_t i = 0; i < expectedPropLoss_conv1dSym_groupsGroupedSym_len; i++) {
+        TEST_ASSERT_INT_WITHIN(propLossMantissaTol_conv1dSym_groupsGroupedSym,
+                               expectedPropLoss_conv1dSym_groupsGroupedSym[i], dx[i]);
+    }
+    float dxScale = symScaleOf(propLoss);
+    TEST_ASSERT_FLOAT_WITHIN(expectedPropLossScale_conv1dSym_groupsGroupedSym * 1e-4f,
+                             expectedPropLossScale_conv1dSym_groupsGroupedSym, dxScale);
+    for (size_t i = 0; i < expectedPropLossDequant_conv1dSym_groupsGroupedSym_len; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(propLossDequantTol_conv1dSym_groupsGroupedSym,
+                                 expectedPropLossDequant_conv1dSym_groupsGroupedSym[i],
+                                 (float)dx[i] * dxScale);
+    }
+    /* weightGrad */
+    int32_t *dw = (int32_t *)weights->grad->data;
+    float dwScale = symScaleOf(weights->grad);
+    for (size_t i = 0; i < expectedWeightGrad_conv1dSym_groupsGroupedSym_len; i++) {
+        TEST_ASSERT_INT_WITHIN(weightGradMantissaTol_conv1dSym_groupsGroupedSym,
+                               expectedWeightGrad_conv1dSym_groupsGroupedSym[i], dw[i]);
+        TEST_ASSERT_FLOAT_WITHIN(weightGradDequantTol_conv1dSym_groupsGroupedSym,
+                                 expectedWeightGradDequant_conv1dSym_groupsGroupedSym[i],
+                                 (float)dw[i] * dwScale);
+    }
+    /* biasGrad */
+    int32_t *db = (int32_t *)bias->grad->data;
+    float dbScale = symScaleOf(bias->grad);
+    for (size_t i = 0; i < expectedBiasGrad_conv1dSym_groupsGroupedSym_len; i++) {
+        TEST_ASSERT_INT_WITHIN(biasGradMantissaTol_conv1dSym_groupsGroupedSym,
+                               expectedBiasGrad_conv1dSym_groupsGroupedSym[i], db[i]);
+        TEST_ASSERT_FLOAT_WITHIN(biasGradDequantTol_conv1dSym_groupsGroupedSym,
+                                 expectedBiasGradDequant_conv1dSym_groupsGroupedSym[i],
+                                 (float)db[i] * dbScale);
+    }
+}
+
+void testConv1dBackwardSymStrideDilation() {
+    size_t weightDims[] = {1, 1, 2};
+    size_t inputDims[] = {1, 1, 9};
+    size_t outputDims[] = {1, 1, 3};
+
+    parameter_t *weights = buildSymParam(3, weightDims, weight_conv1dSym_strideDilationSym);
+    tensor_t *input = buildSymTensor(3, inputDims, input_conv1dSym_strideDilationSym);
+    tensor_t *lossGrad = buildSymTensor(3, outputDims, lossGrad_conv1dSym_strideDilationSym);
+    tensor_t *propLoss = buildSymTensor(3, inputDims, NULL);
+
+    kernel_t kernel;
+    initKernel(&kernel, 2, VALID, 2, 3); /* size=2, VALID, dilation=2, stride=3 */
+    conv1dConfig_t cfg;
+    quantization_t *sq = quantizationInitSymInt32(HALF_AWAY);
+    static layerConfig_t lc;
+    static layer_t layer;
+    initConv1dConfigWithWeightsAndBias(&cfg, &kernel, weights, NULL, 1, sq, sq, sq, sq);
+    layer.type = CONV1D;
+    lc.conv1d = &cfg;
+    layer.config = &lc;
+
+    conv1dBackward(&layer, input, lossGrad, propLoss);
+
+    /* propLoss (dx) */
+    int32_t *dx = (int32_t *)propLoss->data;
+    for (size_t i = 0; i < expectedPropLoss_conv1dSym_strideDilationSym_len; i++) {
+        TEST_ASSERT_INT_WITHIN(propLossMantissaTol_conv1dSym_strideDilationSym,
+                               expectedPropLoss_conv1dSym_strideDilationSym[i], dx[i]);
+    }
+    float dxScale = symScaleOf(propLoss);
+    TEST_ASSERT_FLOAT_WITHIN(expectedPropLossScale_conv1dSym_strideDilationSym * 1e-4f,
+                             expectedPropLossScale_conv1dSym_strideDilationSym, dxScale);
+    for (size_t i = 0; i < expectedPropLossDequant_conv1dSym_strideDilationSym_len; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(propLossDequantTol_conv1dSym_strideDilationSym,
+                                 expectedPropLossDequant_conv1dSym_strideDilationSym[i],
+                                 (float)dx[i] * dxScale);
+    }
+    /* weightGrad */
+    int32_t *dw = (int32_t *)weights->grad->data;
+    float dwScale = symScaleOf(weights->grad);
+    for (size_t i = 0; i < expectedWeightGrad_conv1dSym_strideDilationSym_len; i++) {
+        TEST_ASSERT_INT_WITHIN(weightGradMantissaTol_conv1dSym_strideDilationSym,
+                               expectedWeightGrad_conv1dSym_strideDilationSym[i], dw[i]);
+        TEST_ASSERT_FLOAT_WITHIN(weightGradDequantTol_conv1dSym_strideDilationSym,
+                                 expectedWeightGradDequant_conv1dSym_strideDilationSym[i],
+                                 (float)dw[i] * dwScale);
+    }
+    /* no biasGrad: bias == NULL */
+}
+
 void setUp() {}
 void tearDown() {}
 
@@ -779,5 +1209,15 @@ int main() {
     RUN_TEST(testConv1dBackwardPointwise);
     RUN_TEST(testConv1dForwardExplicitPadding);
     RUN_TEST(testConv1dBackwardExplicitPadding);
+    RUN_TEST(testConv1dForwardSymSingleChannelSingleBatch);
+    RUN_TEST(testConv1dForwardSymSingleChannelWithBias);
+    RUN_TEST(testConv1dForwardSymPointwise);
+    RUN_TEST(testConv1dForwardSymExplicitPadding);
+    RUN_TEST(testConv1dKernelSymScatterStrideDilation);
+    RUN_TEST(testConv1dCalcWeightGradsSymGroupsGrouped);
+    RUN_TEST(testConv1dCalcBiasGradsSymPointwise);
+    RUN_TEST(testConv1dBackwardSymExplicitPadding);
+    RUN_TEST(testConv1dBackwardSymGroupsGrouped);
+    RUN_TEST(testConv1dBackwardSymStrideDilation);
     return UNITY_END();
 }

--- a/test/unit/layer/generate_expected_conv1d.py
+++ b/test/unit/layer/generate_expected_conv1d.py
@@ -6,8 +6,9 @@ test fixture: forward output, plus autograd-derived dL/dx, dL/dW,
 dL/db (when bias is present). Run via `uv run` (CMake wires this
 automatically).
 
-The lossGrad used by autograd is torch.ones_like(y) for every fixture,
-so the C tests pass an all-ones lossGrad of matching shape to backward.
+Most FLOAT fixtures use lossGrad = torch.ones_like(y); the pointwise and
+explicit-padding fixtures (and all SYM grad fixtures) use a random
+(torch.randn) lossGrad to avoid output-channel vacuity in the gradients.
 """
 import argparse
 import sys
@@ -15,6 +16,64 @@ from pathlib import Path
 
 import torch
 import torch.nn.functional as F
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "goldgen"))
+import sym_gold
+from sym_gold import (
+    round_half_away,
+    stable_dequant,
+    emit_int32_array,
+    emit_float_scalar,
+    emit_int32_scalar,
+)
+
+QMAX_F32 = torch.tensor(32767.0, dtype=torch.float32)
+QMIN_F32 = torch.tensor(-32768.0, dtype=torch.float32)
+
+QMAX_I12 = torch.tensor(2047.0, dtype=torch.float32)
+QMIN_I12 = torch.tensor(-2048.0, dtype=torch.float32)
+
+
+def quantize_sym_i12(x):
+    """int12 operand quantize (qMaxBits=12): absmax->scale=absmax/2047, round-clamp half-away."""
+    absmax = x.abs().max().item()
+    scale = 1.0 if absmax == 0.0 else absmax / 2047.0
+    q = round_half_away(torch.clamp(x / scale, -2048.0, 2047.0))
+    return q.to(torch.int32), scale
+
+
+def stable_dequant_i12(x):
+    q, s = quantize_sym_i12(x.to(torch.float64))
+    deq32 = (q.to(torch.float64) * s).to(torch.float32)
+    q2, _ = quantize_sym_i12(deq32.to(torch.float64))
+    assert torch.equal(q, q2), "int12 fixture not dequant round-trip stable"
+    return q, s, deq32
+
+
+def f32_scale_i12(deq32: torch.Tensor) -> float:
+    """int12 scale the C runtime derives from the emitted fixture: absmax_f32/2047 in float32."""
+    absmax = deq32.abs().max().to(torch.float32)
+    if absmax.item() == 0.0:
+        return 1.0
+    return (absmax / QMAX_I12).item()
+
+
+# stable_dequant (sym_gold.py) returns its scale in float64; the C runtime
+# (convertFloatTensorToSymInt32Tensor) derives the scale in float32 from the
+# emitted fixture. Re-derive in float32 here so the emulation's scales match C
+# bit-for-bit; the round-trip-stable fixture guarantees the same mantissas.
+def f32_scale(deq32: torch.Tensor) -> float:
+    """Scale the C runtime derives from the EMITTED float32 fixture:
+    float32(absmax(deq32)) / 32767, all in float32 (convertFloatTensorToSymInt32Tensor)."""
+    absmax = deq32.abs().max().to(torch.float32)
+    if absmax.item() == 0.0:
+        return 1.0
+    return (absmax / QMAX_F32).item()
+
+
+def f32_mul(a: float, b: float) -> float:
+    """One IEEE-754 float32 multiply (matches the C `aScale * bScale`)."""
+    return (torch.tensor(a, dtype=torch.float32) * torch.tensor(b, dtype=torch.float32)).item()
 
 
 def _format_float_literal(v: float) -> str:
@@ -64,6 +123,8 @@ def _run_fixture(name, x, w, b, *, stride, padding, dilation, groups):
         "dx": x.grad.detach(),
         "dw": w.grad.detach(),
         "db": b.grad.detach() if b is not None else None,
+        "_params": {"stride": stride, "padding": padding, "dilation": dilation,
+                    "groups": groups, "has_bias": b is not None},
     }
 
 
@@ -206,6 +267,7 @@ def fixture_pointwise():
         "dw": w.grad.detach(),
         "db": b.grad.detach(),
         "lossGrad": loss_grad.detach(),
+        "_params": {"stride": 1, "padding": 0, "dilation": 1, "groups": 1, "has_bias": True},
     }
 
 
@@ -234,7 +296,208 @@ def fixture_explicit_padding():
         "dw": w.grad.detach(),
         "db": b.grad.detach(),
         "lossGrad": loss_grad.detach(),
+        "_params": {"stride": 2, "padding": 3, "dilation": 1, "groups": 1, "has_bias": True},
     }
+
+
+def fixture_stride_dilation_sym():
+    # SYM twin of strideDilation with a RANDOM lossGrad (uniform-lossGrad vacuity).
+    torch.manual_seed(11)
+    x = torch.tensor([[[1.0, 0.0, 2.0, 0.0, 0.0, 0.0, 3.0, 0.0, 4.0]]]).requires_grad_(True)
+    w = torch.tensor([[[2.0, 4.0]]]).requires_grad_(True)
+    loss_grad = torch.randn(1, 1, 3)
+    y = F.conv1d(x, w, bias=None, stride=3, padding=0, dilation=2, groups=1)
+    y.backward(loss_grad)
+    return {"name": "strideDilationSym", "x": x.detach(), "w": w.detach(), "b": None,
+            "y": y.detach(), "dx": x.grad.detach(), "dw": w.grad.detach(), "db": None,
+            "lossGrad": loss_grad.detach(),
+            "_params": {"stride": 3, "padding": 0, "dilation": 2, "groups": 1, "has_bias": False}}
+
+
+def fixture_groups_grouped_sym():
+    # SYM twin of groupsGrouped with a RANDOM lossGrad.
+    torch.manual_seed(13)
+    x = torch.randn(1, 4, 5).requires_grad_(True)
+    w = torch.randn(8, 2, 2).requires_grad_(True)   # [Cout, Cin/groups=2, K]
+    b = torch.randn(8).requires_grad_(True)
+    loss_grad = torch.randn(1, 8, 4)
+    y = F.conv1d(x, w, bias=b, stride=1, padding=0, dilation=1, groups=2)
+    y.backward(loss_grad)
+    return {"name": "groupsGroupedSym", "x": x.detach(), "w": w.detach(), "b": b.detach(),
+            "y": y.detach(), "dx": x.grad.detach(), "dw": w.grad.detach(), "db": b.grad.detach(),
+            "lossGrad": loss_grad.detach(),
+            "_params": {"stride": 1, "padding": 0, "dilation": 1, "groups": 2, "has_bias": True}}
+
+
+SYM_FIXTURES = [
+    fixture_single_channel_single_batch(),   # reused FLOAT: VALID, no bias, ones (allowed)
+    fixture_single_channel_with_bias(),      # reused FLOAT: VALID, bias, ones (allowed)
+    fixture_pointwise(),                      # reused FLOAT: K=1, bias, RANDOM lossGrad
+    fixture_groups_grouped_sym(),            # new _sym twin: groups=2, bias, RANDOM lossGrad
+    fixture_stride_dilation_sym(),           # new _sym twin: stride=3 dilation=2, no bias, RANDOM
+    fixture_explicit_padding(),              # reused FLOAT: K=7 stride=2 EXPLICIT pad=3, bias, RANDOM
+]
+
+
+def _conv_params(fx):
+    """Recover the conv hyper-params a fixture ran with (mirrors its _run_fixture call)."""
+    return fx["_params"]  # {stride, padding, dilation, groups, has_bias}
+
+
+def _quant_inputs(fx):
+    """int12-quantize x/w/(b)/lossGrad operands; return mantissas, float32 scales, float fixtures.
+    Operands use int12 (qMaxBits=12) so int12*int12 products stay within int32 headroom.
+    Grad accumulators (weightGrad) stay int16 via _requant_absmax_f32."""
+    xq, _, x_deq = stable_dequant_i12(fx["x"])
+    wq, _, w_deq = stable_dequant_i12(fx["w"])
+    s_in = f32_scale_i12(x_deq)
+    s_w = f32_scale_i12(w_deq)
+    bq = b_deq = s_b = None
+    if fx["b"] is not None:
+        bq, _, b_deq = stable_dequant_i12(fx["b"])
+        s_b = f32_scale_i12(b_deq)
+    gy = fx["lossGrad"] if fx.get("lossGrad") is not None else torch.ones_like(fx["y"])
+    gyq, _, gy_deq = stable_dequant_i12(gy)
+    s_loss = f32_scale_i12(gy_deq)
+    return dict(xq=xq, wq=wq, bq=bq, gyq=gyq, s_in=s_in, s_w=s_w, s_b=s_b, s_loss=s_loss,
+                x_deq=x_deq, w_deq=w_deq, b_deq=b_deq, gy_deq=gy_deq)
+
+
+def _int_mac(q, p):
+    """Exact integer forward + autograd grads via float64 conv of integer mantissas.
+    Returns (fwd_mac[B,Cout,L] int64, dw_mac int64 [gather], dx_mac int64 [scatter])."""
+    xqf = q["xq"].to(torch.float64).requires_grad_(True)
+    wqf = q["wq"].to(torch.float64).requires_grad_(True)
+    y = F.conv1d(xqf, wqf, bias=None, stride=p["stride"], padding=p["padding"],
+                 dilation=p["dilation"], groups=p["groups"])
+    y.backward(q["gyq"].to(torch.float64))
+    fwd_mac = y.detach().round().to(torch.int64)
+    dw_mac = wqf.grad.round().to(torch.int64)
+    dx_mac = xqf.grad.round().to(torch.int64)
+    return fwd_mac, dw_mac, dx_mac
+
+
+def _round_away_f32(x: torch.Tensor) -> torch.Tensor:
+    return round_half_away(x.to(torch.float32))
+
+
+def _requant_absmax_f32(mac_int: torch.Tensor, in_scale: float):
+    """addSymInt32TensorsInplace into a zero grad: dequant (f32) -> absmax (f32) ->
+    scale=absmax/32767 (f32) -> round_half_away(clamp(.../scale)). Returns (q int32, scale)."""
+    deq = mac_int.to(torch.float32) * torch.tensor(in_scale, dtype=torch.float32)
+    absmax = deq.abs().max().to(torch.float32)
+    if absmax.item() == 0.0:
+        return torch.zeros_like(mac_int, dtype=torch.int32), 1.0
+    scale = (absmax / QMAX_F32)
+    q = round_half_away(torch.clamp(deq / scale, QMIN_F32, QMAX_F32))
+    return q.to(torch.int32), scale.item()
+
+
+def _autograd_ref_f64(q, p):
+    """float64 torch-autograd on the EXACT dequantized inputs (q*s in f64) — the true
+    grads the SYM dequants must track within analytic bounds."""
+    x64 = (q["xq"].to(torch.float64) * q["s_in"]).requires_grad_(True)
+    w64 = (q["wq"].to(torch.float64) * q["s_w"]).requires_grad_(True)
+    b64 = None
+    if q["bq"] is not None:
+        b64 = (q["bq"].to(torch.float64) * q["s_b"]).requires_grad_(True)
+    y = F.conv1d(x64, w64, bias=b64, stride=p["stride"], padding=p["padding"],
+                 dilation=p["dilation"], groups=p["groups"])
+    y.backward(q["gyq"].to(torch.float64) * q["s_loss"])
+    return (y.detach(), x64.grad, w64.grad, b64.grad if b64 is not None else None)
+
+
+def emulate_sym_conv(fx):
+    """Full SYM emulation of conv1dForward + conv1dBackward for one fixture.
+    Returns a dict of int32 mantissas + float32 scales + float dequant references + tols."""
+    # Rounding-mode canary: half-AWAY must round 0.5 -> 1 and -0.5 -> -1 (NOT
+    # half-to-even's 0). Fires unconditionally if _round_away_f32 is ever a
+    # half-even rounder — the per-fixture tolerances cannot catch this on
+    # non-tie fixtures, so this guards the rounding path directly.
+    _canary = _round_away_f32(torch.tensor([0.5, -0.5], dtype=torch.float32))
+    assert _canary.tolist() == [1.0, -1.0], \
+        "round_half_away is not half-away-from-zero — rounding mode wrong"
+    p = _conv_params(fx)
+    q = _quant_inputs(fx)
+    fwd_mac, dw_mac, dx_mac = _int_mac(q, p)
+    out_scale = f32_mul(q["s_in"], q["s_w"])          # forward output scale
+    dx_scale = f32_mul(q["s_loss"], q["s_w"])         # propLoss scale = s_loss * s_w
+    inter_scale = f32_mul(q["s_loss"], q["s_in"])     # weightGrad intermediate scale
+
+    # forward: int MAC + per-channel bias seed (float32 refold)
+    out_channels = fwd_mac.shape[1]
+    if q["bq"] is not None:
+        seed = _round_away_f32(q["bq"].to(torch.float32)
+                               * torch.tensor(q["s_b"], dtype=torch.float32)
+                               / torch.tensor(out_scale, dtype=torch.float32)).to(torch.int64)
+        fwd_q = (fwd_mac + seed.reshape(1, out_channels, 1)).to(torch.int32)
+        fwd_mtol = 1
+    else:
+        fwd_q = fwd_mac.to(torch.int32)
+        fwd_mtol = 0
+    fwd_deq = fwd_q.to(torch.float32) * torch.tensor(out_scale, dtype=torch.float32)
+
+    # dx (propLoss): raw scatter, no requant, no bias
+    dx_q = dx_mac.to(torch.int32)
+    dx_deq = dx_q.to(torch.float32) * torch.tensor(dx_scale, dtype=torch.float32)
+
+    # weightGrad: strategy A requant of the int gather from a zero grad
+    dw_q, dw_scale = _requant_absmax_f32(dw_mac, inter_scale)
+
+    # biasGrad: int sum over (batch, outLen) per oc, fixed-scale rescale (s_bg = 1.0, zero-init grad).
+    # The division below mirrors rescaleIntoAccumulatorScale(sum_int, s_loss, s_bg=1.0, HALF_AWAY) =
+    # roundByMode(sum_int*s_loss/1.0, HALF_AWAY) — the exact op Task 6's C calls. The #189 ODT_SEED_GUARD
+    # is inactive at these fixture scales (no overflow), so the guarded helper and this raw cast agree.
+    db_q = db_scale = None
+    if q["bq"] is not None:
+        sum_int = q["gyq"].sum(dim=(0, 2))            # exact int per output channel
+        db_q = _round_away_f32(sum_int.to(torch.float32)
+                               * torch.tensor(q["s_loss"], dtype=torch.float32)
+                               / torch.tensor(1.0, dtype=torch.float32)).to(torch.int32)
+        db_scale = 1.0
+
+    # float64 autograd references for the dequant checks
+    ref_y, ref_dx, ref_dw, ref_db = _autograd_ref_f64(q, p)
+
+    # ---- self-checks (fail at generation time, not in C) ----
+    # float32 precision: when fwd_q or dx_q mantissas exceed 2^24, the int32->float32 cast
+    # loses low bits. The C dequant (int32_val * scale) in float32 has the same precision
+    # as our emulation, so the tolerance must include this f32 ULP term.
+    _eps32 = float(torch.finfo(torch.float32).eps)
+    fwd_f32_prec = fwd_q.abs().max().item() * out_scale * _eps32
+    dx_f32_prec = dx_q.abs().max().item() * dx_scale * _eps32
+
+    # forward dequant tracks the true (quantized-input) conv within quantization noise + f32 ULP
+    fwd_err = (fwd_deq.to(torch.float64) - ref_y).abs().max().item()
+    fwd_tol = 8.0 * out_scale + fwd_f32_prec + 1e-9
+    assert fwd_err <= fwd_tol, f"{fx['name']}: fwd emulation err {fwd_err} > tol {fwd_tol}"
+    # dx dequant tracks autograd dx (+ f32 ULP term for large mantissas)
+    dx_err = (dx_deq.to(torch.float64) - ref_dx).abs().max().item()
+    dx_tol = 8.0 * dx_scale + dx_f32_prec + 1e-9
+    assert dx_err <= dx_tol, f"{fx['name']}: dx emulation err {dx_err} > tol {dx_tol}"
+    # weightGrad dequant tracks autograd dw (increment-quant + requant + drift)
+    dw_err = (dw_q.to(torch.float64) * dw_scale - ref_dw.reshape(-1).reshape(dw_q.shape)
+              ).abs().max().item()
+    assert dw_err <= (0.5 * inter_scale + 2.5 * dw_scale) * 1.5 + 1e-9, \
+        f"{fx['name']}: dw emulation err {dw_err}"
+    if db_q is not None:
+        db_err = (db_q.to(torch.float64) * db_scale - ref_db.reshape(-1)).abs().max().item()
+        assert db_err <= (0.5 * q["s_loss"] + 2.5 * 1.0) * 1.5 + 1e-9, \
+            f"{fx['name']}: db emulation err {db_err}"
+
+    return dict(
+        name=fx["name"], has_bias=q["bq"] is not None,
+        x_deq=q["x_deq"], w_deq=q["w_deq"], b_deq=q["b_deq"], gy_deq=q["gy_deq"],
+        fwd_q=fwd_q, fwd_scale=out_scale, fwd_deq=ref_y.to(torch.float32),
+        fwd_mtol=fwd_mtol, fwd_dtol=8.0 * out_scale + fwd_f32_prec + 1e-6,
+        dx_q=dx_q, dx_scale=dx_scale, dx_deq=ref_dx.to(torch.float32),
+        dx_mtol=0, dx_dtol=8.0 * dx_scale + dx_f32_prec + 1e-6,
+        dw_q=dw_q, dw_scale=dw_scale, dw_deq=ref_dw.to(torch.float32),
+        dw_mtol=2, dw_dtol=(0.5 * inter_scale + 2.5 * dw_scale) * 1.5 + 1e-6,
+        db_q=db_q, db_scale=db_scale,
+        db_deq=ref_db.to(torch.float32) if db_q is not None else None,
+        db_mtol=1, db_dtol=(0.5 * q["s_loss"] + 2.5 * 1.0) * 1.5 + 1e-6,
+    )
 
 
 def emit_fixture(parts, fx):
@@ -251,6 +514,41 @@ def emit_fixture(parts, fx):
     # Emitted only for fixtures that supply an explicit (non-ones) lossGrad.
     if fx.get("lossGrad") is not None:
         parts.append(emit_float_array(f"lossGrad_{pre}", fx["lossGrad"]))
+
+
+def emit_sym_fixture(parts, fx):
+    g = emulate_sym_conv(fx)
+    pre = f"conv1dSym_{g['name']}"
+    parts.append(emit_float_array(f"input_{pre}", g["x_deq"]))
+    parts.append(emit_float_array(f"weight_{pre}", g["w_deq"]))
+    if g["has_bias"]:
+        parts.append(emit_float_array(f"bias_{pre}", g["b_deq"]))
+    parts.append(emit_float_array(f"lossGrad_{pre}", g["gy_deq"]))
+    # forward
+    parts.append(emit_int32_array(f"expectedForward_{pre}", g["fwd_q"]))
+    parts.append(emit_float_scalar(f"expectedForwardScale_{pre}", g["fwd_scale"]))
+    parts.append(emit_int32_scalar(f"forwardMantissaTol_{pre}", g["fwd_mtol"]))
+    parts.append(emit_float_array(f"expectedForwardDequant_{pre}", g["fwd_deq"]))
+    parts.append(emit_float_scalar(f"forwardDequantTol_{pre}", g["fwd_dtol"]))
+    # dx / propLoss
+    parts.append(emit_int32_array(f"expectedPropLoss_{pre}", g["dx_q"]))
+    parts.append(emit_float_scalar(f"expectedPropLossScale_{pre}", g["dx_scale"]))
+    parts.append(emit_int32_scalar(f"propLossMantissaTol_{pre}", g["dx_mtol"]))
+    parts.append(emit_float_array(f"expectedPropLossDequant_{pre}", g["dx_deq"]))
+    parts.append(emit_float_scalar(f"propLossDequantTol_{pre}", g["dx_dtol"]))
+    # weightGrad
+    parts.append(emit_int32_array(f"expectedWeightGrad_{pre}", g["dw_q"]))
+    parts.append(emit_float_scalar(f"expectedWeightGradScale_{pre}", g["dw_scale"]))
+    parts.append(emit_int32_scalar(f"weightGradMantissaTol_{pre}", g["dw_mtol"]))
+    parts.append(emit_float_array(f"expectedWeightGradDequant_{pre}", g["dw_deq"]))
+    parts.append(emit_float_scalar(f"weightGradDequantTol_{pre}", g["dw_dtol"]))
+    # biasGrad
+    if g["has_bias"]:
+        parts.append(emit_int32_array(f"expectedBiasGrad_{pre}", g["db_q"]))
+        parts.append(emit_float_scalar(f"expectedBiasGradScale_{pre}", g["db_scale"]))
+        parts.append(emit_int32_scalar(f"biasGradMantissaTol_{pre}", g["db_mtol"]))
+        parts.append(emit_float_array(f"expectedBiasGradDequant_{pre}", g["db_deq"]))
+        parts.append(emit_float_scalar(f"biasGradDequantTol_{pre}", g["db_dtol"]))
 
 
 def main() -> int:
@@ -281,6 +579,9 @@ def main() -> int:
     ]
     for fx in fixtures:
         emit_fixture(parts, fx)
+
+    for fx in SYM_FIXTURES:
+        emit_sym_fixture(parts, fx)
 
     parts.append("\n#endif // ODT_EXPECTED_CONV1D_H\n")
 


### PR DESCRIPTION
PR2 of #45 (Milestone M2). Adds the full SYM_INT32 (integer fixed-point) path to Conv1d.

## What

- **Two integer sliding-window cores** in `src/arithmetic/`, siblings of the FLOAT kernels sharing the `SlidingWindow1d` geometry:
  - `conv1dKernelSymInt32` (gather) — Conv1d SYM forward.
  - `convTranspose1dKernelSymInt32` (scatter) — Conv1d's `dx` adjoint (and Conv1dTransposed's forward in PR3).
- **Conv1d full SYM backward** via 3 independent dtype switches (`weightGradQ` / `biasGradQ` / `propLossQ`), mirroring `linearBackward`:
  - weightGrad = strategy A (reserveMemory int32 intermediate at `s_in·s_loss` + `addSymInt32TensorsInplace`).
  - biasGrad = fixed-scale refold via `rescaleIntoAccumulatorScale` (#218 scheme).
  - dx = the scatter core, with the #187 fail-fast guard.
- Per-output-channel bias seed refolded through the #189 helper (never raw-added).

## int12 operands (design decision)

SYM kernels accumulate **products** of operands in an **int32** accumulator (no int64 — hard rule). int16×int16 overflows int32 after ~2 terms; **int12 operands** (qMaxBits=12) give ~512-term headroom — ample for the batch=1 MCU regime, matching low-bit×low-bit→int32 (Deutel FQT / TFLite). Grad accumulators stay int16 (wider = free; SYM stores int32 regardless). The kernels are bit-width-agnostic; only the quant configs change. This is a framework-wide property (Linear/Matmul/LayerNorm share the int16 2-term ceiling) — tracked in #227.

## Tests

- PyTorch integer gold fixtures (importing `test/unit/goldgen/sym_gold.py`): int-exact MAC + float32 downstream requant; mantissa + scale + dequant + analytic tolerances; random lossGrad off the VALID-single-channel cases; mutation-verified.
- Full suite **62/62**; `unit_test_ubsan` (signed-integer-overflow + float-cast-overflow) **clean** on the 28 Conv1d tests (validates int12 = no overflow).

## Scope / deferred to PR3

Conv1dTransposed full SYM (reuses both cores), the `producerForwardQ` validator case, and the Conv→Quant→…→MSE train/converge chain test are **PR3** — not in this PR.

Depends on #189 (seed helper) + #192 (Quant layer), both merged. Part of #45 (not auto-closing — multi-PR epic, develop-merge). Follow-up: #227.

🤖 Generated with [Claude Code](https://claude.com/claude-code)