### PR TITLE
fix(tensor): harden converters + matmul bias per #247 review

### DIFF
--- a/src/arithmetic/Matmul.c
+++ b/src/arithmetic/Matmul.c
@@ -258,6 +258,13 @@ void matmulSymInt32TensorsWithBias(tensor_t *aTensor, tensor_t *bTensor, tensor_
     if (bias == NULL) {
         matmulIntCore(aTensor, bTensor, outputTensor, NULL);
     } else {
+        /* Bias is a value-sum seed (not a product operand), so it is exempt from
+         * the int12 operand bound but must still be SYM_INT32: the branch below
+         * reads its data as int32 and its qConfig as symInt32QConfig_t (#247). */
+        if (bias->quantization->type != SYM_INT32) {
+            PRINT_ERROR("matmul SYM_INT32: bias must be SYM_INT32");
+            exit(1);
+        }
         size_t bColumns =
             (bTensor->shape->numberOfDimensions < 2) ? 1 : getDimensionsByIndex(bTensor, 1);
         if (calcNumberOfElementsByTensor(bias) != bColumns) {

--- a/src/tensor/TensorConversion.c
+++ b/src/tensor/TensorConversion.c
@@ -23,13 +23,6 @@ void zeroTensorData(tensor_t *tensor) {
     memset(tensor->data, 0, numberOfElements * bytesPerElement);
 }
 
-void copyDimsAndSparsityToTensor(tensor_t *inputTensor, tensor_t *outputTensor) {
-    outputTensor->shape = inputTensor->shape;
-    if (inputTensor->sparsity) {
-        memcpy(outputTensor->sparsity, inputTensor->sparsity, sizeof(sparsity_t));
-    }
-}
-
 void convertInt32TensorToFloatTensor(tensor_t *inputTensor, tensor_t *outputTensor) {
     size_t numberOfElements = calcNumberOfElementsByTensor(inputTensor);
     int32_t inputData[numberOfElements];
@@ -40,7 +33,6 @@ void convertInt32TensorToFloatTensor(tensor_t *inputTensor, tensor_t *outputTens
         outputData[i] = (float)inputData[i];
     }
     writeFloatArrayToByteArray(numberOfElements, outputData, outputTensor->data);
-    copyDimsAndSparsityToTensor(inputTensor, outputTensor);
 }
 
 void convertInt32TensorToSymInt32Tensor(tensor_t *inputTensor, tensor_t *outputTensor) {
@@ -88,7 +80,6 @@ void convertInt32TensorToAsymTensor(tensor_t *inputTensor, tensor_t *outputTenso
     }
     asymQConfig_t *asymQConfig = outputTensor->quantization->qConfig;
     quantizeFloatToAsym(vals, numberOfElements, asymQConfig, outputTensor->data);
-    copyDimsAndSparsityToTensor(inputTensor, outputTensor);
 }
 
 void convertFloatTensorToInt32Tensor(tensor_t *inputTensor, tensor_t *outputTensor) {
@@ -101,7 +92,6 @@ void convertFloatTensorToInt32Tensor(tensor_t *inputTensor, tensor_t *outputTens
         outputData[i] = (int32_t)inputData[i];
     }
     writeInt32ArrayToByteArray(numberOfElements, outputData, outputTensor->data);
-    copyDimsAndSparsityToTensor(inputTensor, outputTensor);
 }
 
 void convertFloatTensorToSymInt32Tensor(tensor_t *inputTensor, tensor_t *outputTensor) {
@@ -141,7 +131,6 @@ void convertInt32TensorToSymTensor(tensor_t *inputTensor, tensor_t *outputTensor
     int32_t codes[n];
     readBytesAsInt32Array(n, inputTensor->data, codes);
     packFitGuarded(codes, n, outputTensor->data, outQC->qBits, "convertInt32TensorToSymTensor");
-    copyDimsAndSparsityToTensor(inputTensor, outputTensor);
 }
 
 void convertFloatTensorToSymTensor(tensor_t *inputTensor, tensor_t *outputTensor) {
@@ -149,7 +138,6 @@ void convertFloatTensorToSymTensor(tensor_t *inputTensor, tensor_t *outputTensor
     symQConfig_t *outQC = outputTensor->quantization->qConfig;
     packFloatBufferAsSym((float *)inputTensor->data, n, outQC, outputTensor->data,
                          "convertFloatTensorToSymTensor");
-    copyDimsAndSparsityToTensor(inputTensor, outputTensor);
 }
 
 void convertFloatTensorToAsymTensor(tensor_t *inputTensor, tensor_t *outputTensor) {
@@ -157,7 +145,6 @@ void convertFloatTensorToAsymTensor(tensor_t *inputTensor, tensor_t *outputTenso
     asymQConfig_t *asymQConfig = outputTensor->quantization->qConfig;
     quantizeFloatToAsym((float *)inputTensor->data, numberOfElements, asymQConfig,
                         outputTensor->data);
-    copyDimsAndSparsityToTensor(inputTensor, outputTensor);
 }
 
 // Important: Scale is ignored!
@@ -285,7 +272,6 @@ void convertAsymTensorToInt32Tensor(tensor_t *inputTensor, tensor_t *outputTenso
         outputElements[elementIndex] = outputElements[elementIndex] + zeroPoint;
     }
     writeInt32ArrayToByteArray(numberOfElements, outputElements, outputTensor->data);
-    copyDimsAndSparsityToTensor(inputTensor, outputTensor);
 }
 
 void convertAsymTensorToFloatTensor(tensor_t *inputTensor, tensor_t *outputTensor) {
@@ -303,8 +289,6 @@ void convertAsymTensorToFloatTensor(tensor_t *inputTensor, tensor_t *outputTenso
         outputElements[elementIndex] =
             ((float)inputInt[elementIndex] + (float)zeroPoint) * asymQConfig->scale;
     }
-
-    copyDimsAndSparsityToTensor(inputTensor, outputTensor);
 }
 
 void convertAsymTensorToSymInt32Tensor(tensor_t *inputTensor, tensor_t *outputTensor) {
@@ -331,6 +315,11 @@ void convertAsymTensorToSymInt32Tensor(tensor_t *inputTensor, tensor_t *outputTe
 }
 
 static void unpackSignExtend(const uint8_t *src, size_t srcBits, int32_t *dst, size_t n) {
+    if (srcBits == 0) {
+        /* 1 << (srcBits - 1) below underflows size_t to SIZE_MAX -> UB shift (#247). */
+        PRINT_ERROR("unpackSignExtend: srcBits must be > 0");
+        exit(1);
+    }
     byteConversion((uint8_t *)src, srcBits, (uint8_t *)dst, 32, n); /* zero-fills high bits */
     if (srcBits >= 32) {
         return;
@@ -428,6 +417,12 @@ void unsupportedConversionTypes(tensor_t *inputTensor, tensor_t *outputTensor) {
 
 static void packFitGuarded(const int32_t *src, size_t n, uint8_t *dst, size_t dstBits,
                            const char *what) {
+    if (dstBits == 0 || dstBits > 31) {
+        /* 1 << (dstBits - 1) needs dstBits in [1, 31]: 0 underflows size_t and
+         * >= 32 overshoots the int32 sign bit -> UB shift (#247). */
+        PRINT_ERROR("%s: dstBits (%u) must be in [1, 31]", what, (unsigned)dstBits);
+        exit(1);
+    }
     const int32_t hi = ((int32_t)1 << (dstBits - 1)) - 1;
     const int32_t lo = -((int32_t)1 << (dstBits - 1));
     for (size_t i = 0; i < n; i++) {

--- a/src/userApi/tensor/TensorApi.c
+++ b/src/userApi/tensor/TensorApi.c
@@ -111,15 +111,11 @@ void tensorFillFromFloatBuffer(tensor_t *tensor, const float *source, size_t cou
 
     /* Non-FLOAT32: route through convertTensor, mirroring the pattern in
      * initTensorWithQSymInt32. Build a temporary FLOAT32 view over `source`
-     * and convert into `tensor`. The const-cast is safe per converter:
-     *   - SYM_INT32: convertFloatTensorToSymInt32Tensor writes only to
-     *     outputTensor->data and outputTensor->quantization->qConfig->scale.
-     *   - INT32 / ASYM: convertFloatTensorTo{Int32,Asym}Tensor end with
-     *     copyDimsAndSparsityToTensor(input, output), which writes
-     *     outputTensor->shape = inputTensor->shape. Since we set
-     *     srcView.shape = tensor->shape, that write self-assigns the same
-     *     pointer back into tensor — harmless. srcView.sparsity is NULL so
-     *     the sparsity memcpy branch is skipped. */
+     * and convert into `tensor`. The const-cast is safe: every converter writes
+     * only outputTensor->data and outputTensor->quantization->qConfig (scale /
+     * zeroPoint); none touch outputTensor->shape or ->sparsity (#247). srcView
+     * still needs a valid shape because the converter reads it for the element
+     * count, so it aliases tensor->shape. */
     quantization_t floatQ;
     initFloat32Quantization(&floatQ);
     tensor_t srcView;

--- a/test/unit/arithmetic/UnitTestMatmul.c
+++ b/test/unit/arithmetic/UnitTestMatmul.c
@@ -442,6 +442,46 @@ void testMatmulSymInt32RejectsOperandWiderThanInt12() {
     ASSERT_EXITS_WITH_FAILURE(matmulSymInt32Tensors(&a, &b, &out));
 }
 
+void testMatmulSymInt32TensorsWithBiasRejectsNonSymInt32Bias() {
+    /* aTensor/bTensor are valid SYM_INT32 operands, but the bias is FLOAT32.
+     * Without a type guard the bias branch reinterprets the float bytes as
+     * int32 and dereferences a FLOAT32 qConfig as symInt32QConfig_t (#247). */
+    tensor_t a, b, out;
+    int32_t aData[] = {1, 2, 3, 4, 5, 6};
+    int32_t bData[] = {1, 4, 2, 5, 3, 6};
+    int32_t outData[4];
+    size_t aDims[] = {2, 3}, bDims[] = {3, 2}, oDims[] = {2, 2}, order[] = {0, 1};
+    shape_t aS, bS, oS;
+    setShape(&aS, aDims, 2, order);
+    setShape(&bS, bDims, 2, order);
+    setShape(&oS, oDims, 2, order);
+
+    symInt32QConfig_t aQC, bQC, oQC;
+    initSymInt32QConfig(HALF_AWAY, &aQC);
+    initSymInt32QConfig(HALF_AWAY, &bQC);
+    initSymInt32QConfig(HALF_AWAY, &oQC);
+    quantization_t aQ, bQ, oQ;
+    initSymInt32Quantization(&aQC, &aQ);
+    initSymInt32Quantization(&bQC, &bQ);
+    initSymInt32Quantization(&oQC, &oQ);
+    setTensorValues(&a, (uint8_t *)aData, &aS, &aQ, NULL);
+    setTensorValues(&b, (uint8_t *)bData, &bS, &bQ, NULL);
+    setTensorValues(&out, (uint8_t *)outData, &oS, &oQ, NULL);
+
+    /* bias: FLOAT32, element count == output columns (2) so it clears the
+     * count check and reaches the type-confusing read. */
+    tensor_t bias;
+    float biasData[] = {1.f, 2.f};
+    size_t biasDims[] = {2}, biasOrder[] = {0};
+    shape_t biasS;
+    setShape(&biasS, biasDims, 1, biasOrder);
+    quantization_t biasQ;
+    initFloat32Quantization(&biasQ);
+    setTensorValues(&bias, (uint8_t *)biasData, &biasS, &biasQ, NULL);
+
+    ASSERT_EXITS_WITH_FAILURE(matmulSymInt32TensorsWithBias(&a, &b, &out, &bias));
+}
+
 void setUp() {}
 void tearDown() {}
 
@@ -456,6 +496,7 @@ int main(void) {
     RUN_TEST(testMatmulFloat32TensorsWithBiasNullEqualsPlain);
     RUN_TEST(testMatmulSymInt32TensorsWithBiasRescalesBias);
     RUN_TEST(testMatmulSymInt32RejectsOperandWiderThanInt12);
+    RUN_TEST(testMatmulSymInt32TensorsWithBiasRejectsNonSymInt32Bias);
 
     return UNITY_END();
 }

--- a/test/unit/layer/UnitTestLinear.c
+++ b/test/unit/layer/UnitTestLinear.c
@@ -836,13 +836,11 @@ void testLinearBackwardFloatWithMismatchedQuantizations() {
     tensor_t *forwardInput = initTensor(fwdShape, quantizationInitFloat(), NULL);
     tensorFillFromFloatBuffer(forwardInput, (float[]){0.f, 1.f, 2.f}, 3);
 
-    /* 4. Build heap ASYM loss tensor directly via tensorFillFromFloatBuffer.
-     *    Going through an intermediate Float tensor + convertTensor would alias
-     *    the two shape pointers (copyDimsAndSparsityToTensor in
-     *    convertFloatTensorToAsymTensor writes outputTensor->shape =
-     *    inputTensor->shape), which then causes a double-free. The fill helper
-     *    builds an internal Float view that aliases tensor->shape, so the
-     *    self-assignment is harmless. */
+    /* 4. Build heap ASYM loss tensor directly via tensorFillFromFloatBuffer
+     *    (the fill helper does the Float->ASYM conversion internally). Converters
+     *    write only data + qconfig and no longer touch output->shape (#247), so
+     *    an intermediate Float tensor would work too; the direct fill is simply
+     *    fewer allocations. */
     size_t *lossAsymDims = reserveMemory(2 * sizeof(size_t));
     lossAsymDims[0] = 1;
     lossAsymDims[1] = 2;

--- a/test/unit/tensor/UnitTestTensorConversion.c
+++ b/test/unit/tensor/UnitTestTensorConversion.c
@@ -1361,6 +1361,123 @@ void testConversionAsymToSymRescaleOffCenterRoundTrips() {
     }
 }
 
+void testConvertSymToInt32RejectsZeroQBits() {
+    /* qBits==0 makes unpackSignExtend compute 1 << (srcBits - 1); srcBits is
+     * size_t so 0 - 1 wraps to SIZE_MAX and the shift is UB (#247). The guard
+     * must reject it before the shift. */
+    size_t dims[] = {4};
+    size_t order[] = {0};
+    shape_t shape = {.dimensions = dims, .numberOfDimensions = 1, .orderOfDimensions = order};
+
+    symQConfig_t inQC = {0};
+    inQC.scale = 0.5f;
+    inQC.qBits = 0; /* degenerate */
+    quantization_t inQ;
+    initSymQuantization(&inQC, &inQ);
+    uint8_t inBuf[4] = {0}; /* never read: the guard fires first */
+    tensor_t inTensor;
+    setTensorValues(&inTensor, inBuf, &shape, &inQ, NULL);
+
+    quantization_t outQ;
+    initInt32Quantization(&outQ);
+    int32_t outData[4];
+    tensor_t outTensor;
+    setTensorValues(&outTensor, (uint8_t *)outData, &shape, &outQ, NULL);
+
+    ASSERT_EXITS_WITH_FAILURE(convertTensor(&inTensor, &outTensor));
+}
+
+void testConvertInt32ToSymRejectsZeroQBits() {
+    /* qBits==0 makes packFitGuarded compute 1 << (dstBits - 1) with dstBits as
+     * size_t (0 - 1 -> SIZE_MAX): UB shift, plus a 0-width byteConversion whose
+     * memset size underflows (#247). The guard must reject it up front. */
+    size_t dims[] = {4};
+    size_t order[] = {0};
+    shape_t shape = {.dimensions = dims, .numberOfDimensions = 1, .orderOfDimensions = order};
+
+    int32_t intData[] = {1, -1, 2, -2};
+    quantization_t intQ;
+    initInt32Quantization(&intQ);
+    tensor_t intTensor;
+    setTensorValues(&intTensor, (uint8_t *)intData, &shape, &intQ, NULL);
+
+    symQConfig_t outQC = {0};
+    outQC.qBits = 0; /* degenerate */
+    quantization_t outQ;
+    initSymQuantization(&outQC, &outQ);
+    uint8_t symBuf[4] = {0};
+    tensor_t symTensor;
+    setTensorValues(&symTensor, symBuf, &shape, &outQ, NULL);
+
+    ASSERT_EXITS_WITH_FAILURE(convertTensor(&intTensor, &symTensor));
+}
+
+void testConvertersPreserveCallerOutputShape() {
+    /* Contract (#247): converters write data + qconfig only; the CALLER owns the
+     * output tensor's shape, so the converter must NOT repoint output->shape.
+     * Pins the removal of the copyDimsAndSparsityToTensor shape-pointer steal,
+     * which double-freed heap-owned-shape outputs (see UnitTestLinear /
+     * UnitTestAdd). Distinct in/out shape structs make the steal observable as a
+     * changed pointer. */
+    size_t inDims[] = {6};
+    size_t inOrder[] = {0};
+    shape_t inShape = {.dimensions = inDims, .numberOfDimensions = 1, .orderOfDimensions = inOrder};
+    size_t outDims[] = {6};
+    size_t outOrder[] = {0};
+    shape_t outShape = {
+        .dimensions = outDims, .numberOfDimensions = 1, .orderOfDimensions = outOrder};
+
+    /* FLOAT32 -> ASYM (the converter UnitTestLinear documents as the double-free) */
+    float floatData[6] = {1.f, 2.f, 3.f, 4.f, -1.f, -2.f};
+    quantization_t floatInQ;
+    initFloat32Quantization(&floatInQ);
+    tensor_t floatIn;
+    setTensorValues(&floatIn, (uint8_t *)floatData, &inShape, &floatInQ, NULL);
+    asymQConfig_t asymQC;
+    initAsymQConfig(5, HALF_AWAY, &asymQC);
+    quantization_t asymQ;
+    initAsymQuantization(&asymQC, &asymQ);
+    uint8_t asymData[calcNumberOfBytesForData(&asymQ, 6)];
+    tensor_t asymOut;
+    setTensorValues(&asymOut, asymData, &outShape, &asymQ, NULL);
+    convertTensor(&floatIn, &asymOut);
+    TEST_ASSERT_EQUAL_PTR(&outShape, asymOut.shape);
+
+    /* INT32 -> FLOAT32 */
+    int32_t intData[6] = {1, 2, 3, 4, -1, -2};
+    quantization_t intInQ;
+    initInt32Quantization(&intInQ);
+    tensor_t intIn;
+    setTensorValues(&intIn, (uint8_t *)intData, &inShape, &intInQ, NULL);
+    quantization_t floatOutQ;
+    initFloat32Quantization(&floatOutQ);
+    float floatOutData[6];
+    tensor_t floatOut;
+    setTensorValues(&floatOut, (uint8_t *)floatOutData, &outShape, &floatOutQ, NULL);
+    convertTensor(&intIn, &floatOut);
+    TEST_ASSERT_EQUAL_PTR(&outShape, floatOut.shape);
+
+    /* ASYM -> FLOAT32 */
+    asymQConfig_t asymInQC;
+    initAsymQConfig(5, HALF_AWAY, &asymInQC);
+    asymInQC.scale = 0.25f;
+    asymInQC.zeroPoint = -4;
+    quantization_t asymInQ;
+    initAsymQuantization(&asymInQC, &asymInQ);
+    int32_t asymCodes[6] = {12, 16, 20, 8, 24, 14};
+    uint8_t asymInData[calcNumberOfBytesForData(&asymInQ, 6)];
+    byteConversion((uint8_t *)asymCodes, 32, asymInData, 5, 6);
+    tensor_t asymIn;
+    setTensorValues(&asymIn, asymInData, &inShape, &asymInQ, NULL);
+    quantization_t floatOut2Q;
+    initFloat32Quantization(&floatOut2Q);
+    float floatOut2Data[6];
+    tensor_t floatOut2;
+    setTensorValues(&floatOut2, (uint8_t *)floatOut2Data, &outShape, &floatOut2Q, NULL);
+    convertTensor(&asymIn, &floatOut2);
+    TEST_ASSERT_EQUAL_PTR(&outShape, floatOut2.shape);
+}
+
 void setUp() {}
 void tearDown() {}
 
@@ -1407,6 +1524,9 @@ int main(void) {
     RUN_TEST(testConversionInt32ToSymNoRescaleScale1);
     RUN_TEST(testConversionInt32ToSymRejectsOutOfRange);
     RUN_TEST(testConversionAsymToSymRescaleOffCenterRoundTrips);
+    RUN_TEST(testConvertSymToInt32RejectsZeroQBits);
+    RUN_TEST(testConvertInt32ToSymRejectsZeroQBits);
+    RUN_TEST(testConvertersPreserveCallerOutputShape);
 
     return UNITY_END();
 }


### PR DESCRIPTION
Addresses the actionable CodeRabbit findings on #247. Each was verified against the live code before acting; one was found to be inverted (see ④).

## Changes

**① matmul SYM_INT32 bias type-check** — `matmulSymInt32TensorsWithBias` now rejects a non-`SYM_INT32` bias before the bias branch reads its data as int32 and casts its qConfig to `symInt32QConfig_t` (was silent type-confusion UB). Type check only: the bias is a value-sum *seed*, not a product operand, so it stays exempt from the int12 operand bound.

**② operand-width `#error` clamp — intentionally declined.** Widening `ODT_SYM_OPERAND_QMAXBITS` is a deliberate research knob (pushing past the int12/no-int64 limit is a thing we want to be able to do); the runtime validators still reject wider operands at the matmul/layernorm boundary.

**③ sub-byte bit-width guards** — `unpackSignExtend` rejects `srcBits==0`, `packFitGuarded` rejects `dstBits ∉ [1,31]`, before `1 << (bits-1)`. `bits` is `size_t`, so `0-1` wraps to `SIZE_MAX` → UB shift (and a 0-width `byteConversion` underflows its `memset` size).

**④ converters no longer mutate `output->shape` / `->sparsity`.** CodeRabbit suggested *adding* `copyDimsAndSparsityToTensor` to the SYM converters — but that helper **steals** the input's shape pointer (`output->shape = input->shape`), which double-frees heap-owned-shape outputs (the convert-then-`freeTensor` pattern in `UnitTestAdd`/`UnitTestLinear`; the latter already carried a comment documenting this exact double-free hazard). Implementing the suggestion crashed 7 tests. The real contract is "the caller owns the output shape" (see the requant docs and `setTensorValuesForConversion`), so the fix is the inverse: remove the 8 existing copies + the now-unused helper, making every converter consistent and deleting the footgun. Two stale comments updated.

## Tests (TDD red→green verified)

- matmul non-`SYM_INT32`-bias death test
- two zero-bit-width death tests (`unpackSignExtend` / `packFitGuarded`)
- a converter output-shape-ownership regression test (RED with the copies present → GREEN after removal)

Full `ctest --preset unit_test_debug`: **62/62 passed**. clang-format clean. (ASan/pytest run on CI — local ASan is unusable on this host's macOS, and no Python is touched.)

## Merge note

Targets `develop`; once merged, the develop→main release PR #247 picks these up automatically since its head is `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)