### PR TITLE
feat(tensor): SYM→ unpack side of the conversion bridge (#227 PR-B)

### DIFF
--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -520,6 +520,36 @@ high-level factory keeps grads FLOAT32, matching the Linear KAIMING factory).
 `Conv1dTransposed → Quant → MSE` trains under
 `calculateGradsSequential` + `sgdStepM(SYM_INT32)`.
 
+## SYM ↔ * conversion bridge (#227)
+
+`SYM` is the sub-byte bit-packed **storage** dtype; `SYM_INT32` is the int32-slot
+**compute** dtype. The MCU lifecycle is store-packed (`SYM`) → unpack to int32
+(`SYM_INT32`) → compute → repack. `conversionMatrix`
+(`src/tensor/TensorConversion.c`) fills these cells: PR-B implements the **unpack
+row** (`SYM → {SYM_INT32, FLOAT32, INT32, ASYM}`); the pack column (`* → SYM`) is
+PR-C.
+
+**Sign-extend on unpack.** `byteConversion` is a pure bit-copy that ZERO-FILLS on
+widen, so a packed signed mantissa (e.g. `−3` at qBits=6 = `0b111101`) would read
+back as `61`. Every `SYM →` cell routes through the shared
+`unpackSignExtend(src, srcBits, dst, n)` helper, which widens then sign-extends the
+two's-complement payload from `srcBits` (`(v ^ signBit) − signBit`). ASYM codes are
+non-negative, so the ASYM **pack** path does not sign-extend.
+
+**`int_repr` vs `dequantize` (deliberate, documented asymmetry).** A conversion
+whose destination is `INT32` emits the integer **codes** and drops the scale
+(`int_repr`); a conversion whose destination is `FLOAT32` emits the **values** with
+the scale applied (`dequantize`). This mirrors PyTorch `int_repr()` vs
+`dequantize()` and is consistent across both source dtypes: `SYM → INT32` and
+`SYM_INT32 → INT32` are both `int_repr`; `SYM → FLOAT32` and `SYM_INT32 → FLOAT32`
+are both `dequantize`. No value-rounding `→INT32` variant exists (YAGNI;
+near-useless for `scale ≪ 1`).
+
+**Rescale on the symmetric↔asymmetric transition.** `SYM → ASYM` always rescales
+(dequantize → derive a fresh asym `scale`+`zeroPoint` from min/max → requantize →
+pack): a symmetric code grid cannot hold an off-center `+zeroPoint` band at the
+carried scale, independent of width.
+
 ## Vision: memory over float accuracy
 
 ODT is a memory-light on-device-training research framework. SYM_INT32 paths

--- a/src/tensor/TensorConversion.c
+++ b/src/tensor/TensorConversion.c
@@ -374,6 +374,29 @@ void convertAsymTensorToSymInt32Tensor(tensor_t *inputTensor, tensor_t *outputTe
     outputSymInt32QConfig->scale = inputAsymQConfig->scale;
 }
 
