### PR TITLE
feat(#227): SYM int12 operand contract (Part 1/3)

### DIFF
--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -470,6 +470,10 @@ only the quantization configs change; the int32 accumulator (no int64) is kept.
 - Note: the conv weightGrad product mixes an int12 input with an int16 grad
   operand under the #218 grad-accumulator scheme — its budget is governed by
   #218/#45, not closed by this operand flip.
+- The unit-test gold suite validates the **default** int12/int16 contract
+  (`ODT_SYM_OPERAND_QMAXBITS=12`, `ODT_SYM_GRAD_QMAXBITS=16`); building with a
+  knob override (e.g. `-DODT_SYM_OPERAND_QMAXBITS=8`) diverges from those gold
+  fixtures, which is expected and intentional.
 
 The training loop (`CalculateGradsSequential.c`) allocates grad/activation
 tensors from the **forward** qConfig, not the backward qConfigs — so a full-SYM

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -430,11 +430,15 @@ int64 — hard rule). For symmetric `b`-bit operands each product is ≤ 2^(2b�
 so an int32 accumulator (~2^31) holds only ~2^(33−2b) worst-case product terms
 before signed overflow (UB):
 
-| operand width | max product | int32 product-terms before overflow |
+| operand width | max product | int32 term at which overflow first occurs |
 |---|---|---|
 | int16 (qMaxBits=16) | 2^30 | 2 |
 | int12 (qMaxBits=12) | 2^22 | 512 |
 | int8  (qMaxBits=8)  | 2^14 | 131072 |
+
+The number of worst-case terms that still **fit** is one less: int16 survives 1,
+int12 survives **511**, int8 survives 131071 — i.e. int12 is sound for reductions
+of length **N ≤ 511** (`512·2^22 = 2^31 > INT32_MAX`).
 
 int16×int16→int32 is **unsound for product-accumulation** (forward, dx,
 weightGrad) — it overflows after ~2 full-scale terms; it is sound only for
@@ -446,11 +450,26 @@ TFLite. The **grad accumulators stay int16** (wider accumulator, free since SYM
 stores int32 regardless of qMaxBits). The **kernels are bit-width-agnostic** —
 only the quantization configs change; the int32 accumulator (no int64) is kept.
 
-> **Framework-wide follow-up:** Linear's `matmulIntCore` and LayerNorm accumulate
-> int16 products in int32 with the identical 2-term ceiling and have not yet moved
-> to int12 — tracked in a follow-up issue. The #189 policy (release runs free, CI
-> UBSan #204 traps occurrences) backstops any residual overflow beyond int12's
-> headroom.
+**Realized framework-wide int12 contract (PR-A, #227):**
+
+- The SYM_INT32 **operand** default is int12 via the compile-time knob
+  `ODT_SYM_OPERAND_QMAXBITS` (=12), set in `initSymInt32QConfig`
+  (`src/tensor/include/Quantization.h`). Override per-build with
+  `-DODT_SYM_OPERAND_QMAXBITS=N` (e.g. =8 for layers wider than 511).
+- `matmulIntCore` (Linear forward / propLoss / weightGrad) and the LayerNorm
+  **affine product** now run on int12 operands, enforced by op-entry guards
+  (`matmulValidateSymOperand` at both Matmul SYM entries;
+  `layerNormValidateSymTensor` lowered to the knob). LayerNorm's per-group
+  mantissa-sum is a value-sum and stays sound at any qMaxBits ≤ 16.
+- **Grad accumulators stay int16** via `ODT_SYM_GRAD_QMAXBITS` (=16), pinned
+  in `gradInitSymInt32` (`getQLike` preserves the source width). They are
+  value-sums; wider is free.
+- int12 is sound only for reductions **N ≤ 511**; the runtime N-vs-budget check
+  is a deferred follow-up. The #189 policy (release runs free, CI UBSan #204)
+  backstops residual overflow.
+- Note: the conv weightGrad product mixes an int12 input with an int16 grad
+  operand under the #218 grad-accumulator scheme — its budget is governed by
+  #218/#45, not closed by this operand flip.
 
 The training loop (`CalculateGradsSequential.c`) allocates grad/activation
 tensors from the **forward** qConfig, not the backward qConfigs — so a full-SYM

--- a/src/arithmetic/Matmul.c
+++ b/src/arithmetic/Matmul.c
@@ -231,12 +231,30 @@ void matmulSymIntTensorsWithInstructionCounter(tensor_t *aTensor, tensor_t *bTen
     ++matmulInstructionCounter;
 }
 
+static void matmulValidateSymOperand(tensor_t *t, const char *what) {
+    if (t->quantization->type != SYM_INT32) {
+        PRINT_ERROR("matmul SYM_INT32: %s must be SYM_INT32", what);
+        exit(1);
+    }
+    symInt32QConfig_t *qc = t->quantization->qConfig;
+    if (qc->qMaxBits > ODT_SYM_OPERAND_QMAXBITS) {
+        PRINT_ERROR("matmul SYM_INT32: %s qMaxBits (%u) exceeds operand contract (%u) — int32 "
+                    "product accumulation would overflow (#227)",
+                    what, (unsigned)qc->qMaxBits, (unsigned)ODT_SYM_OPERAND_QMAXBITS);
+        exit(1);
+    }
+}
+
 void matmulSymInt32Tensors(tensor_t *aTensor, tensor_t *bTensor, tensor_t *outputTensor) {
+    matmulValidateSymOperand(aTensor, "aTensor");
+    matmulValidateSymOperand(bTensor, "bTensor");
     MATMUL_FUNC_SYM_INT32(aTensor, bTensor, outputTensor);
 }
 
 void matmulSymInt32TensorsWithBias(tensor_t *aTensor, tensor_t *bTensor, tensor_t *outputTensor,
                                    tensor_t *bias) {
+    matmulValidateSymOperand(aTensor, "aTensor");
+    matmulValidateSymOperand(bTensor, "bTensor");
     if (bias == NULL) {
         matmulIntCore(aTensor, bTensor, outputTensor, NULL);
     } else {

--- a/src/layer/LayerNorm.c
+++ b/src/layer/LayerNorm.c
@@ -196,7 +196,7 @@ static void layerNormGroupStatsSymInt32(tensor_t *t, size_t numNormDims, size_t 
  *            -DODT_SEED_GUARD) outside the safe envelope instead of casting an
  *            out-of-range float to int32 (UB). Spec errata: "int32 is safe
  *            throughout" holds only while the rescaled seed leaves one worst-case
- *            int16xint16 product (32768*32767) of int32 headroom for the
+ *            int12xint12 product (2047*2047 ≈ 4.2e6, #227) of int32 headroom for the
  *            gamma-product, i.e. |beta| <~ absmax_n * absmax_gamma.)
  * gamma/beta are contiguous default-order rank-D tensors -> flat index j. */
 static void layerNormAffineSymInt32(layerNormConfig_t *cfg, tensor_t *output, float sNorm) {

--- a/src/layer/LayerNorm.c
+++ b/src/layer/LayerNorm.c
@@ -118,21 +118,35 @@ static void layerNormGroupStats(tensor_t *t, size_t numNormDims, size_t g, size_
 }
 
 /* The SYM_INT32 path reinterprets tensor data as int32 mantissas; a FLOAT32
- * buffer read that way is silent garbage, so fail fast. qMaxBits > 16 would
- * break two int32 bounds: the per-group mantissa-sum accumulator and the
- * affine product q*gamma_q <= qMax^2 (spec: int64 is NOT used). NOTE: the
- * guard can only check the config — int16-range mantissas are the SYM_INT32
- * input CONTRACT; upstream ops must deliver requantized mantissas — an open
- * inter-layer requantization question for the quantized-training epic (#137). */
+ * buffer read that way is silent garbage, so fail fast. The int12 bound
+ * (ODT_SYM_OPERAND_QMAXBITS) is required by the affine product q*gamma_q
+ * (out[off]*gammaQ[j]); the per-group mantissa-SUM is a value-sum and is
+ * sound at any qMaxBits <= 16. (#227) */
 static void layerNormValidateSymTensor(tensor_t *t, const char *what) {
     if (t->quantization->type != SYM_INT32) {
         PRINT_ERROR("LayerNorm SYM_INT32: %s must be SYM_INT32", what);
         exit(1);
     }
     symInt32QConfig_t *qc = t->quantization->qConfig;
-    if (qc->qMaxBits > 16) {
-        PRINT_ERROR("LayerNorm SYM_INT32: %s qMaxBits (%u) exceeds 16", what,
-                    (unsigned)qc->qMaxBits);
+    if (qc->qMaxBits > ODT_SYM_OPERAND_QMAXBITS) {
+        PRINT_ERROR("LayerNorm SYM_INT32: %s qMaxBits (%u) exceeds operand contract (%u)", what,
+                    (unsigned)qc->qMaxBits, (unsigned)ODT_SYM_OPERAND_QMAXBITS);
+        exit(1);
+    }
+}
+
+/* Grad tensors accumulate via addSymInt32TensorsInplace (no multiply) so they
+ * may be as wide as ODT_SYM_GRAD_QMAXBITS (16). Only the SYM_INT32 type is
+ * required; the width guard is intentionally looser than the operand contract. */
+static void layerNormValidateSymGrad(tensor_t *t, const char *what) {
+    if (t->quantization->type != SYM_INT32) {
+        PRINT_ERROR("LayerNorm SYM_INT32: %s must be SYM_INT32", what);
+        exit(1);
+    }
+    symInt32QConfig_t *qc = t->quantization->qConfig;
+    if (qc->qMaxBits > ODT_SYM_GRAD_QMAXBITS) {
+        PRINT_ERROR("LayerNorm SYM_INT32: %s qMaxBits (%u) exceeds grad contract (%u)", what,
+                    (unsigned)qc->qMaxBits, (unsigned)ODT_SYM_GRAD_QMAXBITS);
         exit(1);
     }
 }
@@ -466,8 +480,8 @@ static void layerNormBackwardSymInt32(layerNormConfig_t *cfg, tensor_t *forwardI
     layerNormValidateSymTensor(loss, "loss");
     layerNormValidateSymTensor(propLoss, "propLoss");
     layerNormValidateSymTensor(cfg->gamma->param, "gamma");
-    layerNormValidateSymTensor(cfg->gamma->grad, "gamma grad");
-    layerNormValidateSymTensor(cfg->beta->grad, "beta grad");
+    layerNormValidateSymGrad(cfg->gamma->grad, "gamma grad");
+    layerNormValidateSymGrad(cfg->beta->grad, "beta grad");
     /* beta->param is never read here (beta does not enter dx; dbeta needs only
      * dy) — deliberately not validated. */
 

--- a/src/tensor/Quantization.c
+++ b/src/tensor/Quantization.c
@@ -9,7 +9,7 @@
 void initSymInt32QConfig(roundingMode_t roundingMode, symInt32QConfig_t *symInt32QConfig) {
     symInt32QConfig->roundingMode = roundingMode;
     symInt32QConfig->scale = 1.f;
-    symInt32QConfig->qMaxBits = 16;
+    symInt32QConfig->qMaxBits = ODT_SYM_OPERAND_QMAXBITS; /* was 16 — #227 int12 operands */
 }
 
 void initSymInt32QConfigWithQMaxBits(roundingMode_t roundingMode,

--- a/src/tensor/include/Quantization.h
+++ b/src/tensor/include/Quantization.h
@@ -11,6 +11,18 @@ typedef struct symInt32QConfig {
     uint8_t qMaxBits;
 } symInt32QConfig_t;
 
+/* SYM_INT32 operand bit-width contract (#227). Operands feeding product
+ * accumulators are int12 so int12*int12 products stay within an int32
+ * accumulator (no int64). Sound for reductions N <= 511 (512*2^22 > INT32_MAX);
+ * narrow the knob for wider layers. Grad accumulators are value-sums and stay
+ * wide (int16) per the #45 contract. Override with -DODT_SYM_OPERAND_QMAXBITS=N. */
+#ifndef ODT_SYM_OPERAND_QMAXBITS
+#define ODT_SYM_OPERAND_QMAXBITS 12
+#endif
+#ifndef ODT_SYM_GRAD_QMAXBITS
+#define ODT_SYM_GRAD_QMAXBITS 16
+#endif
+
 typedef struct symQConfig {
     float scale;
     uint8_t qBits;
@@ -29,7 +41,7 @@ typedef struct quantization {
     void *qConfig;
 } quantization_t;
 
-// Important: This sets qMaxBits to 16
+// Important: This sets qMaxBits to ODT_SYM_OPERAND_QMAXBITS (12)
 void initSymInt32QConfig(roundingMode_t roundingMode, symInt32QConfig_t *symInt32QConfig);
 void initSymInt32QConfigWithQMaxBits(roundingMode_t roundingMode,
                                      symInt32QConfig_t *symInt32QConfig, uint8_t qMaxBits);

--- a/src/userApi/layer/LayerNormApi.c
+++ b/src/userApi/layer/LayerNormApi.c
@@ -31,8 +31,9 @@ static shape_t *buildOwnedShape(const size_t *srcDims, size_t numberOfDims) {
 
 /* Constant fill via tensorFillFromFloatBuffer: plain memcpy for FLOAT32; for
  * SYM_INT32 it routes through convertFloatTensorToSymInt32Tensor, which IS
- * the spec's parameter quantization (all-ones -> mantissa 32767, scale
- * 1/32767; all-zeros -> mantissa 0, scale 1.0 via the absMax==0 guard).
+ * the spec's parameter quantization (all-ones -> mantissa 2047, scale
+ * 1/2047 (#227 int12 operand default); all-zeros -> mantissa 0, scale 1.0
+ * via the absMax==0 guard).
  * initDistribution cannot be used here: it is FLOAT32-only by guard, and
  * extending it is Issue-C scope. */
 static void fillParamTensorWithConstant(tensor_t *paramTensor, float value) {
@@ -46,8 +47,8 @@ static void fillParamTensorWithConstant(tensor_t *paramTensor, float value) {
 }
 
 /* gamma: shape normalizedShape, init all-ones (FLOAT32: 1.0f each; SYM_INT32:
- * mantissa 32767, scale 1/32767); grad dtype from gradQ (= the profile's
- * backwardMath). */
+ * mantissa 2047, scale 1/2047 (#227 int12 operand default)); grad dtype from
+ * gradQ (= the profile's backwardMath). */
 static parameter_t *allocateLayerNormGamma(const size_t *normalizedShape, size_t numNormDims,
                                            quantization_t *storageQ, quantization_t *gradQ) {
     shape_t *shape = buildOwnedShape(normalizedShape, numNormDims);

--- a/src/userApi/tensor/TensorApi.c
+++ b/src/userApi/tensor/TensorApi.c
@@ -283,7 +283,7 @@ tensor_t *gradInitFloat(tensor_t *param, sparsity_t *sparsity) {
 }
 
 tensor_t *gradInitSymInt32(tensor_t *param, roundingMode_t roundingMode, sparsity_t *sparsity) {
-    quantization_t *symQ = quantizationInitSymInt32(roundingMode);
+    quantization_t *symQ = quantizationInitSymInt32WithBits(roundingMode, ODT_SYM_GRAD_QMAXBITS);
     tensor_t *grad = gradInit(param, symQ, sparsity);
     freeQuantization(symQ);
     return grad;
@@ -325,8 +325,9 @@ quantization_t *getQLike(quantization_t *quantization) {
     case SYM_INT32:
         symInt32QConfig_t *likeSymInt32QC = reserveMemory(sizeof(symInt32QConfig_t));
         symInt32QConfig_t *symInt32QC = quantization->qConfig;
-
-        initSymInt32QConfig(symInt32QC->roundingMode, likeSymInt32QC);
+        /* preserve the source width — do NOT reset to the operand default (#227) */
+        initSymInt32QConfigWithQMaxBits(symInt32QC->roundingMode, likeSymInt32QC,
+                                        symInt32QC->qMaxBits);
         initSymInt32Quantization(likeSymInt32QC, likeQ);
         break;
     case ASYM:

--- a/test/unit/arithmetic/CMakeLists.txt
+++ b/test/unit/arithmetic/CMakeLists.txt
@@ -83,6 +83,7 @@ add_elastic_ai_unit_test(
         MORE_LIBS
         Arithmetic
         Tensor
+        odt_test_death
 )
 
 add_elastic_ai_unit_test(

--- a/test/unit/arithmetic/UnitTestMatmul.c
+++ b/test/unit/arithmetic/UnitTestMatmul.c
@@ -1,4 +1,5 @@
 #include "Arithmetic.h"
+#include "DeathTest.h"
 #include "Matmul.h"
 #include "Tensor.h"
 #include "unity.h"
@@ -415,6 +416,32 @@ void testMatmulSymInt32TensorsWithBiasRescalesBias() {
     TEST_ASSERT_EQUAL_FLOAT_ARRAY(expected, actual.data, 4);
 }
 
+void testMatmulSymInt32RejectsOperandWiderThanInt12() {
+    tensor_t a, b, out;
+    int32_t aData[] = {1, 2, 3, 4, 5, 6};
+    int32_t bData[] = {1, 4, 2, 5, 3, 6};
+    int32_t outData[4];
+    size_t aDims[] = {2, 3}, bDims[] = {3, 2}, oDims[] = {2, 2}, order[] = {0, 1};
+    shape_t aS, bS, oS;
+    setShape(&aS, aDims, 2, order);
+    setShape(&bS, bDims, 2, order);
+    setShape(&oS, oDims, 2, order);
+
+    symInt32QConfig_t aQC, bQC, oQC;
+    initSymInt32QConfigWithQMaxBits(HALF_AWAY, &aQC, 13); /* violates int12 contract */
+    initSymInt32QConfig(HALF_AWAY, &bQC);                 /* default int12 */
+    initSymInt32QConfig(HALF_AWAY, &oQC);
+    quantization_t aQ, bQ, oQ;
+    initSymInt32Quantization(&aQC, &aQ);
+    initSymInt32Quantization(&bQC, &bQ);
+    initSymInt32Quantization(&oQC, &oQ);
+    setTensorValues(&a, (uint8_t *)aData, &aS, &aQ, NULL);
+    setTensorValues(&b, (uint8_t *)bData, &bS, &bQ, NULL);
+    setTensorValues(&out, (uint8_t *)outData, &oS, &oQ, NULL);
+
+    ASSERT_EXITS_WITH_FAILURE(matmulSymInt32Tensors(&a, &b, &out));
+}
+
 void setUp() {}
 void tearDown() {}
 
@@ -428,6 +455,7 @@ int main(void) {
     RUN_TEST(testMatmulFloat32TensorsWithBiasBroadcastsOverRows);
     RUN_TEST(testMatmulFloat32TensorsWithBiasNullEqualsPlain);
     RUN_TEST(testMatmulSymInt32TensorsWithBiasRescalesBias);
+    RUN_TEST(testMatmulSymInt32RejectsOperandWiderThanInt12);
 
     return UNITY_END();
 }

--- a/test/unit/layer/CMakeLists.txt
+++ b/test/unit/layer/CMakeLists.txt
@@ -253,6 +253,7 @@ add_elastic_ai_unit_test(
         Rounding
         Arithmetic
         StorageApi
+        odt_test_death
 )
 add_dependencies(UnitTestLayerNorm generate_expected_layernorm)
 add_dependencies(UnitTestLayerNorm generate_expected_layernorm_sym)

--- a/test/unit/layer/UnitTestLayerNorm.c
+++ b/test/unit/layer/UnitTestLayerNorm.c
@@ -16,6 +16,7 @@
 #include "TensorApi.h"
 #include "unity.h"
 
+#include "DeathTest.h"
 #include "expected_layernorm.h"
 #include "expected_layernorm_sym.h"
 #include "expected_layernorm_sym_bwd.h"
@@ -1839,6 +1840,48 @@ void testFactoryFullSymProfileTrainsSymGrads(void) {
     TEST_ASSERT_TRUE(dxScale > 0.0f && dxScale != 1.0f);
 }
 
+/* layerNormValidateSymTensor is static; exercise it through layerNormForward.
+ * The INPUT tensor is built with qMaxBits=13, which exceeds the int12 operand
+ * contract (ODT_SYM_OPERAND_QMAXBITS=12); the forward must exit(1). */
+void testLayerNormSymRejectsOperandWiderThanInt12(void) {
+    size_t dims[] = {2, 4};
+    /* Build input with a width-13 qMaxBits — violates ODT_SYM_OPERAND_QMAXBITS. */
+    size_t *inDims = reserveMemory(2 * sizeof(size_t));
+    inDims[0] = 2;
+    inDims[1] = 4;
+    size_t *inOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, inOrder);
+    shape_t *inShape = reserveMemory(sizeof(shape_t));
+    setShape(inShape, inDims, 2, inOrder);
+    quantization_t *wideQ = quantizationInitSymInt32WithBits(HALF_AWAY, 13);
+    tensor_t *in = initTensor(inShape, wideQ, NULL);
+
+    tensor_t *out = buildSymInt32TensorND(2, dims, NULL);
+
+    size_t ns[] = {4};
+    parameter_t *gamma = buildSymParam(1, ns, (float[]){1.f, 1.f, 1.f, 1.f});
+    parameter_t *beta = buildSymParam(1, ns, (float[]){0.f, 0.f, 0.f, 0.f});
+    size_t *normShape = reserveMemory(sizeof(size_t));
+    normShape[0] = 4;
+
+    quantization_t *fq = quantizationInitSymInt32(HALF_AWAY);
+    quantization_t *bq = quantizationInitFloat();
+    layerNormConfig_t cfg;
+    initLayerNormConfig(&cfg, gamma, beta, normShape, 1, 1e-5f, fq, bq);
+    layerConfig_t lcfg;
+    layer_t layer = makeLayerNormLayer(&cfg, &lcfg);
+
+    ASSERT_EXITS_WITH_FAILURE(layerNormForward(&layer, in, out));
+
+    freeQuantization(bq);
+    freeQuantization(fq);
+    freeReservedMemory(normShape);
+    freeParameter(beta);
+    freeParameter(gamma);
+    freeTensor(out);
+    freeTensor(in);
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(testConfigStructIsPopulated);
@@ -1881,5 +1924,6 @@ int main(void) {
     RUN_TEST(testSymBackwardVarNearEpsGold);
     RUN_TEST(testSymBackwardDivergentLayoutsBitIdentical);
     RUN_TEST(testFactoryFullSymProfileTrainsSymGrads);
+    RUN_TEST(testLayerNormSymRejectsOperandWiderThanInt12);
     return UNITY_END();
 }

--- a/test/unit/layer/UnitTestLayerNorm.c
+++ b/test/unit/layer/UnitTestLayerNorm.c
@@ -154,7 +154,7 @@ static layer_t makeLayerNormLayer(layerNormConfig_t *cfg, layerConfig_t *lcfg) {
 /* Dequant-domain invariants (gamma=1, beta=0): per-group dequantized mean ~ 0,
  * per-group dequantized variance ~ var/(var+eps) (PyTorch eps behavior).
  * Affine-stable: with gamma=ones the dequantized values are unchanged by the
- * Task-3 affine stage (mantissa*32767 and scale/32767 cancel). */
+ * Task-3 affine stage (mantissa*2047 and scale/2047 cancel at int12, #227). */
 void testSymForwardDequantInvariantsMultiGroup(void) {
     size_t dims[] = {2, 4};
     tensor_t *in =
@@ -204,7 +204,8 @@ void testSymForwardDequantInvariantsMultiGroup(void) {
     freeTensor(in);
 
     /* var/(var+eps): row0 1.25/(1.25+1e-5)=0.999992; row1 125/(125+1e-5)~1.0.
-     * Tolerances absorb input quantization noise (s_x = 40/32767 ~ 1.2e-3). */
+     * Tolerances absorb input quantization noise (s_x = 40/2047 ~ 1.95e-2 at
+     * int12, #227; the scale-invariant dequant-domain mean/var still fit). */
     TEST_ASSERT_FLOAT_WITHIN(1e-3f, 0.f, groupMean[0]);
     TEST_ASSERT_FLOAT_WITHIN(1e-3f, 0.f, groupMean[1]);
     TEST_ASSERT_FLOAT_WITHIN(5e-3f, 0.999992f, groupVar[0]);
@@ -882,7 +883,10 @@ static void runSymGoldForward(size_t numDims, const size_t *dims, size_t numNorm
         float deq = (float)m[i] * scale;
         TEST_ASSERT_FLOAT_WITHIN(dequantTol, expDequant[i], deq);
         if (expXhat != NULL) {
-            TEST_ASSERT_FLOAT_WITHIN(3e-5f, expXhat[i], deq);
+            /* int12 operands (#227): normalized-output LSB is s_norm <= 1.9/2047
+             * (parity fixtures cap absmax(xhat) <= 1.9), so the dequant tracks
+             * xhat to s_norm/2 <= 4.64e-4. Was 3e-5f under int16 (1.9/65534). */
+            TEST_ASSERT_FLOAT_WITHIN(5e-4f, expXhat[i], deq);
         }
     }
     if (expGroupVarRatio != NULL) {
@@ -1226,10 +1230,16 @@ void testSymForwardConstantInputEmitsZeros(void) {
 }
 
 /* The affine with gamma=ones multiplies every normalized mantissa by exactly
- * 32767. Recover qNorm = y_q/32767 (remainder must be 0 — pins that the gamma
- * multiply actually happened) and assert the normalization-stage invariants:
- * full-range stretch (max |qNorm| == 32767) and near-zero per-group mantissa
- * sums (Σ n == 0 exactly in real arithmetic; rounding adds <= 0.5/element). */
+ * the gamma operand qMax. At int12 operands (#227) gamma=ones quantizes to
+ * qMax=2047 (absmax=1 -> every gamma_q = 2047) and beta=zeros -> seed=0, so
+ * y_q = qNorm * 2047 EXACTLY. Recover qNorm = y_q/2047 (remainder must be 0 —
+ * pins that the gamma multiply actually happened) and assert the
+ * normalization-stage invariants: full-range stretch (max |qNorm| == 2047, the
+ * normalized output also saturates to the int12 qMax) and near-zero per-group
+ * mantissa sums (Σ n == 0 exactly in real arithmetic; rounding adds <= 0.5/
+ * element, so |Σ qNorm| <= N/2 = 2, asserted within the width-independent
+ * [-4, 4]). Pure width substitution from the int16 era (32767 -> 2047); the
+ * structural invariant is unchanged. */
 void testSymForwardMantissaInvariantsViaOnesGamma(void) {
     size_t dims[] = {2, 4};
     tensor_t *in =
@@ -1267,14 +1277,14 @@ void testSymForwardMantissaInvariantsViaOnesGamma(void) {
     int32_t qNorm[8];
     int32_t maxAbs = 0;
     for (size_t i = 0; i < 8; i++) {
-        TEST_ASSERT_EQUAL_INT(0, m[i] % 32767);
-        qNorm[i] = m[i] / 32767;
+        TEST_ASSERT_EQUAL_INT(0, m[i] % 2047);
+        qNorm[i] = m[i] / 2047;
         int32_t a = (qNorm[i] < 0) ? -qNorm[i] : qNorm[i];
         if (a > maxAbs) {
             maxAbs = a;
         }
     }
-    TEST_ASSERT_EQUAL_INT(32767, maxAbs);
+    TEST_ASSERT_EQUAL_INT(2047, maxAbs);
     for (size_t g = 0; g < 2; g++) {
         int32_t sum = 0;
         for (size_t j = 0; j < 4; j++) {
@@ -1286,8 +1296,9 @@ void testSymForwardMantissaInvariantsViaOnesGamma(void) {
 
 /* Constant input + nonzero beta: y = gamma*0 + beta. Pins (a) the affine runs
  * AFTER the constant guard, (b) the beta-rescale idiom (raw beta_q would
- * dequantize to 2x the right value here since s_beta = 0.5/32767 != s_y), and
- * (c) the post-affine output scale s_y = s_norm * s_gamma = 1/32767. */
+ * dequantize to 2x the right value here since s_beta = 0.5/2047 != s_y), and
+ * (c) the post-affine output scale s_y = s_norm * s_gamma = 1/2047 (int12
+ * operand gamma=ones quantizes to qMax=2047 with scale 1/2047, #227). */
 void testSymForwardConstantInputAppliesBeta(void) {
     size_t dims[] = {2, 3};
     tensor_t *in = buildSymInt32TensorND(2, dims, (float[]){7.f, 7.f, 7.f, 7.f, 7.f, 7.f});
@@ -1322,7 +1333,7 @@ void testSymForwardConstantInputAppliesBeta(void) {
     freeTensor(out);
     freeTensor(in);
 
-    float expectedScale = 1.0f / 32767.0f;
+    float expectedScale = 1.0f / 2047.0f;
     TEST_ASSERT_FLOAT_WITHIN(expectedScale * 1e-4f, expectedScale, scale);
     float expBeta[] = {0.5f, -0.25f, 0.125f};
     for (size_t g = 0; g < 2; g++) {
@@ -1500,10 +1511,12 @@ void testFactorySymInt32StorageQuantizesGammaBeta(void) {
     freeQuantization(symQ);
 
     for (size_t i = 0; i < 4; i++) {
-        TEST_ASSERT_EQUAL_INT(32767, g[i]);
+        /* gamma=ones is OPERAND storage (default int12, #227): absmax=1 ->
+         * every mantissa = qMax = 2047, scale = 1/2047. beta=zeros -> 0, scale 1. */
+        TEST_ASSERT_EQUAL_INT(2047, g[i]);
         TEST_ASSERT_EQUAL_INT(0, b[i]);
     }
-    TEST_ASSERT_FLOAT_WITHIN(1e-9f, 1.0f / 32767.0f, gScale);
+    TEST_ASSERT_FLOAT_WITHIN(1e-9f, 1.0f / 2047.0f, gScale);
     TEST_ASSERT_FLOAT_WITHIN(1e-9f, 1.0f, bScale);
     TEST_ASSERT_TRUE(gammaGradFloat);
     TEST_ASSERT_TRUE(betaGradFloat);

--- a/test/unit/layer/generate_expected_layernorm_sym.py
+++ b/test/unit/layer/generate_expected_layernorm_sym.py
@@ -13,7 +13,9 @@ Self-checks:
  - the emulated dequantized output matches F.layer_norm on the dequantized
    inputs within the analytic quantization bound;
  - parity fixtures keep absmax(xhat) <= 1.9, which guarantees the documented
-   3e-5 C-side xhat tolerance (s_norm/2 <= 1.9/65534 ~ 2.9e-5).
+   5e-4 C-side xhat tolerance: at int12 operands (qMaxBits=12, #227) the
+   normalized output LSB is s_norm <= 1.9/2047, so s_norm/2 <= 4.64e-4 < 5e-4
+   (the int16 era used 1.9/65534 ~ 2.9e-5 -> a 3e-5 tolerance).
 
 Biased variance (/N) via explicit emulation + F.layer_norm; NEVER torch.var
 (ddof=1 default). Rounding: the framework's roundByMode(HALF_AWAY) is C
@@ -29,8 +31,14 @@ from pathlib import Path
 import torch
 import torch.nn.functional as F
 
-QMAX = 32767.0
-QMIN = -32768.0
+# SYM_INT32 forward is operand-domain end-to-end (#227 int12 operand flip).
+# input/gamma/beta and the normalized OUTPUT all live in default-initialized
+# (quantizationInitSymInt32) tensors, which are now int12 (qMaxBits=12):
+#   absmax -> scale = absmax/2047, round-clamp to [-2048, 2047].
+# There is NO grad accumulator in the forward, so every QMAX/QMIN here is int12.
+# (The backward generator carries the operand-int12 vs grad-int16 split.)
+QMAX = 2047.0
+QMIN = -2048.0
 
 
 def round_half_away(x: torch.Tensor) -> torch.Tensor:
@@ -177,7 +185,8 @@ def fixture_sym_parity():
 
 def fixture_sym_affine():
     # [2,4], non-trivial gamma/beta with deliberately different scales:
-    # s_gamma = 2/32767, s_beta = 0.05/32767 — the beta rescale MUST matter.
+    # s_gamma = 2/2047, s_beta = 0.05/2047 (int12 operands, #227) — the beta
+    # rescale MUST matter (s_beta != s_y).
     x = torch.tensor([[0.2, -1.0, 0.6, 1.4],
                       [1.0, 3.0, -2.0, 0.0]], dtype=torch.float64)
     gamma = torch.tensor([1.5, -0.5, 2.0, 0.25], dtype=torch.float64)

--- a/test/unit/layer/generate_expected_layernorm_sym_bwd.py
+++ b/test/unit/layer/generate_expected_layernorm_sym_bwd.py
@@ -35,8 +35,21 @@ from pathlib import Path
 import torch
 import torch.nn.functional as F
 
-QMAX = 32767.0
-QMIN = -32768.0
+# SYM_INT32 backward carries the #227 operand-int12 / grad-int16 split (mirrors
+# generate_expected_conv1d.py's quantize_sym_i12 vs the int16 grad requant):
+#   OPERAND width (int12, qMaxBits=12) — default-initialized tensors:
+#     forwardInput / gamma / dy, the propLoss (dx) requant (propLoss is built via
+#     quantizationInitSymInt32 -> int12), AND the per-call grad INCREMENT
+#     quantization (layerNormAccumulateGradSymInt32's incSym uses the int12
+#     default initSymInt32QConfig).
+#   GRAD-ACCUMULATOR width (int16, qMaxBits=16) — gradInitSymInt32 tensors:
+#     ONLY the running-sum requant of dgamma/dbeta back into the grad tensor
+#     (addSymInt32TensorsInplace -> convertTensor into the int16 grad).
+QMAX = 2047.0
+QMIN = -2048.0
+
+QMAX_GRAD = 32767.0
+QMIN_GRAD = -32768.0
 
 
 def round_half_away(x: torch.Tensor) -> torch.Tensor:
@@ -79,11 +92,24 @@ def emit_int32_scalar(name: str, v: int) -> str:
 
 
 def quantize_sym(x: torch.Tensor):
-    """convertFloatTensorToSymInt32Tensor: absmax -> scale (1.0 if absmax==0),
-    round-clamp with the C rounding (half-away-from-zero)."""
+    """int12 OPERAND quantize (qMaxBits=12): convertFloatTensorToSymInt32Tensor on
+    a default-initialized tensor — absmax -> scale (1.0 if absmax==0), round-clamp
+    [-2048, 2047] with the C rounding (half-away-from-zero). Used for forwardInput/
+    gamma/dy operands, the propLoss (dx) requant, and the grad INCREMENT."""
     absmax = x.abs().max().item()
     scale = 1.0 if absmax == 0.0 else absmax / QMAX
     q = round_half_away(torch.clamp(x / scale, QMIN, QMAX))
+    return q.to(torch.int32), scale
+
+
+def quantize_sym_grad(x: torch.Tensor):
+    """int16 GRAD-ACCUMULATOR requant (qMaxBits=16): the running-sum requant of
+    dgamma/dbeta back into a gradInitSymInt32 tensor (addSymInt32TensorsInplace ->
+    convertTensor into the int16 grad). absmax -> scale=absmax/32767, round-clamp
+    [-32768, 32767]. ONLY the grad running sum uses this width (#227)."""
+    absmax = x.abs().max().item()
+    scale = 1.0 if absmax == 0.0 else absmax / QMAX_GRAD
+    q = round_half_away(torch.clamp(x / scale, QMIN_GRAD, QMAX_GRAD))
     return q.to(torch.int32), scale
 
 
@@ -138,9 +164,11 @@ def emulate_accumulate(grad_q, grad_s, inc):
     (2) addSymInt32TensorsInplace: dequantize BOTH with their own scales,
         float-add, requantize the sum with a fresh absmax/QMAX scale.
     Returns ((mantissas, scale) after accumulation, increment scale)."""
+    # Increment is quantized at the int12 OPERAND width (incSym is default-init);
+    # the running sum is requantized back into the int16 GRAD tensor.
     inc_q, inc_s = quantize_sym(inc)
     total = grad_q.to(torch.float64) * grad_s + inc_q.to(torch.float64) * inc_s
-    out_q, out_s = quantize_sym(total)
+    out_q, out_s = quantize_sym_grad(total)
     return (out_q, out_s), inc_s
 
 
@@ -261,8 +289,8 @@ def _run_bwd_fixture(name, x, gamma, dy, normalized_shape, *, eps=1e-5,
 def fixture_bwd_base():
     # [3,4], D=1, G=3, N=4 (N>=3). Per-group variance ratio ~445x (row1) pins
     # per-group invSigma in dx. Non-uniform dy with sign/magnitude structure
-    # per group; gamma non-trivial with s_gamma = 2/32767 (scale-blindness
-    # mutations must show up in the dequant/scale asserts).
+    # per group; gamma non-trivial with s_gamma = 2/2047 (int12 operand, #227;
+    # scale-blindness mutations must show up in the dequant/scale asserts).
     x = torch.tensor([[0.1, -0.4, 0.7, 1.2],
                       [20.0, 10.0, -15.0, 5.0],
                       [-0.3, -0.8, 0.2, 0.9]], dtype=torch.float64)

--- a/test/unit/tensor/UnitTestTensorApi.c
+++ b/test/unit/tensor/UnitTestTensorApi.c
@@ -654,6 +654,23 @@ void testGradInit_SymInt32_MatchesParamShapeAndDtype(void) {
     TEST_ASSERT_EQUAL_UINT(5, d1);
 }
 
+void testGradInitSymInt32StaysInt16WhileDefaultIsInt12() {
+    /* default operand config is int12 after the #227 flip */
+    symInt32QConfig_t opQC;
+    initSymInt32QConfig(HALF_AWAY, &opQC);
+    TEST_ASSERT_EQUAL_UINT8(12, opQC.qMaxBits);
+
+    /* a grad accumulator built from a param stays int16 (#45 contract) */
+    size_t dims[] = {2, 3};
+    size_t order[] = {0, 1};
+    shape_t shape = {.dimensions = dims, .numberOfDimensions = 2, .orderOfDimensions = order};
+    tensor_t *param = initTensor(getShapeLike(&shape), quantizationInitSymInt32(HALF_AWAY), NULL);
+    tensor_t *grad = gradInitSymInt32(param, HALF_AWAY, NULL);
+    TEST_ASSERT_EQUAL_UINT8(16, ((symInt32QConfig_t *)grad->quantization->qConfig)->qMaxBits);
+    freeTensor(grad);
+    freeTensor(param);
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(testTensorInitWithDistribution_Zeros_InitializesProductOfDimsValues);
@@ -681,5 +698,6 @@ int main(void) {
     RUN_TEST(testInitDistribution_KaimingUniform_NotAllZero);
     RUN_TEST(testInitDistribution_KaimingNormal_NotAllZero);
     RUN_TEST(testTensorFillFromBoolBuffer_RoundTrip_N12);
+    RUN_TEST(testGradInitSymInt32StaysInt16WhileDefaultIsInt12);
     return UNITY_END();
 }

--- a/test/unit/tensor/UnitTestTensorConversion.c
+++ b/test/unit/tensor/UnitTestTensorConversion.c
@@ -173,8 +173,10 @@ void testConversionFloatSymInt32() {
     setTensorValues(&symInt32Tensor, (uint8_t *)symInt32Data, &shape, &symInt32Q, NULL);
     convertTensor(&floatTensor, &symInt32Tensor);
 
-    float expectedScale = 0.000204474f;
-    int32_t expectedData[] = {7336, 14183, 15650, 22008, -5869, -32767};
+    /* absmax = 6.7; int12 scale = 6.7/2047 ≈ 0.003273083.
+     * Quantized values: round(v / scale): 458, 886, 978, 1375, -367, -2047. */
+    float expectedScale = 6.7f / 2047.0f;
+    int32_t expectedData[] = {458, 886, 978, 1375, -367, -2047};
 
     symInt32QConfig_t *outputSymInt32QC = symInt32Tensor.quantization->qConfig;
     TEST_ASSERT_FLOAT_WITHIN(0.000001f, expectedScale, outputSymInt32QC->scale);
@@ -183,8 +185,10 @@ void testConversionFloatSymInt32() {
     convertTensor(&symInt32Tensor, &floatTensor);
     float expectedFloat[] = {1.5f, 2.9f, 3.2f, 4.5f, -1.2f, -6.7f};
     float *actualFloat = (float *)floatTensor.data;
+    /* int12 quantisation step = scale ≈ 0.00327; worst-case round-trip
+     * error is scale/2 ≈ 0.00164, so tolerance 0.002 is sufficient. */
     for (size_t i = 0; i < 6; i++) {
-        TEST_ASSERT_FLOAT_WITHIN(0.0001f, expectedFloat[i], actualFloat[i]);
+        TEST_ASSERT_FLOAT_WITHIN(0.002f, expectedFloat[i], actualFloat[i]);
     }
 }
 

--- a/test/unit/userAPI/UnitTestLayerWeightsApi.c
+++ b/test/unit/userAPI/UnitTestLayerWeightsApi.c
@@ -219,21 +219,21 @@ void testLayerLoadWeightsLayerNormQuantizesForSymStorage(void) {
     freeQuantization(bwd);
     freeQuantization(symQ);
 
-    /* gamma absmax 4 -> scale 4/32767; mantissas round(v*32767/4):
-     * 16383.5 -> 16384 (half-away-from-zero: the framework's roundHalfAway is C
-     * round() — see #188), 24575.25 -> 24575, 32767 exact. INT_WITHIN(1)
+    /* gamma absmax 4 -> int12 scale 4/2047; mantissas round(v*2047/4):
+     * 1023.5 -> 1024 (half-away-from-zero: the framework's roundHalfAway is C
+     * round() — see #188), 1535.25 -> 1535, 2047 exact. INT_WITHIN(1)
      * on the non-absmax elements (float division may land a hair off the
      * exact midpoint); exact on the absmax element. */
-    TEST_ASSERT_FLOAT_WITHIN(1e-9f, 4.0f / 32767.0f, gScale);
-    TEST_ASSERT_INT_WITHIN(1, 16384, g[0]);
-    TEST_ASSERT_INT_WITHIN(1, 24575, g[1]);
-    TEST_ASSERT_EQUAL_INT(32767, g[2]);
-    /* beta absmax 3 -> scale 3/32767; round(-10922.33) = -10922,
-     * round(-21844.67) = -21845, -32767 exact. */
-    TEST_ASSERT_FLOAT_WITHIN(1e-9f, 3.0f / 32767.0f, bScale);
-    TEST_ASSERT_INT_WITHIN(1, -10922, b[0]);
-    TEST_ASSERT_INT_WITHIN(1, -21845, b[1]);
-    TEST_ASSERT_EQUAL_INT(-32767, b[2]);
+    TEST_ASSERT_FLOAT_WITHIN(1e-9f, 4.0f / 2047.0f, gScale);
+    TEST_ASSERT_INT_WITHIN(1, 1024, g[0]);
+    TEST_ASSERT_INT_WITHIN(1, 1535, g[1]);
+    TEST_ASSERT_EQUAL_INT(2047, g[2]);
+    /* beta absmax 3 -> int12 scale 3/2047; round(-682.33) = -682,
+     * round(-1364.67) = -1365, -2047 exact. */
+    TEST_ASSERT_FLOAT_WITHIN(1e-9f, 3.0f / 2047.0f, bScale);
+    TEST_ASSERT_INT_WITHIN(1, -682, b[0]);
+    TEST_ASSERT_INT_WITHIN(1, -1365, b[1]);
+    TEST_ASSERT_EQUAL_INT(-2047, b[2]);
 }
 
 int main(void) {


### PR DESCRIPTION
## Part 1 of 3 — #227 (SYM int12 operand contract)

Makes `SYM_INT32` product-accumulation overflow-safe by adopting an **int12 operand contract** framework-wide, while keeping **grad accumulators at int16**. This brings Linear/`matmulIntCore` and the LayerNorm affine product in line with what Conv #45 already does.

### Why
`SYM_INT32` kernels accumulate int×int products in an int32 accumulator (no int64 — hard rule). int16×int16→int32 overflows after ~2 full-scale terms; int12 operands give ~512-term headroom (sound for reductions `N ≤ 511`). Grad accumulators are *value*-sums, so they stay wide (int16) for free.

### Changes
- **Knobs** `ODT_SYM_OPERAND_QMAXBITS=12` / `ODT_SYM_GRAD_QMAXBITS=16` (compile-time, `-D`-overridable) as the single source of truth.
- Flip the `initSymInt32QConfig` operand default 16→12; pin `gradInitSymInt32` to the grad knob and fix `getQLike` to **preserve** a cloned config's width (it previously reset it, which would have silently downgraded the grad pin).
- Op-entry guards: both Matmul SYM entry points (`matmulValidateSymOperand`) and LayerNorm (`layerNormValidateSymTensor` lowered to the operand knob; a second `layerNormValidateSymGrad` keeps the int16 bound for grad tensors).
- Regenerate LayerNorm SYM gold with an **operand-int12 / grad-int16 split** in the generators; reconcile two cross-suite FLOAT→SYM_INT32 scale assertions to int12 (derived, not pasted).
- `docs/CONVENTIONS.md`: realized contract + the `N ≤ 511` caveat (and an off-by-one fix in the overflow table).

### Testing
Full unit suite green (62/62). New fail-fast death-tests for both guards. No int64 introduced. Adversarial whole-branch review (independent): operand/grad width seam verified coherent across runtime, validators, and gold generators.

### Notes
- `Closes #227` intentionally omitted — this is Part 1 of 3 (PR-B = SYM→* conversion unpack, PR-C = →SYM pack). Close #227 manually after all three land on `develop`.
- A7 (Linear gold regen) was a no-op — Linear SYM tests use raw mantissas and didn't shift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
