### PR TITLE
feat(layer): Conv1dTransposed weightGrad Lout-consistency guard (FLOAT + SYM)

### DIFF
--- a/src/layer/Conv1dTransposed.c
+++ b/src/layer/Conv1dTransposed.c
@@ -87,6 +87,15 @@ static void conv1dTransposedCalcWeightGradsFloat32(conv1dTransposedConfig_t *cfg
     size_t outputLength = lossGrad->shape->dimensions[2];
     size_t kernelSize = cfg->weights->param->shape->dimensions[2];
 
+    size_t expectedOutLen = (inputLength - 1) * cfg->kernel->stride +
+                            cfg->kernel->dilation * (kernelSize - 1) + cfg->outputPadding + 1;
+    if (expectedOutLen != outputLength) {
+        PRINT_ERROR("Conv1dTransposed backward (weightGrad): lossGrad outputLength (%zu) does "
+                    "not match the transpose geometry from forwardInput (expected %zu)",
+                    outputLength, expectedOutLen);
+        exit(1);
+    }
+
     size_t groups = cfg->groups;
     size_t inChPerGroup = inChannels / groups;
     size_t outChPerGroup = outChannels / groups;
@@ -156,6 +165,15 @@ void conv1dTransposedCalcWeightGradsSymInt32(conv1dTransposedConfig_t *cfg, tens
     size_t outChannels = lossGrad->shape->dimensions[1];
     size_t outputLength = lossGrad->shape->dimensions[2];
     size_t kernelSize = cfg->weights->param->shape->dimensions[2];
+
+    size_t expectedOutLen = (inputLength - 1) * cfg->kernel->stride +
+                            cfg->kernel->dilation * (kernelSize - 1) + cfg->outputPadding + 1;
+    if (expectedOutLen != outputLength) {
+        PRINT_ERROR("Conv1dTransposed backward (weightGrad): lossGrad outputLength (%zu) does "
+                    "not match the transpose geometry from forwardInput (expected %zu)",
+                    outputLength, expectedOutLen);
+        exit(1);
+    }
 
     size_t groups = cfg->groups;
     size_t inChPerGroup = inChannels / groups;


### PR DESCRIPTION
## What

Adds a length-consistency guard to **both** Conv1dTransposed weight-gradient
helpers in `src/layer/Conv1dTransposed.c`:

- `conv1dTransposedCalcWeightGradsFloat32`
- `conv1dTransposedCalcWeightGradsSymInt32`

## Why

Both helpers accepted `lossGrad` without checking its length against the
transpose geometry of `forwardInput`. A mis-shaped `lossGrad` (wrong
`outputLength`) produced **wrong-but-in-bounds** gradients: the in-loop
`0 <= outIdx < outputLength` check kept the access safe but *silently masked*
the shape mismatch. The Conv1d twins (`Conv1d.c:80`, `:152`) already fail fast;
these did not.

## How

Fail-fast guard mirroring the Conv1d pattern, but using the **transpose**
output-length relation (inverse of the forward conv; VALID-only in Phase 1, so
`padLeft == 0`):

```c
expectedOutLen = (inputLength - 1) * stride
                 + dilation * (kernelSize - 1) + outputPadding + 1;
if (expectedOutLen != outputLength) { PRINT_ERROR(...); exit(1); }
```

This formula is **identical** to the established forward geometry in
`conv1dTransposedCalcOutputShape` and the forward kernel. The two guards are
kept byte-identical.

## Verification

The repo has no death-test harness, so `exit(1)` guards aren't asserted in the
Unity runner (the Conv1d guards aren't either — consistent with convention).
Instead:

1. **No false-positive:** all 23 ConvT fixtures still pass, spanning
   stride∈{1,2}, dilation∈{1,2}, outputPadding∈{0,1}, groups∈{1,2,4}.
2. **Each guard fires:** demonstrated via a *reverted* throwaway mis-sized
   `lossGrad` — FLOAT aborts with `expected 4`, SYM aborts with `expected 8`
   (exit code 1). Nothing committed.
3. **Full suite green: 62/62** (`ctest --preset unit_test`, gcc).
4. Allocation-locality + clang-format gates pass. ASan + sanitizer-pytest
   deferred to GitHub Linux CI (macOS ASan host hang; C-only change, no new
   allocations).

An adversarial review across three independent lenses (formula correctness,
false-positive/false-negative behavior, convention parity) returned PASS on all
three, with only out-of-scope minors (e.g. the guard checks `dim[2]` only —
exactly issue #230's scope, matching the Conv1d reference).

## Notes

- Default branch is `main`, so a `develop`-base merge will **not** auto-close
  #230 — close it manually after merge.
- Out of scope (noted by review, deliberately not done here — "no new
  features"): the transpose Lout formula is now inlined in 3 sites; a shared
  transpose-geometry helper could dedupe it in a future refactor.

Refs #230