### PR TITLE
feat(layer): parametrize factory init, default to PyTorch parity (Issue C)

### DIFF
--- a/src/userApi/CMakeLists.txt
+++ b/src/userApi/CMakeLists.txt
@@ -4,8 +4,14 @@ add_subdirectory(optimizer)
 add_subdirectory(tensor)
 add_subdirectory(training_loop)
 
-add_library(LayerCommon INTERFACE)
-target_include_directories(LayerCommon INTERFACE include)
+add_library(LayerCommon LayerCommon.c)
+target_include_directories(LayerCommon PUBLIC include)
+target_link_libraries(LayerCommon PRIVATE
+        Common
+        Distributions
+        Tensor
+        TensorApi
+)
 
 add_library(InferenceApi InferenceApi.c)
 target_include_directories(InferenceApi PUBLIC include)

--- a/src/userApi/LayerCommon.c
+++ b/src/userApi/LayerCommon.c
@@ -1,0 +1,71 @@
+#define SOURCE_FILE "LAYER_COMMON"
+
+#include <stdlib.h>
+
+#include "Common.h"
+#include "Distributions.h"
+#include "LayerCommon.h"
+#include "TensorApi.h"
+
+/* PyTorch's default weight/bias init draws from uniform(+/- 1/sqrt(fan_in)).
+ * kaimingUniform(gain, fan) = uniform(+/- gain*sqrt(3/fan)), so the gain that
+ * reproduces the 1/sqrt(fan_in) bound is sqrt(1/3): gain*sqrt(3/fan) =
+ * sqrt(1/3)*sqrt(3/fan) = sqrt(1/fan) = 1/sqrt(fan). This is exactly PyTorch's
+ * kaiming_uniform_(a=sqrt(5)) default for Linear/Conv weights. */
+#define INIT_DEFAULT_GAIN 0.57735026919f         /* sqrt(1/3) */
+#define INIT_KAIMING_DEFAULT_GAIN 1.41421356237f /* sqrt(2), He */
+#define INIT_XAVIER_DEFAULT_GAIN 1.0f
+
+static void requireFloat32(const tensor_t *t, const char *what) {
+    if (t->quantization->type != FLOAT32) {
+        PRINT_ERROR("%s: tensor init currently requires FLOAT32 storage (got type %d)", what,
+                    (int)t->quantization->type);
+        exit(1);
+    }
+}
+
+void initWeightTensor(tensor_t *weight, weightInit_t cfg, size_t fanIn, size_t fanOut) {
+    requireFloat32(weight, "initWeightTensor");
+
+    distribution_t dist;
+    switch (cfg.scheme) {
+    case INIT_DEFAULT:
+        dist = (distribution_t){
+            .type = KAIMING_UNIFORM,
+            .params.kaiming = {.gain = INIT_DEFAULT_GAIN, .fanMode = fanIn},
+        };
+        break;
+    case INIT_KAIMING_UNIFORM:
+        dist = (distribution_t){
+            .type = KAIMING_UNIFORM,
+            .params.kaiming = {.gain = cfg.gain != 0.0f ? cfg.gain : INIT_KAIMING_DEFAULT_GAIN,
+                               .fanMode = fanIn},
+        };
+        break;
+    case INIT_XAVIER_UNIFORM:
+        dist = (distribution_t){
+            .type = XAVIER_UNIFORM,
+            .params.xavier = {.gain = cfg.gain != 0.0f ? cfg.gain : INIT_XAVIER_DEFAULT_GAIN,
+                              .fanIn = fanIn,
+                              .fanOut = fanOut},
+        };
+        break;
+    default:
+        PRINT_ERROR("initWeightTensor: invalid init scheme (got %d)", (int)cfg.scheme);
+        exit(1);
+    }
+
+    initDistribution(weight, &dist);
+}
+
+void initBiasTensor(tensor_t *bias, size_t fanIn) {
+    requireFloat32(bias, "initBiasTensor");
+
+    /* PyTorch bias default: uniform(+/- 1/sqrt(fan_in)), independent of the
+     * weight scheme. Reuse kaimingUniform(sqrt(1/3), fan_in) = that bound. */
+    distribution_t dist = {
+        .type = KAIMING_UNIFORM,
+        .params.kaiming = {.gain = INIT_DEFAULT_GAIN, .fanMode = fanIn},
+    };
+    initDistribution(bias, &dist);
+}

--- a/src/userApi/include/LayerCommon.h
+++ b/src/userApi/include/LayerCommon.h
@@ -2,6 +2,9 @@
 #define LAYER_COMMON_H
 
 #include <assert.h>
+#include <stddef.h>
+
+#include "Tensor.h"
 
 /*! Bias presence tri-state for layer init structs.
  *  BIAS_DEFAULT lands at C99 zero-init; factories resolve it to the PyTorch
@@ -14,5 +17,41 @@ typedef enum {
 
 _Static_assert(BIAS_DEFAULT == 0,
                "BIAS_DEFAULT must be enum value 0 so .bias zero-init defaults to PyTorch default");
+
+/*! Weight initialization scheme for layer init structs.
+ *  INIT_DEFAULT lands at C99 zero-init; factories resolve it to PyTorch's
+ *  default weight init for that layer type — kaiming_uniform_(a=sqrt(5)),
+ *  i.e. uniform(+/- 1/sqrt(fan_in)). The bias is ALWAYS uniform(+/- 1/sqrt(fan_in))
+ *  regardless of the weight scheme (PyTorch convention). */
+typedef enum initScheme {
+    INIT_DEFAULT = 0,     /*!< PyTorch parity: weight kaiming a=sqrt(5) (bound 1/sqrt(fan_in)) */
+    INIT_KAIMING_UNIFORM, /*!< He; .gain (0 -> sqrt(2)) */
+    INIT_XAVIER_UNIFORM,  /*!< Glorot; .gain (0 -> 1) */
+} initScheme_t;
+
+_Static_assert(INIT_DEFAULT == 0,
+               "INIT_DEFAULT must be enum value 0 so .weightInit zero-init defaults to PyTorch");
+
+/*! Weight init recipe carried on the layer init structs. Zero-init
+ *  (scheme INIT_DEFAULT, gain 0) reproduces PyTorch's default. */
+typedef struct weightInit {
+    initScheme_t scheme;
+    float gain; /*!< 0 selects the scheme's default gain. Ignored for INIT_DEFAULT. */
+} weightInit_t;
+
+/*! Initialize a FLOAT32 weight tensor in place according to `cfg`.
+ *  Resolves scheme -> distribution and calls initDistribution.
+ *
+ *  - INIT_DEFAULT: kaimingUniform(gain = sqrt(1/3), fanIn) = uniform(+/- 1/sqrt(fanIn)),
+ *                  matching PyTorch kaiming_uniform_(a=sqrt(5)). gain ignored.
+ *  - INIT_KAIMING_UNIFORM: kaimingUniform(gain ? gain : sqrt(2), fanIn).
+ *  - INIT_XAVIER_UNIFORM: xavierUniform(gain ? gain : 1, fanIn, fanOut).
+ *
+ *  Aborts (PRINT_ERROR + exit) if the tensor is not FLOAT32. */
+void initWeightTensor(tensor_t *weight, weightInit_t cfg, size_t fanIn, size_t fanOut);
+
+/*! Initialize a FLOAT32 bias tensor in place to PyTorch's default
+ *  uniform(+/- 1/sqrt(fanIn)). Aborts if the tensor is not FLOAT32. */
+void initBiasTensor(tensor_t *bias, size_t fanIn);
 
 #endif /* LAYER_COMMON_H */

