### PR TITLE
ci(examples): build full 'all' target in bit-parity job (rot guard)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,10 +176,11 @@ jobs:
       - name: Configure
         run: cmake --preset examples
 
-      - name: Build example binaries
-        run: |
-          cmake --build --preset examples --target train_c_har_classifier
-          cmake --build --preset examples --target train_c_ecg_anomaly_ae
+      - name: Build ALL example binaries (rot guard — any broken example fails CI)
+        # Builds the default `all` target so every example executable is compiled,
+        # not just the two run below. Closes the gap that let example/MnistExperiment
+        # (#235) and the legacy v1 trainers silently rot — nothing built them.
+        run: cmake --build --preset examples
 
       - name: Run HAR in BIT_PARITY mode
         run: BIT_PARITY=1 build/examples/examples/har_classifier/train_c_har_classifier


### PR DESCRIPTION
## What

Makes the CI `c-bit-parity` job build the examples preset's default `all` target instead of only the two named example binaries.

## Why

The job built only `--target train_c_har_classifier` + `--target train_c_ecg_anomaly_ae`, so any *other* example executable was never compiled in CI. That is exactly how `example/MnistExperiment` (#235) and the legacy v1 trainers rotted against API changes unnoticed — nothing built them. Building `all` means any example that fails to compile now fails CI.

## Note

Rot-guard completing the examples-cleanup series (#249 delete legacy, #250 Issue C init, #251 v1/v2 consolidation). Compilation needs no data, so it runs before the data-dependent bit-parity steps with no extra setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)