### PR TITLE
refactor(arithmetic): centralize transposed-conv VALID Lout + enforce kernel-size invariant (#233)

### DIFF
--- a/src/arithmetic/ConvTranspose1dKernel.c
+++ b/src/arithmetic/ConvTranspose1dKernel.c
@@ -33,8 +33,7 @@ void convTranspose1dKernelFloat32(tensor_t const *input, tensor_t const *weight,
     size_t padLeft = 0;
 
     if (kernel->paddingType == VALID) {
-        size_t expectedOutLen = (inputLength - 1) * kernel->stride +
-                                kernel->dilation * (kernelSize - 1) + outputPadding + 1;
+        size_t expectedOutLen = convTranspose1dOutputLength(inputLength, kernel, outputPadding);
         if (expectedOutLen != outputLength) {
             PRINT_ERROR("convTranspose1dKernelFloat32: VALID output_length mismatch "
                         "(expected=%zu, got=%zu)",
@@ -158,8 +157,7 @@ void convTranspose1dKernelSymInt32(tensor_t const *input, tensor_t const *weight
     size_t padLeft = 0;
 
     if (kernel->paddingType == VALID) {
-        size_t expectedOutLen = (inputLength - 1) * kernel->stride +
-                                kernel->dilation * (kernelSize - 1) + outputPadding + 1;
+        size_t expectedOutLen = convTranspose1dOutputLength(inputLength, kernel, outputPadding);
         if (expectedOutLen != outputLength) {
             PRINT_ERROR("convTranspose1dKernelSymInt32: VALID output_length mismatch "
                         "(expected=%zu, got=%zu)",

--- a/src/arithmetic/SlidingWindow1d.c
+++ b/src/arithmetic/SlidingWindow1d.c
@@ -92,3 +92,9 @@ windowSlice1d_t windowSlice1dAt(windowGeometry1d_t const *geometry, size_t outpu
     s.validCount = (size_t)(lastK - firstK + 1);
     return s;
 }
+
+size_t convTranspose1dOutputLength(size_t inputLength, kernel_t const *kernel,
+                                   size_t outputPadding) {
+    return (inputLength - 1) * kernel->stride + kernel->dilation * (kernel->size - 1) +
+           outputPadding + 1;
+}

--- a/src/arithmetic/include/SlidingWindow1d.h
+++ b/src/arithmetic/include/SlidingWindow1d.h
@@ -17,6 +17,15 @@ typedef struct windowGeometry1d {
 
 windowGeometry1d_t windowGeometry1dCalc(size_t inputLength, kernel_t const *kernel);
 
+/*! VALID-mode transposed-conv forward output length:
+ *    Lout = (inputLength - 1)*stride + dilation*(kernelSize - 1) + outputPadding + 1
+ *  Uses kernel->size as the kernel tap count (enforced == weight kernelSize at
+ *  layer init, see initConv1dConfigWithWeightsAndBias /
+ *  initConv1dTransposedConfigWithWeightsAndBias). SAME/EXPLICIT transpose geometry
+ *  is NOT this — it is recovered via windowGeometry1dCalc(outputLength, kernel). */
+size_t convTranspose1dOutputLength(size_t inputLength, kernel_t const *kernel,
+                                   size_t outputPadding);
+
 typedef struct windowSlice1d {
     size_t firstValidInputIdx;
     size_t firstValidKernelOffset;

--- a/src/layer/Conv1d.c
+++ b/src/layer/Conv1d.c
@@ -22,6 +22,11 @@ void initConv1dConfigWithWeightsAndBias(conv1dConfig_t *conv1dConfig, kernel_t *
         PRINT_ERROR("Conv1d: groups must be >= 1");
         exit(1);
     }
+    if (kernel->size != weights->param->shape->dimensions[2]) {
+        PRINT_ERROR("Conv1d: kernel->size (%zu) must equal weight kernelSize (%zu)", kernel->size,
+                    weights->param->shape->dimensions[2]);
+        exit(1);
+    }
     conv1dConfig->kernel = kernel;
     conv1dConfig->weights = weights;
     conv1dConfig->bias = bias;

--- a/src/layer/Conv1dTransposed.c
+++ b/src/layer/Conv1dTransposed.c
@@ -92,8 +92,8 @@ static void conv1dTransposedCalcWeightGradsFloat32(conv1dTransposedConfig_t *cfg
     size_t outputLength = lossGrad->shape->dimensions[2];
     size_t kernelSize = cfg->weights->param->shape->dimensions[2];
 
-    size_t expectedOutLen = (inputLength - 1) * cfg->kernel->stride +
-                            cfg->kernel->dilation * (kernelSize - 1) + cfg->outputPadding + 1;
+    size_t expectedOutLen =
+        convTranspose1dOutputLength(inputLength, cfg->kernel, cfg->outputPadding);
     if (expectedOutLen != outputLength) {
         PRINT_ERROR("Conv1dTransposed backward (weightGrad): lossGrad outputLength (%zu) does "
                     "not match the transpose geometry from forwardInput (expected %zu)",
@@ -171,8 +171,8 @@ void conv1dTransposedCalcWeightGradsSymInt32(conv1dTransposedConfig_t *cfg, tens
     size_t outputLength = lossGrad->shape->dimensions[2];
     size_t kernelSize = cfg->weights->param->shape->dimensions[2];
 
-    size_t expectedOutLen = (inputLength - 1) * cfg->kernel->stride +
-                            cfg->kernel->dilation * (kernelSize - 1) + cfg->outputPadding + 1;
+    size_t expectedOutLen =
+        convTranspose1dOutputLength(inputLength, cfg->kernel, cfg->outputPadding);
     if (expectedOutLen != outputLength) {
         PRINT_ERROR("Conv1dTransposed backward (weightGrad): lossGrad outputLength (%zu) does "
                     "not match the transpose geometry from forwardInput (expected %zu)",
@@ -349,14 +349,12 @@ void conv1dTransposedCalcOutputShape(layer_t *layer, shape_t *inputShape, shape_
     conv1dTransposedConfig_t *cfg = layer->config->conv1dTransposed;
     size_t batchSize = inputShape->dimensions[0];
     size_t inputLength = inputShape->dimensions[2];
-    size_t kernelSize = cfg->weights->param->shape->dimensions[2];
     // Conv1dTransposed weight shape: [Cin, Cout/groups, K]
     // Cout = (Cout/groups) * groups
     size_t outChannelsPerGroup = cfg->weights->param->shape->dimensions[1];
     size_t outChannels = outChannelsPerGroup * cfg->groups;
 
-    size_t outputLength = (inputLength - 1) * cfg->kernel->stride +
-                          cfg->kernel->dilation * (kernelSize - 1) + cfg->outputPadding + 1;
+    size_t outputLength = convTranspose1dOutputLength(inputLength, cfg->kernel, cfg->outputPadding);
 
     outputShape->dimensions[0] = batchSize;
     outputShape->dimensions[1] = outChannels;

--- a/src/layer/Conv1dTransposed.c
+++ b/src/layer/Conv1dTransposed.c
@@ -34,6 +34,11 @@ void initConv1dTransposedConfigWithWeightsAndBias(
                     outputPadding, kernel->stride, kernel->dilation);
         exit(1);
     }
+    if (kernel->size != weights->param->shape->dimensions[2]) {
+        PRINT_ERROR("Conv1dTransposed: kernel->size (%zu) must equal weight kernelSize (%zu)",
+                    kernel->size, weights->param->shape->dimensions[2]);
+        exit(1);
+    }
     cfg->kernel = kernel;
     cfg->weights = weights;
     cfg->bias = bias;

--- a/test/unit/arithmetic/UnitTestSlidingWindow1d.c
+++ b/test/unit/arithmetic/UnitTestSlidingWindow1d.c
@@ -216,6 +216,36 @@ void testGeometryExplicitZeroPaddingEqualsValid() {
     TEST_ASSERT_EQUAL_size_t(0, g.padRight);
 }
 
+void testTransposeOutputLengthBasic() {
+    // (4-1)*1 + 1*(2-1) + 0 + 1 = 5
+    kernel_t kernel = {.size = 2, .stride = 1, .dilation = 1, .paddingType = VALID};
+    TEST_ASSERT_EQUAL_size_t(5, convTranspose1dOutputLength(4, &kernel, 0));
+}
+
+void testTransposeOutputLengthWithStride() {
+    // (4-1)*2 + 1*(2-1) + 0 + 1 = 8
+    kernel_t kernel = {.size = 2, .stride = 2, .dilation = 1, .paddingType = VALID};
+    TEST_ASSERT_EQUAL_size_t(8, convTranspose1dOutputLength(4, &kernel, 0));
+}
+
+void testTransposeOutputLengthWithDilation() {
+    // (4-1)*1 + 2*(3-1) + 0 + 1 = 8
+    kernel_t kernel = {.size = 3, .stride = 1, .dilation = 2, .paddingType = VALID};
+    TEST_ASSERT_EQUAL_size_t(8, convTranspose1dOutputLength(4, &kernel, 0));
+}
+
+void testTransposeOutputLengthWithOutputPadding() {
+    // (4-1)*2 + 1*(2-1) + 1 + 1 = 9
+    kernel_t kernel = {.size = 2, .stride = 2, .dilation = 1, .paddingType = VALID};
+    TEST_ASSERT_EQUAL_size_t(9, convTranspose1dOutputLength(4, &kernel, 1));
+}
+
+void testTransposeOutputLengthStrideDilationOutputPadding() {
+    // (5-1)*2 + 2*(3-1) + 1 + 1 = 14
+    kernel_t kernel = {.size = 3, .stride = 2, .dilation = 2, .paddingType = VALID};
+    TEST_ASSERT_EQUAL_size_t(14, convTranspose1dOutputLength(5, &kernel, 1));
+}
+
 void setUp() {}
 void tearDown() {}
 
@@ -231,6 +261,11 @@ int main(void) {
     RUN_TEST(testGeometryExplicitPaddingStride2);
     RUN_TEST(testGeometryExplicitPaddingOddKernelStride1MatchesSame);
     RUN_TEST(testGeometryExplicitZeroPaddingEqualsValid);
+    RUN_TEST(testTransposeOutputLengthBasic);
+    RUN_TEST(testTransposeOutputLengthWithStride);
+    RUN_TEST(testTransposeOutputLengthWithDilation);
+    RUN_TEST(testTransposeOutputLengthWithOutputPadding);
+    RUN_TEST(testTransposeOutputLengthStrideDilationOutputPadding);
     RUN_TEST(testSliceCenterFullWindow);
     RUN_TEST(testSliceLeftEdgeWithPadding);
     RUN_TEST(testSliceRightEdgeWithPadding);


### PR DESCRIPTION
Closes #233.

## What

Centralizes the transposed-conv VALID output-length formula — previously inlined in **5** sites — into a single helper, and enforces the kernel-size invariant that makes the consolidation safe.

- **Helper** (`922323b`): `convTranspose1dOutputLength(inputLength, kernel, outputPadding)` in `SlidingWindow1d`, beside its forward dual `windowGeometry1dCalc`. Pure arithmetic, reads `kernel->size`. 5 mutation-verified unit tests (stride / dilation / outputPadding, independently and combined).
- **Invariant** (`7e7dee2`): asserts `kernel->size == weight kernelSize` at init in **both** `Conv1d` and `Conv1dTransposed`. This makes a previously-unchecked assumption real, closing a latent forward-path OOB (geometry used `kernel->size` while weight-memory indexing used the weight dimension) and making `kernel->size` provably safe in the helper.
- **Refactor** (`406add8`): routes all 5 sites through the helper. Pure refactor; bit-parity unchanged.

## Verification

- Full suite **62/62 green**; clang-format-21 clean.
- Per-task spec+quality reviews clean; whole-branch review confirmed merge-ready with the cross-task safety argument verified on all reachable paths.

## Notes

- `exit(1)` assert branches are verified by code review per repo convention (Unity cannot trap `exit`).
- **Non-goals (intentional):** no `inputLength==0` underflow guard, no weight-rank check in the assert, no `windowGeometry1dCalc` rewrite; SAME/EXPLICIT transpose geometry untouched.
- Targets `develop`, so GitHub will **not** auto-close #233 on merge — close manually afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)