### PR TITLE
feat(examples/kws_raw): per-conv LayerNorm (10-seed-validated) replacing fragile end-LN

### DIFF
--- a/examples/kws_raw/README.md
+++ b/examples/kws_raw/README.md
@@ -15,21 +15,30 @@ One binary, two modes — **bit-parity** (`BIT_PARITY=1`, the exact CI gate) and
 explanation and the `KWS_CLASSES` knob; commands are identical with `kws_raw`
 substituted.
 
-## Why LayerNorm + a longer schedule
+## Why per-conv LayerNorm + a longer schedule
 
 Raw waveforms are far harder to train than MFCC features: at the `kws_mfcc`
-settings (lr=0.001, 15 epochs) the raw model never escapes its random-init
-fixed point (flat loss, every clip predicted as one class), which would make the
-bit-parity gate degenerate. Two changes fix it without leaving the framework's
-bit-parity-covered layers:
+settings (lr=0.001) the raw model just trains *very* slowly and looks stuck at
+random init within 15–20 epochs, which would make the bit-parity gate degenerate
+(a one-class reference). The fix uses **LayerNorm**, the framework's only
+bit-parity-covered normalizer (BatchNorm is not), at **lr=0.005, 50 epochs**.
 
-- a rate-agnostic **`LayerNorm(64)`** on the pooled features before the classifier
-  (the C framework has bit-parity LayerNorm; BatchNorm is not covered), and
-- **lr=0.005, 20 epochs** (the model breaks through around epoch 15).
+A 10-seed sweep (3 placements × 3 learning rates × 10 seeds × 50 epochs) settled
+*where* the LayerNorm goes:
 
