### PR TITLE
build(cmake): suppress benign duplicate-library link warning on Apple ld-prime

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,18 @@ if(ODT_TOP_LEVEL_PROJECT)
         set(ODT_PATH ${CMAKE_CURRENT_LIST_DIR})
     endif()
 
+    # Apple's ld-prime (multi-pass) warns "ignoring duplicate libraries" on the
+    # repeated static archives CMake emits so single-pass GNU ld can resolve the
+    # framework's circular static-lib deps (see #234). The repeats are required
+    # on the Linux CI linker and benign on macOS — silence the noise where the
+    # linker supports the flag. Feature-detected, so arm-gcc / GNU ld (which do
+    # not know the flag, and where the repeats are needed) are left untouched.
+    include(CheckLinkerFlag)
+    check_linker_flag(C "-Wl,-no_warn_duplicate_libraries" ODT_LD_HAS_NO_WARN_DUP_LIBS)
+    if(ODT_LD_HAS_NO_WARN_DUP_LIBS)
+        add_link_options("-Wl,-no_warn_duplicate_libraries")
+    endif()
+
     add_unity()
     add_ctest()
 


### PR DESCRIPTION
## Summary

Silences the `ld: warning: ignoring duplicate libraries` flood on macOS unit-test links (**59 → 0** per full clean build).

## Root cause

Not the hand-maintained `MORE_LIBS` lists — it's **CMake's strongly-connected-component repetition** for the framework's *circular* static-lib deps (the C-vtable dispatcher pattern): `Arithmetic`↔`Add`/`Sub`/`Mul`/`Div`, `Layer`↔`Linear`/`Relu`/`Conv1d`/…, `Tensor`↔`DataStorage`↔`MinMax`. CMake repeats each SCC on the link line (every cyclic archive appears exactly 2×) so single-pass GNU `ld` (Linux CI) can resolve back-references. macOS `ld-prime` is multi-pass, doesn't need the repeats, and warns.

The repeats are **required** on the Linux linker, so removing them is not an option — the right fix is to silence the benign warning on the linker that emits it.

## Change

A feature-detected linker flag in the root `CMakeLists.txt` (inside `if(ODT_TOP_LEVEL_PROJECT)`):

```cmake
include(CheckLinkerFlag)
check_linker_flag(C "-Wl,-no_warn_duplicate_libraries" ODT_LD_HAS_NO_WARN_DUP_LIBS)
if(ODT_LD_HAS_NO_WARN_DUP_LIBS)
    add_link_options("-Wl,-no_warn_duplicate_libraries")
endif()
```

- **Self-scoping:** arm-gcc / GNU ld fail the `check_linker_flag` probe (unknown option) → the flag is never added there, and the needed repeats stay intact.
- **Keeps the safety net:** only the duplicate-*library* warning is silenced; duplicate-*symbol* problems remain hard errors.

## Verification

- Full clean build (`unit_test_debug`): **59 → 0** `ignoring duplicate` warnings.
- `ctest --preset unit_test_debug`: **62/62** pass.
- `uv run pytest python/tests/`: **22/22** pass.

## Follow-up

The structural root cause (circular micro-libraries) is tracked separately in #238 — consolidating each cyclic cluster into one archive per `src/` subdir would remove the duplication at the source on all platforms. Low priority, crosses ownership.

Closes #234

🤖 Generated with [Claude Code](https://claude.com/claude-code)