### PR TITLE
feat(layer): guard conv weightGrad/biasGrad against batch/outChannels mismatch (#232)

### DIFF
--- a/src/layer/Conv1d.c
+++ b/src/layer/Conv1d.c
@@ -76,6 +76,20 @@ static void conv1dCalcWeightGradsFloat32(conv1dConfig_t *cfg, tensor_t *forwardI
     size_t outChannels = lossGrad->shape->dimensions[1];
     size_t outputLength = lossGrad->shape->dimensions[2];
     size_t kernelSize = cfg->weights->param->shape->dimensions[2];
+    size_t weightOutChannels = cfg->weights->param->shape->dimensions[0];
+
+    if (batch != lossGrad->shape->dimensions[0]) {
+        PRINT_ERROR("Conv1d backward (weightGrad): lossGrad batch (%zu) does not match "
+                    "forwardInput batch (%zu)",
+                    lossGrad->shape->dimensions[0], batch);
+        exit(1);
+    }
+    if (outChannels != weightOutChannels) {
+        PRINT_ERROR("Conv1d backward (weightGrad): lossGrad outChannels (%zu) does not match "
+                    "weight Cout (%zu)",
+                    outChannels, weightOutChannels);
+        exit(1);
+    }
 
     size_t groups = cfg->groups;
     size_t inChPerGroup = inChannels / groups;
@@ -125,6 +139,14 @@ static void conv1dCalcBiasGradsFloat32(conv1dConfig_t *cfg, tensor_t *lossGrad) 
     size_t batch = lossGrad->shape->dimensions[0];
     size_t outChannels = lossGrad->shape->dimensions[1];
     size_t outputLength = lossGrad->shape->dimensions[2];
+    size_t biasOutChannels = cfg->bias->param->shape->dimensions[0];
+
+    if (outChannels != biasOutChannels) {
+        PRINT_ERROR("Conv1d backward (biasGrad): lossGrad outChannels (%zu) does not match "
+                    "bias Cout (%zu)",
+                    outChannels, biasOutChannels);
+        exit(1);
+    }
 
     float const *gyArr = (float const *)lossGrad->data;
     float *gbArr = (float *)cfg->bias->grad->data;
@@ -148,6 +170,20 @@ void conv1dCalcWeightGradsSymInt32(conv1dConfig_t *cfg, tensor_t *forwardInput,
     size_t outChannels = lossGrad->shape->dimensions[1];
     size_t outputLength = lossGrad->shape->dimensions[2];
     size_t kernelSize = cfg->weights->param->shape->dimensions[2];
+    size_t weightOutChannels = cfg->weights->param->shape->dimensions[0];
+
+    if (batch != lossGrad->shape->dimensions[0]) {
+        PRINT_ERROR("Conv1d backward (weightGrad): lossGrad batch (%zu) does not match "
+                    "forwardInput batch (%zu)",
+                    lossGrad->shape->dimensions[0], batch);
+        exit(1);
+    }
+    if (outChannels != weightOutChannels) {
+        PRINT_ERROR("Conv1d backward (weightGrad): lossGrad outChannels (%zu) does not match "
+                    "weight Cout (%zu)",
+                    outChannels, weightOutChannels);
+        exit(1);
+    }
 
     size_t groups = cfg->groups;
     size_t inChPerGroup = inChannels / groups;
@@ -220,6 +256,14 @@ void conv1dCalcBiasGradsSymInt32(conv1dConfig_t *cfg, tensor_t *lossGrad) {
     size_t batch = lossGrad->shape->dimensions[0];
     size_t outChannels = lossGrad->shape->dimensions[1];
     size_t outputLength = lossGrad->shape->dimensions[2];
+    size_t biasOutChannels = cfg->bias->param->shape->dimensions[0];
+
+    if (outChannels != biasOutChannels) {
+        PRINT_ERROR("Conv1d backward (biasGrad): lossGrad outChannels (%zu) does not match "
+                    "bias Cout (%zu)",
+                    outChannels, biasOutChannels);
+        exit(1);
+    }
 
     int32_t const *gyArr = (int32_t const *)lossGrad->data;
     tensor_t *biasGrad = cfg->bias->grad;

--- a/src/layer/Conv1dTransposed.c
+++ b/src/layer/Conv1dTransposed.c
@@ -105,6 +105,21 @@ static void conv1dTransposedCalcWeightGradsFloat32(conv1dTransposedConfig_t *cfg
     size_t inChPerGroup = inChannels / groups;
     size_t outChPerGroup = outChannels / groups;
 
+    // Conv1dTransposed weight shape [Cin, Cout/groups, K] -> Cout = dim[1] * groups.
+    size_t weightOutChannels = cfg->weights->param->shape->dimensions[1] * groups;
+    if (batch != lossGrad->shape->dimensions[0]) {
+        PRINT_ERROR("Conv1dTransposed backward (weightGrad): lossGrad batch (%zu) does not "
+                    "match forwardInput batch (%zu)",
+                    lossGrad->shape->dimensions[0], batch);
+        exit(1);
+    }
+    if (outChannels != weightOutChannels) {
+        PRINT_ERROR("Conv1dTransposed backward (weightGrad): lossGrad outChannels (%zu) does "
+                    "not match weight Cout (%zu)",
+                    outChannels, weightOutChannels);
+        exit(1);
+    }
+
     long long outputLengthSigned = (long long)outputLength;
     long long dilation = (long long)cfg->kernel->dilation;
     size_t stride = cfg->kernel->stride;
@@ -148,6 +163,14 @@ static void conv1dTransposedCalcBiasGradsFloat32(conv1dTransposedConfig_t *cfg,
     size_t outChannels = lossGrad->shape->dimensions[1];
     size_t outputLength = lossGrad->shape->dimensions[2];
 
+    size_t biasOutChannels = cfg->bias->param->shape->dimensions[0];
+    if (outChannels != biasOutChannels) {
+        PRINT_ERROR("Conv1dTransposed backward (biasGrad): lossGrad outChannels (%zu) does not "
+                    "match bias Cout (%zu)",
+                    outChannels, biasOutChannels);
+        exit(1);
+    }
+
     float const *gyArr = (float const *)lossGrad->data;
     float *gbArr = (float *)cfg->bias->grad->data;
 
@@ -183,6 +206,21 @@ void conv1dTransposedCalcWeightGradsSymInt32(conv1dTransposedConfig_t *cfg, tens
     size_t groups = cfg->groups;
     size_t inChPerGroup = inChannels / groups;
     size_t outChPerGroup = outChannels / groups;
+
+    // Conv1dTransposed weight shape [Cin, Cout/groups, K] -> Cout = dim[1] * groups.
+    size_t weightOutChannels = cfg->weights->param->shape->dimensions[1] * groups;
+    if (batch != lossGrad->shape->dimensions[0]) {
+        PRINT_ERROR("Conv1dTransposed backward (weightGrad): lossGrad batch (%zu) does not "
+                    "match forwardInput batch (%zu)",
+                    lossGrad->shape->dimensions[0], batch);
+        exit(1);
+    }
+    if (outChannels != weightOutChannels) {
+        PRINT_ERROR("Conv1dTransposed backward (weightGrad): lossGrad outChannels (%zu) does "
+                    "not match weight Cout (%zu)",
+                    outChannels, weightOutChannels);
+        exit(1);
+    }
 
     float inScale = ((symInt32QConfig_t *)forwardInput->quantization->qConfig)->scale;
     float lossScale = ((symInt32QConfig_t *)lossGrad->quantization->qConfig)->scale;
@@ -247,6 +285,14 @@ void conv1dTransposedCalcBiasGradsSymInt32(conv1dTransposedConfig_t *cfg, tensor
     size_t batch = lossGrad->shape->dimensions[0];
     size_t outChannels = lossGrad->shape->dimensions[1];
     size_t outputLength = lossGrad->shape->dimensions[2];
+
+    size_t biasOutChannels = cfg->bias->param->shape->dimensions[0];
+    if (outChannels != biasOutChannels) {
+        PRINT_ERROR("Conv1dTransposed backward (biasGrad): lossGrad outChannels (%zu) does not "
+                    "match bias Cout (%zu)",
+                    outChannels, biasOutChannels);
+        exit(1);
+    }
 
     int32_t const *gyArr = (int32_t const *)lossGrad->data;
     tensor_t *biasGrad = cfg->bias->grad;

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -1,5 +1,6 @@
 include(unit_test.cmake)
 
+add_subdirectory(support)
 add_subdirectory(arithmetic)
 add_subdirectory(common)
 add_subdirectory(csv)

--- a/test/unit/layer/CMakeLists.txt
+++ b/test/unit/layer/CMakeLists.txt
@@ -62,6 +62,7 @@ add_elastic_ai_unit_test(
         ConvTranspose1dKernel
         Kernel
         StorageApi
+        odt_test_death
 )
 add_dependencies(UnitTestConv1d generate_expected_conv1d)
 target_include_directories(UnitTestConv1d PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
@@ -134,6 +135,7 @@ add_elastic_ai_unit_test(
         ConvTranspose1dKernel
         Kernel
         StorageApi
+        odt_test_death
 )
 add_dependencies(UnitTestConv1dTransposed generate_expected_conv1d_transposed)
 target_include_directories(UnitTestConv1dTransposed PRIVATE ${CMAKE_CURRENT_BINARY_DIR})

--- a/test/unit/layer/UnitTestConv1d.c
+++ b/test/unit/layer/UnitTestConv1d.c
@@ -3,6 +3,7 @@
 #include "Conv1d.h"
 #include "Conv1dApi.h"
 #include "ConvTranspose1dKernel.h"
+#include "DeathTest.h"
 #include "Layer.h"
 #include "QuantizationApi.h"
 #include "StorageApi.h"
@@ -1186,6 +1187,175 @@ void testConv1dBackwardSymStrideDilation() {
     /* no biasGrad: bias == NULL */
 }
 
+/* ---------------------------------------------------------------------------
+ * Shape-guard death tests (#232).
+ *
+ * The weightGrad helpers stride into lossGrad by `batch` (from forwardInput) and
+ * write the weight grad by `outChannels` (from lossGrad). A mis-shaped lossGrad
+ * is therefore a latent OOB read (too-few batches) / OOB write (outChannels !=
+ * weight Cout). Each guard must fail-fast via exit(1). FLOAT helpers are static,
+ * so they are exercised through the public conv1dBackward entry point; the SYM
+ * helpers are exported and called directly. Data is all-zero — the guards read
+ * shapes only and fire before any allocation or accumulation.
+ * ------------------------------------------------------------------------- */
+
+void testConv1dWeightGradFloatRejectsBatchMismatch() {
+    size_t weightDims[] = {1, 1, 2};
+    size_t inputDims[] = {2, 1, 5}; // forward batch 2
+    size_t outputDims[] = {2, 1, 4};
+    float weightData[2] = {0};
+    float inputData[10] = {0};
+    float outBuf[8] = {0};
+    conv1dFixtureSetup_t s = {
+        .weightDims = weightDims,
+        .biasDims = NULL,
+        .inputDims = inputDims,
+        .outputDims = outputDims,
+        .hasBias = 0,
+        .kSize = 2,
+        .padding = VALID,
+        .paddingAmount = 0,
+        .dilation = 1,
+        .stride = 1,
+        .groups = 1,
+        .weightData = weightData,
+        .biasData = NULL,
+        .inputData = inputData,
+    };
+    conv1dRunResult_t r = conv1dRunForward(s, outBuf);
+
+    size_t lossDims[] = {1, 1, 4}; // lossGrad batch 1 != forward batch 2
+    float lossData[4] = {0};
+    tensor_t *lossGrad = tensorInitFloat(lossData, lossDims, 3, NULL);
+    size_t propDims[] = {2, 1, 5};
+    float propBuf[10] = {0};
+    tensor_t *propLoss = tensorInitFloat(propBuf, propDims, 3, NULL);
+
+    ASSERT_EXITS_WITH_FAILURE(conv1dBackward(r.layer, r.input, lossGrad, propLoss));
+}
+
+void testConv1dWeightGradFloatRejectsOutChannelMismatch() {
+    size_t weightDims[] = {1, 1, 2}; // weight Cout = 1
+    size_t inputDims[] = {1, 1, 5};
+    size_t outputDims[] = {1, 1, 4};
+    float weightData[2] = {0};
+    float inputData[5] = {0};
+    float outBuf[4] = {0};
+    conv1dFixtureSetup_t s = {
+        .weightDims = weightDims,
+        .biasDims = NULL,
+        .inputDims = inputDims,
+        .outputDims = outputDims,
+        .hasBias = 0,
+        .kSize = 2,
+        .padding = VALID,
+        .paddingAmount = 0,
+        .dilation = 1,
+        .stride = 1,
+        .groups = 1,
+        .weightData = weightData,
+        .biasData = NULL,
+        .inputData = inputData,
+    };
+    conv1dRunResult_t r = conv1dRunForward(s, outBuf);
+
+    size_t lossDims[] = {1, 3, 4}; // outChannels 3 != weight Cout 1
+    float lossData[12] = {0};
+    tensor_t *lossGrad = tensorInitFloat(lossData, lossDims, 3, NULL);
+    size_t propDims[] = {1, 1, 5};
+    float propBuf[5] = {0};
+    tensor_t *propLoss = tensorInitFloat(propBuf, propDims, 3, NULL);
+
+    ASSERT_EXITS_WITH_FAILURE(conv1dBackward(r.layer, r.input, lossGrad, propLoss));
+}
+
+void testConv1dWeightGradSymRejectsBatchMismatch() {
+    size_t weightDims[] = {8, 2, 2};
+    size_t inputDims[] = {2, 4, 5}; // forward batch 2
+    size_t lossDims[] = {1, 8, 4};  // lossGrad batch 1 != forward batch 2
+
+    parameter_t *weights = buildSymParam(3, weightDims, NULL);
+    tensor_t *input = buildSymTensor(3, inputDims, NULL);
+    tensor_t *lossGrad = buildSymTensor(3, lossDims, NULL);
+
+    kernel_t kernel;
+    initKernel(&kernel, 2, VALID, 1, 1);
+    conv1dConfig_t cfg;
+    quantization_t *sq = quantizationInitSymInt32(HALF_AWAY);
+    initConv1dConfigWithWeightsAndBias(&cfg, &kernel, weights, NULL, 2, sq, sq, sq, sq);
+
+    ASSERT_EXITS_WITH_FAILURE(conv1dCalcWeightGradsSymInt32(&cfg, input, lossGrad));
+}
+
+void testConv1dWeightGradSymRejectsOutChannelMismatch() {
+    size_t weightDims[] = {8, 2, 2}; // weight Cout = 8
+    size_t inputDims[] = {1, 4, 5};
+    size_t lossDims[] = {1, 10, 4}; // outChannels 10 != weight Cout 8
+
+    parameter_t *weights = buildSymParam(3, weightDims, NULL);
+    tensor_t *input = buildSymTensor(3, inputDims, NULL);
+    tensor_t *lossGrad = buildSymTensor(3, lossDims, NULL);
+
+    kernel_t kernel;
+    initKernel(&kernel, 2, VALID, 1, 1);
+    conv1dConfig_t cfg;
+    quantization_t *sq = quantizationInitSymInt32(HALF_AWAY);
+    initConv1dConfigWithWeightsAndBias(&cfg, &kernel, weights, NULL, 2, sq, sq, sq, sq);
+
+    ASSERT_EXITS_WITH_FAILURE(conv1dCalcWeightGradsSymInt32(&cfg, input, lossGrad));
+}
+
+void testConv1dBiasGradFloatRejectsOutChannelMismatch() {
+    /* weight Cout == lossGrad outChannels so the weightGrad guard passes; bias
+     * Cout differs, so the biasGrad guard must fire. The layer is intentionally
+     * inconsistent, so forward is skipped (it would OOB-read bias in the parent);
+     * the layer is built directly and only backward is exercised, in the child. */
+    size_t weightDims[] = {2, 1, 2}; // weight Cout = 2
+    size_t biasDims[] = {1};         // bias Cout = 1 (intentionally inconsistent)
+    size_t inputDims[] = {1, 1, 5};
+    float weightData[4] = {0};
+    float biasData[1] = {0};
+    float inputData[5] = {0};
+
+    tensor_t *weightParam = tensorInitFloat(weightData, weightDims, 3, NULL);
+    parameter_t *weights = parameterInit(weightParam, gradInitFloat(weightParam, NULL));
+    tensor_t *biasParam = tensorInitFloat(biasData, biasDims, 1, NULL);
+    parameter_t *bias = parameterInit(biasParam, gradInitFloat(biasParam, NULL));
+
+    kernel_t kernel;
+    initKernel(&kernel, 2, VALID, 1, 1);
+    quantization_t *q = quantizationInitFloat();
+    layer_t *layer = conv1dLayerInitLegacy(weights, bias, &kernel, q, q, q, q);
+
+    tensor_t *input = tensorInitFloat(inputData, inputDims, 3, NULL);
+    size_t lossDims[] = {1, 2, 4}; // outChannels 2 == weight Cout, != bias Cout 1
+    float lossData[8] = {0};
+    tensor_t *lossGrad = tensorInitFloat(lossData, lossDims, 3, NULL);
+    size_t propDims[] = {1, 1, 5};
+    float propBuf[5] = {0};
+    tensor_t *propLoss = tensorInitFloat(propBuf, propDims, 3, NULL);
+
+    ASSERT_EXITS_WITH_FAILURE(conv1dBackward(layer, input, lossGrad, propLoss));
+}
+
+void testConv1dBiasGradSymRejectsOutChannelMismatch() {
+    size_t weightDims[] = {3, 1, 1}; // K=1 to satisfy the config kernel-size check
+    size_t biasDims[] = {1};         // bias Cout = 1
+    size_t lossDims[] = {1, 3, 4};   // outChannels 3 != bias Cout 1
+
+    parameter_t *weights = buildSymParam(3, weightDims, NULL);
+    parameter_t *bias = buildSymParam(1, biasDims, NULL);
+    tensor_t *lossGrad = buildSymTensor(3, lossDims, NULL);
+
+    kernel_t kernel;
+    initKernel(&kernel, 1, VALID, 1, 1);
+    conv1dConfig_t cfg;
+    quantization_t *sq = quantizationInitSymInt32(HALF_AWAY);
+    initConv1dConfigWithWeightsAndBias(&cfg, &kernel, weights, bias, 1, sq, sq, sq, sq);
+
+    ASSERT_EXITS_WITH_FAILURE(conv1dCalcBiasGradsSymInt32(&cfg, lossGrad));
+}
+
 void setUp() {}
 void tearDown() {}
 
@@ -1219,5 +1389,11 @@ int main() {
     RUN_TEST(testConv1dBackwardSymExplicitPadding);
     RUN_TEST(testConv1dBackwardSymGroupsGrouped);
     RUN_TEST(testConv1dBackwardSymStrideDilation);
+    RUN_TEST(testConv1dWeightGradFloatRejectsBatchMismatch);
+    RUN_TEST(testConv1dWeightGradFloatRejectsOutChannelMismatch);
+    RUN_TEST(testConv1dWeightGradSymRejectsBatchMismatch);
+    RUN_TEST(testConv1dWeightGradSymRejectsOutChannelMismatch);
+    RUN_TEST(testConv1dBiasGradFloatRejectsOutChannelMismatch);
+    RUN_TEST(testConv1dBiasGradSymRejectsOutChannelMismatch);
     return UNITY_END();
 }

--- a/test/unit/layer/UnitTestConv1dTransposed.c
+++ b/test/unit/layer/UnitTestConv1dTransposed.c
@@ -2,6 +2,7 @@
 
 #include "Conv1dTransposed.h"
 #include "ConvTranspose1dKernel.h"
+#include "DeathTest.h"
 #include "Layer.h"
 #include "QuantizationApi.h"
 #include "StorageApi.h"
@@ -839,6 +840,144 @@ void testConv1dTransposedBackwardSymDilation2() {
     /* no biasGrad: bias == NULL */
 }
 
+/* ---------------------------------------------------------------------------
+ * Shape-guard death tests (#232).
+ *
+ * Conv1dTransposed weight layout is [Cin, Cout/groups, K], so weight Cout is
+ * dimensions[1] * groups (mirror image of Conv1d). The weightGrad helpers stride
+ * lossGrad by `batch` (from forwardInput) and write the weight grad by
+ * `outChannels` (from lossGrad); the biasGrad helpers write the bias grad by
+ * `outChannels`. Each guard must fail-fast via exit(1). FLOAT helpers are static
+ * and exercised through conv1dTransposedBackward; SYM helpers are called
+ * directly. Data is all-zero — guards read shapes only. convT1dBuild does not
+ * run forward, so intentionally inconsistent layers are safe to build here.
+ * ------------------------------------------------------------------------- */
+
+void testConv1dTransposedWeightGradFloatRejectsBatchMismatch() {
+    size_t weightDims[] = {1, 1, 2}; // [Cin=1, Cout/groups=1, K=2], groups=1 -> Cout=1
+    size_t inputDims[] = {2, 1, 3};  // forward batch 2
+    size_t outputDims[] = {2, 1, 4};
+    float weightData[2] = {0};
+    float inputData[6] = {0};
+    float outBuf[8] = {0};
+    convT1dRunResult_t r;
+    convT1dBuild(&r, weightData, weightDims, NULL, NULL, 0, inputData, inputDims, 2, 1, 1, 1, 0,
+                 outBuf, outputDims);
+
+    size_t lossDims[] = {1, 1, 4}; // lossGrad batch 1 != forward batch 2
+    float lossData[4] = {0};
+    tensor_t *lossGrad = tensorInitFloat(lossData, lossDims, 3, NULL);
+    size_t propDims[] = {2, 1, 3};
+    float propBuf[6] = {0};
+    tensor_t *propLoss = tensorInitFloat(propBuf, propDims, 3, NULL);
+
+    ASSERT_EXITS_WITH_FAILURE(conv1dTransposedBackward(&r.layer, r.input, lossGrad, propLoss));
+}
+
+void testConv1dTransposedWeightGradFloatRejectsOutChannelMismatch() {
+    size_t weightDims[] = {1, 1, 2}; // weight Cout = 1
+    size_t inputDims[] = {1, 1, 3};
+    size_t outputDims[] = {1, 1, 4};
+    float weightData[2] = {0};
+    float inputData[3] = {0};
+    float outBuf[4] = {0};
+    convT1dRunResult_t r;
+    convT1dBuild(&r, weightData, weightDims, NULL, NULL, 0, inputData, inputDims, 2, 1, 1, 1, 0,
+                 outBuf, outputDims);
+
+    size_t lossDims[] = {1, 3, 4}; // outChannels 3 != weight Cout 1
+    float lossData[12] = {0};
+    tensor_t *lossGrad = tensorInitFloat(lossData, lossDims, 3, NULL);
+    size_t propDims[] = {1, 1, 3};
+    float propBuf[3] = {0};
+    tensor_t *propLoss = tensorInitFloat(propBuf, propDims, 3, NULL);
+
+    ASSERT_EXITS_WITH_FAILURE(conv1dTransposedBackward(&r.layer, r.input, lossGrad, propLoss));
+}
+
+void testConv1dTransposedWeightGradSymRejectsBatchMismatch() {
+    size_t weightDims[] = {4, 4, 2}; // [Cin=4, Cout/groups=4, K=2], groups=2 -> Cout=8
+    size_t inputDims[] = {2, 4, 4};  // forward batch 2
+    size_t lossDims[] = {1, 8, 5};   // lossGrad batch 1 != forward batch 2
+
+    parameter_t *weights = buildSymParam(3, weightDims, NULL);
+    tensor_t *input = buildSymTensor(3, inputDims, NULL);
+    tensor_t *lossGrad = buildSymTensor(3, lossDims, NULL);
+
+    kernel_t kernel;
+    initKernel(&kernel, 2, VALID, 1, 1);
+    conv1dTransposedConfig_t cfg;
+    quantization_t *sq = quantizationInitSymInt32(HALF_AWAY);
+    initConv1dTransposedConfigWithWeightsAndBias(&cfg, &kernel, weights, NULL, 2, 0, sq, sq, sq,
+                                                 sq);
+
+    ASSERT_EXITS_WITH_FAILURE(conv1dTransposedCalcWeightGradsSymInt32(&cfg, input, lossGrad));
+}
+
+void testConv1dTransposedWeightGradSymRejectsOutChannelMismatch() {
+    size_t weightDims[] = {4, 4, 2}; // groups=2 -> weight Cout = 8
+    size_t inputDims[] = {1, 4, 4};
+    size_t lossDims[] = {1, 10, 5}; // outChannels 10 != weight Cout 8
+
+    parameter_t *weights = buildSymParam(3, weightDims, NULL);
+    tensor_t *input = buildSymTensor(3, inputDims, NULL);
+    tensor_t *lossGrad = buildSymTensor(3, lossDims, NULL);
+
+    kernel_t kernel;
+    initKernel(&kernel, 2, VALID, 1, 1);
+    conv1dTransposedConfig_t cfg;
+    quantization_t *sq = quantizationInitSymInt32(HALF_AWAY);
+    initConv1dTransposedConfigWithWeightsAndBias(&cfg, &kernel, weights, NULL, 2, 0, sq, sq, sq,
+                                                 sq);
+
+    ASSERT_EXITS_WITH_FAILURE(conv1dTransposedCalcWeightGradsSymInt32(&cfg, input, lossGrad));
+}
+
+void testConv1dTransposedBiasGradFloatRejectsOutChannelMismatch() {
+    /* weight Cout == lossGrad outChannels so weightGrad passes; bias Cout differs
+     * so the biasGrad guard must fire. convT1dBuild runs no forward, so the
+     * inconsistent layer is safe; only backward runs, in the child. */
+    size_t weightDims[] = {1, 2, 2}; // [Cin=1, Cout/groups=2, K=2], groups=1 -> Cout=2
+    size_t biasDims[] = {1};         // bias Cout = 1 (intentionally inconsistent)
+    size_t inputDims[] = {1, 1, 3};
+    float weightData[4] = {0};
+    float biasData[1] = {0};
+    float inputData[3] = {0};
+    float outBuf[8] = {0};
+    size_t outputDims[] = {1, 2, 4};
+    convT1dRunResult_t r;
+    convT1dBuild(&r, weightData, weightDims, biasData, biasDims, 1, inputData, inputDims, 2, 1, 1,
+                 1, 0, outBuf, outputDims);
+
+    size_t lossDims[] = {1, 2, 4}; // outChannels 2 == weight Cout, != bias Cout 1
+    float lossData[8] = {0};
+    tensor_t *lossGrad = tensorInitFloat(lossData, lossDims, 3, NULL);
+    size_t propDims[] = {1, 1, 3};
+    float propBuf[3] = {0};
+    tensor_t *propLoss = tensorInitFloat(propBuf, propDims, 3, NULL);
+
+    ASSERT_EXITS_WITH_FAILURE(conv1dTransposedBackward(&r.layer, r.input, lossGrad, propLoss));
+}
+
+void testConv1dTransposedBiasGradSymRejectsOutChannelMismatch() {
+    size_t weightDims[] = {3, 2, 2}; // K=2 satisfies the config kernel-size check
+    size_t biasDims[] = {1};         // bias Cout = 1
+    size_t lossDims[] = {1, 3, 5};   // outChannels 3 != bias Cout 1
+
+    parameter_t *weights = buildSymParam(3, weightDims, NULL);
+    parameter_t *bias = buildSymParam(1, biasDims, NULL);
+    tensor_t *lossGrad = buildSymTensor(3, lossDims, NULL);
+
+    kernel_t kernel;
+    initKernel(&kernel, 2, VALID, 1, 1);
+    conv1dTransposedConfig_t cfg;
+    quantization_t *sq = quantizationInitSymInt32(HALF_AWAY);
+    initConv1dTransposedConfigWithWeightsAndBias(&cfg, &kernel, weights, bias, 1, 0, sq, sq, sq,
+                                                 sq);
+
+    ASSERT_EXITS_WITH_FAILURE(conv1dTransposedCalcBiasGradsSymInt32(&cfg, lossGrad));
+}
+
 void setUp() {}
 void tearDown() {}
 
@@ -867,5 +1006,11 @@ int main() {
     RUN_TEST(testConv1dTransposedBackwardSymStride2OutputPadding);
     RUN_TEST(testConv1dTransposedBackwardSymGroupsGrouped);
     RUN_TEST(testConv1dTransposedBackwardSymDilation2);
+    RUN_TEST(testConv1dTransposedWeightGradFloatRejectsBatchMismatch);
+    RUN_TEST(testConv1dTransposedWeightGradFloatRejectsOutChannelMismatch);
+    RUN_TEST(testConv1dTransposedWeightGradSymRejectsBatchMismatch);
+    RUN_TEST(testConv1dTransposedWeightGradSymRejectsOutChannelMismatch);
+    RUN_TEST(testConv1dTransposedBiasGradFloatRejectsOutChannelMismatch);
+    RUN_TEST(testConv1dTransposedBiasGradSymRejectsOutChannelMismatch);
     return UNITY_END();
 }

--- a/test/unit/support/CMakeLists.txt
+++ b/test/unit/support/CMakeLists.txt
@@ -1,0 +1,8 @@
+# Header-only test-support utilities shared across unit-test modules.
+#
+# An INTERFACE library carries no compiled sources: linking it only propagates
+# its INTERFACE_INCLUDE_DIRECTORIES to the consumer. A test target that lists
+# `odt_test_death` in MORE_LIBS can therefore `#include "DeathTest.h"` without
+# any per-target include plumbing.
+add_library(odt_test_death INTERFACE)
+target_include_directories(odt_test_death INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)

--- a/test/unit/support/include/DeathTest.h
+++ b/test/unit/support/include/DeathTest.h
@@ -1,0 +1,54 @@
+#ifndef ODT_TEST_DEATH_TEST_H
+#define ODT_TEST_DEATH_TEST_H
+
+/*
+ * Fork-based death-test harness.
+ *
+ * Asserts that a statement terminates the process via exit(<code>) - the idiom
+ * the framework uses for fail-fast guards (PRINT_ERROR(...); exit(1)). The
+ * statement runs in a forked child so a *missing* guard, which may dereference
+ * out of bounds and crash, cannot take down the parent test process: the parent
+ * only inspects the child's exit status.
+ *
+ * Host-only: relies on POSIX fork()/waitpid(). ODT unit tests run on the host
+ * (Linux CI / macOS dev), never on the MCU, so this is always available here.
+ *
+ * Outcomes inspected by the parent:
+ *   - child called exit(code)        -> WIFEXITED && WEXITSTATUS == code  (pass)
+ *   - statement returned (no exit)   -> child _exit(0): code mismatch     (fail)
+ *   - child died by signal (SIGSEGV) -> !WIFEXITED: clear failure message (fail)
+ */
+
+#include <stdio.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "unity.h"
+
+#define ASSERT_EXITS_WITH(expectedCode, statement)                                                 \
+    do {                                                                                           \
+        fflush(stdout);                                                                            \
+        fflush(stderr);                                                                            \
+        pid_t _odtDeathPid = fork();                                                               \
+        TEST_ASSERT_MESSAGE(_odtDeathPid >= 0, "fork() failed in death test");                     \
+        if (_odtDeathPid == 0) {                                                                   \
+            /* Child: silence the guard's PRINT_ERROR banner, run, and - if the                    \
+             * statement does NOT exit - report "no death" via exit code 0. */                     \
+            (void)freopen("/dev/null", "w", stdout);                                               \
+            (void)freopen("/dev/null", "w", stderr);                                               \
+            statement;                                                                             \
+            _exit(0);                                                                              \
+        }                                                                                          \
+        int _odtDeathStatus = 0;                                                                   \
+        (void)waitpid(_odtDeathPid, &_odtDeathStatus, 0);                                          \
+        TEST_ASSERT_TRUE_MESSAGE(WIFEXITED(_odtDeathStatus),                                       \
+                                 "death-test child terminated by signal, expected exit()");        \
+        TEST_ASSERT_EQUAL_INT_MESSAGE((expectedCode), WEXITSTATUS(_odtDeathStatus),                \
+                                      "death-test child exit code mismatch");                      \
+    } while (0)
+
+/* Convenience for the framework's fail-fast convention (exit(1)). */
+#define ASSERT_EXITS_WITH_FAILURE(statement) ASSERT_EXITS_WITH(1, statement)
+
+#endif /* ODT_TEST_DEATH_TEST_H */


### PR DESCRIPTION
## What

Follow-up to #230 / #231. The conv **weightGrad** helpers validated only the `lossGrad` length dimension against the forward geometry, leaving `batch` (`dim[0]`) and `outChannels` (`dim[1]`) unchecked — both latent out-of-bounds hazards:

- `batch` is read from `forwardInput` but strides into `lossGrad` → **OOB read** when `lossGrad` has fewer batches.
- `outChannels` is read from `lossGrad` but strides the weight-grad **write** index → **OOB write** when it disagrees with the weight tensor's `Cout`.

On benign data these surface as *silently wrong gradients*. This converts both into fail-fast, matching the #230/#231 philosophy.

## Changes

**Guards (before the accumulation loop, mirroring the existing `PRINT_ERROR(...); exit(1)` / `%zu` style):**

| Helper set | Guard added |
|---|---|
| 4× weightGrad (Conv1d + ConvT, FLOAT32 + SYM_INT32) | `batch == forwardInput.dim[0] == lossGrad.dim[0]` and `outChannels == lossGrad.dim[1] == weight Cout` |
| 4× biasGrad (the folded-in extension from #232's note) | `outChannels == bias Cout` |

`Cout` per layout: **Conv1d** `weight dim[0]`; **Conv1dTransposed** `weight dim[1] * groups` (mirror-image layouts). Guards in the SYM helpers fire **before** `reserveMemory`, so the error path neither allocates nor leaks.

**Test infrastructure:** the repo had no death-test harness, so this adds a reusable fork-based one — `test/unit/support/include/DeathTest.h` (`ASSERT_EXITS_WITH[_FAILURE]`) wired in via a header-only INTERFACE CMake library `odt_test_death`. A statement runs in a forked child so a *missing* guard (which may OOB-crash) can't take down the parent; the parent asserts on the child's exit status.

**12 death tests** (6 per layer) — each watched fail (RED) before its guard existed, then pass (GREEN).

## Verification

- `ctest` **62/62** pass on `unit_test_debug` and `unit_test`; existing fixtures unaffected (no false-positive).
- `clang-format` clean; allocation-locality gate clean (no `malloc/calloc/free` added).
- ASan/UBSan job: guards fire before any OOB/alloc and the asan preset sets `detect_leaks=0`, so the fork+`exit(1)` death tests are safe under the Linux ASan CI (not runnable on the macOS dev host).
- Adversarial multi-agent review (5 dimensions): 0/9 findings confirmed.

Closes #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)