+static void unpackSignExtend(const uint8_t *src, size_t srcBits, int32_t *dst, size_t n) {
+    byteConversion((uint8_t *)src, srcBits, (uint8_t *)dst, 32, n); /* zero-fills high bits */
+    if (srcBits >= 32) {
+        return;
+    }
+    const int32_t signBit = (int32_t)1 << (srcBits - 1);
+    const int32_t mask = (int32_t)(((uint32_t)1 << srcBits) - 1u);
+    for (size_t i = 0; i < n; i++) {
+        int32_t v = dst[i] & mask;
+        dst[i] = (v ^ signBit) - signBit; /* sign-extend from srcBits */
+    }
+}
+
+void convertSymTensorToSymInt32Tensor(tensor_t *inputTensor, tensor_t *outputTensor) {
+    size_t n = calcNumberOfElementsByTensor(inputTensor);
+    symQConfig_t *inQC = inputTensor->quantization->qConfig;
+    symInt32QConfig_t *outQC = outputTensor->quantization->qConfig;
+
+    unpackSignExtend(inputTensor->data, inQC->qBits, (int32_t *)outputTensor->data, n);
+    outQC->scale = inQC->scale;
+    outQC->qMaxBits = inQC->qBits;
+}
+
 char *quantTypeToString(qtype_t t) {
     switch (t) {
     case INT32:
@@ -425,7 +448,7 @@ conversionFunction_t conversionMatrix[6][6] = {
                    [BOOL] = unsupportedConversionTypes},
     [SYM] = {[INT32] = unsupportedConversionTypes,
              [FLOAT32] = unsupportedConversionTypes,
-             [SYM_INT32] = unsupportedConversionTypes,
+             [SYM_INT32] = convertSymTensorToSymInt32Tensor,
              [SYM] = NULL,
              [ASYM] = unsupportedConversionTypes,
              [BOOL] = unsupportedConversionTypes},

--- a/src/tensor/TensorConversion.c
+++ b/src/tensor/TensorConversion.c
@@ -415,6 +415,40 @@ void convertSymTensorToSymInt32Tensor(tensor_t *inputTensor, tensor_t *outputTen
     outQC->qMaxBits = inQC->qBits;
 }
 
+void convertSymTensorToAsymTensor(tensor_t *inputTensor, tensor_t *outputTensor) {
+    size_t n = calcNumberOfElementsByTensor(inputTensor);
+    symQConfig_t *inQC = inputTensor->quantization->qConfig;
+    int32_t mant[n];
+    unpackSignExtend(inputTensor->data, inQC->qBits, mant, n);
+    float deq[n];
+    for (size_t i = 0; i < n; i++) {
+        deq[i] = (float)mant[i] * inQC->scale;
+    }
+    /* mirror convertFloatTensorToAsymTensor on `deq` */
+    float mn = findMinFloat((uint8_t *)deq, n), mx = findMaxFloat((uint8_t *)deq, n);
+    asymQConfig_t *outQC = outputTensor->quantization->qConfig;
+    float qMax = powf(2, outQC->qBits);
+    float scale;
+    int16_t zeroPoint;
+    if (mn == mx) {
+        scale = (mn == 0.f) ? 1.f : mn;
+        zeroPoint = 1;
+    } else {
+        scale = (mx - mn) / qMax;
+        zeroPoint = (int16_t)roundByMode(mn / scale, outQC->roundingMode);
+    }
+    int32_t codes[n];
+    for (size_t i = 0; i < n; i++) {
+        codes[i] = roundByMode(clamp(deq[i] / scale - (float)zeroPoint, 0.f, qMax - 1),
+                               outQC->roundingMode);
+    }
+    outQC->scale = scale;
+    outQC->zeroPoint = zeroPoint;
+    uint8_t wide[n * sizeof(int32_t)];
+    writeInt32ArrayToByteArray(n, codes, wide);
+    byteConversion(wide, 32, outputTensor->data, outQC->qBits, n);
+}
+
 char *quantTypeToString(qtype_t t) {
     switch (t) {
     case INT32:
@@ -468,7 +502,7 @@ conversionFunction_t conversionMatrix[6][6] = {
              [FLOAT32] = convertSymTensorToFloat32Tensor,
              [SYM_INT32] = convertSymTensorToSymInt32Tensor,
              [SYM] = NULL,
-             [ASYM] = unsupportedConversionTypes,
+             [ASYM] = convertSymTensorToAsymTensor,
              [BOOL] = unsupportedConversionTypes},
     [ASYM] = {[INT32] = convertAsymTensorToInt32Tensor,
               [FLOAT32] = convertAsymTensorToFloatTensor,

--- a/src/tensor/TensorConversion.c
+++ b/src/tensor/TensorConversion.c
@@ -387,6 +387,13 @@ static void unpackSignExtend(const uint8_t *src, size_t srcBits, int32_t *dst, s
     }
 }
 
+// Important: Scale is ignored! Emits sign-extended integer codes (int_repr).
+void convertSymTensorToInt32Tensor(tensor_t *inputTensor, tensor_t *outputTensor) {
+    size_t n = calcNumberOfElementsByTensor(inputTensor);
+    symQConfig_t *inQC = inputTensor->quantization->qConfig;
+    unpackSignExtend(inputTensor->data, inQC->qBits, (int32_t *)outputTensor->data, n);
+}
+
 void convertSymTensorToFloat32Tensor(tensor_t *inputTensor, tensor_t *outputTensor) {
     size_t n = calcNumberOfElementsByTensor(inputTensor);
     symQConfig_t *inQC = inputTensor->quantization->qConfig;
@@ -457,7 +464,7 @@ conversionFunction_t conversionMatrix[6][6] = {
                    [SYM] = unsupportedConversionTypes,
                    [ASYM] = convertSymInt32TensorToAsymTensor,
                    [BOOL] = unsupportedConversionTypes},
-    [SYM] = {[INT32] = unsupportedConversionTypes,
+    [SYM] = {[INT32] = convertSymTensorToInt32Tensor,
              [FLOAT32] = convertSymTensorToFloat32Tensor,
              [SYM_INT32] = convertSymTensorToSymInt32Tensor,
              [SYM] = NULL,

--- a/src/tensor/TensorConversion.c
+++ b/src/tensor/TensorConversion.c
@@ -387,6 +387,17 @@ static void unpackSignExtend(const uint8_t *src, size_t srcBits, int32_t *dst, s
     }
 }
 
+void convertSymTensorToFloat32Tensor(tensor_t *inputTensor, tensor_t *outputTensor) {
+    size_t n = calcNumberOfElementsByTensor(inputTensor);
+    symQConfig_t *inQC = inputTensor->quantization->qConfig;
+    int32_t mant[n];
+    unpackSignExtend(inputTensor->data, inQC->qBits, mant, n);
+    float *out = (float *)outputTensor->data;
+    for (size_t i = 0; i < n; i++) {
+        out[i] = (float)mant[i] * inQC->scale;
+    }
+}
+
 void convertSymTensorToSymInt32Tensor(tensor_t *inputTensor, tensor_t *outputTensor) {
     size_t n = calcNumberOfElementsByTensor(inputTensor);
     symQConfig_t *inQC = inputTensor->quantization->qConfig;
@@ -447,7 +458,7 @@ conversionFunction_t conversionMatrix[6][6] = {
                    [ASYM] = convertSymInt32TensorToAsymTensor,
                    [BOOL] = unsupportedConversionTypes},
     [SYM] = {[INT32] = unsupportedConversionTypes,
-             [FLOAT32] = unsupportedConversionTypes,
+             [FLOAT32] = convertSymTensorToFloat32Tensor,
              [SYM_INT32] = convertSymTensorToSymInt32Tensor,
              [SYM] = NULL,
              [ASYM] = unsupportedConversionTypes,

--- a/test/unit/tensor/UnitTestTensorConversion.c
+++ b/test/unit/tensor/UnitTestTensorConversion.c
@@ -979,6 +979,65 @@ void testConversionSymInt32CodesDropScale() {
     freeReservedMemory(inBuf);
 }
 
+void testConversionSymAsymRescaleRoundTrips() {
+    /* Round-trip: SYM -> ASYM -> FLOAT32 recovers dequantized SYM values.
+     *
+     * Fixture: n=6, SYM qBits=6, scale=0.5, mantissas {10,-8,4,-2,6,-10}.
+     * Dequantized SYM: deq[i] = mant[i] * 0.5 => {5.0, -4.0, 2.0, -1.0, 3.0, -5.0}.
+     *
+     * ASYM qBits=5: range=10.0, qMax=32, asym scale=10/32=0.3125.
+     * convertFloatTensorToAsymTensor clamps codes to [0, qMax-1=31].
+     * zeroPoint = round(-5.0/0.3125) = -16; max code = clamp(32, 0, 31) = 31.
+     * Recovered max = (31+(-16))*0.3125 = 4.6875; error = 0.3125 = 1 scale step.
+     * Tolerance widened to 0.35 > 0.3125 to cover the clipped extremes.
+     */
+    size_t n = 6;
+    size_t dims[] = {6};
+    size_t order[] = {0};
+    shape_t shape = {.dimensions = dims, .numberOfDimensions = 1, .orderOfDimensions = order};
+
+    /* Build SYM input */
+    symQConfig_t inQC = {0};
+    inQC.scale = 0.5f;
+    inQC.qBits = 6;
+    quantization_t inQ;
+    initSymQuantization(&inQC, &inQ);
+    int32_t srcMant[] = {10, -8, 4, -2, 6, -10};
+    uint8_t *inBuf = reserveMemory(calcNumberOfBytesForData(&inQ, n));
+    tensor_t inTensor;
+    setTensorValues(&inTensor, inBuf, &shape, &inQ, NULL);
+    byteConversion((uint8_t *)srcMant, 32, inTensor.data, 6, n);
+
+    /* ASYM output tensor */
+    asymQConfig_t asymQC;
+    initAsymQConfig(5, HALF_AWAY, &asymQC);
+    quantization_t asymQ;
+    initAsymQuantization(&asymQC, &asymQ);
+    uint8_t asymData[n * calcBytesPerElement(&asymQ)];
+    tensor_t asymTensor;
+    setTensorValues(&asymTensor, asymData, &shape, &asymQ, NULL);
+
+    /* FLOAT32 output tensor for round-trip verification */
+    quantization_t floatQ;
+    initFloat32Quantization(&floatQ);
+    float outF[6];
+    tensor_t floatTensor;
+    setTensorValues(&floatTensor, (uint8_t *)outF, &shape, &floatQ, NULL);
+
+    /* Convert SYM -> ASYM -> FLOAT32 */
+    convertTensor(&inTensor, &asymTensor);
+    convertTensor(&asymTensor, &floatTensor);
+
+    /* Expected: dequantized SYM values */
+    float expected[] = {5.0f, -4.0f, 2.0f, -1.0f, 3.0f, -5.0f};
+
+    for (size_t i = 0; i < n; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(0.35f, expected[i], outF[i]);
+    }
+
+    freeReservedMemory(inBuf);
+}
+
 void setUp() {}
 void tearDown() {}
 
@@ -1016,6 +1075,7 @@ int main(void) {
     RUN_TEST(testConversionSymSymInt32SignExtends);
     RUN_TEST(testConversionSymFloat32Dequantizes);
     RUN_TEST(testConversionSymInt32CodesDropScale);
+    RUN_TEST(testConversionSymAsymRescaleRoundTrips);
 
     return UNITY_END();
 }

--- a/test/unit/tensor/UnitTestTensorConversion.c
+++ b/test/unit/tensor/UnitTestTensorConversion.c
@@ -921,6 +921,35 @@ void testConversionSymSymInt32SignExtends() {
     freeReservedMemory(inBuf);
 }
 
+void testConversionSymFloat32Dequantizes() {
+    size_t n = 3;
+    size_t dims[] = {3};
+    size_t order[] = {0};
+    shape_t shape = {.dimensions = dims, .numberOfDimensions = 1, .orderOfDimensions = order};
+    symQConfig_t inQC = {0};
+    inQC.scale = 0.25f;
+    inQC.qBits = 6;
+    quantization_t inQ;
+    initSymQuantization(&inQC, &inQ);
+    int32_t mant[] = {4, -4, 2};
+    uint8_t *inBuf = reserveMemory(calcNumberOfBytesForData(&inQ, n));
+    tensor_t inTensor;
+    setTensorValues(&inTensor, inBuf, &shape, &inQ, NULL);
+    byteConversion((uint8_t *)mant, 32, inTensor.data, 6, n);
+
+    quantization_t outQ;
+    initFloat32Quantization(&outQ);
+    float outData[3];
+    tensor_t outTensor;
+    setTensorValues(&outTensor, (uint8_t *)outData, &shape, &outQ, NULL);
+
+    convertTensor(&inTensor, &outTensor);
+
+    float expected[] = {1.0f, -1.0f, 0.5f};
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(expected, outData, n);
+    freeReservedMemory(inBuf);
+}
+
 void setUp() {}
 void tearDown() {}
 
@@ -956,6 +985,7 @@ int main(void) {
     RUN_TEST(testConversionSymInt32SameTypeCopyPropagatesScale);
     RUN_TEST(testQuantTypeToStringBool);
     RUN_TEST(testConversionSymSymInt32SignExtends);
+    RUN_TEST(testConversionSymFloat32Dequantizes);
 
     return UNITY_END();
 }

--- a/test/unit/tensor/UnitTestTensorConversion.c
+++ b/test/unit/tensor/UnitTestTensorConversion.c
@@ -950,6 +950,35 @@ void testConversionSymFloat32Dequantizes() {
     freeReservedMemory(inBuf);
 }
 
+void testConversionSymInt32CodesDropScale() {
+    size_t n = 4;
+    size_t dims[] = {4};
+    size_t order[] = {0};
+    shape_t shape = {.dimensions = dims, .numberOfDimensions = 1, .orderOfDimensions = order};
+    symQConfig_t inQC = {0};
+    inQC.scale = 7.5f;
+    inQC.qBits = 6; /* scale must be IGNORED */
+    quantization_t inQ;
+    initSymQuantization(&inQC, &inQ);
+    int32_t mant[] = {5, -5, 1, -32};
+    uint8_t *inBuf = reserveMemory(calcNumberOfBytesForData(&inQ, n));
+    tensor_t inTensor;
+    setTensorValues(&inTensor, inBuf, &shape, &inQ, NULL);
+    byteConversion((uint8_t *)mant, 32, inTensor.data, 6, n);
+
+    quantization_t outQ;
+    initInt32Quantization(&outQ);
+    int32_t outData[4];
+    tensor_t outTensor;
+    setTensorValues(&outTensor, (uint8_t *)outData, &shape, &outQ, NULL);
+
+    convertTensor(&inTensor, &outTensor);
+
+    int32_t expected[] = {5, -5, 1, -32};
+    TEST_ASSERT_EQUAL_INT32_ARRAY(expected, outData, n);
+    freeReservedMemory(inBuf);
+}
+
 void setUp() {}
 void tearDown() {}
 
@@ -986,6 +1015,7 @@ int main(void) {
     RUN_TEST(testQuantTypeToStringBool);
     RUN_TEST(testConversionSymSymInt32SignExtends);
     RUN_TEST(testConversionSymFloat32Dequantizes);
+    RUN_TEST(testConversionSymInt32CodesDropScale);
 
     return UNITY_END();
 }

--- a/test/unit/tensor/UnitTestTensorConversion.c
+++ b/test/unit/tensor/UnitTestTensorConversion.c
@@ -885,6 +885,42 @@ void testRequantToScaleSharedBufferAliasMatchesGold() {
     TEST_ASSERT_EQUAL_FLOAT(targetScale_requant_f6ToScaleSat, outQc.scale);
 }
 
+void testConversionSymSymInt32SignExtends() {
+    size_t numValues = 4;
+    size_t dims[] = {4};
+    size_t order[] = {0};
+    shape_t shape = {.dimensions = dims, .numberOfDimensions = 1, .orderOfDimensions = order};
+
+    /* SYM source, qBits=6, scale 0.5; mantissas {3,-3,31,-32} packed */
+    symQConfig_t inQC = {0};
+    inQC.scale = 0.5f;
+    inQC.qBits = 6;
+    quantization_t inQ;
+    initSymQuantization(&inQC, &inQ);
+    int32_t srcMant[] = {3, -3, 31, -32};
+    uint8_t *inBuf = reserveMemory(calcNumberOfBytesForData(&inQ, numValues));
+    tensor_t inTensor;
+    setTensorValues(&inTensor, inBuf, &shape, &inQ, NULL);
+    /* pack the signed mantissas into the SYM bitstream */
+    byteConversion((uint8_t *)srcMant, 32, inTensor.data, 6, numValues);
+
+    symInt32QConfig_t outQC = {0};
+    outQC.qMaxBits = 16;
+    quantization_t outQ;
+    initSymInt32Quantization(&outQC, &outQ);
+    int32_t outData[4];
+    tensor_t outTensor;
+    setTensorValues(&outTensor, (uint8_t *)outData, &shape, &outQ, NULL);
+
+    convertTensor(&inTensor, &outTensor);
+
+    int32_t expectedMant[] = {3, -3, 31, -32};
+    TEST_ASSERT_EQUAL_INT32_ARRAY(expectedMant, outData, numValues); /* sign preserved */
+    TEST_ASSERT_EQUAL_FLOAT(0.5f, outQC.scale);                      /* scale carried */
+    TEST_ASSERT_EQUAL_UINT8(6, outQC.qMaxBits);                      /* width recorded */
+    freeReservedMemory(inBuf);
+}
+
 void setUp() {}
 void tearDown() {}
 
@@ -919,6 +955,7 @@ int main(void) {
     RUN_TEST(testConversionBoolBoolCopiesOnlyPackedBytes);
     RUN_TEST(testConversionSymInt32SameTypeCopyPropagatesScale);
     RUN_TEST(testQuantTypeToStringBool);
+    RUN_TEST(testConversionSymSymInt32SignExtends);
 
     return UNITY_END();
 }


### PR DESCRIPTION
## What

Part **2 of 3** of #227 (the `SYM ↔ *` conversion bridge). This fills the `SYM →` **unpack row** of `conversionMatrix` (`src/tensor/TensorConversion.c`), which was entirely `unsupportedConversionTypes` before. `SYM` is the sub-byte bit-packed **storage** dtype; `SYM_INT32` is the int32-slot **compute** dtype — the MCU lifecycle is store-packed → unpack to int32 → compute.

PR-A (the int12 operand contract, #241) is already merged into `develop`. The `→ SYM` **pack column** is PR-C (separate, later).

## Changes

- **`unpackSignExtend(src, srcBits, dst, n)`** — shared `static` helper. `byteConversion` zero-fills on widen, so a packed `−3` at qBits=6 (`0b111101`) would read back as `61`; this widens then sign-extends the two's-complement payload (`(v ^ signBit) − signBit`), with a `srcBits >= 32` early-return to avoid `1 << 31` UB.
- **`SYM → SYM_INT32`** — no-rescale, sign-extend, carry `scale`, out `qMaxBits = src qBits` (value-preserving).
- **`SYM → FLOAT32`** — dequantize: `f = (sign-extended mantissa) × scale`.
- **`SYM → INT32`** — `int_repr`: emit the integer **codes**, drop scale. Mirrors the existing `SYM_INT32 → INT32` ("scale ignored") cell.
- **`SYM → ASYM`** — rescale: dequant → derive a fresh asym `scale`+`zeroPoint` from min/max → requantize → bit-pack (a symmetric grid can't hold an off-center `+zeroPoint` band at the carried scale).
- Wires the four `[SYM]`-row cells into `conversionMatrix` (`[SYM][SYM]` stays `NULL`; the `→SYM` column is untouched).
- `docs/CONVENTIONS.md`: new **SYM ↔ \* conversion bridge** section documenting the sign-extend rule, the deliberate `int_repr` (`→INT32`) vs `dequantize` (`→FLOAT32`) asymmetry, and the symmetric↔asymmetric rescale rule.

## Tests (TDD throughout)

Added to `test/unit/tensor/UnitTestTensorConversion.c`, dispatched via the public `convertTensor` path. Discriminating oracles:
- sign-extension proven at the qBits=6 boundaries (`−3`, `−32`, `31`);
- `→INT32` proves scale is dropped (input `scale = 7.5f`, codes emitted verbatim);
- `→FLOAT32` value preservation;
- `SYM → ASYM → FLOAT32` value round-trip within tolerance (a missed sign-extend blows the oracle by ~90×).

`ctest --preset unit_test_debug`: **62/62 pass**. Conversion suite 29/29, output pristine. clang-format clean.

## Notes

- No `int64` anywhere (framework hard rule); int32 only.
- Per repo policy this PR does **not** use `Closes #227` — #227 is closed manually only after PR-A + PR-B + PR-C all merge to `develop`.

## Follow-up (out of scope here)

The whole-branch review flagged that the asym-quantize body (min/max → scale/zeroPoint → clamp/round → pack) is now duplicated near-verbatim across **three** cells (`convertFloatTensorToAsymTensor`, `convertSymInt32TensorToAsymTensor`, `convertSymTensorToAsymTensor`) and has already drifted — clamp upper bound is `qMax−1` in two but `qMax` in the third, and the `mn==mx` degenerate guard differs across all three. Extracting a shared `quantizeFloatToAsym` helper would fix this, but it touches the FLOAT/SYMINT32-source converters outside PR-B's scope → candidate for a separate follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)