### PR TITLE
feat(examples): mnist_mlp — PyTorch + C MNIST dense-MLP parity demo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,7 +159,8 @@ jobs:
           path: |
             examples/har_classifier/data/raw
             examples/ecg_anomaly_ae/data/raw
-          key: datasets-raw-${{ hashFiles('examples/har_classifier/prepare_data.py', 'examples/ecg_anomaly_ae/prepare_data.py') }}
+            examples/mnist_mlp/data/raw
+          key: datasets-raw-${{ hashFiles('examples/har_classifier/prepare_data.py', 'examples/ecg_anomaly_ae/prepare_data.py', 'examples/mnist_mlp/prepare_data.py') }}
 
       - name: Prepare HAR data
         run: uv run examples/har_classifier/prepare_data.py
@@ -172,6 +173,12 @@ jobs:
 
       - name: Train PyTorch ECG (produces reference reconstructions + weights)
         run: uv run examples/ecg_anomaly_ae/train_pytorch.py
+
+      - name: Prepare MNIST MLP data
+        run: uv run examples/mnist_mlp/prepare_data.py
+
+      - name: Train PyTorch MNIST MLP (produces reference predictions + weights)
+        run: uv run examples/mnist_mlp/train_pytorch.py
 
       - name: Configure
         run: cmake --preset examples
@@ -203,6 +210,16 @@ jobs:
             --dtype float32 \
             --rtol 1e-4 \
             --atol 1e-5
+
+      - name: Run MNIST MLP in BIT_PARITY mode
+        run: BIT_PARITY=1 build/examples/examples/mnist_mlp/train_c_mnist_mlp
+
+      - name: Diff MNIST MLP predictions (int32, exact match required)
+        run: |
+          uv run examples/_shared/compare_predictions.py \
+            --pytorch examples/mnist_mlp/outputs/pytorch_predictions.npy \
+            --c examples/mnist_mlp/outputs/c_predictions.npy \
+            --dtype int32
 
   python-test:
     runs-on: ubuntu-latest

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_subdirectory(_shared)
 add_subdirectory(har_classifier)
 add_subdirectory(ecg_anomaly_ae)
+add_subdirectory(mnist_mlp)

