### PR TITLE
feat(tensor): →SYM pack column of the conversion bridge (#227 PR-C)

### DIFF
--- a/src/tensor/TensorConversion.c
+++ b/src/tensor/TensorConversion.c
@@ -452,6 +452,29 @@ void convertSymTensorToAsymTensor(tensor_t *inputTensor, tensor_t *outputTensor)
     byteConversion(wide, 32, outputTensor->data, outQC->qBits, n);
 }
 
+void convertAsymTensorToSymTensor(tensor_t *inputTensor, tensor_t *outputTensor) {
+    size_t n = calcNumberOfElementsByTensor(inputTensor);
+    asymQConfig_t *inQC = inputTensor->quantization->qConfig;
+    size_t inBits = calcBitsPerElement(inputTensor->quantization);
+    int32_t codes[n];
+    byteConversion(inputTensor->data, inBits, (uint8_t *)codes, 32, n); /* asym codes >= 0 */
+    float deq[n];
+    for (size_t i = 0; i < n; i++) {
+        deq[i] = ((float)codes[i] + (float)inQC->zeroPoint) * inQC->scale;
+    }
+    float absMax = findAbsMaxFloat((uint8_t *)deq, n);
+    symQConfig_t *outQC = outputTensor->quantization->qConfig;
+    const float qMax = powf(2, (float)outQC->qBits - 1) - 1;
+    const float qMin = -powf(2, (float)outQC->qBits - 1);
+    float scale = (absMax == 0.f) ? 1.f : absMax / qMax;
+    outQC->scale = scale;
+    int32_t out[n];
+    for (size_t i = 0; i < n; i++) {
+        out[i] = roundByMode(clamp(deq[i] / scale, qMin, qMax), outQC->roundingMode);
+    }
+    packFitGuarded(out, n, outputTensor->data, outQC->qBits, "convertAsymTensorToSymTensor");
+}
+
 char *quantTypeToString(qtype_t t) {
     switch (t) {
     case INT32:
@@ -564,7 +587,7 @@ conversionFunction_t conversionMatrix[6][6] = {
     [ASYM] = {[INT32] = convertAsymTensorToInt32Tensor,
               [FLOAT32] = convertAsymTensorToFloatTensor,
               [SYM_INT32] = convertAsymTensorToSymInt32Tensor,
-              [SYM] = unsupportedConversionTypes,
+              [SYM] = convertAsymTensorToSymTensor,
               [ASYM] = NULL,
               [BOOL] = unsupportedConversionTypes},
     [BOOL] = {[INT32] = unsupportedConversionTypes,

--- a/src/tensor/TensorConversion.c
+++ b/src/tensor/TensorConversion.c
@@ -522,6 +522,15 @@ void convertSymInt32TensorToSymTensor(tensor_t *inputTensor, tensor_t *outputTen
     packFitGuarded(codes, n, outputTensor->data, outQC->qBits, "convertSymInt32TensorToSymTensor");
 }
 
+void repackSymInt32ToSymNoRescale(tensor_t *inputTensor, tensor_t *outputTensor) {
+    size_t n = calcNumberOfElementsByTensor(inputTensor);
+    symInt32QConfig_t *inQC = inputTensor->quantization->qConfig;
+    symQConfig_t *outQC = outputTensor->quantization->qConfig;
+    outQC->scale = inQC->scale;
+    packFitGuarded((int32_t *)inputTensor->data, n, outputTensor->data, outQC->qBits,
+                   "repackSymInt32ToSymNoRescale");
+}
+
 _Static_assert(BOOL + 1 == 6, "extend conversionMatrix when adding qtype_t entries");
 
 conversionFunction_t conversionMatrix[6][6] = {

--- a/src/tensor/TensorConversion.c
+++ b/src/tensor/TensorConversion.c
@@ -119,6 +119,16 @@ void convertFloatTensorToSymInt32Tensor(tensor_t *inputTensor, tensor_t *outputT
     }
 }
 
+void convertInt32TensorToSymTensor(tensor_t *inputTensor, tensor_t *outputTensor) {
+    size_t n = calcNumberOfElementsByTensor(inputTensor);
+    symQConfig_t *outQC = outputTensor->quantization->qConfig;
+    outQC->scale = 1.f;
+    int32_t codes[n];
+    readBytesAsInt32Array(n, inputTensor->data, codes);
+    packFitGuarded(codes, n, outputTensor->data, outQC->qBits, "convertInt32TensorToSymTensor");
+    copyDimsAndSparsityToTensor(inputTensor, outputTensor);
+}
+
 void convertFloatTensorToSymTensor(tensor_t *inputTensor, tensor_t *outputTensor) {
     size_t n = calcNumberOfElementsByTensor(inputTensor);
     float absMax = findAbsMaxFloat(inputTensor->data, n);
@@ -530,7 +540,7 @@ conversionFunction_t conversionMatrix[6][6] = {
     [INT32] = {[INT32] = NULL,
                [FLOAT32] = convertInt32TensorToFloatTensor,
                [SYM_INT32] = convertInt32TensorToSymInt32Tensor,
-               [SYM] = unsupportedConversionTypes,
+               [SYM] = convertInt32TensorToSymTensor,
                [ASYM] = convertInt32TensorToAsymTensor,
                [BOOL] = unsupportedConversionTypes},
     [FLOAT32] = {[INT32] = convertFloatTensorToInt32Tensor,

--- a/src/tensor/TensorConversion.c
+++ b/src/tensor/TensorConversion.c
@@ -11,6 +11,9 @@
 #include "TensorConversion.h"
 #include "math.h"
 
+static void packFitGuarded(const int32_t *src, size_t n, uint8_t *dst, size_t dstBits,
+                           const char *what);
+
 void zeroTensorData(tensor_t *tensor) {
     size_t numberOfElements = calcNumberOfElementsByTensor(tensor);
     size_t bytesPerElement = calcBytesPerElement(tensor->quantization);
@@ -116,31 +119,21 @@ void convertFloatTensorToSymInt32Tensor(tensor_t *inputTensor, tensor_t *outputT
     }
 }
 
-// I DON'T HAVE TO IMPLEMENT SYM CONVERSIONS!
 void convertFloatTensorToSymTensor(tensor_t *inputTensor, tensor_t *outputTensor) {
-    size_t numberOfElements = calcNumberOfElementsByTensor(inputTensor);
-
-    float min = findMinFloat(inputTensor->data, numberOfElements);
-    float max = findMaxFloat(inputTensor->data, numberOfElements);
-
-    symQConfig_t *outputSymQConfig = outputTensor->quantization->qConfig;
-    float qMax = powf(2, outputSymQConfig->qBits);
-
-    float scale = (min - max) / qMax;
-    outputSymQConfig->scale = scale;
-
-    float inputs[numberOfElements];
-    readBytesAsFloatArray(numberOfElements, inputTensor->data, inputs);
-
-    size_t bytesPerOutputElement = calcBytesPerElement(outputTensor->quantization);
-    uint8_t outputs[numberOfElements * bytesPerOutputElement];
-
-    for (size_t i = 0; i < numberOfElements; i++) {
-        outputs[i] =
-            roundByMode(clamp(inputs[i] / scale, 0.f, qMax - 1), outputSymQConfig->roundingMode);
+    size_t n = calcNumberOfElementsByTensor(inputTensor);
+    float absMax = findAbsMaxFloat(inputTensor->data, n);
+    symQConfig_t *outQC = outputTensor->quantization->qConfig;
+    const float qMax = powf(2, (float)outQC->qBits - 1) - 1;
+    const float qMin = -powf(2, (float)outQC->qBits - 1);
+    float scale = (absMax == 0.f) ? 1.f : absMax / qMax;
+    outQC->scale = scale;
+    float *in = (float *)inputTensor->data;
+    int32_t codes[n];
+    for (size_t i = 0; i < n; i++) {
+        codes[i] = roundByMode(clamp(in[i] / scale, qMin, qMax), outQC->roundingMode);
     }
-
-    memcpy(outputTensor->data, outputs, numberOfElements * bytesPerOutputElement);
+    packFitGuarded(codes, n, outputTensor->data, outQC->qBits, "convertFloatTensorToSymTensor");
+    copyDimsAndSparsityToTensor(inputTensor, outputTensor);
 }
 
 // conversion from float to asym should not be needed/used
@@ -543,7 +536,7 @@ conversionFunction_t conversionMatrix[6][6] = {
     [FLOAT32] = {[INT32] = convertFloatTensorToInt32Tensor,
                  [FLOAT32] = NULL,
                  [SYM_INT32] = convertFloatTensorToSymInt32Tensor,
-                 [SYM] = unsupportedConversionTypes,
+                 [SYM] = convertFloatTensorToSymTensor,
                  [ASYM] = convertFloatTensorToAsymTensor,
                  [BOOL] = unsupportedConversionTypes},
     [SYM_INT32] = {[INT32] = extractInt32TensorFromSymInt32Tensor,

--- a/src/tensor/TensorConversion.c
+++ b/src/tensor/TensorConversion.c
@@ -477,6 +477,51 @@ void unsupportedConversionTypes(tensor_t *inputTensor, tensor_t *outputTensor) {
     exit(1);
 }
 
+static void packFitGuarded(const int32_t *src, size_t n, uint8_t *dst, size_t dstBits,
+                           const char *what) {
+    const int32_t hi = ((int32_t)1 << (dstBits - 1)) - 1;
+    const int32_t lo = -((int32_t)1 << (dstBits - 1));
+    for (size_t i = 0; i < n; i++) {
+        if (src[i] < lo || src[i] > hi) {
+            PRINT_ERROR("%s: value %d does not fit %u-bit SYM range [%d, %d] (#227)", what, src[i],
+                        (unsigned)dstBits, lo, hi);
+            exit(1);
+        }
+    }
+    int32_t tmp[n];
+    for (size_t i = 0; i < n; i++) {
+        tmp[i] = src[i];
+    }
+    byteConversion((uint8_t *)tmp, 32, dst, dstBits, n);
+}
+
+void convertSymInt32TensorToSymTensor(tensor_t *inputTensor, tensor_t *outputTensor) {
+    size_t n = calcNumberOfElementsByTensor(inputTensor);
+    symInt32QConfig_t *inQC = inputTensor->quantization->qConfig;
+    symQConfig_t *outQC = outputTensor->quantization->qConfig;
+    float inScale = inQC->scale;
+    const float qMax = powf(2, (float)outQC->qBits - 1) - 1;
+    const float qMin = -powf(2, (float)outQC->qBits - 1);
+    int32_t *in = (int32_t *)inputTensor->data;
+
+    float absMax = 0.f;
+    for (size_t i = 0; i < n; i++) {
+        float d = fabsf((float)in[i] * inScale);
+        if (d > absMax) {
+            absMax = d;
+        }
+    }
+    float scale = (absMax == 0.f) ? 1.f : absMax / qMax;
+    outQC->scale = scale;
+
+    int32_t codes[n];
+    for (size_t i = 0; i < n; i++) {
+        codes[i] = (int32_t)roundByMode(clamp(((float)in[i] * inScale) / scale, qMin, qMax),
+                                        outQC->roundingMode);
+    }
+    packFitGuarded(codes, n, outputTensor->data, outQC->qBits, "convertSymInt32TensorToSymTensor");
+}
+
 _Static_assert(BOOL + 1 == 6, "extend conversionMatrix when adding qtype_t entries");
 
 conversionFunction_t conversionMatrix[6][6] = {
@@ -495,7 +540,7 @@ conversionFunction_t conversionMatrix[6][6] = {
     [SYM_INT32] = {[INT32] = extractInt32TensorFromSymInt32Tensor,
                    [FLOAT32] = convertSymInt32TensorToFloat32Tensor,
                    [SYM_INT32] = requantSymInt32Tensor,
-                   [SYM] = unsupportedConversionTypes,
+                   [SYM] = convertSymInt32TensorToSymTensor,
                    [ASYM] = convertSymInt32TensorToAsymTensor,
                    [BOOL] = unsupportedConversionTypes},
     [SYM] = {[INT32] = convertSymTensorToInt32Tensor,

--- a/src/tensor/TensorConversion.c
+++ b/src/tensor/TensorConversion.c
@@ -13,6 +13,8 @@
 
 static void packFitGuarded(const int32_t *src, size_t n, uint8_t *dst, size_t dstBits,
                            const char *what);
+static void packFloatBufferAsSym(const float *values, size_t n, symQConfig_t *outQC, uint8_t *dst,
+                                 const char *what);
 
 void zeroTensorData(tensor_t *tensor) {
     size_t numberOfElements = calcNumberOfElementsByTensor(tensor);
@@ -131,18 +133,9 @@ void convertInt32TensorToSymTensor(tensor_t *inputTensor, tensor_t *outputTensor
 
 void convertFloatTensorToSymTensor(tensor_t *inputTensor, tensor_t *outputTensor) {
     size_t n = calcNumberOfElementsByTensor(inputTensor);
-    float absMax = findAbsMaxFloat(inputTensor->data, n);
     symQConfig_t *outQC = outputTensor->quantization->qConfig;
-    const float qMax = powf(2, (float)outQC->qBits - 1) - 1;
-    const float qMin = -powf(2, (float)outQC->qBits - 1);
-    float scale = (absMax == 0.f) ? 1.f : absMax / qMax;
-    outQC->scale = scale;
-    float *in = (float *)inputTensor->data;
-    int32_t codes[n];
-    for (size_t i = 0; i < n; i++) {
-        codes[i] = roundByMode(clamp(in[i] / scale, qMin, qMax), outQC->roundingMode);
-    }
-    packFitGuarded(codes, n, outputTensor->data, outQC->qBits, "convertFloatTensorToSymTensor");
+    packFloatBufferAsSym((float *)inputTensor->data, n, outQC, outputTensor->data,
+                         "convertFloatTensorToSymTensor");
     copyDimsAndSparsityToTensor(inputTensor, outputTensor);
 }
 
@@ -462,17 +455,8 @@ void convertAsymTensorToSymTensor(tensor_t *inputTensor, tensor_t *outputTensor)
     for (size_t i = 0; i < n; i++) {
         deq[i] = ((float)codes[i] + (float)inQC->zeroPoint) * inQC->scale;
     }
-    float absMax = findAbsMaxFloat((uint8_t *)deq, n);
     symQConfig_t *outQC = outputTensor->quantization->qConfig;
-    const float qMax = powf(2, (float)outQC->qBits - 1) - 1;
-    const float qMin = -powf(2, (float)outQC->qBits - 1);
-    float scale = (absMax == 0.f) ? 1.f : absMax / qMax;
-    outQC->scale = scale;
-    int32_t out[n];
-    for (size_t i = 0; i < n; i++) {
-        out[i] = roundByMode(clamp(deq[i] / scale, qMin, qMax), outQC->roundingMode);
-    }
-    packFitGuarded(out, n, outputTensor->data, outQC->qBits, "convertAsymTensorToSymTensor");
+    packFloatBufferAsSym(deq, n, outQC, outputTensor->data, "convertAsymTensorToSymTensor");
 }
 
 char *quantTypeToString(qtype_t t) {
@@ -521,31 +505,31 @@ static void packFitGuarded(const int32_t *src, size_t n, uint8_t *dst, size_t ds
     byteConversion((uint8_t *)tmp, 32, dst, dstBits, n);
 }
 
+static void packFloatBufferAsSym(const float *values, size_t n, symQConfig_t *outQC, uint8_t *dst,
+                                 const char *what) {
+    float absMax = findAbsMaxFloat((uint8_t *)values, n);
+    const float qMax = powf(2, (float)outQC->qBits - 1) - 1;
+    const float qMin = -powf(2, (float)outQC->qBits - 1);
+    float scale = (absMax == 0.f) ? 1.f : absMax / qMax;
+    outQC->scale = scale;
+    int32_t codes[n];
+    for (size_t i = 0; i < n; i++) {
+        codes[i] = roundByMode(clamp(values[i] / scale, qMin, qMax), outQC->roundingMode);
+    }
+    packFitGuarded(codes, n, dst, outQC->qBits, what);
+}
+
 void convertSymInt32TensorToSymTensor(tensor_t *inputTensor, tensor_t *outputTensor) {
     size_t n = calcNumberOfElementsByTensor(inputTensor);
     symInt32QConfig_t *inQC = inputTensor->quantization->qConfig;
     symQConfig_t *outQC = outputTensor->quantization->qConfig;
     float inScale = inQC->scale;
-    const float qMax = powf(2, (float)outQC->qBits - 1) - 1;
-    const float qMin = -powf(2, (float)outQC->qBits - 1);
     int32_t *in = (int32_t *)inputTensor->data;
-
-    float absMax = 0.f;
+    float vals[n];
     for (size_t i = 0; i < n; i++) {
-        float d = fabsf((float)in[i] * inScale);
-        if (d > absMax) {
-            absMax = d;
-        }
+        vals[i] = (float)in[i] * inScale;
     }
-    float scale = (absMax == 0.f) ? 1.f : absMax / qMax;
-    outQC->scale = scale;
-
-    int32_t codes[n];
-    for (size_t i = 0; i < n; i++) {
-        codes[i] = (int32_t)roundByMode(clamp(((float)in[i] * inScale) / scale, qMin, qMax),
-                                        outQC->roundingMode);
-    }
-    packFitGuarded(codes, n, outputTensor->data, outQC->qBits, "convertSymInt32TensorToSymTensor");
+    packFloatBufferAsSym(vals, n, outQC, outputTensor->data, "convertSymInt32TensorToSymTensor");
 }
 
 void repackSymInt32ToSymNoRescale(tensor_t *inputTensor, tensor_t *outputTensor) {

--- a/src/tensor/include/TensorConversion.h
+++ b/src/tensor/include/TensorConversion.h
@@ -49,6 +49,11 @@ void requantSymInt32Tensor(tensor_t *inputTensor, tensor_t *outputTensor);
  * diagonal). */
 void requantSymInt32TensorToScale(tensor_t *inputTensor, tensor_t *outputTensor);
 char *quantTypeToString(qtype_t t);
+/*! SYM_INT32 -> SYM with NO rescale: carry the input scale, pack mantissas
+ *  verbatim. Exits if any mantissa exceeds the target qBits. The no-rescale
+ *  partner of convertSymTensorToSymInt32Tensor (#227). Not a conversionMatrix
+ *  cell (the rescale variant owns [SYM_INT32][SYM]); call directly. */
+void repackSymInt32ToSymNoRescale(tensor_t *inputTensor, tensor_t *outputTensor);
 
 extern conversionFunction_t conversionMatrix[6][6];
 

--- a/test/unit/tensor/CMakeLists.txt
+++ b/test/unit/tensor/CMakeLists.txt
@@ -23,6 +23,7 @@ add_elastic_ai_unit_test(
         Quantization
         TensorApi
         StorageApi
+        odt_test_death
 )
 set(GEN_REQUANT_HEADER ${CMAKE_CURRENT_BINARY_DIR}/expected_requant.h)
 add_custom_command(

--- a/test/unit/tensor/UnitTestTensorConversion.c
+++ b/test/unit/tensor/UnitTestTensorConversion.c
@@ -1,4 +1,5 @@
 #include "DTypes.h"
+#include "DeathTest.h"
 #include "Quantization.h"
 #include "StorageApi.h"
 #include "Tensor.h"
@@ -12,6 +13,19 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+
+/* PR-C pack tests verify the packed SYM output by unpacking it here in-test:
+ * byteConversion zero-fills on widen, so sign-extend each value from qBits.
+ * (The SYM->* unpack cells live on the parallel PR-B branch, not here.) */
+static void symTestUnpackSignExtend(const uint8_t *packed, size_t qBits, int32_t *out, size_t n) {
+    byteConversion((uint8_t *)packed, qBits, (uint8_t *)out, 32, n);
+    const int32_t signBit = (int32_t)1 << (qBits - 1);
+    const int32_t mask = (int32_t)(((uint32_t)1 << qBits) - 1u);
+    for (size_t i = 0; i < n; i++) {
+        int32_t v = out[i] & mask;
+        out[i] = (v ^ signBit) - signBit;
+    }
+}
 
 void testConversionIntFloat() {
     uint8_t numValues = 6;
@@ -1038,6 +1052,55 @@ void testConversionSymAsymRescaleRoundTrips() {
     freeReservedMemory(inBuf);
 }
 
+void testConversionSymInt32ToSymRescaleRoundTrips() {
+    size_t n = 6;
+    size_t dims[] = {6};
+    size_t numberOfDims = 1;
+    size_t orderOfDims[] = {0};
+    shape_t shape = {
+        .dimensions = dims, .numberOfDimensions = numberOfDims, .orderOfDimensions = orderOfDims};
+
+    /* Input: SYM_INT32 with scale=0.25, mantissas span [-40, 40].
+     * Dequantized values: mantissa * 0.25 = {10, -8, 4, -2, 6, -10}; absmax = 10.0. */
+    symInt32QConfig_t inQC;
+    initSymInt32QConfigWithQMaxBits(HALF_AWAY, &inQC, 16);
+    inQC.scale = 0.25f;
+    quantization_t inQ;
+    initSymInt32Quantization(&inQC, &inQ);
+    int32_t inData[] = {40, -32, 16, -8, 24, -40};
+    tensor_t inTensor;
+    setTensorValues(&inTensor, (uint8_t *)inData, &shape, &inQ, NULL);
+
+    /* Output: SYM with qBits=6.
+     * Expected fresh scale = absmax / (2^(6-1) - 1) = 10.0 / 31 ≈ 0.322580645. */
+    symQConfig_t outQC;
+    initSymQConfig(6, HALF_AWAY, &outQC);
+    quantization_t outQ;
+    initSymQuantization(&outQC, &outQ);
+    uint8_t symData[calcNumberOfBytesForData(&outQ, n)];
+    tensor_t symTensor;
+    setTensorValues(&symTensor, symData, &shape, &outQ, NULL);
+
+    convertTensor(&inTensor, &symTensor);
+
+    /* Assert fresh output scale. */
+    TEST_ASSERT_FLOAT_WITHIN(1e-6f, 10.0f / 31.0f, outQC.scale);
+
+    /* Manually unpack codes and dequantize; verify within one quant step.
+     * One quant step = scale ≈ 0.323; tolerance = 0.33f. */
+    int32_t codes[6];
+    symTestUnpackSignExtend(symTensor.data, 6, codes, 6);
+    float expectedVal[] = {10.f, -8.f, 4.f, -2.f, 6.f, -10.f};
+    for (size_t i = 0; i < n; i++) {
+        float rec = (float)codes[i] * outQC.scale;
+        TEST_ASSERT_FLOAT_WITHIN(0.33f, expectedVal[i], rec);
+    }
+
+    /* Representative codes: 10.0 / (10.0/31) = 31; -10.0 / (10.0/31) = -31. */
+    TEST_ASSERT_INT32_WITHIN(1, 31, codes[0]);
+    TEST_ASSERT_INT32_WITHIN(1, -31, codes[5]);
+}
+
 void setUp() {}
 void tearDown() {}
 
@@ -1076,6 +1139,7 @@ int main(void) {
     RUN_TEST(testConversionSymFloat32Dequantizes);
     RUN_TEST(testConversionSymInt32CodesDropScale);
     RUN_TEST(testConversionSymAsymRescaleRoundTrips);
+    RUN_TEST(testConversionSymInt32ToSymRescaleRoundTrips);
 
     return UNITY_END();
 }

--- a/test/unit/tensor/UnitTestTensorConversion.c
+++ b/test/unit/tensor/UnitTestTensorConversion.c
@@ -1160,6 +1160,46 @@ void testRepackSymInt32ToSymNoRescaleRejectsOverflow() {
     ASSERT_EXITS_WITH_FAILURE(repackSymInt32ToSymNoRescale(&inTensor, &symTensor));
 }
 
+void testConversionFloatToSymRoundTripsSymmetric() {
+    /* n=6, absMax=3.5 => scale = 3.5 / (2^(6-1) - 1) = 3.5/31 ≈ 0.112903226.
+     * One quant step = scale ≈ 0.113; worst-case round-trip error = scale/2 ≈ 0.056;
+     * tolerance 0.12 is > one full step to cover HALF_AWAY rounding at the boundary. */
+    size_t n = 6;
+    size_t dims[] = {6};
+    size_t orderOfDims[] = {0};
+    shape_t shape = {.dimensions = dims, .numberOfDimensions = 1, .orderOfDimensions = orderOfDims};
+
+    float floatData[] = {1.5f, -2.5f, 3.0f, -1.0f, 0.5f, -3.5f};
+    quantization_t floatQ;
+    initFloat32Quantization(&floatQ);
+    tensor_t floatTensor;
+    setTensorValues(&floatTensor, (uint8_t *)floatData, &shape, &floatQ, NULL);
+
+    symQConfig_t outQC;
+    initSymQConfig(6, HALF_AWAY, &outQC);
+    quantization_t outQ;
+    initSymQuantization(&outQC, &outQ);
+    uint8_t symData[calcNumberOfBytesForData(&outQ, n)];
+    tensor_t symTensor;
+    setTensorValues(&symTensor, symData, &shape, &outQ, NULL);
+
+    convertTensor(&floatTensor, &symTensor);
+
+    TEST_ASSERT_FLOAT_WITHIN(1e-6f, 3.5f / 31.0f, outQC.scale);
+
+    int32_t codes[6];
+    symTestUnpackSignExtend(symTensor.data, 6, codes, 6);
+    for (size_t i = 0; i < n; i++) {
+        float rec = (float)codes[i] * outQC.scale;
+        TEST_ASSERT_FLOAT_WITHIN(0.12f, floatData[i], rec);
+    }
+
+    /* Prove symmetric range: the OLD buggy code clamped to [0, qMax-1] so
+     * negative inputs became 0; a non-zero negative code proves correct range. */
+    TEST_ASSERT_TRUE(codes[1] < 0); /* floatData[1] = -2.5 */
+    TEST_ASSERT_TRUE(codes[5] < 0); /* floatData[5] = -3.5 */
+}
+
 void setUp() {}
 void tearDown() {}
 
@@ -1201,6 +1241,7 @@ int main(void) {
     RUN_TEST(testConversionSymInt32ToSymRescaleRoundTrips);
     RUN_TEST(testRepackSymInt32ToSymNoRescaleFittingCarriesScale);
     RUN_TEST(testRepackSymInt32ToSymNoRescaleRejectsOverflow);
+    RUN_TEST(testConversionFloatToSymRoundTripsSymmetric);
 
     return UNITY_END();
 }

--- a/test/unit/tensor/UnitTestTensorConversion.c
+++ b/test/unit/tensor/UnitTestTensorConversion.c
@@ -1200,6 +1200,62 @@ void testConversionFloatToSymRoundTripsSymmetric() {
     TEST_ASSERT_TRUE(codes[5] < 0); /* floatData[5] = -3.5 */
 }
 
+void testConversionInt32ToSymNoRescaleScale1() {
+    /* INT32 codes fitting qBits=6 range [-32, 31] pack with scale=1. */
+    size_t n = 6;
+    size_t dims[] = {6};
+    size_t orderOfDims[] = {0};
+    shape_t shape = {.dimensions = dims, .numberOfDimensions = 1, .orderOfDimensions = orderOfDims};
+
+    int32_t intData[] = {5, -5, 31, -32, 0, 12};
+    quantization_t intQ;
+    initInt32Quantization(&intQ);
+    tensor_t intTensor;
+    setTensorValues(&intTensor, (uint8_t *)intData, &shape, &intQ, NULL);
+
+    symQConfig_t outQC;
+    initSymQConfig(6, HALF_AWAY, &outQC);
+    outQC.scale = 999.0f; /* garbage — proves scale=1 is written by the cell */
+    quantization_t outQ;
+    initSymQuantization(&outQC, &outQ);
+    uint8_t symData[calcNumberOfBytesForData(&outQ, n)];
+    tensor_t symTensor;
+    setTensorValues(&symTensor, symData, &shape, &outQ, NULL);
+
+    convertTensor(&intTensor, &symTensor);
+
+    int32_t codes[6];
+    symTestUnpackSignExtend(symTensor.data, 6, codes, 6);
+    TEST_ASSERT_EQUAL_INT32_ARRAY(intData, codes, 6);
+    TEST_ASSERT_EQUAL_FLOAT(1.0f, outQC.scale);
+}
+
+void testConversionInt32ToSymRejectsOutOfRange() {
+    /* An INT32 code outside [-32, 31] for qBits=6 must exit(1).
+     * Mutation guard: if packFitGuarded's range check is removed, the out-of-range
+     * code 40 truncates silently and the child exits 0, failing this test. */
+    size_t n = 6;
+    size_t dims[] = {6};
+    size_t orderOfDims[] = {0};
+    shape_t shape = {.dimensions = dims, .numberOfDimensions = 1, .orderOfDimensions = orderOfDims};
+
+    int32_t intData[] = {5, 40, -5, 0, 0, 0}; /* 40 > 31: out of range for qBits=6 */
+    quantization_t intQ;
+    initInt32Quantization(&intQ);
+    tensor_t intTensor;
+    setTensorValues(&intTensor, (uint8_t *)intData, &shape, &intQ, NULL);
+
+    symQConfig_t outQC;
+    initSymQConfig(6, HALF_AWAY, &outQC);
+    quantization_t outQ;
+    initSymQuantization(&outQC, &outQ);
+    uint8_t symData[calcNumberOfBytesForData(&outQ, n)];
+    tensor_t symTensor;
+    setTensorValues(&symTensor, symData, &shape, &outQ, NULL);
+
+    ASSERT_EXITS_WITH_FAILURE(convertTensor(&intTensor, &symTensor));
+}
+
 void setUp() {}
 void tearDown() {}
 
@@ -1242,6 +1298,8 @@ int main(void) {
     RUN_TEST(testRepackSymInt32ToSymNoRescaleFittingCarriesScale);
     RUN_TEST(testRepackSymInt32ToSymNoRescaleRejectsOverflow);
     RUN_TEST(testConversionFloatToSymRoundTripsSymmetric);
+    RUN_TEST(testConversionInt32ToSymNoRescaleScale1);
+    RUN_TEST(testConversionInt32ToSymRejectsOutOfRange);
 
     return UNITY_END();
 }

--- a/test/unit/tensor/UnitTestTensorConversion.c
+++ b/test/unit/tensor/UnitTestTensorConversion.c
@@ -1101,6 +1101,65 @@ void testConversionSymInt32ToSymRescaleRoundTrips() {
     TEST_ASSERT_INT32_WITHIN(1, -31, codes[5]);
 }
 
+void testRepackSymInt32ToSymNoRescaleFittingCarriesScale() {
+    size_t n = 6;
+    size_t dims[] = {6};
+    size_t orderOfDims[] = {0};
+    shape_t shape = {.dimensions = dims, .numberOfDimensions = 1, .orderOfDimensions = orderOfDims};
+
+    symInt32QConfig_t inQC;
+    initSymInt32QConfigWithQMaxBits(HALF_AWAY, &inQC, 16);
+    inQC.scale = 0.5f;
+    quantization_t inQ;
+    initSymInt32Quantization(&inQC, &inQ);
+    int32_t inData[] = {5, -5, 31, -32, 0, 12};
+    tensor_t inTensor;
+    setTensorValues(&inTensor, (uint8_t *)inData, &shape, &inQ, NULL);
+
+    symQConfig_t outQC;
+    initSymQConfig(6, HALF_AWAY, &outQC);
+    outQC.scale = 999.0f;
+    quantization_t outQ;
+    initSymQuantization(&outQC, &outQ);
+    uint8_t symData[calcNumberOfBytesForData(&outQ, n)];
+    tensor_t symTensor;
+    setTensorValues(&symTensor, symData, &shape, &outQ, NULL);
+
+    repackSymInt32ToSymNoRescale(&inTensor, &symTensor);
+
+    int32_t codes[6];
+    symTestUnpackSignExtend(symTensor.data, 6, codes, 6);
+    TEST_ASSERT_EQUAL_INT32_ARRAY(inData, codes, 6);
+    TEST_ASSERT_EQUAL_FLOAT(0.5f, outQC.scale);
+}
+
+void testRepackSymInt32ToSymNoRescaleRejectsOverflow() {
+    size_t n = 6;
+    size_t dims[] = {6};
+    size_t orderOfDims[] = {0};
+    shape_t shape = {.dimensions = dims, .numberOfDimensions = 1, .orderOfDimensions = orderOfDims};
+
+    symInt32QConfig_t inQC;
+    initSymInt32QConfigWithQMaxBits(HALF_AWAY, &inQC, 16);
+    inQC.scale = 0.5f;
+    quantization_t inQ;
+    initSymInt32Quantization(&inQC, &inQ);
+    int32_t inData[] = {5, 40, -5, 0, 0, 0};
+    tensor_t inTensor;
+    setTensorValues(&inTensor, (uint8_t *)inData, &shape, &inQ, NULL);
+
+    symQConfig_t outQC;
+    initSymQConfig(6, HALF_AWAY, &outQC);
+    outQC.scale = 999.0f;
+    quantization_t outQ;
+    initSymQuantization(&outQC, &outQ);
+    uint8_t symData[calcNumberOfBytesForData(&outQ, n)];
+    tensor_t symTensor;
+    setTensorValues(&symTensor, symData, &shape, &outQ, NULL);
+
+    ASSERT_EXITS_WITH_FAILURE(repackSymInt32ToSymNoRescale(&inTensor, &symTensor));
+}
+
 void setUp() {}
 void tearDown() {}
 
@@ -1140,6 +1199,8 @@ int main(void) {
     RUN_TEST(testConversionSymInt32CodesDropScale);
     RUN_TEST(testConversionSymAsymRescaleRoundTrips);
     RUN_TEST(testConversionSymInt32ToSymRescaleRoundTrips);
+    RUN_TEST(testRepackSymInt32ToSymNoRescaleFittingCarriesScale);
+    RUN_TEST(testRepackSymInt32ToSymNoRescaleRejectsOverflow);
 
     return UNITY_END();
 }

--- a/test/unit/tensor/UnitTestTensorConversion.c
+++ b/test/unit/tensor/UnitTestTensorConversion.c
@@ -1256,6 +1256,66 @@ void testConversionInt32ToSymRejectsOutOfRange() {
     ASSERT_EXITS_WITH_FAILURE(convertTensor(&intTensor, &symTensor));
 }
 
+void testConversionAsymToSymRescaleOffCenterRoundTrips() {
+    /* Strategy: build an ASYM input representing an off-center ALL-POSITIVE band [2, 6],
+     * convert ASYM -> SYM, manually unpack the SYM output (sign-extend), dequantize with
+     * the fresh SYM scale, and assert recovery within tolerance — proving the cell RESCALED
+     * (a symmetric grid holds the [2,6] band only because the scale was recomputed). */
+    size_t n = 6;
+    size_t dims[] = {6};
+    size_t orderOfDims[] = {0};
+    shape_t shape = {.dimensions = dims, .numberOfDimensions = 1, .orderOfDimensions = orderOfDims};
+
+    /* Build ASYM input: qBits=5, scale=0.25, zeroPoint=-4.
+     * asym codes {12,16,20,24,28,14} -> reals = (code + zeroPoint)*scale = (code-4)*0.25
+     * = {2.0, 3.0, 4.0, 5.0, 6.0, 2.5} — off-center all-positive band [2, 6]. */
+    asymQConfig_t inQC;
+    initAsymQConfig(5, HALF_AWAY, &inQC);
+    inQC.scale = 0.25f;
+    inQC.zeroPoint = -4;
+    quantization_t inQ;
+    initAsymQuantization(&inQC, &inQ);
+
+    int32_t asymCodes[] = {12, 16, 20, 24, 28, 14};
+    uint8_t asymData[calcNumberOfBytesForData(&inQ, 6)];
+    byteConversion((uint8_t *)asymCodes, 32, asymData, 5, 6);
+    tensor_t asymTensor;
+    setTensorValues(&asymTensor, asymData, &shape, &inQ, NULL);
+
+    float reference[] = {2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 2.5f};
+
+    /* SYM output qBits=6. */
+    symQConfig_t outQC;
+    initSymQConfig(6, HALF_AWAY, &outQC);
+    quantization_t outQ;
+    initSymQuantization(&outQC, &outQ);
+    uint8_t symData[calcNumberOfBytesForData(&outQ, 6)];
+    tensor_t symTensor;
+    setTensorValues(&symTensor, symData, &shape, &outQ, NULL);
+
+    convertTensor(&asymTensor, &symTensor);
+
+    /* Assert FRESH symmetric scale proves rescale (NOT the carried asym 0.25):
+     * absMax = 6.0; scale = 6.0 / (2^(6-1) - 1) = 6.0/31. */
+    TEST_ASSERT_FLOAT_WITHIN(1e-6f, 6.0f / 31.0f, outQC.scale);
+
+    /* Manual unpack + dequant + compare.
+     * asym codes are exact integers so the only error is the SYM requantization step
+     * ≈ scale/2 = (6/31)/2 ≈ 0.097; tolerance 0.2 is conservative (< one full step). */
+    int32_t symCodes[6];
+    symTestUnpackSignExtend(symTensor.data, 6, symCodes, 6);
+    for (size_t i = 0; i < 6; i++) {
+        float rec = (float)symCodes[i] * outQC.scale;
+        TEST_ASSERT_FLOAT_WITHIN(0.2f, reference[i], rec);
+    }
+
+    /* All codes positive: off-center [2,6] band maps onto the positive half of the
+     * symmetric grid after rescaling. */
+    for (size_t i = 0; i < 6; i++) {
+        TEST_ASSERT_TRUE(symCodes[i] > 0);
+    }
+}
+
 void setUp() {}
 void tearDown() {}
 
@@ -1300,6 +1360,7 @@ int main(void) {
     RUN_TEST(testConversionFloatToSymRoundTripsSymmetric);
     RUN_TEST(testConversionInt32ToSymNoRescaleScale1);
     RUN_TEST(testConversionInt32ToSymRejectsOutOfRange);
+    RUN_TEST(testConversionAsymToSymRescaleOffCenterRoundTrips);
 
     return UNITY_END();
 }


### PR DESCRIPTION
## What

Part **3 of 3** of #227 (the `SYM ↔ *` conversion bridge). Fills the `→ SYM` **pack column** of `conversionMatrix` (`src/tensor/TensorConversion.c`), rewrites the dormant buggy `convertFloatTensorToSymTensor`, and de-duplicates the resulting float→SYM-quant logic into one shared helper.

**Stacked on PR-B (#242)** — this PR's base is the `227-pr-b-sym-unpack` branch, so its diff shows only the pack-side changes and it sits cleanly on top of the unpack row. History is linear **A → B → C** (#241 → #242 → this). When #242 merges into `develop`, GitHub auto-retargets this PR's base to `develop`. **Merge #242 first.**

## Changes

- **`packFitGuarded(src, n, dst, dstBits, what)`** — shared `static` fit-guard (exits on out-of-range, else `byteConversion`-narrows).
- **`SYM_INT32 → SYM`** (rescale, matrix cell) — absmax → fresh `scale = absMax/(2^(qBits−1)−1)` → requantize → pack.
- **`repackSymInt32ToSymNoRescale`** (PUBLIC, in `TensorConversion.h`, **NOT** a matrix cell) — no-rescale partner of PR-B's `SYM → SYM_INT32`: carries scale, packs raw mantissas, exits on overflow.
- **`FLOAT32 → SYM`** — rewrites the dormant converter, fixing three bugs (negative scale, asymmetric `[0,qMax−1]` clamp, no bit-packing) → symmetric scale + symmetric clamp + `packFitGuarded`.
- **`INT32 → SYM`** (no-rescale, `scale=1`) — packs raw codes.
- **`ASYM → SYM`** (rescale) — dequant `(code + zeroPoint) × scale` → fresh symmetric scale → requantize → pack.
- Wires the four `[*][SYM]` column cells (`[SYM][SYM]`=`NULL`, `[BOOL][SYM]`=unsupported).
- **`refactor: packFloatBufferAsSym`** (final commit) — the three rescale cells (`SYM_INT32`/`FLOAT32`/`ASYM` → SYM) shared an identical float→SYM-quant tail (absmax → symmetric scale → clamp/round → `packFitGuarded`); extracted into one `static` helper. Behavior-preserving (the three round-trip tests are unchanged and green). This folds in the dedup originally flagged as a follow-up. (The sibling float→**ASYM**-quant duplication remains tracked separately in #243 — different target dtype.)

## Tests (TDD throughout)

In `test/unit/tensor/UnitTestTensorConversion.c`. Each pack test verifies the packed output by manually unpacking it in-test (`symTestUnpackSignExtend`: `byteConversion` widen + sign-extend) → dequantize → compare within one quant step, each asserting the **fresh** scale (proving rescale); `FLOAT32→SYM` asserts negatives survive; two `ASSERT_EXITS_WITH_FAILURE` death-tests (`DeathTest.h`) exercise `packFitGuarded`'s overflow guard.

`ctest --preset unit_test_debug`: **62/62 pass** (conversion suite 36/36 — 25 base + PR-B's 4 unpack + this PR's 7 pack, pristine). clang-format clean. No `int64` anywhere (framework hard rule).

## Notes

- Per repo policy this PR does **not** use `Closes #227` — close #227 manually only after PR-A + PR-B + PR-C all merge to `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)