### PR TITLE
fix(tensor): unify the four float→asym quantizers to the standard affine convention (#243)

### DIFF
--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -550,6 +550,19 @@ near-useless for `scale ≪ 1`).
 pack): a symmetric code grid cannot hold an off-center `+zeroPoint` band at the
 carried scale, independent of width.
 
+**Asymmetric quantization convention (#243).** Every `* → ASYM` cell builds a float
+buffer (from its own preamble) and routes through one shared helper,
+`quantizeFloatToAsym` (`src/tensor/TensorConversion.c`) — the single source of truth.
+Standard affine: `scale = (max − min) / (2^qBits − 1)`, `zeroPoint = round(min/scale)`,
+`code = clamp(round(v/scale − zeroPoint), 0, 2^qBits − 1)` (HALF_AWAY). Dequant is
+`(code + zeroPoint)·scale` — note the **additive** `zeroPoint` (ODT's sign convention,
+the inverse of PyTorch's `q − zeroPoint`). A constant tensor (`min == max`) uses
+`scale = (min != 0) ? |min| : 1` to avoid divide-by-zero. The denominator is
+`2^qBits − 1`, **not** `2^qBits` — the latter is an off-by-one that leaves the top code
+unreachable. New asym-producing converters MUST call this helper and never re-derive the
+grid inline: hand-rolled copies are exactly how the four `*→ASYM` converters drifted
+before #243. The float→SYM pack sibling is `packFloatBufferAsSym`.
+
 ## Vision: memory over float accuracy
 
 ODT is a memory-light on-device-training research framework. SYM_INT32 paths

--- a/src/tensor/TensorConversion.c
+++ b/src/tensor/TensorConversion.c
@@ -166,41 +166,11 @@ void convertFloatTensorToSymTensor(tensor_t *inputTensor, tensor_t *outputTensor
     copyDimsAndSparsityToTensor(inputTensor, outputTensor);
 }
 
-// conversion from float to asym should not be needed/used
 void convertFloatTensorToAsymTensor(tensor_t *inputTensor, tensor_t *outputTensor) {
     size_t numberOfElements = calcNumberOfElementsByTensor(inputTensor);
-    float min = findMinFloat(inputTensor->data, numberOfElements);
-    float max = findMaxFloat(inputTensor->data, numberOfElements);
-
     asymQConfig_t *asymQConfig = outputTensor->quantization->qConfig;
-    float qMax = pow(2, asymQConfig->qBits);
-
-    float scale;
-    int16_t zeroPoint;
-    if (min == max) {
-        scale = min;
-        zeroPoint = 1;
-    } else {
-        scale = (max - min) / qMax;
-        zeroPoint = (int16_t)roundByMode(min / scale, asymQConfig->roundingMode);
-    }
-
-    int32_t outputElements[numberOfElements];
-    float *inputFloat = (float *)inputTensor->data;
-
-    for (size_t i = 0; i < numberOfElements; i++) {
-        outputElements[i] =
-            roundByMode(clamp(inputFloat[i] / scale - (float)zeroPoint, 0.f, qMax - 1),
-                        asymQConfig->roundingMode);
-    }
-
-    asymQConfig->scale = scale;
-    asymQConfig->zeroPoint = zeroPoint;
-    uint8_t outputElement[numberOfElements * sizeof(int32_t)];
-    writeInt32ArrayToByteArray(numberOfElements, outputElements, outputElement);
-
-    byteConversion(outputElement, 32, outputTensor->data, asymQConfig->qBits, numberOfElements);
-
+    quantizeFloatToAsym((float *)inputTensor->data, numberOfElements, asymQConfig,
+                        outputTensor->data);
     copyDimsAndSparsityToTensor(inputTensor, outputTensor);
 }
 

--- a/src/tensor/TensorConversion.c
+++ b/src/tensor/TensorConversion.c
@@ -380,29 +380,8 @@ void convertSymTensorToAsymTensor(tensor_t *inputTensor, tensor_t *outputTensor)
     for (size_t i = 0; i < n; i++) {
         deq[i] = (float)mant[i] * inQC->scale;
     }
-    /* mirror convertFloatTensorToAsymTensor on `deq` */
-    float mn = findMinFloat((uint8_t *)deq, n), mx = findMaxFloat((uint8_t *)deq, n);
     asymQConfig_t *outQC = outputTensor->quantization->qConfig;
-    float qMax = powf(2, outQC->qBits);
-    float scale;
-    int16_t zeroPoint;
-    if (mn == mx) {
-        scale = (mn == 0.f) ? 1.f : mn;
-        zeroPoint = 1;
-    } else {
-        scale = (mx - mn) / qMax;
-        zeroPoint = (int16_t)roundByMode(mn / scale, outQC->roundingMode);
-    }
-    int32_t codes[n];
-    for (size_t i = 0; i < n; i++) {
-        codes[i] = roundByMode(clamp(deq[i] / scale - (float)zeroPoint, 0.f, qMax - 1),
-                               outQC->roundingMode);
-    }
-    outQC->scale = scale;
-    outQC->zeroPoint = zeroPoint;
-    uint8_t wide[n * sizeof(int32_t)];
-    writeInt32ArrayToByteArray(n, codes, wide);
-    byteConversion(wide, 32, outputTensor->data, outQC->qBits, n);
+    quantizeFloatToAsym(deq, n, outQC, outputTensor->data);
 }
 
 void convertAsymTensorToSymTensor(tensor_t *inputTensor, tensor_t *outputTensor) {

--- a/src/tensor/TensorConversion.c
+++ b/src/tensor/TensorConversion.c
@@ -80,28 +80,14 @@ static void quantizeFloatToAsym(const float *values, size_t n, asymQConfig_t *ou
 
 void convertInt32TensorToAsymTensor(tensor_t *inputTensor, tensor_t *outputTensor) {
     size_t numberOfElements = calcNumberOfElementsByTensor(inputTensor);
-    int32_t min = findMinInt32(inputTensor->data, numberOfElements);
-    int32_t max = findMaxInt32(inputTensor->data, numberOfElements);
-    asymQConfig_t *linearQConfig = outputTensor->quantization->qConfig;
-    int32_t qMax = pow(2, linearQConfig->qBits) - 1;
-
-    float scale = (float)(max - min) / (float)qMax;
-    int16_t zeroPoint = (int16_t)roundByMode((float)min / scale, linearQConfig->roundingMode);
-
-    int32_t outputElements[numberOfElements];
-    for (size_t elementIndex = 0; elementIndex < numberOfElements; elementIndex++) {
-        int32_t inputElement = readBytesAsInt32(&inputTensor->data[elementIndex * sizeof(int32_t)]);
-
-        outputElements[elementIndex] =
-            roundByMode(clamp((float)inputElement / scale - (float)zeroPoint, 0.f, qMax - 1),
-                        linearQConfig->roundingMode);
+    int32_t inputAsInt32[numberOfElements];
+    readBytesAsInt32Array(numberOfElements, inputTensor->data, inputAsInt32);
+    float vals[numberOfElements];
+    for (size_t i = 0; i < numberOfElements; i++) {
+        vals[i] = (float)inputAsInt32[i];
     }
-    linearQConfig->scale = scale;
-    linearQConfig->zeroPoint = zeroPoint;
-    uint8_t outputElement[numberOfElements * sizeof(int32_t)];
-    writeInt32ArrayToByteArray(numberOfElements, outputElements, outputElement);
-
-    byteConversion(outputElement, 32, outputTensor->data, linearQConfig->qBits, numberOfElements);
+    asymQConfig_t *asymQConfig = outputTensor->quantization->qConfig;
+    quantizeFloatToAsym(vals, numberOfElements, asymQConfig, outputTensor->data);
     copyDimsAndSparsityToTensor(inputTensor, outputTensor);
 }
 

--- a/src/tensor/TensorConversion.c
+++ b/src/tensor/TensorConversion.c
@@ -15,6 +15,7 @@ static void packFitGuarded(const int32_t *src, size_t n, uint8_t *dst, size_t ds
                            const char *what);
 static void packFloatBufferAsSym(const float *values, size_t n, symQConfig_t *outQC, uint8_t *dst,
                                  const char *what);
+static void quantizeFloatToAsym(const float *values, size_t n, asymQConfig_t *outQC, uint8_t *dst);
 
 void zeroTensorData(tensor_t *tensor) {
     size_t numberOfElements = calcNumberOfElementsByTensor(tensor);
@@ -49,6 +50,32 @@ void convertInt32TensorToSymInt32Tensor(tensor_t *inputTensor, tensor_t *outputT
     outputSymInt32QConfig->scale = 1;
 
     memcpy(outputTensor->data, inputTensor->data, numberOfElements * sizeof(int32_t));
+}
+
+/* Standard affine asymmetric quantization (#243). scale = (max-min)/(2^qBits-1),
+ * zeroPoint = round(min/scale), code = clamp(round(v/scale - zeroPoint), 0, 2^qBits-1).
+ * Dequant (elsewhere) is (code + zeroPoint)*scale. Constant tensor (min==max) uses a
+ * nonzero scale to avoid divide-by-zero. The single source of truth for all four
+ * *ToAsymTensor converters. */
+static void quantizeFloatToAsym(const float *values, size_t n, asymQConfig_t *outQC, uint8_t *dst) {
+    float mn = findMinFloat((uint8_t *)values, n);
+    float mx = findMaxFloat((uint8_t *)values, n);
+    const float qMax = powf(2, (float)outQC->qBits) - 1;
+    float scale;
+    if (mn == mx) {
+        scale = (mn != 0.f) ? fabsf(mn) : 1.f;
+    } else {
+        scale = (mx - mn) / qMax;
+    }
+    int16_t zeroPoint = (int16_t)roundByMode(mn / scale, outQC->roundingMode);
+    int32_t codes[n];
+    for (size_t i = 0; i < n; i++) {
+        codes[i] = roundByMode(clamp(values[i] / scale - (float)zeroPoint, 0.f, qMax),
+                               outQC->roundingMode);
+    }
+    outQC->scale = scale;
+    outQC->zeroPoint = zeroPoint;
+    byteConversion((uint8_t *)codes, 32, dst, outQC->qBits, n);
 }
 
 void convertInt32TensorToAsymTensor(tensor_t *inputTensor, tensor_t *outputTensor) {
@@ -276,38 +303,15 @@ void requantSymInt32TensorToScale(tensor_t *inputTensor, tensor_t *outputTensor)
 
 void convertSymInt32TensorToAsymTensor(tensor_t *inputTensor, tensor_t *outputTensor) {
     size_t numberOfValues = calcNumberOfElementsByTensor(inputTensor);
-
     symInt32QConfig_t *inputSymInt32QConfig = inputTensor->quantization->qConfig;
     asymQConfig_t *outputAsymQConfig = outputTensor->quantization->qConfig;
-
     float inputScale = inputSymInt32QConfig->scale;
-
     int32_t *inputAsInt32 = (int32_t *)inputTensor->data;
-
     float inputAsFloat[numberOfValues];
     for (size_t i = 0; i < numberOfValues; i++) {
         inputAsFloat[i] = inputScale * (float)inputAsInt32[i];
     }
-
-    float min = findMinFloat((uint8_t *)inputAsFloat, numberOfValues);
-    float max = findMaxFloat((uint8_t *)inputAsFloat, numberOfValues);
-    int32_t qMax = (1 << outputAsymQConfig->qBits) - 1;
-
-    float outputScale = (max - min) / (float)qMax;
-    outputAsymQConfig->scale = outputScale;
-
-    int16_t zeroPoint = (int16_t)roundByMode(min / outputScale, outputAsymQConfig->roundingMode);
-    outputAsymQConfig->zeroPoint = zeroPoint;
-
-    int32_t outputInt[numberOfValues];
-    for (size_t i = 0; i < numberOfValues; i++) {
-        outputInt[i] =
-            roundByMode(clamp(inputAsFloat[i] / outputScale - (float)zeroPoint, 0.f, qMax),
-                        outputAsymQConfig->roundingMode);
-    }
-
-    byteConversion((uint8_t *)outputInt, 32, outputTensor->data, outputAsymQConfig->qBits,
-                   numberOfValues);
+    quantizeFloatToAsym(inputAsFloat, numberOfValues, outputAsymQConfig, outputTensor->data);
 }
 
 void convertAsymTensorToInt32Tensor(tensor_t *inputTensor, tensor_t *outputTensor) {

--- a/test/unit/tensor/UnitTestTensorConversion.c
+++ b/test/unit/tensor/UnitTestTensorConversion.c
@@ -999,11 +999,10 @@ void testConversionSymAsymRescaleRoundTrips() {
      * Fixture: n=6, SYM qBits=6, scale=0.5, mantissas {10,-8,4,-2,6,-10}.
      * Dequantized SYM: deq[i] = mant[i] * 0.5 => {5.0, -4.0, 2.0, -1.0, 3.0, -5.0}.
      *
-     * ASYM qBits=5: range=10.0, qMax=32, asym scale=10/32=0.3125.
-     * convertFloatTensorToAsymTensor clamps codes to [0, qMax-1=31].
-     * zeroPoint = round(-5.0/0.3125) = -16; max code = clamp(32, 0, 31) = 31.
-     * Recovered max = (31+(-16))*0.3125 = 4.6875; error = 0.3125 = 1 scale step.
-     * Tolerance widened to 0.35 > 0.3125 to cover the clipped extremes.
+     * ASYM qBits=5: range=10.0, qMax-1=31, asym scale=10/31≈0.32258.
+     * Codes clamped to [0, 31]; zeroPoint = round(-5.0/(10/31)) = -16 (approx).
+     * Worst-case round-trip error ≈0.16 < tolerance 0.35.
+     * Tolerance stays at 0.35 to cover the clipped extremes.
      */
     size_t n = 6;
     size_t dims[] = {6};
@@ -1040,6 +1039,8 @@ void testConversionSymAsymRescaleRoundTrips() {
 
     /* Convert SYM -> ASYM -> FLOAT32 */
     convertTensor(&inTensor, &asymTensor);
+    /* #243: standard affine asym scale = range/(2^qBits-1) = 10/31 (was 10/32). */
+    TEST_ASSERT_FLOAT_WITHIN(1e-5f, 10.0f / 31.0f, asymQC.scale);
     convertTensor(&asymTensor, &floatTensor);
 
     /* Expected: dequantized SYM values */

--- a/test/unit/tensor/UnitTestTensorConversion.c
+++ b/test/unit/tensor/UnitTestTensorConversion.c
@@ -121,7 +121,7 @@ void testConversionIntAsym() {
     int32_t expectedZeroPoint = -11;
     float expectedScale = 0.1875f;*/
 
-    uint8_t expectedAsym[] = {15, 20, 26, 30, 5, 0};
+    uint8_t expectedAsym[] = {15, 20, 26, 31, 5, 0};
     int32_t expectedZeroPoint = -10;
     float expectedScale = 0.1935484f;
 

--- a/test/unit/tensor/UnitTestTensorConversion.c
+++ b/test/unit/tensor/UnitTestTensorConversion.c
@@ -1256,6 +1256,47 @@ void testConversionInt32ToSymRejectsOutOfRange() {
     ASSERT_EXITS_WITH_FAILURE(convertTensor(&intTensor, &symTensor));
 }
 
+void testConversionSymInt32AsymConstantTensorNoDivByZero() {
+    /* Constant tensor: min==max. The quantizeFloatToAsym degenerate branch must avoid
+     * divide-by-zero and recover the constant. Before the dedup,
+     * convertSymInt32TensorToAsymTensor had no min==max guard: scale=(max-min)/qMax=0,
+     * so value/scale was inf and the result was garbage (UB on the float->int cast). */
+    size_t n = 4;
+    size_t dims[] = {4};
+    size_t order[] = {0};
+    shape_t shape = {.dimensions = dims, .numberOfDimensions = 1, .orderOfDimensions = order};
+
+    symInt32QConfig_t inQC;
+    initSymInt32QConfigWithQMaxBits(HALF_AWAY, &inQC, 16);
+    inQC.scale = 0.5f;
+    quantization_t inQ;
+    initSymInt32Quantization(&inQC, &inQ);
+    int32_t inData[] = {8, 8, 8, 8}; /* dequantized = 4.0 each (constant) */
+    tensor_t inTensor;
+    setTensorValues(&inTensor, (uint8_t *)inData, &shape, &inQ, NULL);
+
+    asymQConfig_t asymQC;
+    initAsymQConfig(5, HALF_AWAY, &asymQC);
+    quantization_t asymQ;
+    initAsymQuantization(&asymQC, &asymQ);
+    uint8_t asymData[n * calcBytesPerElement(&asymQ)];
+    tensor_t asymTensor;
+    setTensorValues(&asymTensor, asymData, &shape, &asymQ, NULL);
+
+    quantization_t floatQ;
+    initFloat32Quantization(&floatQ);
+    float outF[4];
+    tensor_t floatTensor;
+    setTensorValues(&floatTensor, (uint8_t *)outF, &shape, &floatQ, NULL);
+
+    convertTensor(&inTensor, &asymTensor);    /* SYM_INT32 -> ASYM (constant) */
+    convertTensor(&asymTensor, &floatTensor); /* ASYM -> FLOAT32 round-trip */
+
+    for (size_t i = 0; i < n; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(1e-4f, 4.0f, outF[i]);
+    }
+}
+
 void testConversionAsymToSymRescaleOffCenterRoundTrips() {
     /* Strategy: build an ASYM input representing an off-center ALL-POSITIVE band [2, 6],
      * convert ASYM -> SYM, manually unpack the SYM output (sign-extend), dequantize with
@@ -1333,6 +1374,7 @@ int main(void) {
     RUN_TEST(testConversionSymInt32Int);
     RUN_TEST(testConversionSymInt32Float);
     RUN_TEST(testConversionSymInt32Asym);
+    RUN_TEST(testConversionSymInt32AsymConstantTensorNoDivByZero);
 
     RUN_TEST(testConversionAsymInt);
     RUN_TEST(testConversionAsymFloat);

--- a/test/unit/tensor/UnitTestTensorConversion.c
+++ b/test/unit/tensor/UnitTestTensorConversion.c
@@ -236,9 +236,9 @@ void testConversionFloatAsym() {
     uint8_t flattenedAsymData[numValues];
     byteConversion(asymTensor.data, asymQConfig.qBits, flattenedAsymData, 8, numValues);
 
-    uint8_t expectedAsym[] = {16, 22, 27, 31, 6, 0};
-    int32_t expectedZeroPoint = -11;
-    float expectedScale = 0.1875f;
+    uint8_t expectedAsym[] = {15, 20, 26, 31, 5, 0};
+    int32_t expectedZeroPoint = -10;
+    float expectedScale = 6.0f / 31.0f;
 
     TEST_ASSERT_EQUAL_UINT8_ARRAY(expectedAsym, flattenedAsymData, numValues);
     TEST_ASSERT_EQUAL_INT32(expectedZeroPoint, asymQConfig.zeroPoint);

--- a/test/unit/tensor/UnitTestTensorConversion.c
+++ b/test/unit/tensor/UnitTestTensorConversion.c
@@ -117,10 +117,6 @@ void testConversionIntAsym() {
     uint8_t flattenedAsymData[numValues];
     byteConversion(asymTensor.data, asymQConfig.qBits, flattenedAsymData, 8, numValues);
 
-    /*uint8_t expectedAsym[] = {16, 22, 25, 31, 6, 0};
-    int32_t expectedZeroPoint = -11;
-    float expectedScale = 0.1875f;*/
-
     uint8_t expectedAsym[] = {15, 20, 26, 31, 5, 0};
     int32_t expectedZeroPoint = -10;
     float expectedScale = 0.1935484f;
@@ -999,10 +995,10 @@ void testConversionSymAsymRescaleRoundTrips() {
      * Fixture: n=6, SYM qBits=6, scale=0.5, mantissas {10,-8,4,-2,6,-10}.
      * Dequantized SYM: deq[i] = mant[i] * 0.5 => {5.0, -4.0, 2.0, -1.0, 3.0, -5.0}.
      *
-     * ASYM qBits=5: range=10.0, qMax-1=31, asym scale=10/31≈0.32258.
-     * Codes clamped to [0, 31]; zeroPoint = round(-5.0/(10/31)) = -16 (approx).
-     * Worst-case round-trip error ≈0.16 < tolerance 0.35.
-     * Tolerance stays at 0.35 to cover the clipped extremes.
+     * ASYM qBits=5: range=10.0, qMax=2^5-1=31, asym scale=10/31≈0.32258.
+     * zeroPoint=round(-5.0/(10/31))=-16; codes={31,4,22,13,25,1} (clamped to [0,31]).
+     * Codes + scale + zeroPoint are pinned exactly below; the round-trip leg is a
+     * secondary sanity check (worst-case error ≈0.16, tolerance 0.35 covers clipping).
      */
     size_t n = 6;
     size_t dims[] = {6};
@@ -1041,6 +1037,13 @@ void testConversionSymAsymRescaleRoundTrips() {
     convertTensor(&inTensor, &asymTensor);
     /* #243: standard affine asym scale = range/(2^qBits-1) = 10/31 (was 10/32). */
     TEST_ASSERT_FLOAT_WITHIN(1e-5f, 10.0f / 31.0f, asymQC.scale);
+    /* Pin the grid exactly: the 0.35 round-trip tolerance below cannot distinguish
+     * 10/31 from the old 10/32, so assert zeroPoint and the unpacked codes directly. */
+    TEST_ASSERT_EQUAL_INT32(-16, asymQC.zeroPoint);
+    uint8_t flattenedAsymData[n];
+    byteConversion(asymTensor.data, asymQC.qBits, flattenedAsymData, 8, n);
+    uint8_t expectedCodes[] = {31, 4, 22, 13, 25, 1};
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(expectedCodes, flattenedAsymData, n);
     convertTensor(&asymTensor, &floatTensor);
 
     /* Expected: dequantized SYM values */


### PR DESCRIPTION
## What

Closes #243.

`src/tensor/TensorConversion.c` had **four** converters that each independently derived an asymmetric quant grid, and they had **drifted** on two axes — scale denominator (`2^b` vs `2^b−1`) and clamp upper bound (`2^b−2` vs `2^b−1`) — with two of them dividing by zero on a constant tensor. This unifies them onto one shared `static quantizeFloatToAsym` helper using the **standard affine** convention.

## The fix

`quantizeFloatToAsym(values, n, outQC, dst)` — single source of truth:
- `scale = (max − min) / (2^qBits − 1)` (standard affine; maps `max` onto the top code `2^b−1`)
- `zeroPoint = round(min/scale)`; `code = clamp(round(value/scale − zeroPoint), 0, 2^qBits − 1)` (HALF_AWAY)
- degenerate `min==max`: `scale = (min != 0) ? fabsf(min) : 1` — no divide-by-zero
- dequant elsewhere (`(code + zeroPoint)·scale`) is unchanged and consistent with this.

All four `*ToAsymTensor` converters now build their float buffer (their own preambles preserved) and delegate to the helper. `convertSymInt32TensorToAsymTensor` was already canonical, so its rewire is **behavior-preserving** — its gold test `testConversionSymInt32Asym` is the unchanged green anchor proving the helper == the standard.

### Why `2^b` was wrong (not a convention choice)

Standard affine has `2^b` codes spanning `2^b − 1` intervals, so the scale denominator must be `2^b − 1`. Dividing by `2^b` (in the old `FLOAT32→ASYM`, inherited by `SYM→ASYM` via mirroring) made the scale too large so `max` never reached the top code; `INT32→ASYM` had the right denominator but a `2^b−2` clamp that wasted the top code a different way. Three of four were subtly wrong; this corrects them all.

## Behavior changes (reconciled gold, inline)

For the shared `{1,2,3,4,-1,-2}` / qBits=5 fixtures:
- `FLOAT32→ASYM`: `{16,22,27,31,6,0}` / `0.1875` / zp `-11`  →  `{15,20,26,31,5,0}` / `6/31` / zp `-10`.
- `INT32→ASYM`: only the top code changes (`30 → 31`); scale/zeroPoint unchanged.
- `SYM→ASYM`: asym scale `10/32 → 10/31` (round-trip error drops; existing tolerance test stays green, with a new exact-scale assertion).
- `SYM_INT32→ASYM`: unchanged (anchor).

## Tests

- New degenerate test (`testConversionSymInt32AsymConstantTensorNoDivByZero`): a constant tensor round-trips through ASYM without divide-by-zero (RED before the guard → garbage; GREEN after).
- `testConversionFloatAsym` / `testConversionIntAsym` gold reconciled inline (hand-derived, shown per-commit).
- `testConversionSymAsymRescaleRoundTrips` gains a `10/31` scale assertion.
- `ctest --preset unit_test_debug`: **62/62** (conversion suite 37/37, pristine). clang-format clean. No `int64`. No `conversionMatrix`/header/dequant changes; net **−108 lines** of duplication.

## Note

Targets `develop`; per repo policy `Closes #243` only auto-fires on the default branch, so #243 will be closed manually after the develop-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)