--- a/examples/_shared/mnist_data.py
+++ b/examples/_shared/mnist_data.py
@@ -1,0 +1,32 @@
+"""Shared MNIST loader for the mnist_mlp and mnist_cnn examples.
+
+Wraps torchvision.datasets.MNIST so both examples download/cache once and
+deliver identical arrays. Images are float32 [N,1,28,28] in [0,1]; labels are
+int32 [N] (0..9). Reshaping into each model's input geometry is the first layer
+of the model (flatten for the MLP) or loader-side shape surgery (the CNN), per
+the repo's data-shape convention — not done here.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+from torchvision import datasets, transforms
+
+NUM_CLASSES = 10
+
+
+def load_mnist(root, split: str) -> tuple[np.ndarray, np.ndarray]:
+    assert split in ("train", "test"), split
+    ds = datasets.MNIST(
+        root=str(root), train=(split == "train"),
+        download=True, transform=transforms.ToTensor(),
+    )
+    n = len(ds)
+    images = np.empty((n, 1, 28, 28), dtype=np.float32)
+    labels = np.empty((n,), dtype=np.int32)
+    for i in range(n):
+        x, y = ds[i]
+        images[i] = x.numpy()
+        labels[i] = y
+    return images, labels

--- a/examples/_shared/mnist_data.py
+++ b/examples/_shared/mnist_data.py
@@ -16,7 +16,7 @@ from torchvision import datasets, transforms
 NUM_CLASSES = 10
 
 
-def load_mnist(root, split: str) -> tuple[np.ndarray, np.ndarray]:
+def load_mnist(root: str | Path, split: str) -> tuple[np.ndarray, np.ndarray]:
     assert split in ("train", "test"), split
     ds = datasets.MNIST(
         root=str(root), train=(split == "train"),

--- a/examples/mnist_mlp/CMakeLists.txt
+++ b/examples/mnist_mlp/CMakeLists.txt
@@ -1,0 +1,62 @@
+add_executable(train_c_mnist_mlp train_c.c)
+
+target_link_libraries(train_c_mnist_mlp PRIVATE
+        DataLoaderApi
+        DataLoader
+        NPYLoaderApi
+        NPYLoader
+
+        Layer
+
+        Conv1dApi
+        Conv1d
+
+        LinearApi
+        Linear
+
+        ReluApi
+        Relu
+
+        FlattenApi
+        Flatten
+
+        Pool1dApi
+        MaxPool1d
+        AvgPool1d
+
+        QuantizationApi
+        Quantization
+
+        TensorApi
+        Tensor
+        Rounding
+
+        TrainingLoopApi
+        CalculateGradsSequential
+        TrainingBatchDefault
+        TrainingEpochDefault
+        Optimizer
+
+        LossFunction
+        CrossEntropy
+
+        SoftmaxApi
+        Softmax
+
+        Sgd
+        SgdApi
+
+        InferenceApi
+
+        StateDictApi
+        LayerWeightsApi
+        LayerQuant
+        LayerCommon
+        Distributions
+
+        Common
+        StorageApi
+        RNG
+
+        examples_shared
+)

--- a/examples/mnist_mlp/README.md
+++ b/examples/mnist_mlp/README.md
@@ -1,0 +1,52 @@
+# MNIST MLP — PyTorch + C Parity Demo
+
+Trains a small dense classifier on MNIST using the factory layer API in both
+PyTorch (reference) and the ODT C framework. Replaces the deleted legacy
+`example/MnistExperiment`. The framework is 1D-only (no `Conv2d`); this example
+treats each `[1,28,28]` image as a flat 784-vector — the `flatten` layer is the
+model's first op (no preprocessing reshape).
+
+One binary, two verification modes:
+
+- **Bit-parity** (what CI runs): `BIT_PARITY=1` loads PyTorch's trained weights
+  into the C model and runs inference only — C predictions must be
+  **bit-identical** to PyTorch's. Deterministic and exact.
+- **Train-from-scratch demo**: with no env var the C model trains from its own
+  random init; `compare.py` checks final-state parity within tolerance and emits
+  plots. Independent init, so it verifies *convergence*, not bits — informational.
+
+## Run it
+
+```bash
+uv run python examples/mnist_mlp/prepare_data.py
+uv run python examples/mnist_mlp/train_pytorch.py
+cmake --preset examples
+cmake --build --preset examples --target train_c_mnist_mlp
+
+# Bit-parity (exact — the CI gate)
+BIT_PARITY=1 ./build/examples/examples/mnist_mlp/train_c_mnist_mlp
+uv run python examples/_shared/compare_predictions.py \
+  --pytorch examples/mnist_mlp/outputs/pytorch_predictions.npy \
+  --c examples/mnist_mlp/outputs/c_predictions.npy --dtype int32
+
+# …or the train-from-scratch demo + plots (~75 min on full MNIST — slow; bit-parity above is the fast gate)
+./build/examples/examples/mnist_mlp/train_c_mnist_mlp
+uv run python examples/mnist_mlp/compare.py
+```
+
+## Model
+
+- Input: `[1, 28, 28]` (collapsed to `784` by the first `flatten` layer)
+- `Flatten → Linear(784→64) → ReLU → Linear(64→10) → Softmax → CrossEntropy`
+- ~51 K parameters
+- State-dict layers: `fc1` (784→64), `fc2` (64→10)
+
+## Parity tolerance (train-from-scratch demo — informational)
+
+| Metric | Tolerance |
+|---|---|
+| test_acc  | ±2.5 pp absolute |
+| test_loss | ±0.15 nats absolute |
+
+Bit-parity mode requires exact equality instead. See
+`examples/_shared/DETERMINISM.md` for the determinism contract.

--- a/examples/mnist_mlp/compare.py
+++ b/examples/mnist_mlp/compare.py
@@ -1,0 +1,80 @@
+"""Compare PyTorch and C runs of the MNIST MLP classifier.
+
+Reads logs/{pytorch,c}.json and outputs/{pytorch,c}_predictions.npy.
+Writes plots into plots/. Prints a final-state parity report within tolerances.
+INFORMATIONAL only — the bit-parity check (compare_predictions.py) is the gate.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+from examples._shared.log_schema import load_log  # noqa: E402
+from examples._shared.parity import ParityCheck, run_parity_checks  # noqa: E402
+from examples._shared.plotting import (  # noqa: E402
+    plot_accuracy_curves,
+    plot_confusion_matrix,
+    plot_loss_curves,
+)
+
+HERE = Path(__file__).resolve().parent
+LOGS = HERE / "logs"
+OUTPUTS = HERE / "outputs"
+PLOTS = HERE / "plots"
+DATA = HERE / "data"
+
+CLASS_NAMES = [str(d) for d in range(10)]
+
+CHECKS = [
+    ParityCheck("test_acc", abs_tol=0.025),   # ±2.5 pp
+    ParityCheck("test_loss", abs_tol=0.15),   # ±0.15 nats (HAR-calibrated; informational)
+]
+
+
+def confusion_matrix(preds: np.ndarray, labels: np.ndarray, num_classes: int) -> np.ndarray:
+    cm = np.zeros((num_classes, num_classes), dtype=np.int64)
+    for p, a in zip(preds, labels):
+        cm[int(p), int(a)] += 1
+    return cm
+
+
+def main() -> int:
+    PLOTS.mkdir(parents=True, exist_ok=True)
+    pt = load_log(LOGS / "pytorch.json")
+    c = load_log(LOGS / "c.json")
+
+    plot_loss_curves(PLOTS / "loss_curves.png", pt, c)
+    plot_accuracy_curves(PLOTS / "accuracy_curves.png", pt, c)
+
+    test_y = np.load(DATA / "test_y.npy")
+    pt_pred = np.load(OUTPUTS / "pytorch_predictions.npy")
+    c_pred = np.load(OUTPUTS / "c_predictions.npy")
+    cm_pt = confusion_matrix(pt_pred, test_y, len(CLASS_NAMES))
+    cm_c = confusion_matrix(c_pred, test_y, len(CLASS_NAMES))
+    plot_confusion_matrix(PLOTS / "confusion_matrix_pt.png", cm_pt, CLASS_NAMES, "PyTorch MNIST MLP")
+    plot_confusion_matrix(PLOTS / "confusion_matrix_c.png", cm_c, CLASS_NAMES, "C MNIST MLP")
+
+    pt_finals = pt["final"]
+    c_finals = c["final"]
+    overall_pass, results = run_parity_checks(
+        CHECKS,
+        {"test_acc": pt_finals["test_acc"], "test_loss": pt_finals["test_loss"]},
+        {"test_acc": c_finals["test_acc"], "test_loss": c_finals["test_loss"]},
+    )
+
+    print("\nParity report (PyTorch vs C) — INFORMATIONAL:")
+    print(f"{'metric':<14} {'pt':>10} {'c':>10} {'diff':>10} {'tol':>8} {'type':>5} {'pass':>6}")
+    for r in results:
+        print(f"{r.metric:<14} {r.pt_value:>10.5f} {r.c_value:>10.5f} {r.diff:>10.5f} "
+              f"{r.tolerance:>8.4f} {r.tolerance_type:>5} {str(r.passed):>6}")
+    print(f"\nOverall: {'PASS' if overall_pass else 'FAIL'} (informational; not a CI gate)")
+    return 0 if overall_pass else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/mnist_mlp/prepare_data.py
+++ b/examples/mnist_mlp/prepare_data.py
@@ -1,0 +1,48 @@
+"""Prepare MNIST for the mnist_mlp example.
+
+Output (under examples/mnist_mlp/data/):
+  train_x.npy [N,1,28,28] f32   train_y.npy [N] i32 (0..9)
+  val_x.npy, val_y.npy   (10% of train, deterministic via SHUFFLE_SEED)
+  test_x.npy, test_y.npy
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+from examples._shared.mnist_data import load_mnist  # noqa: E402
+from examples._shared.seeds import SHUFFLE_SEED  # noqa: E402
+
+HERE = Path(__file__).resolve().parent
+DATA_DIR = HERE / "data"
+RAW_DIR = DATA_DIR / "raw"
+
+
+def main() -> None:
+    RAW_DIR.mkdir(parents=True, exist_ok=True)
+    train_x, train_y = load_mnist(RAW_DIR, "train")
+    test_x, test_y = load_mnist(RAW_DIR, "test")
+
+    rng = np.random.default_rng(SHUFFLE_SEED)
+    perm = rng.permutation(train_x.shape[0])
+    n_val = train_x.shape[0] // 10
+    val_idx, train_idx = perm[:n_val], perm[n_val:]
+    val_x, val_y = train_x[val_idx], train_y[val_idx]
+    train_x, train_y = train_x[train_idx], train_y[train_idx]
+
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+    np.save(DATA_DIR / "train_x.npy", train_x)
+    np.save(DATA_DIR / "train_y.npy", train_y)
+    np.save(DATA_DIR / "val_x.npy", val_x)
+    np.save(DATA_DIR / "val_y.npy", val_y)
+    np.save(DATA_DIR / "test_x.npy", test_x)
+    np.save(DATA_DIR / "test_y.npy", test_y)
+    print(f"train: {train_x.shape}, val: {val_x.shape}, test: {test_x.shape}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/mnist_mlp/train_c.c
+++ b/examples/mnist_mlp/train_c.c
@@ -1,0 +1,320 @@
+#define SOURCE_FILE "mnist_mlp_train_c"
+
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <time.h>
+
+#include "CalculateGradsSequential.h"
+#include "Common.h"
+#include "Conv1dApi.h"
+#include "DataLoader.h"
+#include "DataLoaderApi.h"
+#include "FlattenApi.h"
+#include "InferenceApi.h"
+#include "Layer.h"
+#include "LayerCommon.h"
+#include "LayerQuant.h"
+#include "LinearApi.h"
+#include "LossFunction.h"
+#include "NPYLoaderApi.h"
+#include "Pool1dApi.h"
+#include "Quantization.h"
+#include "QuantizationApi.h"
+#include "ReluApi.h"
+#include "SgdApi.h"
+#include "SoftmaxApi.h"
+#include "StateDictApi.h"
+#include "StorageApi.h"
+#include "Tensor.h"
+#include "TensorApi.h"
+#include "TrainingLoopApi.h"
+
+#include "npy_writer.h"
+
+#define EPOCHS 10
+#define BATCH 64
+#define LR 0.01f
+#define MOMENTUM 0.9f
+#define SEED 42
+#define SHUFFLE_SEED 42
+#define NUM_CLASSES 10
+
+/* Flatten + Linear + ReLU + Linear + Softmax = 5 layers */
+#define MODEL_SIZE 5
+
+static dataset_t g_trainDataset;
+static dataset_t g_valDataset;
+static dataset_t g_testDataset;
+
+static tensorArray_t *buildOneHotLabels(tensorArray_t *intLabels) {
+    tensorArray_t *out = reserveMemory(sizeof(tensorArray_t));
+    tensor_t **arr = reserveMemory(intLabels->size * sizeof(tensor_t *));
+    out->array = arr;
+    out->size = intLabels->size;
+
+    for (size_t i = 0; i < intLabels->size; ++i) {
+        size_t *dims = reserveMemory(1 * sizeof(size_t));
+        size_t *order = reserveMemory(1 * sizeof(size_t));
+        dims[0] = NUM_CLASSES;
+        order[0] = 0;
+        shape_t *shape = reserveMemory(sizeof(shape_t));
+        shape->dimensions = dims;
+        shape->orderOfDimensions = order;
+        shape->numberOfDimensions = 1;
+
+        quantization_t *q = quantizationInitFloat();
+        tensor_t *t = initTensor(shape, q, NULL);
+
+        int32_t cls = ((int32_t *)intLabels->array[i]->data)[0];
+        float *data = (float *)t->data;
+        for (size_t c = 0; c < NUM_CLASSES; ++c) {
+            data[c] = (c == (size_t)cls) ? 1.0f : 0.0f;
+        }
+        arr[i] = t;
+    }
+    return out;
+}
+
+static void initDataSets(void) {
+    tensorArray_t *trainItems = npyLoad("examples/mnist_mlp/data/train_x.npy");
+    tensorArray_t *trainLabelsRaw = npyLoad("examples/mnist_mlp/data/train_y.npy");
+    g_trainDataset.items = trainItems;
+    g_trainDataset.labels = buildOneHotLabels(trainLabelsRaw);
+
+    tensorArray_t *valItems = npyLoad("examples/mnist_mlp/data/val_x.npy");
+    tensorArray_t *valLabelsRaw = npyLoad("examples/mnist_mlp/data/val_y.npy");
+    g_valDataset.items = valItems;
+    g_valDataset.labels = buildOneHotLabels(valLabelsRaw);
+
+    tensorArray_t *testItems = npyLoad("examples/mnist_mlp/data/test_x.npy");
+    tensorArray_t *testLabelsRaw = npyLoad("examples/mnist_mlp/data/test_y.npy");
+    g_testDataset.items = testItems;
+    g_testDataset.labels = buildOneHotLabels(testLabelsRaw);
+}
+
+static sample_t *getTrainSample(size_t id) {
+    return npyGetSample(&g_trainDataset, id);
+}
+static sample_t *getValSample(size_t id) {
+    return npyGetSample(&g_valDataset, id);
+}
+static sample_t *getTestSample(size_t id) {
+    return npyGetSample(&g_testDataset, id);
+}
+static size_t getTrainSize(void) {
+    return g_trainDataset.items->size;
+}
+static size_t getValSize(void) {
+    return g_valDataset.items->size;
+}
+static size_t getTestSize(void) {
+    return g_testDataset.items->size;
+}
+
+static void buildModel(layer_t **model, layerQuant_t *lq) {
+    /* Flatten [1,28,28] -> [1,784] (the channel-1 acts as batch). */
+    model[0] = flattenLayerInit();
+    model[1] = linearLayerInit(&(linearInit_t){.inFeatures = 28 * 28, .outFeatures = 64}, lq);
+    model[2] = reluLayerInit(lq);
+    model[3] = linearLayerInit(&(linearInit_t){.inFeatures = 64, .outFeatures = NUM_CLASSES}, lq);
+    model[4] = softmaxLayerInit(lq);
+}
+
+/* Load PyTorch state_dict from per-layer .npy files written by
+ * examples/mnist_mlp/train_pytorch.py --save-weights.
+ *
+ * Returns 0 on success, non-zero on first missing file. */
+static int loadStateDictFromDir(layer_t **model, const char *weightsDir) {
+    char wPath[256], bPath[256];
+    const char *names[2] = {"fc1", "fc2"};
+    tensor_t *w[2] = {0};
+    tensor_t *b[2] = {0};
+
+    for (int i = 0; i < 2; i++) {
+        snprintf(wPath, sizeof(wPath), "%s/%s.weight.npy", weightsDir, names[i]);
+        snprintf(bPath, sizeof(bPath), "%s/%s.bias.npy", weightsDir, names[i]);
+        /* npyLoadFlat (not npyLoad): a weight file is ONE [out,in] tensor; npyLoad
+         * would slice dim0 into rows and corrupt the memcpy (issue #177). */
+        w[i] = npyLoadFlat(wPath);
+        b[i] = npyLoadFlat(bPath);
+        if (w[i] == NULL || b[i] == NULL) {
+            fprintf(stderr, "loadStateDictFromDir: missing %s or %s\n", wPath, bPath);
+            return 1;
+        }
+    }
+
+    modelLoadStateDict(
+        model, MODEL_SIZE,
+        (stateDictEntry_t[]){
+            {.name = names[0], .weightData = (float *)w[0]->data, .biasData = (float *)b[0]->data},
+            {.name = names[1], .weightData = (float *)w[1]->data, .biasData = (float *)b[1]->data},
+        },
+        2);
+
+    for (int i = 0; i < 2; i++) {
+        freeTensor(w[i]);
+        freeTensor(b[i]);
+    }
+    return 0;
+}
+
+static FILE *g_log_file = NULL;
+static int g_first_epoch = 1;
+static struct timespec g_epoch_t0;
+
+static void epochCallback(size_t epoch, float trainLoss, epochStats_t evalStats) {
+    struct timespec t1;
+    clock_gettime(CLOCK_MONOTONIC, &t1);
+    double wall_s =
+        (double)(t1.tv_sec - g_epoch_t0.tv_sec) + (double)(t1.tv_nsec - g_epoch_t0.tv_nsec) * 1e-9;
+
+    if (!g_first_epoch) {
+        fprintf(g_log_file, ",\n");
+    }
+    fprintf(g_log_file,
+            "    {\"epoch\": %zu, \"step_losses\": [], \"train_loss\": %.6f, "
+            "\"val_loss\": %.6f, \"val_acc\": %.6f, \"wall_s\": %.4f}",
+            epoch, (double)trainLoss, (double)evalStats.loss, (double)evalStats.accuracy, wall_s);
+    fflush(g_log_file);
+    g_first_epoch = 0;
+
+    fprintf(stdout, "epoch %zu: train_loss=%.4f val_loss=%.4f val_acc=%.4f wall_s=%.2f\n", epoch,
+            (double)trainLoss, (double)evalStats.loss, (double)evalStats.accuracy, wall_s);
+    fflush(stdout);
+
+    clock_gettime(CLOCK_MONOTONIC, &g_epoch_t0);
+}
+
+static int ensureDir(const char *p) {
+    if (mkdir(p, S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH) == 0) {
+        return 0;
+    }
+    if (errno == EEXIST) {
+        return 0;
+    }
+    fprintf(stderr, "ERROR: cannot create %s: %s\n", p, strerror(errno));
+    return 1;
+}
+
+int main(void) {
+    if (ensureDir("examples/mnist_mlp/logs") != 0) {
+        return 1;
+    }
+    if (ensureDir("examples/mnist_mlp/outputs") != 0) {
+        return 1;
+    }
+
+    initDataSets();
+
+    dataLoader_t *testLoader = dataLoaderInit(getTestSample, getTestSize, 1, NULL, NULL,
+                                              /*shuffle*/ false, /*shuffleSeed*/ 0,
+                                              /*dropLast*/ true);
+
+    layerQuant_t lq;
+    layerQuantInitUniform(&lq, quantizationInitFloat());
+
+    layer_t *model[MODEL_SIZE];
+    buildModel(model, &lq);
+
+    const char *bitParity = getenv("BIT_PARITY");
+    if (bitParity != NULL && bitParity[0] != '\0') {
+        /* Bit-parity mode: load PyTorch state_dict, skip training, run inference. */
+        const char *wDir = "examples/mnist_mlp/weights";
+        if (loadStateDictFromDir(model, wDir) != 0) {
+            fprintf(stderr, "BIT_PARITY: state_dict load failed\n");
+            return 1;
+        }
+        fprintf(stdout, "BIT_PARITY: loaded state_dict from %s\n", wDir);
+    } else {
+        dataLoader_t *trainLoader = dataLoaderInit(getTrainSample, getTrainSize, BATCH, NULL, NULL,
+                                                   /*shuffle*/ true, /*shuffleSeed*/ SHUFFLE_SEED,
+                                                   /*dropLast*/ true);
+        dataLoader_t *valLoader = dataLoaderInit(getValSample, getValSize, 1, NULL, NULL,
+                                                 /*shuffle*/ false, /*shuffleSeed*/ 0,
+                                                 /*dropLast*/ true);
+
+        optimizer_t *sgd =
+            sgdMCreateOptim(LR, MOMENTUM, /*weightDecay*/ 0.0f, model, MODEL_SIZE, FLOAT32);
+
+        g_log_file = fopen("examples/mnist_mlp/logs/c.json", "w");
+        if (!g_log_file) {
+            fprintf(stderr, "ERROR: cannot open log file for writing\n");
+            return 1;
+        }
+        fprintf(g_log_file,
+                "{\n"
+                "  \"impl\": \"c\",\n"
+                "  \"example\": \"mnist_mlp\",\n"
+                "  \"config\": {\"epochs\": %d, \"batch\": %d, \"lr\": %.6f, "
+                "\"momentum\": %.6f, \"seed\": %d, \"shuffle_seed\": %d},\n"
+                "  \"epochs\": [\n",
+                EPOCHS, BATCH, (double)LR, (double)MOMENTUM, SEED, SHUFFLE_SEED);
+        fflush(g_log_file);
+
+        clock_gettime(CLOCK_MONOTONIC, &g_epoch_t0);
+
+        trainingRunResult_t result =
+            trainingRun(model, MODEL_SIZE,
+                        (lossConfig_t){.funcType = CROSS_ENTROPY,
+                                       .backwardReduction = REDUCTION_MEAN,
+                                       .classWeights = NULL},
+                        trainLoader, valLoader, sgd, EPOCHS, calculateGradsSequential,
+                        inferenceWithLoss, epochCallback);
+        (void)result;
+
+        epochStats_t testStats = evaluationEpochWithMetrics(
+            model, MODEL_SIZE, CROSS_ENTROPY, testLoader, inferenceWithLoss, REDUCTION_MEAN);
+
+        fprintf(g_log_file,
+                "\n  ],\n"
+                "  \"final\": {\"test_loss\": %.6f, \"test_acc\": %.6f, "
+                "\"test_auc\": null}\n"
+                "}\n",
+                (double)testStats.loss, (double)testStats.accuracy);
+        fclose(g_log_file);
+
+        fprintf(stdout, "FINAL test_loss=%.4f test_acc=%.4f\n", (double)testStats.loss,
+                (double)testStats.accuracy);
+    }
+
+    /* Predictions on test set (both modes). */
+    size_t numTest = getTestSize();
+    int32_t *predictions = malloc(numTest * sizeof(int32_t));
+    if (!predictions) {
+        fprintf(stderr, "OOM allocating predictions\n");
+        return 1;
+    }
+
+    for (size_t i = 0; i < numTest; ++i) {
+        sample_t *s = getTestSample(i);
+        tensor_t *out = inference(model, MODEL_SIZE, s->item);
+        float *probs = (float *)out->data;
+        size_t argmax = 0;
+        float best = probs[0];
+        for (size_t c = 1; c < NUM_CLASSES; ++c) {
+            if (probs[c] > best) {
+                best = probs[c];
+                argmax = c;
+            }
+        }
+        predictions[i] = (int32_t)argmax;
+        freeTensor(out);
+        freeSample(s);
+    }
+
+    size_t outShape[] = {numTest};
+    int status = 0;
+    int rc =
+        npyWriteInt32("examples/mnist_mlp/outputs/c_predictions.npy", predictions, outShape, 1);
+    if (rc != 0) {
+        fprintf(stderr, "ERROR: npyWriteInt32 failed (rc=%d)\n", rc);
+        status = 1;
+    }
+    free(predictions);
+
+    return status;
+}

--- a/examples/mnist_mlp/train_pytorch.py
+++ b/examples/mnist_mlp/train_pytorch.py
@@ -1,0 +1,159 @@
+"""PyTorch reference implementation of the MNIST MLP classifier.
+
+Input: train/val/test .npy from prepare_data.py.
+Output: logs/pytorch.json + outputs/pytorch_predictions.npy
+        + weights/{fc1,fc2}.{weight,bias}.npy for the C-side BIT_PARITY mode.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+from examples._shared.log_schema import RunLog, dump_log  # noqa: E402
+from examples._shared.seeds import SEED, SHUFFLE_SEED  # noqa: E402
+from examples._shared.xorshift32 import shuffle_indices  # noqa: E402
+
+HERE = Path(__file__).resolve().parent
+DATA = HERE / "data"
+LOGS = HERE / "logs"
+OUTPUTS = HERE / "outputs"
+
+EPOCHS = 10
+BATCH = 64
+LR = 0.01
+MOMENTUM = 0.9
+NUM_CLASSES = 10
+
+
+class MnistDataset(torch.utils.data.Dataset):
+    def __init__(self, x: np.ndarray, y: np.ndarray) -> None:
+        self.x = torch.from_numpy(x.astype(np.float32))
+        self.y = torch.from_numpy(y.astype(np.int64))  # CrossEntropy wants int64
+
+    def __len__(self) -> int:
+        return self.x.shape[0]
+
+    def __getitem__(self, idx: int) -> tuple[torch.Tensor, torch.Tensor]:
+        return self.x[idx], self.y[idx]
+
+
+class XorShift32Sampler(torch.utils.data.Sampler[int]):
+    """Single-shot shuffle, no per-epoch reshuffle, matching framework DataLoader.c."""
+    def __init__(self, n: int, seed: int) -> None:
+        self.indices = shuffle_indices(n, seed)
+
+    def __iter__(self):
+        return iter(self.indices)
+
+    def __len__(self) -> int:
+        return len(self.indices)
+
+
+class MnistMlp(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.fc1 = nn.Linear(28 * 28, 64)
+        self.fc2 = nn.Linear(64, NUM_CLASSES)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = x.flatten(start_dim=1)  # [B,1,28,28] -> [B,784]
+        x = F.relu(self.fc1(x))
+        return self.fc2(x)  # logits, CrossEntropyLoss applies log_softmax internally
+
+
+def evaluate(model: nn.Module, x: np.ndarray, y: np.ndarray, batch: int) -> tuple[float, float]:
+    model.eval()
+    total_loss, total_correct, total = 0.0, 0, 0
+    with torch.no_grad():
+        for i in range(0, len(x), batch):
+            xb = torch.from_numpy(x[i : i + batch].astype(np.float32))
+            yb = torch.from_numpy(y[i : i + batch].astype(np.int64))
+            logits = model(xb)
+            loss = F.cross_entropy(logits, yb, reduction="sum")
+            total_loss += loss.item()
+            total_correct += (logits.argmax(dim=1) == yb).sum().item()
+            total += yb.shape[0]
+    return total_loss / total, total_correct / total
+
+
+def main() -> None:
+    torch.manual_seed(SEED)
+    np.random.seed(SEED)
+    torch.use_deterministic_algorithms(True, warn_only=True)
+
+    train_x = np.load(DATA / "train_x.npy")
+    train_y = np.load(DATA / "train_y.npy")
+    val_x = np.load(DATA / "val_x.npy")
+    val_y = np.load(DATA / "val_y.npy")
+    test_x = np.load(DATA / "test_x.npy")
+    test_y = np.load(DATA / "test_y.npy")
+
+    train_ds = MnistDataset(train_x, train_y)
+    sampler = XorShift32Sampler(len(train_ds), SHUFFLE_SEED)
+    loader = torch.utils.data.DataLoader(train_ds, batch_size=BATCH, sampler=sampler, drop_last=True)
+
+    model = MnistMlp()
+    optimizer = torch.optim.SGD(model.parameters(), lr=LR, momentum=MOMENTUM)
+
+    epoch_records = []
+    for epoch in range(EPOCHS):
+        t0 = time.time()
+        model.train()
+        step_losses: list[float] = []
+        for xb, yb in loader:
+            optimizer.zero_grad()
+            loss = F.cross_entropy(model(xb), yb)
+            loss.backward()
+            optimizer.step()
+            step_losses.append(loss.item())
+        train_loss = float(np.mean(step_losses)) if step_losses else 0.0
+        val_loss, val_acc = evaluate(model, val_x, val_y, BATCH)
+        epoch_records.append({
+            "epoch": epoch, "step_losses": step_losses, "train_loss": train_loss,
+            "val_loss": val_loss, "val_acc": val_acc, "wall_s": time.time() - t0,
+        })
+        print(f"epoch {epoch:2d}: train_loss={train_loss:.4f} val_loss={val_loss:.4f} val_acc={val_acc:.4f}", flush=True)
+
+    test_loss, test_acc = evaluate(model, test_x, test_y, BATCH)
+    log: RunLog = {
+        "impl": "pytorch", "example": "mnist_mlp",
+        "config": {"epochs": EPOCHS, "batch": BATCH, "lr": LR, "momentum": MOMENTUM,
+                   "seed": SEED, "shuffle_seed": SHUFFLE_SEED},
+        "epochs": epoch_records,  # type: ignore[typeddict-item]
+        "final": {"test_loss": test_loss, "test_acc": test_acc, "test_auc": None},
+    }
+    LOGS.mkdir(parents=True, exist_ok=True)
+    OUTPUTS.mkdir(parents=True, exist_ok=True)
+    dump_log(LOGS / "pytorch.json", log)
+
+    model.eval()
+    with torch.no_grad():
+        preds = model(torch.from_numpy(test_x.astype(np.float32))).argmax(dim=1).numpy().astype(np.int32)
+    np.save(OUTPUTS / "pytorch_predictions.npy", preds)
+    print(f"FINAL test_loss={test_loss:.4f} test_acc={test_acc:.4f}", flush=True)
+
+    # Per-layer weights for the C-side BIT_PARITY mode.
+    weights_dir = HERE / "weights"
+    os.makedirs(weights_dir, exist_ok=True)
+    layer_map = {"fc1": model.fc1, "fc2": model.fc2}
+    print("Saving per-layer weights:", flush=True)
+    for name, layer in layer_map.items():
+        w = layer.weight.detach().cpu().numpy().astype(np.float32)
+        np.save(weights_dir / f"{name}.weight.npy", w)
+        if layer.bias is not None:
+            b = layer.bias.detach().cpu().numpy().astype(np.float32)
+            np.save(weights_dir / f"{name}.bias.npy", b)
+        print(f"  wrote {name}.weight.npy shape={w.shape}", flush=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Adds `examples/mnist_mlp/` — a self-contained MNIST **dense-MLP** classifier demo with exact PyTorch ↔ C bit-parity, plus a shared `examples/_shared/mnist_data.py` loader. First of two MNIST examples (the conv twin `mnist_cnn` follows in a separate PR), replacing the deleted legacy `example/MnistExperiment` with the factory layer API.

Mirrors the canonical `har_classifier/` pattern: `prepare_data.py` → `train_pytorch.py` (reference + per-layer weight export) → `train_c.c` (factory-API trainer, two modes) → `compare.py` (informational) → `README.md` + `CMakeLists.txt`, wired into the `c-bit-parity` CI job.

**Model:** `Flatten[1,28,28]→Linear(784→64)→ReLU→Linear(64→10)→Softmax`, CrossEntropy (~51 K params). The framework is 1D-only (no Conv2d); the MLP's `flatten` consumes `[1,28,28]` directly (the channel-1 acts as batch), so no loader reshape is needed — matching the legacy MLP.

## Verification

- **Bit-parity gate (the CI gate): C predictions int32 bit-identical to PyTorch, 10000/10000.** `BIT_PARITY=1` loads PyTorch weights via `StateDictApi` (`npyLoadFlat`, per #177) and runs inference only.
- C unit tests 62/62, pytest 22 passed, all examples build (rot guard), `train_c.c` clang-format-21 clean.
- Final whole-branch review (Opus): READY TO MERGE, no Critical/Important findings.

## Notes

- The train-from-scratch demo (`compare.py`) is **informational, not a gate** — independent random init, and the known C-vs-PyTorch training divergence is deferred. On full MNIST the C demo runs ~75 min (framework trains one sample at a time over 54k samples); the README documents this and points at the fast bit-parity check instead.
- Spec: `docs/superpowers/specs/2026-06-26-mnist-examples-design.md`; plan: `docs/superpowers/plans/2026-06-26-mnist-examples.md` (both gitignored scratch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