-The reference then reaches ~0.59 test accuracy with predictions spread across all
-six classes, so the gate genuinely exercises the `AvgPool1d[1,16000]` + Conv +
-LayerNorm arithmetic (C reproduces PyTorch's predictions int32-exactly).
+| placement | mean ± std test_acc | seeds converged |
+|---|---|---|
+| no LayerNorm | 0.70 ± 0.02 | 10/10 |
+| LayerNorm(64) after pooling | **0.47 ± 0.25** | **~6/10** |
+| **per-conv `LayerNorm([C,L])`** | **0.72 ± 0.01** | **10/10** |
+
+A single LayerNorm *after* global pooling is the **worst** option — it amplifies a
+bad init and collapses on ~40 % of seeds. Per-conv LayerNorm (one over each conv's
+full `[C, L]` feature map, pre-ReLU) normalises *inside* the stack and converges
+reliably (`0.72 ± 0.01`, every seed, all six classes), so the gate genuinely
+exercises the `AvgPool1d[1,16000]` + Conv + LayerNorm arithmetic (C reproduces
+PyTorch's predictions int32-exactly). Even plain no-LayerNorm trains fine given 50
+epochs — the model was never un-trainable, just slow.
 
 ## Run it (6-class)
 
@@ -48,12 +57,12 @@ uv run python examples/_shared/compare_predictions.py \
 ## Model
 
 - Input: `[1, 16000]` → `reshapeItemsAddBatchDim` → `[1, 1, 16000]`
-- `AvgPool1d(16) → Conv1d(1→16,K3,SAME) → ReLU → MaxPool(4) → Conv1d(16→32,K3,SAME)
-  → ReLU → MaxPool(4) → Conv1d(32→64,K3,SAME) → ReLU → MaxPool(4) →
-  AdaptiveAvgPool1d(1) → Flatten → LayerNorm(64) → Linear(64→C) → Softmax → CE`
-- Lengths: 16000 → 1000 → 250 → 62 → 15 → 1; ~10 K params
-- State-dict layers: `conv1`, `conv2`, `conv3`, `ln`, `fc`
-- Hyperparameters: SGD lr=0.005, momentum=0.9, batch=32, 20 epochs
+- `AvgPool1d(16) → 3× [Conv1d(K3,SAME) → LayerNorm([C,L]) → ReLU → MaxPool(4)] →
+  AdaptiveAvgPool1d(1) → Flatten → Linear(64→C) → Softmax → CE`
+  (channels 1→16→32→64; LayerNorm shapes `[16,1000]`, `[32,250]`, `[64,62]`)
+- Lengths: 16000 → 1000 → 250 → 62 → 15 → 1; ~64 K params (the LayerNorm gamma/beta dominate)
+- State-dict layers: `conv1`, `ln1`, `conv2`, `ln2`, `conv3`, `ln3`, `fc`
+- Hyperparameters: SGD lr=0.005, momentum=0.9, batch=32, 50 epochs
 
 The train-from-scratch demo is the slowest in the suite (raw `[1,16000]` is the
 heaviest input even after the AvgPool downsample) — run it offline. Bit-parity

--- a/examples/kws_raw/train_c.c
+++ b/examples/kws_raw/train_c.c
@@ -37,7 +37,7 @@
 
 #include "npy_writer.h"
 
-#define EPOCHS 20
+#define EPOCHS 50
 #define BATCH 32
 #define LR 0.005f
 #define MOMENTUM 0.9f
@@ -56,9 +56,9 @@
 #define C3_OUT 64
 #define C3_K 3
 
-/* AvgPool(ds) + 3x(Conv1d+ReLU+MaxPool) + AdaptiveAvgPool + Flatten + LayerNorm + Linear + Softmax
- * = 15 layers */
-#define MODEL_SIZE 15
+/* AvgPool(ds) + 3x(Conv1d+LayerNorm+ReLU+MaxPool) + AdaptiveAvgPool + Flatten + Linear + Softmax
+ * = 17 layers */
+#define MODEL_SIZE 17
 
 static dataset_t g_trainDataset;
 static dataset_t g_valDataset;
@@ -184,47 +184,59 @@ static void buildModel(layer_t **model, layerQuant_t *lq) {
     /* Front downsample: AvgPool1d(K=16,S=16) -> length 1000 (16 kHz -> 1 kHz). */
     model[0] = avgPool1dLayerInit(&(avgPool1dInit_t){.kernelSize = DS_K, .stride = DS_K}, lq);
 
+    /* 3x [Conv1d -> LayerNorm([C,L]) -> ReLU -> MaxPool(4)]. Per-conv LayerNorm over the full
+     * feature map (mirrors PyTorch nn.LayerNorm([C,L]), eps 1e-5) is what gives the raw model
+     * stable convergence: a 10-seed sweep showed end-feature LayerNorm collapses on ~40% of
+     * seeds while per-conv converges 10/10. normalizedShape is L-coupled like the MaxPool
+     * inputLengths, so it tracks the downsample rate. */
     model[1] = conv1dLayerInit(
         &(conv1dInit_t){
             .inChannels = IN_CHANNELS, .outChannels = C1_OUT, .kernelSize = C1_K, .padding = SAME},
         lq);
-    model[2] = reluLayerInit(lq);
-    model[3] = maxPool1dLayerInit(
+    model[2] = layerNormLayerInit(&(layerNormInit_t){.normalizedShape = (size_t[]){C1_OUT, LEN_DS},
+                                                     .numNormDims = 2,
+                                                     .eps = 1e-5f},
+                                  lq);
+    model[3] = reluLayerInit(lq);
+    model[4] = maxPool1dLayerInit(
         &(maxPool1dInit_t){
             .kernelSize = 4, .stride = 4, .inputChannels = C1_OUT, .inputLength = LEN_DS},
         lq);
 
-    model[4] = conv1dLayerInit(
+    model[5] = conv1dLayerInit(
         &(conv1dInit_t){
             .inChannels = C1_OUT, .outChannels = C2_OUT, .kernelSize = C2_K, .padding = SAME},
         lq);
-    model[5] = reluLayerInit(lq);
-    model[6] = maxPool1dLayerInit(
+    model[6] = layerNormLayerInit(
+        &(layerNormInit_t){
+            .normalizedShape = (size_t[]){C2_OUT, LEN_DS / 4}, .numNormDims = 2, .eps = 1e-5f},
+        lq);
+    model[7] = reluLayerInit(lq);
+    model[8] = maxPool1dLayerInit(
         &(maxPool1dInit_t){
             .kernelSize = 4, .stride = 4, .inputChannels = C2_OUT, .inputLength = LEN_DS / 4},
         lq);
 
-    model[7] = conv1dLayerInit(
+    model[9] = conv1dLayerInit(
         &(conv1dInit_t){
             .inChannels = C2_OUT, .outChannels = C3_OUT, .kernelSize = C3_K, .padding = SAME},
         lq);
-    model[8] = reluLayerInit(lq);
-    model[9] = maxPool1dLayerInit(
+    model[10] = layerNormLayerInit(
+        &(layerNormInit_t){
+            .normalizedShape = (size_t[]){C3_OUT, LEN_DS / 16}, .numNormDims = 2, .eps = 1e-5f},
+        lq);
+    model[11] = reluLayerInit(lq);
+    model[12] = maxPool1dLayerInit(
         &(maxPool1dInit_t){
             .kernelSize = 4, .stride = 4, .inputChannels = C3_OUT, .inputLength = LEN_DS / 16},
         lq);
 
-    /* Rate-agnostic head: AdaptiveAvgPool1d(1) -> Flatten -> LayerNorm -> Linear -> Softmax.
-     * LayerNorm(C3_OUT) over the 64 pooled features stabilises raw-model training (mirrors the
-     * PyTorch nn.LayerNorm(64)); eps 1e-5 matches PyTorch's default. */
-    model[10] = adaptiveAvgPool1dLayerInit(&(adaptiveAvgPool1dInit_t){.outputSize = 1}, lq);
-    model[11] = flattenLayerInit();
-    model[12] = layerNormLayerInit(
-        &(layerNormInit_t){.normalizedShape = (size_t[]){C3_OUT}, .numNormDims = 1, .eps = 1e-5f},
-        lq);
-    model[13] =
+    /* Rate-agnostic head: AdaptiveAvgPool1d(1) -> Flatten -> Linear -> Softmax. */
+    model[13] = adaptiveAvgPool1dLayerInit(&(adaptiveAvgPool1dInit_t){.outputSize = 1}, lq);
+    model[14] = flattenLayerInit();
+    model[15] =
         linearLayerInit(&(linearInit_t){.inFeatures = C3_OUT, .outFeatures = g_numClasses}, lq);
-    model[14] = softmaxLayerInit(lq);
+    model[16] = softmaxLayerInit(lq);
 }
 
 /* Load PyTorch state_dict from per-layer .npy files written by
@@ -233,13 +245,13 @@ static void buildModel(layer_t **model, layerQuant_t *lq) {
  * Returns 0 on success, non-zero on first missing file. */
 static int loadStateDictFromDir(layer_t **model, const char *weightsDir) {
     char wPath[300], bPath[300];
-    /* Param layers in order: conv1=model[1], conv2=model[4], conv3=model[7],
-     * ln=model[12] (gamma/beta), fc=model[13]. 5 entries. */
-    const char *names[5] = {"conv1", "conv2", "conv3", "ln", "fc"};
-    tensor_t *w[5] = {0};
-    tensor_t *b[5] = {0};
+    /* Param layers in order: conv1=model[1], ln1=model[2], conv2=model[5], ln2=model[6],
+     * conv3=model[9], ln3=model[10], fc=model[15]. 7 entries (each ln = gamma/beta). */
+    const char *names[7] = {"conv1", "ln1", "conv2", "ln2", "conv3", "ln3", "fc"};
+    tensor_t *w[7] = {0};
+    tensor_t *b[7] = {0};
 
-    for (int i = 0; i < 5; i++) {
+    for (int i = 0; i < 7; i++) {
         snprintf(wPath, sizeof(wPath), "%s/%s.weight.npy", weightsDir, names[i]);
         snprintf(bPath, sizeof(bPath), "%s/%s.bias.npy", weightsDir, names[i]);
         w[i] = npyLoadFlat(wPath);
@@ -258,10 +270,12 @@ static int loadStateDictFromDir(layer_t **model, const char *weightsDir) {
             {.name = names[2], .weightData = (float *)w[2]->data, .biasData = (float *)b[2]->data},
             {.name = names[3], .weightData = (float *)w[3]->data, .biasData = (float *)b[3]->data},
             {.name = names[4], .weightData = (float *)w[4]->data, .biasData = (float *)b[4]->data},
+            {.name = names[5], .weightData = (float *)w[5]->data, .biasData = (float *)b[5]->data},
+            {.name = names[6], .weightData = (float *)w[6]->data, .biasData = (float *)b[6]->data},
         },
-        5);
+        7);
 
-    for (int i = 0; i < 5; i++) {
+    for (int i = 0; i < 7; i++) {
         freeTensor(w[i]);
         freeTensor(b[i]);
     }

--- a/examples/kws_raw/train_pytorch.py
+++ b/examples/kws_raw/train_pytorch.py
@@ -1,10 +1,10 @@
 """PyTorch reference implementation of the kws_raw 1D-CNN classifier.
 
 Input: raw [1,16000] waveform from prepare_data.py. The model downsamples
-16 kHz -> 1 kHz via a front AvgPool1d(K=16), then 3 Conv blocks + a rate-agnostic
-AdaptiveAvgPool1d(1) head + LayerNorm(64). Output: logs/<n>class/pytorch.json +
-outputs/<n>class/pytorch_predictions.npy +
-weights/<n>class/{conv1,conv2,conv3,ln,fc}.{weight,bias}.npy
+16 kHz -> 1 kHz via a front AvgPool1d(K=16), then 3 Conv blocks each with a
+per-conv LayerNorm([C,L]) (pre-ReLU) + a rate-agnostic AdaptiveAvgPool1d(1) head.
+Output: logs/<n>class/pytorch.json + outputs/<n>class/pytorch_predictions.npy +
+weights/<n>class/{conv1,ln1,conv2,ln2,conv3,ln3,fc}.{weight,bias}.npy
 for the C-side BIT_PARITY mode. num_classes from KWS_CLASSES (default 6).
 """
 from __future__ import annotations
@@ -34,7 +34,7 @@ LOGS = HERE / "logs" / TAG
 OUTPUTS = HERE / "outputs" / TAG
 WEIGHTS = HERE / "weights" / TAG
 
-EPOCHS = 20
+EPOCHS = 50
 BATCH = 32
 LR = 0.005
 MOMENTUM = 0.9
@@ -68,26 +68,27 @@ class KwsRawCnn(nn.Module):
     def __init__(self, num_classes: int) -> None:
         super().__init__()
         self.pool0 = nn.AvgPool1d(kernel_size=16, stride=16)     # 16 kHz -> 1 kHz downsample
+        # Per-conv LayerNorm over the full [C, L] feature map, pre-ReLU. Normalising
+        # INSIDE the conv stack (not just before the classifier) is what gives the raw
+        # model stable, reproducible convergence: a 10-seed sweep showed end-feature
+        # LayerNorm collapses on ~40% of seeds (test_acc 0.47 +/- 0.25), while per-conv
+        # LayerNorm converges on 10/10 (0.72 +/- 0.01). The C framework has bit-parity
+        # LayerNorm so the gate is preserved.
         self.conv1 = nn.Conv1d(1, 16, kernel_size=3, padding=1)  # SAME (K odd, stride 1)
+        self.ln1 = nn.LayerNorm([16, 1000])
         self.conv2 = nn.Conv1d(16, 32, kernel_size=3, padding=1)
+        self.ln2 = nn.LayerNorm([32, 250])
         self.conv3 = nn.Conv1d(32, 64, kernel_size=3, padding=1)
-        # LayerNorm over the 64 pooled features (rate-agnostic, 1-D). Stabilises
-        # training of the raw model, which otherwise stalls at random init; the
-        # C framework has bit-parity LayerNorm so the gate is preserved.
-        self.ln = nn.LayerNorm(64)
+        self.ln3 = nn.LayerNorm([64, 62])
         self.fc = nn.Linear(64, num_classes)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        x = self.pool0(x)                  # [B,1,16000] -> [B,1,1000]
-        x = F.relu(self.conv1(x))          # [B,16,1000]
-        x = F.max_pool1d(x, 4)             # [B,16,250]
-        x = F.relu(self.conv2(x))          # [B,32,250]
-        x = F.max_pool1d(x, 4)             # [B,32,62]
-        x = F.relu(self.conv3(x))          # [B,64,62]
-        x = F.max_pool1d(x, 4)             # [B,64,15]
-        x = F.adaptive_avg_pool1d(x, 1)    # [B,64,1]
-        x = x.flatten(start_dim=1)         # [B,64]
-        x = self.ln(x)                     # LayerNorm(64)
+        x = self.pool0(x)                                      # [B,1,16000] -> [B,1,1000]
+        x = F.max_pool1d(F.relu(self.ln1(self.conv1(x))), 4)  # [B,16,1000] -> [B,16,250]
+        x = F.max_pool1d(F.relu(self.ln2(self.conv2(x))), 4)  # [B,32,250]  -> [B,32,62]
+        x = F.max_pool1d(F.relu(self.ln3(self.conv3(x))), 4)  # [B,64,62]   -> [B,64,15]
+        x = F.adaptive_avg_pool1d(x, 1)                        # [B,64,1]
+        x = x.flatten(start_dim=1)                             # [B,64]
         return self.fc(x)
 
 
@@ -165,9 +166,11 @@ def main() -> None:
     WEIGHTS.mkdir(parents=True, exist_ok=True)
     layer_map = {
         "conv1": model.conv1,
+        "ln1": model.ln1,
         "conv2": model.conv2,
+        "ln2": model.ln2,
         "conv3": model.conv3,
-        "ln": model.ln,
+        "ln3": model.ln3,
         "fc": model.fc,
     }
     print("Saving per-layer weights:", flush=True)


### PR DESCRIPTION
Revises the `kws_raw` model after a 10-seed config sweep showed the previously-shipped end-feature `LayerNorm(64)` was the **worst, least-stable** choice.

## Why

A 10-seed × 3-placement × 3-lr sweep (50 epochs each):

| placement | mean ± std test_acc | seeds converged |
|---|---|---|
| no LayerNorm | 0.70 ± 0.02 | 10/10 |
| **LayerNorm(64) after pooling (was shipped)** | **0.47 ± 0.25** | **~6/10** |
| **per-conv `LayerNorm([C,L])`** | **0.72 ± 0.01** | **10/10** |

The shipped end-feature LayerNorm collapses to a one-class reference on ~40% of seeds (the original seed-42 pick was lucky → a fragile/degenerate gate). Per-conv LayerNorm — one over each conv's full `[C,L]` feature map, pre-ReLU — converges reliably and highest. (No-LayerNorm also trains fine at 50 epochs; the raw model was never un-trainable, just slow. LayerNorm is kept as the framework's only bit-parity-covered normalizer + to exercise it.)

## Change

- **Model:** `AvgPool1d(16) → 3× [Conv1d(K3,SAME) → LayerNorm([C,L]) → ReLU → MaxPool(4)] → AdaptiveAvgPool1d(1) → Flatten → Linear`. LayerNorm shapes `[16,1000]`, `[32,250]`, `[64,62]`. lr=0.005, **50 epochs**.
- **C:** `MODEL_SIZE` 15→17, three `layerNormLayerInit(numNormDims=2, eps=1e-5)`, 7-entry state-dict `{conv1,ln1,conv2,ln2,conv3,ln3,fc}`.
- **Gate:** `BIT_PARITY=1` C int32 predictions bit-identical to PyTorch (2483/2483), diverse across all 6 classes, test_acc 0.721 — the **first bit-parity exercise of a multi-dim `[C,L]` LayerNorm** in an example.
- README rewritten with the sweep table.

Supersedes the end-LN config from #256. The shipped gate was seed-independent (loads fixed weights) so this is a quality/robustness fix, not a correctness bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)