--- a/src/userApi/layer/Conv1dApi.c
+++ b/src/userApi/layer/Conv1dApi.c
@@ -6,7 +6,6 @@
 #include "Common.h"
 #include "Conv1d.h"
 #include "Conv1dApi.h"
-#include "Distributions.h"
 #include "Kernel.h"
 #include "Layer.h"
 #include "LayerCommon.h"
@@ -87,8 +86,8 @@ static shape_t *buildOwnedShape(const size_t *srcDims, size_t numberOfDims) {
 }
 
 static parameter_t *allocateConv1dWeights(size_t outChannels, size_t inChannels, size_t groups,
-                                          size_t kernelSize, quantization_t *storageQ,
-                                          quantization_t *gradQ) {
+                                          size_t kernelSize, weightInit_t weightInit,
+                                          quantization_t *storageQ, quantization_t *gradQ) {
     /* Conv1d weight shape: [outChannels, inChannels/groups, kernelSize].
      * Per Conv1d.h:11. */
     if (inChannels % groups != 0) {
@@ -106,31 +105,23 @@ static parameter_t *allocateConv1dWeights(size_t outChannels, size_t inChannels,
     shape_t *shape = buildOwnedShape((size_t[]){outChannels, inPerGroup, kernelSize}, 3);
     tensor_t *paramTensor = initTensor(shape, getQLike(storageQ), NULL);
 
-    /* PyTorch-aligned default: Kaiming uniform with fan_in mode.
-     * Note: PyTorch's actual default uses a=sqrt(5); bit-identical parity
-     * requires Issue C (distribution parametrization). */
-    if (storageQ->type != FLOAT32) {
-        PRINT_ERROR("conv1dLayerInit: KAIMING_UNIFORM init currently requires FLOAT32 "
-                    "weight storage (Issue C will lift this limit)");
-        exit(1);
-    }
-    distribution_t dist = {
-        .type = KAIMING_UNIFORM,
-        .params.kaiming = {.gain = 1.4142135623730951f /* sqrtf(2.0f) */,
-                           .fanMode = inPerGroup * kernelSize},
-    };
-    initDistribution(paramTensor, &dist);
+    /* fan_in = inPerGroup*kernelSize; fan_out = outPerGroup*kernelSize
+     * (PyTorch _calculate_fan_in_and_fan_out for the Conv1d weight layout). */
+    size_t fanIn = inPerGroup * kernelSize;
+    size_t fanOut = (outChannels / groups) * kernelSize;
+    initWeightTensor(paramTensor, weightInit, fanIn, fanOut);
 
     tensor_t *gradTensor = gradInit(paramTensor, gradQ, NULL);
     return parameterInit(paramTensor, gradTensor);
 }
 
-static parameter_t *allocateConv1dBias(size_t outChannels, quantization_t *storageQ,
+static parameter_t *allocateConv1dBias(size_t outChannels, size_t fanIn, quantization_t *storageQ,
                                        quantization_t *gradQ) {
-    /* Bias tensor: shape [outChannels]. Zero-initialized via calloc (reserveMemory). */
+    /* Bias tensor: shape [outChannels]. PyTorch draws bias from
+     * uniform(+/- 1/sqrt(fan_in)) using the WEIGHT's fan_in. */
     shape_t *shape = buildOwnedShape((size_t[]){outChannels}, 1);
     tensor_t *paramTensor = initTensor(shape, getQLike(storageQ), NULL);
-    /* No initDistribution(ZEROS) — calloc already gave us zeros. */
+    initBiasTensor(paramTensor, fanIn);
 
     tensor_t *gradTensor = gradInit(paramTensor, gradQ, NULL);
     return parameterInit(paramTensor, gradTensor);
@@ -211,10 +202,13 @@ layer_t *conv1dLayerInit(conv1dInit_t *init, layerQuant_t *lq) {
     layer->config = layerCfg;
 
     cfg->kernel = buildConv1dKernel(init);
+    size_t fanIn = (init->inChannels / groups) * init->kernelSize;
     quantization_t *gradQ = quantizationInitFloat(); /* Conv1d backward is FLOAT32-only */
-    cfg->weights = allocateConv1dWeights(init->outChannels, init->inChannels, groups,
-                                         init->kernelSize, lq->weightStorage, gradQ);
-    cfg->bias = hasBias ? allocateConv1dBias(init->outChannels, lq->biasStorage, gradQ) : NULL;
+    cfg->weights =
+        allocateConv1dWeights(init->outChannels, init->inChannels, groups, init->kernelSize,
+                              init->weightInit, lq->weightStorage, gradQ);
+    cfg->bias =
+        hasBias ? allocateConv1dBias(init->outChannels, fanIn, lq->biasStorage, gradQ) : NULL;
     freeQuantization(gradQ);
     cfg->groups = groups;
     cfg->forwardQ = lq->forwardMath;
@@ -245,10 +239,13 @@ layer_t *conv1dLayerInitOwning(conv1dInit_t *init, layerQuant_t *lq) {
     /* allocateConv1dWeights / allocateConv1dBias internally clone via getQLike,
      * so the parameter tensors own their quantization_t — caller can drop
      * lq->weightStorage / lq->biasStorage immediately. */
+    size_t fanIn = (init->inChannels / groups) * init->kernelSize;
     quantization_t *gradQ = quantizationInitFloat(); /* Conv1d backward is FLOAT32-only */
-    cfg->weights = allocateConv1dWeights(init->outChannels, init->inChannels, groups,
-                                         init->kernelSize, lq->weightStorage, gradQ);
-    cfg->bias = hasBias ? allocateConv1dBias(init->outChannels, lq->biasStorage, gradQ) : NULL;
+    cfg->weights =
+        allocateConv1dWeights(init->outChannels, init->inChannels, groups, init->kernelSize,
+                              init->weightInit, lq->weightStorage, gradQ);
+    cfg->bias =
+        hasBias ? allocateConv1dBias(init->outChannels, fanIn, lq->biasStorage, gradQ) : NULL;
     freeQuantization(gradQ);
     cfg->groups = groups;
 

--- a/src/userApi/layer/Conv1dTransposedApi.c
+++ b/src/userApi/layer/Conv1dTransposedApi.c
@@ -6,7 +6,6 @@
 #include "Common.h"
 #include "Conv1dTransposed.h"
 #include "Conv1dTransposedApi.h"
-#include "Distributions.h"
 #include "Kernel.h"
 #include "Layer.h"
 #include "LayerCommon.h"
@@ -44,6 +43,7 @@ static shape_t *buildOwnedShape(const size_t *srcDims, size_t numberOfDims) {
 
 static parameter_t *allocateConv1dTransposedWeights(size_t inChannels, size_t outChannels,
                                                     size_t groups, size_t kernelSize,
+                                                    weightInit_t weightInit,
                                                     quantization_t *storageQ,
                                                     quantization_t *gradQ) {
     /* Conv1dTransposed weight shape: [inChannels, outChannels/groups, kernelSize].
@@ -65,25 +65,24 @@ static parameter_t *allocateConv1dTransposedWeights(size_t inChannels, size_t ou
     shape_t *shape = buildOwnedShape((size_t[]){inChannels, outPerGroup, kernelSize}, 3);
     tensor_t *paramTensor = initTensor(shape, getQLike(storageQ), NULL);
 
-    if (storageQ->type != FLOAT32) {
-        PRINT_ERROR("conv1dTransposedLayerInit: KAIMING_UNIFORM init currently requires FLOAT32 "
-                    "weight storage (Issue C will lift this limit)");
-        exit(1);
-    }
-    distribution_t dist = {
-        .type = KAIMING_UNIFORM,
-        .params.kaiming = {.gain = 1.4142135623730951f, .fanMode = outPerGroup * kernelSize},
-    };
-    initDistribution(paramTensor, &dist);
+    /* ConvTranspose weight layout [inChannels, outPerGroup, kernelSize]:
+     * PyTorch fan_in = weight.size(1)*k = outPerGroup*kernelSize,
+     *         fan_out = weight.size(0)*k = inChannels*kernelSize. */
+    size_t fanIn = outPerGroup * kernelSize;
+    size_t fanOut = inChannels * kernelSize;
+    initWeightTensor(paramTensor, weightInit, fanIn, fanOut);
 
     tensor_t *gradTensor = gradInit(paramTensor, gradQ, NULL);
     return parameterInit(paramTensor, gradTensor);
 }
 
-static parameter_t *allocateConv1dTransposedBias(size_t outChannels, quantization_t *storageQ,
-                                                 quantization_t *gradQ) {
+static parameter_t *allocateConv1dTransposedBias(size_t outChannels, size_t fanIn,
+                                                 quantization_t *storageQ, quantization_t *gradQ) {
+    /* PyTorch draws bias from uniform(+/- 1/sqrt(fan_in)) using the WEIGHT's
+     * fan_in (= outPerGroup*kernelSize). */
     shape_t *shape = buildOwnedShape((size_t[]){outChannels}, 1);
     tensor_t *paramTensor = initTensor(shape, getQLike(storageQ), NULL);
+    initBiasTensor(paramTensor, fanIn);
     tensor_t *gradTensor = gradInit(paramTensor, gradQ, NULL);
     return parameterInit(paramTensor, gradTensor);
 }
@@ -150,11 +149,14 @@ static layer_t *buildConv1dTransposedLayerSkeleton(conv1dTransposedInit_t *init,
     layer->config = layerCfg;
 
     cfg->kernel = buildConv1dTransposedKernel(init);
+    size_t fanIn = (init->outChannels / groups) * init->kernelSize;
     quantization_t *gradQ = quantizationInitFloat(); /* Conv1dTransposed backward is FLOAT32-only */
     cfg->weights = allocateConv1dTransposedWeights(init->inChannels, init->outChannels, groups,
-                                                   init->kernelSize, lq->weightStorage, gradQ);
-    cfg->bias =
-        hasBias ? allocateConv1dTransposedBias(init->outChannels, lq->biasStorage, gradQ) : NULL;
+                                                   init->kernelSize, init->weightInit,
+                                                   lq->weightStorage, gradQ);
+    cfg->bias = hasBias
+                    ? allocateConv1dTransposedBias(init->outChannels, fanIn, lq->biasStorage, gradQ)
+                    : NULL;
     freeQuantization(gradQ);
     cfg->groups = groups;
     cfg->outputPadding = init->outputPadding;

--- a/src/userApi/layer/LinearApi.c
+++ b/src/userApi/layer/LinearApi.c
@@ -4,7 +4,6 @@
 #include <stdlib.h>
 
 #include "Common.h"
-#include "Distributions.h"
 #include "Layer.h"
 #include "LayerCommon.h"
 #include "LayerQuant.h"
@@ -98,39 +97,30 @@ static shape_t *buildOwnedShape(const size_t *srcDims, size_t numberOfDims) {
 }
 
 static parameter_t *allocateLinearWeights(size_t inFeatures, size_t outFeatures,
-                                          quantization_t *storageQ, quantization_t *gradQ) {
+                                          weightInit_t weightInit, quantization_t *storageQ,
+                                          quantization_t *gradQ) {
     /* Weight tensor: shape [outFeatures, inFeatures]. The tensor takes ownership
      * of `shape` and `quantization`, so we clone the borrowed storageQ via
      * getQLike to avoid tying the tensor's lifetime to the caller's quant. */
     shape_t *shape = buildOwnedShape((size_t[]){outFeatures, inFeatures}, 2);
     tensor_t *paramTensor = initTensor(shape, getQLike(storageQ), NULL);
 
-    /* PyTorch-aligned default: Kaiming uniform with fan_in mode.
-     * Note: PyTorch's actual default uses a=sqrt(5); bit-identical parity
-     * requires Issue C (distribution parametrization). The current
-     * tensorInitWithDistribution gain (sqrtf(2.0f)) is preserved here. */
-    if (storageQ->type != FLOAT32) {
-        PRINT_ERROR("linearLayerInit: KAIMING_UNIFORM init currently requires FLOAT32 "
-                    "weight storage (Issue C will lift this limit)");
-        exit(1);
-    }
-    distribution_t dist = {
-        .type = KAIMING_UNIFORM,
-        .params.kaiming = {.gain = 1.4142135623730951f /* sqrtf(2.0f) */, .fanMode = inFeatures},
-    };
-    initDistribution(paramTensor, &dist);
+    /* Linear: fan_in = inFeatures, fan_out = outFeatures (PyTorch
+     * _calculate_fan_in_and_fan_out for a 2-D weight). Default scheme is
+     * PyTorch parity: uniform(+/- 1/sqrt(fan_in)). */
+    initWeightTensor(paramTensor, weightInit, inFeatures, outFeatures);
 
     tensor_t *gradTensor = gradInit(paramTensor, gradQ, NULL);
     return parameterInit(paramTensor, gradTensor);
 }
 
-static parameter_t *allocateLinearBias(size_t outFeatures, quantization_t *storageQ,
+static parameter_t *allocateLinearBias(size_t outFeatures, size_t fanIn, quantization_t *storageQ,
                                        quantization_t *gradQ) {
-    /* Bias tensor: shape [outFeatures]. Initialized to ZEROS, which initTensor
-     * already provides (reserveMemory == calloc), so no fill is needed. */
+    /* Bias tensor: shape [outFeatures]. PyTorch draws bias from
+     * uniform(+/- 1/sqrt(fan_in)) using the WEIGHT's fan_in (= inFeatures). */
     shape_t *shape = buildOwnedShape((size_t[]){outFeatures}, 1);
     tensor_t *paramTensor = initTensor(shape, getQLike(storageQ), NULL);
-    /* No initDistribution(ZEROS) call needed: data is already zero from calloc. */
+    initBiasTensor(paramTensor, fanIn);
 
     tensor_t *gradTensor = gradInit(paramTensor, gradQ, NULL);
     return parameterInit(paramTensor, gradTensor);
@@ -187,10 +177,11 @@ layer_t *linearLayerInit(linearInit_t *init, layerQuant_t *lq) {
     layerCfg->linear = cfg;
     layer->config = layerCfg;
 
-    cfg->weights = allocateLinearWeights(init->inFeatures, init->outFeatures, lq->weightStorage,
-                                         lq->backwardMath);
-    cfg->bias =
-        hasBias ? allocateLinearBias(init->outFeatures, lq->biasStorage, lq->backwardMath) : NULL;
+    cfg->weights = allocateLinearWeights(init->inFeatures, init->outFeatures, init->weightInit,
+                                         lq->weightStorage, lq->backwardMath);
+    cfg->bias = hasBias ? allocateLinearBias(init->outFeatures, init->inFeatures, lq->biasStorage,
+                                             lq->backwardMath)
+                        : NULL;
 
     /* Borrowing: store the four quant pointers verbatim, no copy.
      * Per design spec section 4: collapse to a single math Q for forward and
@@ -223,10 +214,11 @@ layer_t *linearLayerInitOwning(linearInit_t *init, layerQuant_t *lq) {
      * T12) internally clone via getQLike, so the parameter tensors hold their
      * own quantization_t copies — the caller can immediately drop the lq's
      * weightStorage/biasStorage pointers without breaking the parameters. */
-    cfg->weights = allocateLinearWeights(init->inFeatures, init->outFeatures, lq->weightStorage,
-                                         lq->backwardMath);
-    cfg->bias =
-        hasBias ? allocateLinearBias(init->outFeatures, lq->biasStorage, lq->backwardMath) : NULL;
+    cfg->weights = allocateLinearWeights(init->inFeatures, init->outFeatures, init->weightInit,
+                                         lq->weightStorage, lq->backwardMath);
+    cfg->bias = hasBias ? allocateLinearBias(init->outFeatures, init->inFeatures, lq->biasStorage,
+                                             lq->backwardMath)
+                        : NULL;
 
     /* Owning: deep-copy each of the four math quantizations.  Always allocate
      * four separate copies, even if multiple lq slots pointed to the same

--- a/src/userApi/layer/include/Conv1dApi.h
+++ b/src/userApi/layer/include/Conv1dApi.h
@@ -47,12 +47,13 @@ typedef struct conv1dInit {
     size_t outChannels;
     size_t kernelSize;
     /* OPTIONAL — zero-init defaults */
-    size_t stride;         /* 0 → 1 */
-    paddingType_t padding; /* 0 → VALID (enum value 0); SAME or EXPLICIT also valid */
-    size_t paddingAmount;  /* symmetric pad per side; used ONLY when padding == EXPLICIT */
-    size_t dilation;       /* 0 → 1 */
-    size_t groups;         /* 0 → 1 */
-    bias_t bias;           /* BIAS_DEFAULT (0) → resolves to true (PyTorch parity) */
+    size_t stride;           /* 0 → 1 */
+    paddingType_t padding;   /* 0 → VALID (enum value 0); SAME or EXPLICIT also valid */
+    size_t paddingAmount;    /* symmetric pad per side; used ONLY when padding == EXPLICIT */
+    size_t dilation;         /* 0 → 1 */
+    size_t groups;           /* 0 → 1 */
+    bias_t bias;             /* BIAS_DEFAULT (0) → resolves to true (PyTorch parity) */
+    weightInit_t weightInit; /* zero-init → INIT_DEFAULT (PyTorch kaiming a=√5) */
 } conv1dInit_t;
 
 /*! Borrowing variant — factory allocates weights/bias/kernel internally

--- a/src/userApi/layer/include/Conv1dTransposedApi.h
+++ b/src/userApi/layer/include/Conv1dTransposedApi.h
@@ -27,12 +27,13 @@ typedef struct conv1dTransposedInit {
     size_t outChannels;
     size_t kernelSize;
     /* OPTIONAL */
-    size_t stride;         /* 0 → 1 */
-    paddingType_t padding; /* 0 → VALID. SAME is rejected by the internal layer in Phase 1. */
-    size_t dilation;       /* 0 → 1 */
-    size_t groups;         /* 0 → 1 */
-    size_t outputPadding;  /* PyTorch parity; default 0; must be < max(stride, dilation) */
-    bias_t bias;           /* BIAS_DEFAULT (0) → resolves to true */
+    size_t stride;           /* 0 → 1 */
+    paddingType_t padding;   /* 0 → VALID. SAME is rejected by the internal layer in Phase 1. */
+    size_t dilation;         /* 0 → 1 */
+    size_t groups;           /* 0 → 1 */
+    size_t outputPadding;    /* PyTorch parity; default 0; must be < max(stride, dilation) */
+    bias_t bias;             /* BIAS_DEFAULT (0) → resolves to true */
+    weightInit_t weightInit; /* zero-init → INIT_DEFAULT (PyTorch kaiming a=√5) */
 } conv1dTransposedInit_t;
 
 /*! Borrowing variant — allocates kernel, weights, bias; stores the four

--- a/src/userApi/layer/include/LinearApi.h
+++ b/src/userApi/layer/include/LinearApi.h
@@ -21,7 +21,8 @@ typedef struct linearInit {
     size_t inFeatures;
     size_t outFeatures;
     /* OPTIONAL */
-    bias_t bias; /* BIAS_DEFAULT (0) → resolves to true */
+    bias_t bias;             /* BIAS_DEFAULT (0) → resolves to true */
+    weightInit_t weightInit; /* zero-init → INIT_DEFAULT (PyTorch kaiming a=√5) */
 } linearInit_t;
 
 /*! Borrowing variant — factory stores the four quantization_t* pointers from

--- a/test/unit/layer/CMakeLists.txt
+++ b/test/unit/layer/CMakeLists.txt
@@ -80,6 +80,8 @@ add_elastic_ai_unit_test(
         Rounding
         StorageApi
         Add
+        Distributions
+        RNG
         SgdApi
         Sgd
         Optimizer

--- a/test/unit/layer/UnitTestLinear.c
+++ b/test/unit/layer/UnitTestLinear.c
@@ -9,6 +9,7 @@
 #include "LinearApi.h"
 #include "Optimizer.h"
 #include "QuantizationApi.h"
+#include "RNG.h"
 #include "Rounding.h"
 #include "SgdApi.h"
 #include "StorageApi.h"
@@ -1361,6 +1362,99 @@ void testLinearSymInt32GradAccumulatesOverTwoMicrobatchesAndSteps(void) {
                              "SYM_INT32 optimizer step left a non-finite weight param");
 }
 
+/*! Returns the max |value| over a FLOAT32 tensor's data buffer. */
+static float linearMaxAbsFloat(const tensor_t *t) {
+    const float *vals = (const float *)t->data;
+    size_t n = t->shape->dimensions[0];
+    for (size_t d = 1; d < t->shape->numberOfDimensions; d++) {
+        n *= t->shape->dimensions[d];
+    }
+    float m = 0.0f;
+    for (size_t i = 0; i < n; i++) {
+        float a = fabsf(vals[i]);
+        if (a > m) {
+            m = a;
+        }
+    }
+    return m;
+}
+
+void testLinearLayerInitDefaultWeightsWithinPyTorchBound(void) {
+    /* PyTorch default Linear init: weight ~ U(-1/sqrt(fan_in), +1/sqrt(fan_in)),
+     * bias ~ U(-1/sqrt(fan_in), +1/sqrt(fan_in)); fan_in = inFeatures. */
+    const size_t inFeatures = 256, outFeatures = 64;
+    const float bound = 1.0f / sqrtf((float)inFeatures);
+
+    quantization_t *q = quantizationInitFloat();
+    layerQuant_t lq;
+    layerQuantInitUniform(&lq, q);
+
+    rngSetSeed(7);
+    layer_t *layer = linearLayerInit(
+        &(linearInit_t){
+            .inFeatures = inFeatures,
+            .outFeatures = outFeatures,
+            .bias = BIAS_TRUE,
+        },
+        &lq);
+
+    linearConfig_t *cfg = layer->config->linear;
+    float weightMaxAbs = linearMaxAbsFloat(cfg->weights->param);
+    float biasMaxAbs = linearMaxAbsFloat(cfg->bias->param);
+
+    freeLinearLayer(layer);
+    freeQuantization(q);
+
+    TEST_ASSERT_TRUE_MESSAGE(weightMaxAbs <= bound * 1.001f,
+                             "Linear default weights exceed PyTorch bound 1/sqrt(fan_in)");
+    TEST_ASSERT_TRUE_MESSAGE(weightMaxAbs >= bound * 0.85f,
+                             "Linear default weights far below PyTorch bound -> wrong scale");
+    TEST_ASSERT_TRUE_MESSAGE(biasMaxAbs > 0.0f,
+                             "Linear default bias is zero (PyTorch draws it from a uniform)");
+    TEST_ASSERT_TRUE_MESSAGE(biasMaxAbs <= bound * 1.001f,
+                             "Linear default bias exceeds PyTorch bound 1/sqrt(fan_in)");
+}
+
+void testLinearLayerInitXavierUniformOverrideUsesGlorotBound(void) {
+    /* Explicit weightInit = {INIT_XAVIER_UNIFORM} -> Glorot, default gain 1:
+     * xavierUniform(1, fan_in, fan_out) = uniform(+/- sqrt(6/(fan_in+fan_out))).
+     * Distinct from the default bound 1/sqrt(fan_in). Bias stays PyTorch
+     * default uniform(+/- 1/sqrt(fan_in)). */
+    const size_t inFeatures = 256, outFeatures = 64;
+    const float defaultBound = 1.0f / sqrtf((float)inFeatures);
+    const float xavierBound = sqrtf(6.0f / (float)(inFeatures + outFeatures));
+
+    quantization_t *q = quantizationInitFloat();
+    layerQuant_t lq;
+    layerQuantInitUniform(&lq, q);
+
+    rngSetSeed(7);
+    layer_t *layer = linearLayerInit(
+        &(linearInit_t){
+            .inFeatures = inFeatures,
+            .outFeatures = outFeatures,
+            .bias = BIAS_TRUE,
+            .weightInit = {INIT_XAVIER_UNIFORM},
+        },
+        &lq);
+
+    linearConfig_t *cfg = layer->config->linear;
+    float weightMaxAbs = linearMaxAbsFloat(cfg->weights->param);
+    float biasMaxAbs = linearMaxAbsFloat(cfg->bias->param);
+
+    freeLinearLayer(layer);
+    freeQuantization(q);
+
+    /* Xavier bound here (~0.137) is wider than the default bound (~0.0625):
+     * confirms the override changed the scale. */
+    TEST_ASSERT_TRUE_MESSAGE(weightMaxAbs > defaultBound,
+                             "Xavier override did not change weights away from the default bound");
+    TEST_ASSERT_TRUE_MESSAGE(weightMaxAbs <= xavierBound * 1.001f,
+                             "Xavier weights exceed the sqrt(6/(fan_in+fan_out)) bound");
+    TEST_ASSERT_TRUE_MESSAGE(biasMaxAbs <= defaultBound * 1.001f,
+                             "Bias must stay PyTorch default uniform regardless of weight scheme");
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(testLinearForwardFloat);
@@ -1386,5 +1480,7 @@ int main(void) {
 
     RUN_TEST(testLinearLayerInitOwningDeepCopiesQuantizations);
     RUN_TEST(testLinearLayerInitOwningFreesAllAllocationsWithoutLeak);
+    RUN_TEST(testLinearLayerInitDefaultWeightsWithinPyTorchBound);
+    RUN_TEST(testLinearLayerInitXavierUniformOverrideUsesGlorotBound);
     return UNITY_END();
 }

--- a/test/unit/userAPI/CMakeLists.txt
+++ b/test/unit/userAPI/CMakeLists.txt
@@ -106,6 +106,8 @@ add_elastic_ai_unit_test(
         Quantization
         Rounding
         Conv1d
+        Distributions
+        RNG
         Kernel
         Tensor
         TensorApi
@@ -121,6 +123,8 @@ add_elastic_ai_unit_test(
         Quantization
         Rounding
         Conv1dTransposed
+        Distributions
+        RNG
         Kernel
         Tensor
         TensorApi

--- a/test/unit/userAPI/UnitTestConv1dApi.c
+++ b/test/unit/userAPI/UnitTestConv1dApi.c
@@ -1,5 +1,7 @@
 #define SOURCE_FILE "UNIT_TEST_CONV1D_API"
 
+#include <math.h>
+
 #include "Conv1d.h"
 #include "Conv1dApi.h"
 #include "Kernel.h"
@@ -7,12 +9,30 @@
 #include "LayerCommon.h"
 #include "LayerQuant.h"
 #include "QuantizationApi.h"
+#include "RNG.h"
 #include "Tensor.h"
 #include "TensorApi.h"
 #include "unity.h"
 
 void setUp() {}
 void tearDown() {}
+
+/*! Returns the max |value| over a FLOAT32 tensor's data buffer. */
+static float maxAbsFloat(const tensor_t *t) {
+    const float *vals = (const float *)t->data;
+    size_t n = t->shape->dimensions[0];
+    for (size_t d = 1; d < t->shape->numberOfDimensions; d++) {
+        n *= t->shape->dimensions[d];
+    }
+    float m = 0.0f;
+    for (size_t i = 0; i < n; i++) {
+        float a = fabsf(vals[i]);
+        if (a > m) {
+            m = a;
+        }
+    }
+    return m;
+}
 
 void testConv1dLayerInitBorrowingBuildsLayerWithCorrectShape(void) {
     quantization_t *q = quantizationInitFloat();
@@ -231,6 +251,91 @@ void testConv1dLayerInitKeepsFloat32GradEvenWithSymInt32BackwardMath(void) {
                                   "Conv1d bias grad must stay FLOAT32 (backward is FLOAT32-only)");
 }
 
+void testConv1dLayerInitDefaultWeightsWithinPyTorchBound(void) {
+    /* PyTorch default Conv1d init: weight ~ U(-1/sqrt(fan_in), +1/sqrt(fan_in)),
+     * bias ~ U(-1/sqrt(fan_in), +1/sqrt(fan_in)); fan_in = inPerGroup*kernelSize.
+     * Today the factory uses gain=sqrt(2) (He) -> bound sqrt(6)/sqrt(fan_in),
+     * ~2.45x too wide, and bias is zero. Both must fail here pre-fix. */
+    const size_t inChannels = 16, outChannels = 64, kernelSize = 8;
+    const size_t fanIn = inChannels * kernelSize; /* groups=1 */
+    const float bound = 1.0f / sqrtf((float)fanIn);
+
+    quantization_t *q = quantizationInitFloat();
+    layerQuant_t lq;
+    layerQuantInitUniform(&lq, q);
+
+    rngSetSeed(123);
+    layer_t *layer = conv1dLayerInit(
+        &(conv1dInit_t){
+            .inChannels = inChannels,
+            .outChannels = outChannels,
+            .kernelSize = kernelSize,
+            .bias = BIAS_TRUE,
+        },
+        &lq);
+
+    conv1dConfig_t *cfg = layer->config->conv1d;
+    float weightMaxAbs = maxAbsFloat(cfg->weights->param);
+    float biasMaxAbs = maxAbsFloat(cfg->bias->param);
+
+    freeConv1dLayer(layer);
+    freeQuantization(q);
+
+    /* Weights must lie inside the PyTorch bound (with float slack). */
+    TEST_ASSERT_TRUE_MESSAGE(weightMaxAbs <= bound * 1.001f,
+                             "Conv1d default weights exceed PyTorch bound 1/sqrt(fan_in)");
+    /* And nearly reach it (a uniform of 8192 samples gets very close). */
+    TEST_ASSERT_TRUE_MESSAGE(weightMaxAbs >= bound * 0.85f,
+                             "Conv1d default weights far below PyTorch bound -> wrong scale");
+    /* Bias must be drawn from the same uniform: nonzero and within bound. */
+    TEST_ASSERT_TRUE_MESSAGE(biasMaxAbs > 0.0f,
+                             "Conv1d default bias is zero (PyTorch draws it from a uniform)");
+    TEST_ASSERT_TRUE_MESSAGE(biasMaxAbs <= bound * 1.001f,
+                             "Conv1d default bias exceeds PyTorch bound 1/sqrt(fan_in)");
+}
+
+void testConv1dLayerInitKaimingUniformOverrideUsesHeBound(void) {
+    /* Explicit weightInit = {INIT_KAIMING_UNIFORM} -> He init, default gain
+     * sqrt(2): kaimingUniform(sqrt(2), fan_in) = uniform(+/- sqrt(6)/sqrt(fan_in)).
+     * Must be wider than the PyTorch default bound (proves the override took
+     * effect) yet within the He bound. */
+    const size_t inChannels = 16, outChannels = 64, kernelSize = 8;
+    const size_t fanIn = inChannels * kernelSize; /* groups=1 */
+    const float defaultBound = 1.0f / sqrtf((float)fanIn);
+    const float heBound = sqrtf(6.0f) / sqrtf((float)fanIn);
+
+    quantization_t *q = quantizationInitFloat();
+    layerQuant_t lq;
+    layerQuantInitUniform(&lq, q);
+
+    rngSetSeed(123);
+    layer_t *layer = conv1dLayerInit(
+        &(conv1dInit_t){
+            .inChannels = inChannels,
+            .outChannels = outChannels,
+            .kernelSize = kernelSize,
+            .bias = BIAS_TRUE,
+            .weightInit = {INIT_KAIMING_UNIFORM},
+        },
+        &lq);
+
+    conv1dConfig_t *cfg = layer->config->conv1d;
+    float weightMaxAbs = maxAbsFloat(cfg->weights->param);
+    /* Bias is ALWAYS the PyTorch default uniform(+/- 1/sqrt(fan_in)),
+     * independent of the weight scheme. */
+    float biasMaxAbs = maxAbsFloat(cfg->bias->param);
+
+    freeConv1dLayer(layer);
+    freeQuantization(q);
+
+    TEST_ASSERT_TRUE_MESSAGE(weightMaxAbs > defaultBound,
+                             "He override did not widen weights beyond the PyTorch default bound");
+    TEST_ASSERT_TRUE_MESSAGE(weightMaxAbs <= heBound * 1.001f,
+                             "He weights exceed the sqrt(6)/sqrt(fan_in) bound");
+    TEST_ASSERT_TRUE_MESSAGE(biasMaxAbs <= defaultBound * 1.001f,
+                             "Bias must stay PyTorch default uniform regardless of weight scheme");
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(testConv1dLayerInitBorrowingBuildsLayerWithCorrectShape);
@@ -240,5 +345,7 @@ int main(void) {
     RUN_TEST(testConv1dLayerInitOwningDeepCopiesQuantizations);
     RUN_TEST(testConv1dLayerInitOwningFreesAllAllocationsWithoutLeak);
     RUN_TEST(testConv1dLayerInitKeepsFloat32GradEvenWithSymInt32BackwardMath);
+    RUN_TEST(testConv1dLayerInitDefaultWeightsWithinPyTorchBound);
+    RUN_TEST(testConv1dLayerInitKaimingUniformOverrideUsesHeBound);
     return UNITY_END();
 }

--- a/test/unit/userAPI/UnitTestConv1dTransposedApi.c
+++ b/test/unit/userAPI/UnitTestConv1dTransposedApi.c
@@ -1,5 +1,7 @@
 #define SOURCE_FILE "UNIT_TEST_CONV1D_TRANSPOSED_API"
 
+#include <math.h>
+
 #include "Conv1dTransposed.h"
 #include "Conv1dTransposedApi.h"
 #include "Kernel.h"
@@ -7,12 +9,30 @@
 #include "LayerCommon.h"
 #include "LayerQuant.h"
 #include "QuantizationApi.h"
+#include "RNG.h"
 #include "Tensor.h"
 #include "TensorApi.h"
 #include "unity.h"
 
 void setUp() {}
 void tearDown() {}
+
+/*! Returns the max |value| over a FLOAT32 tensor's data buffer. */
+static float maxAbsFloat(const tensor_t *t) {
+    const float *vals = (const float *)t->data;
+    size_t n = t->shape->dimensions[0];
+    for (size_t d = 1; d < t->shape->numberOfDimensions; d++) {
+        n *= t->shape->dimensions[d];
+    }
+    float m = 0.0f;
+    for (size_t i = 0; i < n; i++) {
+        float a = fabsf(vals[i]);
+        if (a > m) {
+            m = a;
+        }
+    }
+    return m;
+}
 
 void testConv1dTransposedLayerInitBorrowingBuildsLayerWithCorrectShape(void) {
     quantization_t *q = quantizationInitFloat();
@@ -199,6 +219,85 @@ void testConv1dTransposedLayerInitKeepsFloat32Grad(void) {
                                   "Conv1dTransposed bias grad must stay FLOAT32");
 }
 
+void testConv1dTransposedLayerInitDefaultWeightsWithinPyTorchBound(void) {
+    /* PyTorch default ConvTranspose1d init: weight ~ U(-1/sqrt(fan_in),
+     * +1/sqrt(fan_in)), bias drawn from the same uniform; for the
+     * [inChannels, outPerGroup, kernelSize] layout fan_in = outPerGroup*kernelSize. */
+    const size_t inChannels = 64, outChannels = 32, kernelSize = 8;
+    const size_t fanIn = outChannels * kernelSize; /* groups=1 -> outPerGroup = outChannels */
+    const float bound = 1.0f / sqrtf((float)fanIn);
+
+    quantization_t *q = quantizationInitFloat();
+    layerQuant_t lq;
+    layerQuantInitUniform(&lq, q);
+
+    rngSetSeed(99);
+    layer_t *layer = conv1dTransposedLayerInit(
+        &(conv1dTransposedInit_t){
+            .inChannels = inChannels,
+            .outChannels = outChannels,
+            .kernelSize = kernelSize,
+            .bias = BIAS_TRUE,
+        },
+        &lq);
+
+    conv1dTransposedConfig_t *cfg = layer->config->conv1dTransposed;
+    float weightMaxAbs = maxAbsFloat(cfg->weights->param);
+    float biasMaxAbs = maxAbsFloat(cfg->bias->param);
+
+    freeConv1dTransposedLayer(layer);
+    freeQuantization(q);
+
+    TEST_ASSERT_TRUE_MESSAGE(weightMaxAbs <= bound * 1.001f,
+                             "ConvTranspose default weights exceed PyTorch bound 1/sqrt(fan_in)");
+    TEST_ASSERT_TRUE_MESSAGE(
+        weightMaxAbs >= bound * 0.85f,
+        "ConvTranspose default weights far below PyTorch bound -> wrong scale");
+    TEST_ASSERT_TRUE_MESSAGE(biasMaxAbs > 0.0f,
+                             "ConvTranspose default bias is zero (PyTorch draws from a uniform)");
+    TEST_ASSERT_TRUE_MESSAGE(biasMaxAbs <= bound * 1.001f,
+                             "ConvTranspose default bias exceeds PyTorch bound 1/sqrt(fan_in)");
+}
+
+void testConv1dTransposedLayerInitKaimingUniformOverrideUsesHeBound(void) {
+    /* Explicit weightInit = {INIT_KAIMING_UNIFORM} -> He, default gain sqrt(2):
+     * uniform(+/- sqrt(6)/sqrt(fan_in)). Wider than the default bound; bias
+     * stays PyTorch default uniform. */
+    const size_t inChannels = 64, outChannels = 32, kernelSize = 8;
+    const size_t fanIn = outChannels * kernelSize;
+    const float defaultBound = 1.0f / sqrtf((float)fanIn);
+    const float heBound = sqrtf(6.0f) / sqrtf((float)fanIn);
+
+    quantization_t *q = quantizationInitFloat();
+    layerQuant_t lq;
+    layerQuantInitUniform(&lq, q);
+
+    rngSetSeed(99);
+    layer_t *layer = conv1dTransposedLayerInit(
+        &(conv1dTransposedInit_t){
+            .inChannels = inChannels,
+            .outChannels = outChannels,
+            .kernelSize = kernelSize,
+            .bias = BIAS_TRUE,
+            .weightInit = {INIT_KAIMING_UNIFORM},
+        },
+        &lq);
+
+    conv1dTransposedConfig_t *cfg = layer->config->conv1dTransposed;
+    float weightMaxAbs = maxAbsFloat(cfg->weights->param);
+    float biasMaxAbs = maxAbsFloat(cfg->bias->param);
+
+    freeConv1dTransposedLayer(layer);
+    freeQuantization(q);
+
+    TEST_ASSERT_TRUE_MESSAGE(weightMaxAbs > defaultBound,
+                             "He override did not widen weights beyond the PyTorch default bound");
+    TEST_ASSERT_TRUE_MESSAGE(weightMaxAbs <= heBound * 1.001f,
+                             "He weights exceed the sqrt(6)/sqrt(fan_in) bound");
+    TEST_ASSERT_TRUE_MESSAGE(biasMaxAbs <= defaultBound * 1.001f,
+                             "Bias must stay PyTorch default uniform regardless of weight scheme");
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(testConv1dTransposedLayerInitBorrowingBuildsLayerWithCorrectShape);
@@ -207,5 +306,7 @@ int main(void) {
     RUN_TEST(testConv1dTransposedLayerInitOwningDeepCopiesQuantizations);
     RUN_TEST(testConv1dTransposedLayerInitOwningFreesAllAllocationsWithoutLeak);
     RUN_TEST(testConv1dTransposedLayerInitKeepsFloat32Grad);
+    RUN_TEST(testConv1dTransposedLayerInitDefaultWeightsWithinPyTorchBound);
+    RUN_TEST(testConv1dTransposedLayerInitKaimingUniformOverrideUsesHeBound);
     return UNITY_END();
 }


### PR DESCRIPTION
## What

Parametrizes the factory weight/bias initialization and changes the default to **match PyTorch's**. Implements the deferred **Issue C** (distribution parametrization for PyTorch-compatible init) — the `gain=√2` mismatch the factory code already flagged as *"requires Issue C"*.

## Why

`conv1dLayerInit` / `linearLayerInit` / `conv1dTransposedLayerInit` hardcoded `KAIMING_UNIFORM gain=√2` (He) for weights and **zeroed** biases. PyTorch's default is `kaiming_uniform_(a=√5)` weights (bound `1/√fan_in`) + `uniform(±1/√fan_in)` bias — a `√6 ≈ 2.45×` narrower weight scale. The framework targets PyTorch parity, so the default should match PyTorch.

## How

New `weightInit_t { initScheme_t scheme; float gain; }` field on each init struct (zero-init → `INIT_DEFAULT`, mirroring the existing `bias_t` idiom). All three factories route weight+bias allocation through shared helpers `initWeightTensor` / `initBiasTensor` (new compiled `src/userApi/LayerCommon.c`):

| scheme | weight |
|---|---|
| `INIT_DEFAULT` (0) | `kaimingUniform(√(1/3), fan_in)` = `uniform(±1/√fan_in)` = PyTorch `a=√5` |
| `INIT_KAIMING_UNIFORM` | He, gain `√2` (overridable via `.gain`) |
| `INIT_XAVIER_UNIFORM` | Glorot, gain `1` (overridable) |

Bias is always `uniform(±1/√fan_in)` (PyTorch convention). Fan modes match PyTorch's `_calculate_fan_in_and_fan_out` per layout (Conv1d `in·k`, Linear `in`, ConvT `out·k`). `LayerCommon` changed from a header-only INTERFACE target to a compiled static lib to host the shared helpers.

## TDD / verification

- Seeded statistical value tests (default bound + explicit He override) added to `UnitTestConv1dApi`, `UnitTestLinear`, `UnitTestConv1dTransposedApi`; **mutation-verified non-vacuous** (gain→√2 and bias→0 both flip them red).
- Existing structural factory tests unaffected.
- **62/62 ctest** (`unit_test_debug`); examples build clean against the static-lib change.

## Note

This is a framework-wide **default init change** (all factory-built models now init like PyTorch). It does **not** affect bit-parity (which loads trained weights). Surfaced while making the examples' train-from-scratch demos comparable — and notably, matching the init did *not* close the ECG demo gap, revealing a separate C-vs-PyTorch *training-dynamics* divergence (bit-parity tests inference only). That finding is written up separately for investigation; it does not block this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
