### PR TITLE
Per-layer training-step trace facility (#257)

### DIFF
--- a/examples/_shared/CMakeLists.txt
+++ b/examples/_shared/CMakeLists.txt
@@ -1,2 +1,9 @@
-add_library(examples_shared STATIC npy_writer.c)
+add_library(examples_shared STATIC npy_writer.c npy_dump_sink.c)
 target_include_directories(examples_shared PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(examples_shared PRIVATE
+        Layer
+        Tensor
+        Quantization
+        Rounding
+        Common
+)

--- a/examples/_shared/npy_dump_sink.c
+++ b/examples/_shared/npy_dump_sink.c
@@ -26,8 +26,7 @@ void npyDumpSink(void *ctxV, size_t layerIdx, layerType_t layerType, const char 
     if (ctx->sampleIdx == NPY_DUMP_NO_SAMPLE) {
         snprintf(path, sizeof(path), "%s/%s.%s.npy", ctx->dir, probe, phase);
     } else {
-        snprintf(path, sizeof(path), "%s/%s.%s.s%03zu.npy", ctx->dir, probe, phase,
-                 ctx->sampleIdx);
+        snprintf(path, sizeof(path), "%s/%s.%s.s%03zu.npy", ctx->dir, probe, phase, ctx->sampleIdx);
     }
 
     int rc = npyWriteFloat32(path, (float *)tensor->data, tensor->shape->dimensions,

--- a/examples/_shared/npy_dump_sink.c
+++ b/examples/_shared/npy_dump_sink.c
@@ -1,0 +1,39 @@
+#define SOURCE_FILE "npy_dump_sink"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "Common.h"
+#include "Quantization.h"
+#include "Tensor.h"
+#include "npy_dump_sink.h"
+#include "npy_writer.h"
+
+void npyDumpSink(void *ctxV, size_t layerIdx, layerType_t layerType, const char *phase,
+                 tensor_t *tensor) {
+    (void)layerType;
+    npyDumpCtx_t *ctx = (npyDumpCtx_t *)ctxV;
+
+    if (tensor->quantization->type != FLOAT32) {
+        fprintf(stderr, "npyDumpSink: only FLOAT32 supported (probe %zu, phase %s)\n", layerIdx,
+                phase);
+        exit(1);
+    }
+
+    const char *probe = (layerIdx < ctx->numProbes) ? ctx->probeNames[layerIdx] : "loss";
+
+    char path[512];
+    if (ctx->sampleIdx == NPY_DUMP_NO_SAMPLE) {
+        snprintf(path, sizeof(path), "%s/%s.%s.npy", ctx->dir, probe, phase);
+    } else {
+        snprintf(path, sizeof(path), "%s/%s.%s.s%03zu.npy", ctx->dir, probe, phase,
+                 ctx->sampleIdx);
+    }
+
+    int rc = npyWriteFloat32(path, (float *)tensor->data, tensor->shape->dimensions,
+                             tensor->shape->numberOfDimensions);
+    if (rc != 0) {
+        fprintf(stderr, "npyDumpSink: write failed for %s (rc=%d)\n", path, rc);
+        exit(1);
+    }
+}

--- a/examples/_shared/npy_dump_sink.h
+++ b/examples/_shared/npy_dump_sink.h
@@ -22,7 +22,7 @@ typedef struct npyDumpCtx {
     size_t sampleIdx; /* NPY_DUMP_NO_SAMPLE for batch-level (param/grad) dumps */
 } npyDumpCtx_t;
 
-/* Matches traceSink_t. FLOAT32 only (asserts otherwise). */
+/* Matches traceSink_t. FLOAT32 only (hard-errors (exit 1) otherwise). */
 void npyDumpSink(void *ctx, size_t layerIdx, layerType_t layerType, const char *phase,
                  tensor_t *tensor);
 

--- a/examples/_shared/npy_dump_sink.h
+++ b/examples/_shared/npy_dump_sink.h
@@ -1,0 +1,29 @@
+#ifndef EXAMPLES_SHARED_NPY_DUMP_SINK_H
+#define EXAMPLES_SHARED_NPY_DUMP_SINK_H
+
+#include <stddef.h>
+
+#include "Layer.h"
+#include "Tensor.h"
+
+/* Context for npyDumpSink. probeNames[layerIdx] gives the manifest probe name;
+ * layerIdx == numProbes (the loss-gradient probe) is named "loss". Files are
+ * written to <dir>/<probe>.<phase>.npy as FLOAT32, or
+ * <dir>/<probe>.<phase>.s<NN>.npy when sampleIdx != NPY_DUMP_NO_SAMPLE (used for
+ * the per-sample activation / act-grad tiers). The harness sets sampleIdx before
+ * each per-sample tracedGrads call and resets it to NPY_DUMP_NO_SAMPLE before the
+ * batch-level param/grad dumps. */
+#define NPY_DUMP_NO_SAMPLE ((size_t)-1)
+
+typedef struct npyDumpCtx {
+    const char *dir;
+    const char **probeNames;
+    size_t numProbes;
+    size_t sampleIdx; /* NPY_DUMP_NO_SAMPLE for batch-level (param/grad) dumps */
+} npyDumpCtx_t;
+
+/* Matches traceSink_t. FLOAT32 only (asserts otherwise). */
+void npyDumpSink(void *ctx, size_t layerIdx, layerType_t layerType, const char *phase,
+                 tensor_t *tensor);
+
+#endif

--- a/examples/_shared/trace_compare.py
+++ b/examples/_shared/trace_compare.py
@@ -89,7 +89,7 @@ def compare_dir(c_dir: Path, pt_dir: Path, abs_floor: float = 1e-4) -> int:
     files = sorted(c_dir.glob("*.npy"), key=sort_key)
     if not files:
         print(f"no dumps in {c_dir}", file=sys.stderr)
-        return 2
+        return 2, None
     pairs_by_name = {(d["probe"], d["phase"]): d for d in compare_pairs(c_dir, pt_dir)}
     floor, cur_tier, first_drift = 1e-6, None, None
     print(f"{'probe':12}{'phase':24}{'max_abs':>12}{'max_rel':>12}  status")
@@ -116,7 +116,7 @@ def compare_dir(c_dir: Path, pt_dir: Path, abs_floor: float = 1e-4) -> int:
               f"(max_abs={first_drift[2]:.2e}, max_rel={first_drift[3]:.2e})")
     else:
         print("\nno drift above threshold - all tiers agree")
-    return 0
+    return 0, first_drift
 
 
 def self_test() -> int:
@@ -132,8 +132,9 @@ def self_test() -> int:
         bad = wbase.copy(); bad[0, 0, 0] += 5.0
         np.save(c / "conv1.grad_raw.weight.npy", bad)
         np.save(pt / "conv1.grad_raw.weight.npy", wbase)
-        rc = compare_dir(c, pt)
+        rc, fd = compare_dir(c, pt)
         assert rc == 0
+        assert fd is not None and fd[0] == "conv1" and fd[1] == "grad_raw.weight", fd
         # also verify compare_pairs returns the matched files
         pairs = compare_pairs(c, pt)
         assert len(pairs) == 3, f"expected 3 pairs, got {len(pairs)}"
@@ -156,7 +157,7 @@ def main() -> None:
     root = Path(__file__).resolve().parents[1] / args.example
     step = f"step{args.step:03d}"
     sys.exit(compare_dir(root / "dump_c" / step, root / "dump_pt" / step,
-                         abs_floor=args.abs_floor))
+                         abs_floor=args.abs_floor)[0])
 
 
 if __name__ == "__main__":

--- a/examples/_shared/trace_compare.py
+++ b/examples/_shared/trace_compare.py
@@ -1,0 +1,122 @@
+"""Localize the first tensor where C and PyTorch training diverge.
+
+Pairs examples/<ex>/dump_c/stepNNN/<probe>.<phase>.npy against the dump_pt
+counterpart (identical filenames on both sides), computes max-abs / max-rel error
+per pair, prints a table ordered by tier then network depth, and flags the FIRST
+probe whose error jumps orders of magnitude above the running per-tier floor
+(relative-jump test, not a flat epsilon). The noise floor resets at each tier
+boundary because tiers have independent magnitudes.
+
+Self-test: `uv run examples/_shared/trace_compare.py --self-test`.
+"""
+from __future__ import annotations
+import argparse, sys
+from pathlib import Path
+import numpy as np
+
+# Network depth order (must equal probe_manifest.h / FWD_PROBES) — 17-layer model:
+PROBES = ["pool0","conv1","ln1","relu1","pool1","conv2","ln2","relu2","pool2",
+          "conv3","ln3","relu3","pool3","adaptpool","flatten","fc","softmax"]
+DEPTH = {name: i for i, name in enumerate(PROBES)}
+DEPTH["loss"] = len(PROBES)  # the loss-grad probe sits after the last layer
+# Table tier order, by phase prefix:
+TIERS = [("fwd", 0), ("lossgrad", 1), ("agrad", 2), ("grad_raw", 3),
+         ("grad_scaled", 4), ("w_before", 5), ("w_after", 6)]
+JUMP_FACTOR = 1e3  # error >1000x the running per-tier floor = first drift
+
+
+def tier_of(phase: str) -> int:
+    for prefix, rank in TIERS:
+        if phase.startswith(prefix):
+            return rank
+    return len(TIERS)
+
+
+def sample_of(phase: str) -> int:
+    if ".s" in phase:
+        try:
+            return int(phase.rsplit(".s", 1)[1])
+        except ValueError:
+            return -1
+    return -1
+
+
+def sort_key(p: Path):
+    probe, _, phase = p.name[:-4].partition(".")
+    return (tier_of(phase), DEPTH.get(probe, 99), sample_of(phase), phase)
+
+
+def errs(a: np.ndarray, b: np.ndarray) -> tuple[float, float]:
+    if a.shape != b.shape:
+        return float("inf"), float("inf")
+    diff = np.abs(a.astype(np.float64) - b.astype(np.float64))
+    denom = np.maximum(np.abs(b.astype(np.float64)), 1e-12)
+    return float(diff.max()), float((diff / denom).max())
+
+
+def compare_dir(c_dir: Path, pt_dir: Path) -> int:
+    files = sorted(c_dir.glob("*.npy"), key=sort_key)
+    if not files:
+        print(f"no dumps in {c_dir}", file=sys.stderr)
+        return 2
+    floor, cur_tier, first_drift = 1e-6, None, None
+    print(f"{'probe':12}{'phase':24}{'max_abs':>12}{'max_rel':>12}  status")
+    for f in files:
+        probe, _, phase = f.name[:-4].partition(".")
+        tier = tier_of(phase)
+        if tier != cur_tier:
+            floor, cur_tier = 1e-6, tier  # reset the noise floor per tier
+        pt = pt_dir / f.name
+        if not pt.exists():
+            print(f"{probe:12}{phase:24}{'':>12}{'':>12}  (no PyTorch counterpart)")
+            continue
+        ma, mr = errs(np.load(f), np.load(pt))
+        drift = mr > floor * JUMP_FACTOR and first_drift is None
+        status = "<= FIRST DRIFT" if drift else "ok"
+        if drift:
+            first_drift = (probe, phase, ma, mr)
+        print(f"{probe:12}{phase:24}{ma:12.2e}{mr:12.2e}  {status}")
+        if not drift and mr < 1.0:
+            floor = max(floor, mr)  # raise the running per-tier floor
+    if first_drift:
+        print(f"\nFIRST DRIFT: {first_drift[0]}.{first_drift[1]} "
+              f"(max_abs={first_drift[2]:.2e}, max_rel={first_drift[3]:.2e})")
+    else:
+        print("\nno drift above threshold - all tiers agree")
+    return 0
+
+
+def self_test() -> int:
+    import tempfile
+    rs = np.random.RandomState(0)
+    with tempfile.TemporaryDirectory() as d:
+        c, pt = Path(d) / "c", Path(d) / "pt"
+        c.mkdir(); pt.mkdir()
+        base = rs.randn(1, 16, 8).astype(np.float32)  # per-sample activation, [1,C,L]
+        for nm in ("conv1.fwd.s000.npy", "conv1.fwd.s001.npy"):
+            np.save(c / nm, base); np.save(pt / nm, base.copy())
+        wbase = rs.randn(16, 1, 3).astype(np.float32)
+        bad = wbase.copy(); bad[0, 0, 0] += 5.0
+        np.save(c / "conv1.grad_raw.weight.npy", bad)
+        np.save(pt / "conv1.grad_raw.weight.npy", wbase)
+        rc = compare_dir(c, pt)
+        assert rc == 0
+    print("self-test OK")
+    return 0
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--example", default="kws_raw")
+    ap.add_argument("--step", type=int, default=0)
+    ap.add_argument("--self-test", action="store_true")
+    args = ap.parse_args()
+    if args.self_test:
+        sys.exit(self_test())
+    root = Path(__file__).resolve().parents[1] / args.example
+    step = f"step{args.step:03d}"
+    sys.exit(compare_dir(root / "dump_c" / step, root / "dump_pt" / step))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/_shared/trace_compare.py
+++ b/examples/_shared/trace_compare.py
@@ -7,6 +7,10 @@ probe whose error jumps orders of magnitude above the running per-tier floor
 (relative-jump test, not a flat epsilon). The noise floor resets at each tier
 boundary because tiers have independent magnitudes.
 
+The abs-floor gate (--abs-floor, default 1e-4) prevents spurious drift flags on
+near-zero activations where a tiny absolute error inflates the relative ratio.
+Both abs AND relative-jump must exceed their thresholds before the drift flag fires.
+
 Self-test: `uv run examples/_shared/trace_compare.py --self-test`.
 """
 from __future__ import annotations
@@ -54,11 +58,39 @@ def errs(a: np.ndarray, b: np.ndarray) -> tuple[float, float]:
     return float(diff.max()), float((diff / denom).max())
 
 
-def compare_dir(c_dir: Path, pt_dir: Path) -> int:
+def compare_pairs(c_dir: Path, pt_dir: Path) -> list[dict]:
+    """Load all matched .npy pairs from c_dir and pt_dir; return per-pair error dicts.
+
+    Returns a list of dicts with keys: probe, phase, tier, max_abs, max_rel.
+    Sorted by (tier, depth, sample, phase).  Files without a PyTorch counterpart
+    are silently skipped so the caller can reuse this for aggregation without
+    worrying about missing files.
+    """
+    files = sorted(c_dir.glob("*.npy"), key=sort_key)
+    results = []
+    for f in files:
+        probe, _, phase = f.name[:-4].partition(".")
+        pt = pt_dir / f.name
+        if not pt.exists():
+            continue
+        ma, mr = errs(np.load(f), np.load(pt))
+        results.append({"probe": probe, "phase": phase, "tier": tier_of(phase),
+                        "max_abs": ma, "max_rel": mr})
+    return results
+
+
+def compare_dir(c_dir: Path, pt_dir: Path, abs_floor: float = 1e-4) -> int:
+    """Print the per-probe error table and flag the first meaningful drift.
+
+    Drift requires BOTH a meaningful absolute error (> abs_floor) AND a relative
+    jump of JUMP_FACTOR above the running per-tier noise floor.  This prevents
+    near-zero activations (abs ~3e-7) from triggering a spurious flag.
+    """
     files = sorted(c_dir.glob("*.npy"), key=sort_key)
     if not files:
         print(f"no dumps in {c_dir}", file=sys.stderr)
         return 2
+    pairs_by_name = {(d["probe"], d["phase"]): d for d in compare_pairs(c_dir, pt_dir)}
     floor, cur_tier, first_drift = 1e-6, None, None
     print(f"{'probe':12}{'phase':24}{'max_abs':>12}{'max_rel':>12}  status")
     for f in files:
@@ -66,12 +98,13 @@ def compare_dir(c_dir: Path, pt_dir: Path) -> int:
         tier = tier_of(phase)
         if tier != cur_tier:
             floor, cur_tier = 1e-6, tier  # reset the noise floor per tier
-        pt = pt_dir / f.name
-        if not pt.exists():
+        key = (probe, phase)
+        if key not in pairs_by_name:
             print(f"{probe:12}{phase:24}{'':>12}{'':>12}  (no PyTorch counterpart)")
             continue
-        ma, mr = errs(np.load(f), np.load(pt))
-        drift = mr > floor * JUMP_FACTOR and first_drift is None
+        d = pairs_by_name[key]
+        ma, mr = d["max_abs"], d["max_rel"]
+        drift = (ma > abs_floor) and (mr > floor * JUMP_FACTOR) and (first_drift is None)
         status = "<= FIRST DRIFT" if drift else "ok"
         if drift:
             first_drift = (probe, phase, ma, mr)
@@ -101,6 +134,11 @@ def self_test() -> int:
         np.save(pt / "conv1.grad_raw.weight.npy", wbase)
         rc = compare_dir(c, pt)
         assert rc == 0
+        # also verify compare_pairs returns the matched files
+        pairs = compare_pairs(c, pt)
+        assert len(pairs) == 3, f"expected 3 pairs, got {len(pairs)}"
+        grad_pair = next(p for p in pairs if p["phase"] == "grad_raw.weight")
+        assert grad_pair["max_abs"] > 1.0, "grad perturbation should be >1.0"
     print("self-test OK")
     return 0
 
@@ -110,12 +148,15 @@ def main() -> None:
     ap.add_argument("--example", default="kws_raw")
     ap.add_argument("--step", type=int, default=0)
     ap.add_argument("--self-test", action="store_true")
+    ap.add_argument("--abs-floor", type=float, default=1e-4,
+                    help="minimum absolute error to trigger drift flag (default: 1e-4)")
     args = ap.parse_args()
     if args.self_test:
         sys.exit(self_test())
     root = Path(__file__).resolve().parents[1] / args.example
     step = f"step{args.step:03d}"
-    sys.exit(compare_dir(root / "dump_c" / step, root / "dump_pt" / step))
+    sys.exit(compare_dir(root / "dump_c" / step, root / "dump_pt" / step,
+                         abs_floor=args.abs_floor))
 
 
 if __name__ == "__main__":

--- a/examples/_shared/trace_sweep.py
+++ b/examples/_shared/trace_sweep.py
@@ -1,0 +1,180 @@
+"""Multi-batch aggregator for the C-vs-PyTorch divergence diagnosis.
+
+Runs N non-overlapping controlled steps, collects compare_pairs output for each
+batch, and aggregates the per-probe error statistics so that robust divergence
+(consistently large across batches) is distinguished from accumulation noise
+(varies batch to batch).
+
+CLI:
+    uv run examples/_shared/trace_sweep.py [options]
+
+Options:
+    --example     example name (default: kws_raw)
+    --batches     number of non-overlapping batches (default: 10)
+    --batch       samples per batch B (default: 32)
+    --act-samples activation-dump samples per batch (default: 1)
+    --classes     number of output classes (default: 6)
+    --start0      sample-start for batch 0 (default: 0)
+    --stride      step between batch start indices (default: B)
+"""
+from __future__ import annotations
+import argparse, os, subprocess, sys
+from collections import defaultdict
+from pathlib import Path
+import numpy as np
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parents[1]
+sys.path.insert(0, str(HERE))
+import trace_compare  # noqa: E402
+
+
+def run_c(example: str, start: int, batch: int, act: int, classes: int) -> str:
+    binary = ROOT / "build" / "examples" / "examples" / example / f"trace_c_{example}"
+    if not binary.exists():
+        raise FileNotFoundError(
+            f"C harness not found: {binary}\n"
+            "Build it first: cmake --preset examples && "
+            f"cmake --build --preset examples --target trace_c_{example}"
+        )
+    env = os.environ.copy()
+    env["KWS_CLASSES"] = str(classes)
+    result = subprocess.run(
+        [str(binary), "--sample-start", str(start), "--batch", str(batch),
+         "--act-samples", str(act)],
+        cwd=ROOT, capture_output=True, text=True, env=env, check=True,
+    )
+    return result.stdout.strip()
+
+
+def run_pt(example: str, start: int, batch: int, act: int, classes: int) -> str:
+    result = subprocess.run(
+        ["uv", "run", f"examples/{example}/trace_pytorch.py",
+         "--sample-start", str(start), "--batch", str(batch),
+         "--act-samples", str(act), "--classes", str(classes)],
+        cwd=ROOT, capture_output=True, text=True, check=True,
+    )
+    return result.stdout.strip()
+
+
+def extract_loss(text: str, key: str = "mean_loss=") -> float | None:
+    """Parse a 'mean_loss=<float>' token from a whitespace-separated output line."""
+    for token in text.split():
+        if token.startswith(key):
+            try:
+                return float(token[len(key):])
+            except ValueError:
+                pass
+    return None
+
+
+def row_sort_key(item: tuple) -> tuple:
+    """Sort aggregate rows by tier, then network depth, then sample index, then phase."""
+    (probe, phase), entry = item
+    return (entry["tier"] if entry["tier"] is not None else 99,
+            trace_compare.DEPTH.get(probe, 99),
+            trace_compare.sample_of(phase),
+            phase)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--example", default="kws_raw")
+    ap.add_argument("--batches", type=int, default=10)
+    ap.add_argument("--batch", type=int, default=32)
+    ap.add_argument("--act-samples", type=int, default=1)
+    ap.add_argument("--classes", type=int, default=6)
+    ap.add_argument("--start0", type=int, default=0)
+    ap.add_argument("--stride", type=int, default=None)
+    args = ap.parse_args()
+
+    B = args.batch
+    stride = args.stride if args.stride is not None else B
+
+    c_dump = ROOT / "examples" / args.example / "dump_c" / "step000"
+    pt_dump = ROOT / "examples" / args.example / "dump_pt" / "step000"
+
+    # --- Per-batch loop ---
+    batch_results: list[tuple[float | None, float | None, list[dict]]] = []
+    for i in range(args.batches):
+        start = args.start0 + i * stride
+        print(f"\n--- batch {i:2d}  sample_start={start} ---", flush=True)
+        try:
+            c_out = run_c(args.example, start, B, args.act_samples, args.classes)
+        except subprocess.CalledProcessError as exc:
+            print(f"  C harness FAILED (exit {exc.returncode}):\n{exc.stderr}", file=sys.stderr)
+            raise
+        try:
+            pt_out = run_pt(args.example, start, B, args.act_samples, args.classes)
+        except subprocess.CalledProcessError as exc:
+            print(f"  PyTorch script FAILED (exit {exc.returncode}):\n{exc.stderr}",
+                  file=sys.stderr)
+            raise
+        print(f"  C:  {c_out}")
+        print(f"  PT: {pt_out}", flush=True)
+        c_loss = extract_loss(c_out)
+        pt_loss = extract_loss(pt_out)
+        pairs = trace_compare.compare_pairs(c_dump, pt_dump)
+        batch_results.append((c_loss, pt_loss, pairs))
+
+    # --- Aggregate per (probe, phase) across all batches ---
+    accum: dict[tuple[str, str], dict] = defaultdict(
+        lambda: {"max_abs_list": [], "max_rel_list": [], "tier": None}
+    )
+    for _, _, pairs in batch_results:
+        for d in pairs:
+            key = (d["probe"], d["phase"])
+            entry = accum[key]
+            entry["max_abs_list"].append(d["max_abs"])
+            entry["max_rel_list"].append(d["max_rel"])
+            if entry["tier"] is None:
+                entry["tier"] = d["tier"]
+
+    # --- Header: loss sanity check ---
+    print("\n" + "=" * 76)
+    print("LOSS SANITY (C vs PyTorch mean_loss per batch):")
+    for i, (cl, pl, _) in enumerate(batch_results):
+        c_str = f"{cl:.6f}" if cl is not None else "N/A"
+        p_str = f"{pl:.6f}" if pl is not None else "N/A"
+        delta = ""
+        if cl is not None and pl is not None:
+            delta = f"  |diff|={abs(cl - pl):.2e}"
+        print(f"  batch {i:2d}: C={c_str}  PT={p_str}{delta}")
+
+    # --- Full aggregate table ---
+    rows = sorted(accum.items(), key=row_sort_key)
+    print("\nAGGREGATE TABLE (sorted by tier then network depth):")
+    hdr = f"{'probe':12}{'phase':30}{'mean_abs':>12}{'max_abs':>12}{'mean_rel':>12}{'n':>4}"
+    print(hdr)
+    print("-" * len(hdr))
+    for (probe, phase), entry in rows:
+        abs_list = entry["max_abs_list"]
+        rel_list = entry["max_rel_list"]
+        n = len(abs_list)
+        mean_abs = float(np.mean(abs_list))
+        max_abs = float(np.max(abs_list))
+        mean_rel = float(np.mean(rel_list))
+        print(f"{probe:12}{phase:30}{mean_abs:12.2e}{max_abs:12.2e}{mean_rel:12.2e}{n:4d}")
+
+    # --- Focused summary: param-grad tiers only, sorted by mean_abs desc ---
+    print("\nFOCUSED SUMMARY — param-grad mean_abs across batches (descending):")
+    grad_rows = [
+        ((probe, phase), entry)
+        for (probe, phase), entry in accum.items()
+        if phase.startswith("grad_raw") or phase.startswith("grad_scaled")
+    ]
+    grad_rows.sort(key=lambda kv: -float(np.mean(kv[1]["max_abs_list"])))
+    hdr2 = f"{'probe':12}{'phase':30}{'mean_abs':>12}{'max_abs':>12}{'n':>4}"
+    print(hdr2)
+    print("-" * len(hdr2))
+    for (probe, phase), entry in grad_rows:
+        abs_list = entry["max_abs_list"]
+        n = len(abs_list)
+        mean_abs = float(np.mean(abs_list))
+        max_abs = float(np.max(abs_list))
+        print(f"{probe:12}{phase:30}{mean_abs:12.2e}{max_abs:12.2e}{n:4d}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/_shared/trace_sweep.py
+++ b/examples/_shared/trace_sweep.py
@@ -18,7 +18,7 @@ Options:
     --stride      step between batch start indices (default: B)
 """
 from __future__ import annotations
-import argparse, os, subprocess, sys
+import argparse, os, shutil, subprocess, sys
 from collections import defaultdict
 from pathlib import Path
 import numpy as np
@@ -100,6 +100,8 @@ def main() -> None:
     for i in range(args.batches):
         start = args.start0 + i * stride
         print(f"\n--- batch {i:2d}  sample_start={start} ---", flush=True)
+        shutil.rmtree(c_dump, ignore_errors=True)
+        shutil.rmtree(pt_dump, ignore_errors=True)
         try:
             c_out = run_c(args.example, start, B, args.act_samples, args.classes)
         except subprocess.CalledProcessError as exc:
@@ -145,7 +147,7 @@ def main() -> None:
     # --- Full aggregate table ---
     rows = sorted(accum.items(), key=row_sort_key)
     print("\nAGGREGATE TABLE (sorted by tier then network depth):")
-    hdr = f"{'probe':12}{'phase':30}{'mean_abs':>12}{'max_abs':>12}{'mean_rel':>12}{'n':>4}"
+    hdr = f"{'probe':12}{'phase':30}{'mean(maxabs)':>12}{'max_abs':>12}{'mean_rel':>12}{'n':>4}"
     print(hdr)
     print("-" * len(hdr))
     for (probe, phase), entry in rows:
@@ -165,7 +167,7 @@ def main() -> None:
         if phase.startswith("grad_raw") or phase.startswith("grad_scaled")
     ]
     grad_rows.sort(key=lambda kv: -float(np.mean(kv[1]["max_abs_list"])))
-    hdr2 = f"{'probe':12}{'phase':30}{'mean_abs':>12}{'max_abs':>12}{'n':>4}"
+    hdr2 = f"{'probe':12}{'phase':30}{'mean(maxabs)':>12}{'max_abs':>12}{'n':>4}"
     print(hdr2)
     print("-" * len(hdr2))
     for (probe, phase), entry in grad_rows:

--- a/examples/kws_raw/CMakeLists.txt
+++ b/examples/kws_raw/CMakeLists.txt
@@ -66,3 +66,73 @@ target_link_libraries(train_c_kws_raw PRIVATE
 
         examples_shared
 )
+
+add_executable(trace_c_kws_raw trace_c.c)
+
+target_link_libraries(trace_c_kws_raw PRIVATE
+        DataLoaderApi
+        DataLoader
+        NPYLoaderApi
+        NPYLoader
+
+        Layer
+
+        Conv1dApi
+        Conv1d
+
+        LinearApi
+        Linear
+
+        ReluApi
+        Relu
+
+        FlattenApi
+        Flatten
+
+        Pool1dApi
+        MaxPool1d
+        AvgPool1d
+
+        AdaptivePool1dApi
+        AdaptiveAvgPool1d
+
+        LayerNormApi
+        LayerNorm
+
+        QuantizationApi
+        Quantization
+
+        TensorApi
+        Tensor
+        Rounding
+
+        TrainingLoopApi
+        CalculateGradsSequential
+        TrainingBatchDefault
+        TrainingEpochDefault
+        Optimizer
+        OptimizerApi
+
+        LossFunction
+        CrossEntropy
+
+        SoftmaxApi
+        Softmax
+
+        Sgd
+        SgdApi
+
+        InferenceApi
+
+        StateDictApi
+        LayerWeightsApi
+        LayerQuant
+        LayerCommon
+        Distributions
+
+        Common
+        StorageApi
+        RNG
+
+        examples_shared
+)

--- a/examples/kws_raw/probe_manifest.h
+++ b/examples/kws_raw/probe_manifest.h
@@ -1,0 +1,27 @@
+#ifndef KWS_RAW_PROBE_MANIFEST_H
+#define KWS_RAW_PROBE_MANIFEST_H
+
+/* Indices match model[] in train_c.c::buildModel (MODEL_SIZE == 17, per-conv
+ * LayerNorm pre-ReLU). Each name identifies the tensor produced by that C layer's
+ * forward, and is paired against the same-named PyTorch tensor in trace_pytorch.py. */
+static const char *KWS_RAW_PROBES[17] = {
+    "pool0",     /* 0  AvgPool1d ds */
+    "conv1",     /* 1  Conv1d */
+    "ln1",       /* 2  LayerNorm([16,1000]) */
+    "relu1",     /* 3  ReLU */
+    "pool1",     /* 4  MaxPool1d */
+    "conv2",     /* 5  Conv1d */
+    "ln2",       /* 6  LayerNorm([32,250]) */
+    "relu2",     /* 7  ReLU */
+    "pool2",     /* 8  MaxPool1d */
+    "conv3",     /* 9  Conv1d */
+    "ln3",       /* 10 LayerNorm([64,62]) */
+    "relu3",     /* 11 ReLU */
+    "pool3",     /* 12 MaxPool1d */
+    "adaptpool", /* 13 AdaptiveAvgPool1d */
+    "flatten",   /* 14 Flatten */
+    "fc",        /* 15 Linear (logits) */
+    "softmax",   /* 16 Softmax (probs) */
+};
+
+#endif

--- a/examples/kws_raw/trace_c.c
+++ b/examples/kws_raw/trace_c.c
@@ -1,0 +1,419 @@
+#define SOURCE_FILE "kws_raw_trace_c"
+
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <time.h>
+
+#include "AdaptivePool1dApi.h"
+#include "CalculateGradsSequential.h"
+#include "Common.h"
+#include "Conv1dApi.h"
+#include "DataLoader.h"
+#include "DataLoaderApi.h"
+#include "FlattenApi.h"
+#include "InferenceApi.h"
+#include "Layer.h"
+#include "LayerCommon.h"
+#include "LayerNormApi.h"
+#include "LayerQuant.h"
+#include "LinearApi.h"
+#include "LossFunction.h"
+#include "NPYLoaderApi.h"
+#include "OptimizerApi.h"
+#include "Pool1dApi.h"
+#include "Quantization.h"
+#include "QuantizationApi.h"
+#include "ReluApi.h"
+#include "SgdApi.h"
+#include "SoftmaxApi.h"
+#include "StateDictApi.h"
+#include "StorageApi.h"
+#include "Tensor.h"
+#include "TensorApi.h"
+#include "TrainingLoopApi.h"
+
+#include "TraceApi.h"
+#include "npy_dump_sink.h"
+#include "probe_manifest.h"
+
+#define EPOCHS 50
+#define BATCH 32
+#define LR 0.005f
+#define MOMENTUM 0.9f
+#define SEED 42
+#define SHUFFLE_SEED 42
+#define NUM_CLASSES_DEFAULT 6
+
+#define IN_CHANNELS 1
+#define LEN_INPUT 16000
+#define DS_K 16     /* front AvgPool downsample: 16 kHz -> 1 kHz */
+#define LEN_DS 1000 /* LEN_INPUT / DS_K */
+#define C1_OUT 16
+#define C1_K 3
+#define C2_OUT 32
+#define C2_K 3
+#define C3_OUT 64
+#define C3_K 3
+
+/* AvgPool(ds) + 3x(Conv1d+LayerNorm+ReLU+MaxPool) + AdaptiveAvgPool + Flatten + Linear + Softmax
+ * = 17 layers */
+#define MODEL_SIZE 17
+
+static dataset_t g_trainDataset;
+static dataset_t g_valDataset;
+static dataset_t g_testDataset;
+
+static size_t g_numClasses = NUM_CLASSES_DEFAULT;
+
+static size_t readNumClasses(void) {
+    const char *env = getenv("KWS_CLASSES");
+    if (env == NULL || env[0] == '\0') {
+        return NUM_CLASSES_DEFAULT;
+    }
+    long v = strtol(env, NULL, 10);
+    if (v != 6 && v != 35) {
+        fprintf(stderr, "KWS_CLASSES must be 6 or 35 (got '%s'); using %d\n", env,
+                NUM_CLASSES_DEFAULT);
+        return NUM_CLASSES_DEFAULT;
+    }
+    return (size_t)v;
+}
+
+static void reshapeItemsAddBatchDim(tensorArray_t *items) {
+    for (size_t i = 0; i < items->size; ++i) {
+        tensor_t *t = items->array[i];
+        size_t oldRank = t->shape->numberOfDimensions;
+        size_t newRank = oldRank + 1;
+
+        size_t *newDims = reserveMemory(newRank * sizeof(size_t));
+        size_t *newOrder = reserveMemory(newRank * sizeof(size_t));
+        newDims[0] = 1;
+        for (size_t d = 0; d < oldRank; ++d) {
+            newDims[d + 1] = t->shape->dimensions[d];
+        }
+        for (size_t d = 0; d < newRank; ++d) {
+            newOrder[d] = d;
+        }
+
+        freeReservedMemory(t->shape->dimensions);
+        freeReservedMemory(t->shape->orderOfDimensions);
+        t->shape->dimensions = newDims;
+        t->shape->orderOfDimensions = newOrder;
+        t->shape->numberOfDimensions = newRank;
+    }
+}
+
+static tensorArray_t *buildOneHotLabels(tensorArray_t *intLabels) {
+    tensorArray_t *out = reserveMemory(sizeof(tensorArray_t));
+    tensor_t **arr = reserveMemory(intLabels->size * sizeof(tensor_t *));
+    out->array = arr;
+    out->size = intLabels->size;
+
+    for (size_t i = 0; i < intLabels->size; ++i) {
+        size_t *dims = reserveMemory(1 * sizeof(size_t));
+        size_t *order = reserveMemory(1 * sizeof(size_t));
+        dims[0] = g_numClasses;
+        order[0] = 0;
+        shape_t *shape = reserveMemory(sizeof(shape_t));
+        shape->dimensions = dims;
+        shape->orderOfDimensions = order;
+        shape->numberOfDimensions = 1;
+
+        quantization_t *q = quantizationInitFloat();
+        tensor_t *t = initTensor(shape, q, NULL);
+
+        int32_t cls = ((int32_t *)intLabels->array[i]->data)[0];
+        float *data = (float *)t->data;
+        for (size_t c = 0; c < g_numClasses; ++c) {
+            data[c] = (c == (size_t)cls) ? 1.0f : 0.0f;
+        }
+        arr[i] = t;
+    }
+    return out;
+}
+
+static void initDataSets(const char *dataDir) {
+    char path[300];
+    snprintf(path, sizeof(path), "%s/train_x.npy", dataDir);
+    tensorArray_t *trainItems = npyLoad(path);
+    snprintf(path, sizeof(path), "%s/train_y.npy", dataDir);
+    tensorArray_t *trainLabelsRaw = npyLoad(path);
+    reshapeItemsAddBatchDim(trainItems);
+    g_trainDataset.items = trainItems;
+    g_trainDataset.labels = buildOneHotLabels(trainLabelsRaw);
+
+    snprintf(path, sizeof(path), "%s/val_x.npy", dataDir);
+    tensorArray_t *valItems = npyLoad(path);
+    snprintf(path, sizeof(path), "%s/val_y.npy", dataDir);
+    tensorArray_t *valLabelsRaw = npyLoad(path);
+    reshapeItemsAddBatchDim(valItems);
+    g_valDataset.items = valItems;
+    g_valDataset.labels = buildOneHotLabels(valLabelsRaw);
+
+    snprintf(path, sizeof(path), "%s/test_x.npy", dataDir);
+    tensorArray_t *testItems = npyLoad(path);
+    snprintf(path, sizeof(path), "%s/test_y.npy", dataDir);
+    tensorArray_t *testLabelsRaw = npyLoad(path);
+    reshapeItemsAddBatchDim(testItems);
+    g_testDataset.items = testItems;
+    g_testDataset.labels = buildOneHotLabels(testLabelsRaw);
+}
+
+static sample_t *getTrainSample(size_t id) {
+    return npyGetSample(&g_trainDataset, id);
+}
+static sample_t *getValSample(size_t id) {
+    return npyGetSample(&g_valDataset, id);
+}
+static sample_t *getTestSample(size_t id) {
+    return npyGetSample(&g_testDataset, id);
+}
+static size_t getTrainSize(void) {
+    return g_trainDataset.items->size;
+}
+static size_t getValSize(void) {
+    return g_valDataset.items->size;
+}
+static size_t getTestSize(void) {
+    return g_testDataset.items->size;
+}
+
+static void buildModel(layer_t **model, layerQuant_t *lq) {
+    /* Input reshaped to [1, 1, 16000]. */
+    /* Front downsample: AvgPool1d(K=16,S=16) -> length 1000 (16 kHz -> 1 kHz). */
+    model[0] = avgPool1dLayerInit(&(avgPool1dInit_t){.kernelSize = DS_K, .stride = DS_K}, lq);
+
+    /* 3x [Conv1d -> LayerNorm([C,L]) -> ReLU -> MaxPool(4)]. Per-conv LayerNorm over the full
+     * feature map (mirrors PyTorch nn.LayerNorm([C,L]), eps 1e-5) is what gives the raw model
+     * stable convergence: a 10-seed sweep showed end-feature LayerNorm collapses on ~40% of
+     * seeds while per-conv converges 10/10. normalizedShape is L-coupled like the MaxPool
+     * inputLengths, so it tracks the downsample rate. */
+    model[1] = conv1dLayerInit(
+        &(conv1dInit_t){
+            .inChannels = IN_CHANNELS, .outChannels = C1_OUT, .kernelSize = C1_K, .padding = SAME},
+        lq);
+    model[2] = layerNormLayerInit(&(layerNormInit_t){.normalizedShape = (size_t[]){C1_OUT, LEN_DS},
+                                                     .numNormDims = 2,
+                                                     .eps = 1e-5f},
+                                  lq);
+    model[3] = reluLayerInit(lq);
+    model[4] = maxPool1dLayerInit(
+        &(maxPool1dInit_t){
+            .kernelSize = 4, .stride = 4, .inputChannels = C1_OUT, .inputLength = LEN_DS},
+        lq);
+
+    model[5] = conv1dLayerInit(
+        &(conv1dInit_t){
+            .inChannels = C1_OUT, .outChannels = C2_OUT, .kernelSize = C2_K, .padding = SAME},
+        lq);
+    model[6] = layerNormLayerInit(
+        &(layerNormInit_t){
+            .normalizedShape = (size_t[]){C2_OUT, LEN_DS / 4}, .numNormDims = 2, .eps = 1e-5f},
+        lq);
+    model[7] = reluLayerInit(lq);
+    model[8] = maxPool1dLayerInit(
+        &(maxPool1dInit_t){
+            .kernelSize = 4, .stride = 4, .inputChannels = C2_OUT, .inputLength = LEN_DS / 4},
+        lq);
+
+    model[9] = conv1dLayerInit(
+        &(conv1dInit_t){
+            .inChannels = C2_OUT, .outChannels = C3_OUT, .kernelSize = C3_K, .padding = SAME},
+        lq);
+    model[10] = layerNormLayerInit(
+        &(layerNormInit_t){
+            .normalizedShape = (size_t[]){C3_OUT, LEN_DS / 16}, .numNormDims = 2, .eps = 1e-5f},
+        lq);
+    model[11] = reluLayerInit(lq);
+    model[12] = maxPool1dLayerInit(
+        &(maxPool1dInit_t){
+            .kernelSize = 4, .stride = 4, .inputChannels = C3_OUT, .inputLength = LEN_DS / 16},
+        lq);
+
+    /* Rate-agnostic head: AdaptiveAvgPool1d(1) -> Flatten -> Linear -> Softmax. */
+    model[13] = adaptiveAvgPool1dLayerInit(&(adaptiveAvgPool1dInit_t){.outputSize = 1}, lq);
+    model[14] = flattenLayerInit();
+    model[15] =
+        linearLayerInit(&(linearInit_t){.inFeatures = C3_OUT, .outFeatures = g_numClasses}, lq);
+    model[16] = softmaxLayerInit(lq);
+}
+
+/* Load PyTorch state_dict from per-layer .npy files written by
+ * examples/kws_raw/train_pytorch.py --save-weights.
+ *
+ * Returns 0 on success, non-zero on first missing file. */
+static int loadStateDictFromDir(layer_t **model, const char *weightsDir) {
+    char wPath[300], bPath[300];
+    /* Param layers in order: conv1=model[1], ln1=model[2], conv2=model[5], ln2=model[6],
+     * conv3=model[9], ln3=model[10], fc=model[15]. 7 entries (each ln = gamma/beta). */
+    const char *names[7] = {"conv1", "ln1", "conv2", "ln2", "conv3", "ln3", "fc"};
+    tensor_t *w[7] = {0};
+    tensor_t *b[7] = {0};
+
+    for (int i = 0; i < 7; i++) {
+        snprintf(wPath, sizeof(wPath), "%s/%s.weight.npy", weightsDir, names[i]);
+        snprintf(bPath, sizeof(bPath), "%s/%s.bias.npy", weightsDir, names[i]);
+        w[i] = npyLoadFlat(wPath);
+        b[i] = npyLoadFlat(bPath);
+        if (w[i] == NULL || b[i] == NULL) {
+            fprintf(stderr, "loadStateDictFromDir: missing %s or %s\n", wPath, bPath);
+            return 1;
+        }
+    }
+
+    modelLoadStateDict(
+        model, MODEL_SIZE,
+        (stateDictEntry_t[]){
+            {.name = names[0], .weightData = (float *)w[0]->data, .biasData = (float *)b[0]->data},
+            {.name = names[1], .weightData = (float *)w[1]->data, .biasData = (float *)b[1]->data},
+            {.name = names[2], .weightData = (float *)w[2]->data, .biasData = (float *)b[2]->data},
+            {.name = names[3], .weightData = (float *)w[3]->data, .biasData = (float *)b[3]->data},
+            {.name = names[4], .weightData = (float *)w[4]->data, .biasData = (float *)b[4]->data},
+            {.name = names[5], .weightData = (float *)w[5]->data, .biasData = (float *)b[5]->data},
+            {.name = names[6], .weightData = (float *)w[6]->data, .biasData = (float *)b[6]->data},
+        },
+        7);
+
+    for (int i = 0; i < 7; i++) {
+        freeTensor(w[i]);
+        freeTensor(b[i]);
+    }
+    return 0;
+}
+
+static int ensureDir(const char *p) {
+    if (mkdir(p, S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH) == 0) {
+        return 0;
+    }
+    if (errno == EEXIST) {
+        return 0;
+    }
+    fprintf(stderr, "ERROR: cannot create %s: %s\n", p, strerror(errno));
+    return 1;
+}
+
+/* CLI: --sample-start N (first test sample of the batch, default 0)
+ *      --batch B        (samples per step, default 32)
+ *      --act-samples K  (samples that dump activations/act-grads, default 4)
+ *      --steps S        (re-feed the same batch S times, default 1) */
+static size_t g_sampleStart = 0;
+static size_t g_batch = 32;
+static size_t g_actSamples = 4;
+static size_t g_steps = 1;
+static void parseArgs(int argc, char **argv) {
+    for (int i = 1; i < argc - 1; i++) {
+        if (strcmp(argv[i], "--sample-start") == 0)
+            g_sampleStart = (size_t)strtoul(argv[++i], 0, 10);
+        else if (strcmp(argv[i], "--batch") == 0)
+            g_batch = (size_t)strtoul(argv[++i], 0, 10);
+        else if (strcmp(argv[i], "--act-samples") == 0)
+            g_actSamples = (size_t)strtoul(argv[++i], 0, 10);
+        else if (strcmp(argv[i], "--steps") == 0)
+            g_steps = (size_t)strtoul(argv[++i], 0, 10);
+    }
+}
+
+int main(int argc, char **argv) {
+    parseArgs(argc, argv);
+    g_numClasses = readNumClasses();
+
+    char dataDir[256], weightsDir[256];
+    snprintf(dataDir, sizeof(dataDir), "examples/kws_raw/data/%zuclass", g_numClasses);
+    snprintf(weightsDir, sizeof(weightsDir), "examples/kws_raw/weights/%zuclass", g_numClasses);
+    initDataSets(dataDir);
+
+    layerQuant_t lq;
+    layerQuantInitUniform(&lq, quantizationInitFloat());
+    layer_t *model[MODEL_SIZE];
+    buildModel(model, &lq);
+
+    /* Identical start: load the exported PyTorch state_dict (same as BIT_PARITY). */
+    if (loadStateDictFromDir(model, weightsDir) != 0) {
+        fprintf(stderr, "trace_c: state_dict load failed\n");
+        return 1;
+    }
+
+    optimizer_t *sgd =
+        sgdMCreateOptim(LR, MOMENTUM, /*weightDecay*/ 0.0f, model, MODEL_SIZE, FLOAT32);
+    optimizerFunctions_t optimFns = optimizerFunctions[sgd->type];
+
+    lossConfig_t lossCfg = {.funcType = CROSS_ENTROPY,
+                            .backwardReduction = REDUCTION_MEAN,
+                            .classWeights = NULL};
+
+    /* Effective batch: support ANY --batch, clamped to the samples available from
+     * --sample-start. effB is used for the loop, the mean-scale (1/effB) and the
+     * mean_loss print, so the C-vs-PyTorch scaling stays consistent for any B. */
+    size_t testSize = getTestSize();
+    if (g_sampleStart >= testSize) {
+        fprintf(stderr, "trace_c: --sample-start %zu >= test size %zu\n", g_sampleStart, testSize);
+        return 1;
+    }
+    size_t effB = g_batch;
+    if (g_sampleStart + effB > testSize) {
+        effB = testSize - g_sampleStart;
+        fprintf(stderr, "trace_c: batch clamped to %zu (only %zu samples from start %zu)\n", effB,
+                effB, g_sampleStart);
+    }
+
+    /* mean over effB samples; same vtable entry TrainingEpochDefault.c:35 uses (== 1/effB for
+     * CE). */
+    tensor_t *firstLabel = g_testDataset.labels->array[g_sampleStart];
+    float meanScale = lossFunctions[lossCfg.funcType].computeMeanScale(effB, firstLabel);
+
+    ensureDir("examples/kws_raw/dump_c");
+    for (size_t step = 0; step < g_steps; step++) {
+        char dir[256];
+        snprintf(dir, sizeof(dir), "examples/kws_raw/dump_c/step%03zu", step);
+        ensureDir(dir);
+        npyDumpCtx_t ctx = {.dir = dir,
+                            .probeNames = KWS_RAW_PROBES,
+                            .numProbes = MODEL_SIZE,
+                            .sampleIdx = NPY_DUMP_NO_SAMPLE};
+
+        /* tier 4a: weights before the step (unchanged during accumulation). */
+        traceModelWeights(model, MODEL_SIZE, "w_before", npyDumpSink, &ctx);
+
+        /* tiers 1 & 2 per sample (first g_actSamples); grads accumulate over ALL B samples.
+         * No zero-grad between samples => param->grad ends up the SUM over the batch.
+         * (Grads start at zero: calloc-backed after sgdMCreateOptim / optimFns.zero below.) */
+        double sumLoss = 0.0;
+        for (size_t s = 0; s < effB; s++) {
+            size_t idx = g_sampleStart + s;
+            sample_t *smp = getTestSample(idx);
+            tensor_t *label = g_testDataset.labels->array[idx];
+            bool dumpActs = (s < g_actSamples);
+            ctx.sampleIdx = dumpActs ? s : NPY_DUMP_NO_SAMPLE;
+            trainingStats_t *stats =
+                tracedGrads(model, MODEL_SIZE, lossCfg, REDUCTION_MEAN, smp->item, label,
+                            dumpActs ? npyDumpSink : NULL, dumpActs ? &ctx : NULL);
+            sumLoss += (double)stats->loss;
+            freeTrainingStats(stats);
+            freeSample(smp);
+        }
+        ctx.sampleIdx = NPY_DUMP_NO_SAMPLE;
+
+        /* tier 3a: raw accumulated grads (SUM over the batch, pre-scale). */
+        traceModelGrads(model, MODEL_SIZE, "grad_raw", npyDumpSink, &ctx);
+
+        /* mean-reduction scaling, exactly as TrainingEpochDefault does it. */
+        scaleOptimizerGradients(sgd, meanScale);
+
+        /* tier 3b: scaled grads (MEAN, pre-step). */
+        traceModelGrads(model, MODEL_SIZE, "grad_scaled", npyDumpSink, &ctx);
+
+        /* the update, then tier 4b: weights after. */
+        optimFns.step(sgd);
+        traceModelWeights(model, MODEL_SIZE, "w_after", npyDumpSink, &ctx);
+        optimFns.zero(sgd);
+
+        fprintf(stdout, "trace_c step %zu: effB=%zu mean_loss=%.6f -> %s\n", step, effB,
+                sumLoss / (double)effB, dir);
+    }
+
+    return 0;
+}

--- a/examples/kws_raw/trace_c.c
+++ b/examples/kws_raw/trace_c.c
@@ -306,14 +306,15 @@ static size_t g_actSamples = 4;
 static size_t g_steps = 1;
 static void parseArgs(int argc, char **argv) {
     for (int i = 1; i < argc - 1; i++) {
-        if (strcmp(argv[i], "--sample-start") == 0)
+        if (strcmp(argv[i], "--sample-start") == 0) {
             g_sampleStart = (size_t)strtoul(argv[++i], 0, 10);
-        else if (strcmp(argv[i], "--batch") == 0)
+        } else if (strcmp(argv[i], "--batch") == 0) {
             g_batch = (size_t)strtoul(argv[++i], 0, 10);
-        else if (strcmp(argv[i], "--act-samples") == 0)
+        } else if (strcmp(argv[i], "--act-samples") == 0) {
             g_actSamples = (size_t)strtoul(argv[++i], 0, 10);
-        else if (strcmp(argv[i], "--steps") == 0)
+        } else if (strcmp(argv[i], "--steps") == 0) {
             g_steps = (size_t)strtoul(argv[++i], 0, 10);
+        }
     }
 }
 
@@ -341,9 +342,8 @@ int main(int argc, char **argv) {
         sgdMCreateOptim(LR, MOMENTUM, /*weightDecay*/ 0.0f, model, MODEL_SIZE, FLOAT32);
     optimizerFunctions_t optimFns = optimizerFunctions[sgd->type];
 
-    lossConfig_t lossCfg = {.funcType = CROSS_ENTROPY,
-                            .backwardReduction = REDUCTION_MEAN,
-                            .classWeights = NULL};
+    lossConfig_t lossCfg = {
+        .funcType = CROSS_ENTROPY, .backwardReduction = REDUCTION_MEAN, .classWeights = NULL};
 
     /* Effective batch: support ANY --batch, clamped to the samples available from
      * --sample-start. effB is used for the loop, the mean-scale (1/effB) and the

--- a/examples/kws_raw/trace_c.c
+++ b/examples/kws_raw/trace_c.c
@@ -356,8 +356,8 @@ int main(int argc, char **argv) {
     size_t effB = g_batch;
     if (g_sampleStart + effB > testSize) {
         effB = testSize - g_sampleStart;
-        fprintf(stderr, "trace_c: batch clamped to %zu (only %zu samples from start %zu)\n", effB,
-                effB, g_sampleStart);
+        fprintf(stderr, "trace_c: batch clamped to %zu (requested %zu, only %zu from start %zu)\n",
+                effB, g_batch, effB, g_sampleStart);
     }
 
     /* mean over effB samples; same vtable entry TrainingEpochDefault.c:35 uses (== 1/effB for

--- a/examples/kws_raw/trace_pytorch.py
+++ b/examples/kws_raw/trace_pytorch.py
@@ -1,0 +1,123 @@
+"""Per-layer trace of one controlled SGD step, mirroring kws_raw/trace_c.c.
+
+Loads the SAME exported state_dict the C BIT_PARITY path loads, runs ONE batched
+forward + backward + optimizer.step() on the fixed batch test_x[start:start+B],
+and dumps every probe to dump_pt/step000/<probe>.<phase>[.sNN].npy with names
+matching probe_manifest.h. PyTorch's mean-reduction backward carries a 1/B that
+C's per-sample backward does not, so the unscaled tiers (act-grad, loss-grad,
+grad_raw) are multiplied by B to match the C dumps.
+"""
+from __future__ import annotations
+import argparse, sys
+from pathlib import Path
+import numpy as np, torch, torch.nn.functional as F
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE.parents[1]))
+from examples.kws_raw.train_pytorch import KwsRawCnn  # reuse the model  # noqa: E402
+
+LR, MOMENTUM = 0.005, 0.9
+# Forward probe names in C buildModel order (must equal probe_manifest.h) — 17-layer
+# per-conv-LayerNorm model:
+FWD_PROBES = ["pool0","conv1","ln1","relu1","pool1","conv2","ln2","relu2","pool2",
+              "conv3","ln3","relu3","pool3","adaptpool","flatten","fc","softmax"]
+PARAM_LAYERS = ["conv1","ln1","conv2","ln2","conv3","ln3","fc"]
+
+
+def save(d: Path, probe: str, phase: str, t) -> None:
+    if isinstance(t, torch.Tensor):
+        t = t.detach().cpu().numpy()
+    np.save(d / f"{probe}.{phase}.npy", np.asarray(t, dtype=np.float32))
+
+
+def forward_traced(model: KwsRawCnn, x: torch.Tensor, acts: dict) -> torch.Tensor:
+    acts["pool0"] = (h := model.pool0(x))
+    acts["conv1"] = (h := model.conv1(h)); acts["ln1"] = (h := model.ln1(h))
+    acts["relu1"] = (h := F.relu(h)); acts["pool1"] = (h := F.max_pool1d(h, 4))
+    acts["conv2"] = (h := model.conv2(h)); acts["ln2"] = (h := model.ln2(h))
+    acts["relu2"] = (h := F.relu(h)); acts["pool2"] = (h := F.max_pool1d(h, 4))
+    acts["conv3"] = (h := model.conv3(h)); acts["ln3"] = (h := model.ln3(h))
+    acts["relu3"] = (h := F.relu(h)); acts["pool3"] = (h := F.max_pool1d(h, 4))
+    acts["adaptpool"] = (h := F.adaptive_avg_pool1d(h, 1))
+    acts["flatten"] = (h := h.flatten(start_dim=1))
+    acts["fc"] = (logits := model.fc(h))
+    acts["softmax"] = F.softmax(logits, dim=1)
+    return logits
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--sample-start", type=int, default=0)
+    ap.add_argument("--batch", type=int, default=32)
+    ap.add_argument("--act-samples", type=int, default=4)
+    ap.add_argument("--classes", type=int, default=6)
+    args = ap.parse_args()
+    tag = f"{args.classes}class"
+    data = HERE / "data" / tag
+    weights = HERE / "weights" / tag
+
+    test_x = np.load(data / "test_x.npy"); test_y = np.load(data / "test_y.npy")
+    model = KwsRawCnn(args.classes)
+    sd = {}
+    for name in PARAM_LAYERS:
+        sd[f"{name}.weight"] = torch.from_numpy(np.load(weights / f"{name}.weight.npy"))
+        sd[f"{name}.bias"] = torch.from_numpy(np.load(weights / f"{name}.bias.npy"))
+    model.load_state_dict(sd, strict=True)
+
+    out = HERE / "dump_pt" / "step000"; out.mkdir(parents=True, exist_ok=True)
+    sl = slice(args.sample_start, args.sample_start + args.batch)
+    x = torch.from_numpy(test_x[sl].astype(np.float32))
+    y = torch.from_numpy(test_y[sl].astype(np.int64))
+    B = x.shape[0]              # effective batch (slice truncates at the dataset end)
+    K = min(args.act_samples, B)
+    if B == 0:
+        raise SystemExit(f"--sample-start {args.sample_start} >= test size {len(test_x)}")
+
+    opt = torch.optim.SGD(model.parameters(), lr=LR, momentum=MOMENTUM)
+    for name in PARAM_LAYERS:
+        layer = getattr(model, name)
+        save(out, name, "w_before.weight", layer.weight)
+        save(out, name, "w_before.bias", layer.bias)
+
+    acts: dict = {}
+    logits = forward_traced(model, x, acts)
+    for t in acts.values():
+        if t.requires_grad:
+            t.retain_grad()  # keep act-grads for the backward dump
+
+    loss = F.cross_entropy(logits, y)  # reduction='mean' over the batch (÷B)
+    opt.zero_grad()
+    loss.backward()
+
+    # tier 1: per-sample activation slices; keep the leading batch-dim-1 to match C [1,..]
+    for probe, t in acts.items():
+        a = t.detach()
+        for s in range(K):
+            save(out, probe, f"fwd.s{s:03d}", a[s:s + 1])
+    # tier 2 + loss-grad: per-sample, ×B to undo the mean reduction (match C's unscaled grads)
+    for probe, t in acts.items():
+        if t.grad is None:
+            continue
+        for s in range(K):
+            save(out, probe, f"agrad.s{s:03d}", t.grad[s:s + 1] * B)
+    for s in range(K):
+        save(out, "loss", f"lossgrad.s{s:03d}", acts["fc"].grad[s:s + 1] * B)
+
+    # tier 3: grad_raw == sum (param.grad × B), grad_scaled == mean (param.grad)
+    for name in PARAM_LAYERS:
+        layer = getattr(model, name)
+        save(out, name, "grad_raw.weight", layer.weight.grad * B)
+        save(out, name, "grad_raw.bias", layer.bias.grad * B)
+        save(out, name, "grad_scaled.weight", layer.weight.grad)
+        save(out, name, "grad_scaled.bias", layer.bias.grad)
+
+    opt.step()
+    for name in PARAM_LAYERS:
+        layer = getattr(model, name)
+        save(out, name, "w_after.weight", layer.weight)
+        save(out, name, "w_after.bias", layer.bias)
+    print(f"trace_pytorch: mean_loss={loss.item():.6f} -> {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/kws_raw/trace_pytorch.py
+++ b/examples/kws_raw/trace_pytorch.py
@@ -42,6 +42,7 @@ def forward_traced(model: KwsRawCnn, x: torch.Tensor, acts: dict) -> torch.Tenso
     acts["flatten"] = (h := h.flatten(start_dim=1))
     acts["fc"] = (logits := model.fc(h))
     acts["softmax"] = F.softmax(logits, dim=1)
+    assert list(acts) == FWD_PROBES, (list(acts), FWD_PROBES)
     return logits
 
 

--- a/src/userApi/training_loop/calculate_grads/CalculateGradsSequential.c
+++ b/src/userApi/training_loop/calculate_grads/CalculateGradsSequential.c
@@ -106,6 +106,13 @@ trainingStats_t *calculateGradsSequential(layer_t **model, size_t modelSize,
                               NULL);
 }
 
+trainingStats_t *tracedGrads(layer_t **model, size_t modelSize, lossConfig_t lossConfig,
+                             reduction_t forwardReduction, tensor_t *input, tensor_t *label,
+                             traceSink_t sink, void *ctx) {
+    return calculateGradsImpl(model, modelSize, lossConfig, forwardReduction, input, label, sink,
+                              ctx);
+}
+
 static void initLayerOutputs(tensor_t **layerOutputs, layer_t **model, size_t sizeNetwork) {
     for (size_t i = 0; i < sizeNetwork; i++) {
         layer_t *currentLayer = model[i];

--- a/src/userApi/training_loop/calculate_grads/CalculateGradsSequential.c
+++ b/src/userApi/training_loop/calculate_grads/CalculateGradsSequential.c
@@ -22,6 +22,7 @@
 #include "Softmax.h"
 #include "StorageApi.h"
 #include "TensorApi.h"
+#include "TraceApi.h"
 #include "TrainingLoopApiInternal.h"
 
 static void setDropoutLayersTraining(layer_t **model, size_t modelSize, bool training) {
@@ -32,9 +33,10 @@ static void setDropoutLayersTraining(layer_t **model, size_t modelSize, bool tra
     }
 }
 
-trainingStats_t *calculateGradsSequential(layer_t **model, size_t modelSize,
-                                          lossConfig_t lossConfig, reduction_t forwardReduction,
-                                          tensor_t *input, tensor_t *label) {
+static trainingStats_t *calculateGradsImpl(layer_t **model, size_t modelSize,
+                                           lossConfig_t lossConfig, reduction_t forwardReduction,
+                                           tensor_t *input, tensor_t *label, traceSink_t sink,
+                                           void *sinkCtx) {
 
     tensor_t *layerOutputs[modelSize + 1];
     layerOutputs[0] = input;
@@ -47,6 +49,9 @@ trainingStats_t *calculateGradsSequential(layer_t **model, size_t modelSize,
         layerType_t currentLayerType = currentLayer->type;
         forwardFn_t forward = layerFunctions[currentLayerType].forward;
         forward(currentLayer, layerOutputs[i], layerOutputs[i + 1]);
+        if (sink != NULL) {
+            sink(sinkCtx, i, currentLayerType, "fwd", layerOutputs[i + 1]);
+        }
     }
 
     trainingStats_t *trainingStats = initTrainingStats(layerOutputs[modelSize]);
@@ -67,6 +72,9 @@ trainingStats_t *calculateGradsSequential(layer_t **model, size_t modelSize,
     tensor_t gradNext;
     initGradTensor(&gradNext, layerOutputs[modelSize]);
     lossFns.backward(layerOutputs[modelSize], label, &gradNext);
+    if (sink != NULL) {
+        sink(sinkCtx, modelSize, model[modelSize - 1]->type, "lossgrad", &gradNext);
+    }
 
     for (int i = (int)backwardIndex; i >= 0; i--) {
         tensor_t gradCurr;
@@ -76,6 +84,9 @@ trainingStats_t *calculateGradsSequential(layer_t **model, size_t modelSize,
         backwardFn_t backward = layerFunctions[layerType].backward;
 
         backward(model[i], layerOutputs[i], &gradNext, &gradCurr);
+        if (sink != NULL) {
+            sink(sinkCtx, (size_t)i, layerType, "agrad", &gradCurr);
+        }
 
         deInitGradTensor(&gradNext);
         gradNext = gradCurr;
@@ -86,6 +97,13 @@ trainingStats_t *calculateGradsSequential(layer_t **model, size_t modelSize,
 
     setDropoutLayersTraining(model, modelSize, false);
     return trainingStats;
+}
+
+trainingStats_t *calculateGradsSequential(layer_t **model, size_t modelSize,
+                                          lossConfig_t lossConfig, reduction_t forwardReduction,
+                                          tensor_t *input, tensor_t *label) {
+    return calculateGradsImpl(model, modelSize, lossConfig, forwardReduction, input, label, NULL,
+                              NULL);
 }
 
 static void initLayerOutputs(tensor_t **layerOutputs, layer_t **model, size_t sizeNetwork) {

--- a/src/userApi/training_loop/calculate_grads/CalculateGradsSequential.c
+++ b/src/userApi/training_loop/calculate_grads/CalculateGradsSequential.c
@@ -113,6 +113,60 @@ trainingStats_t *tracedGrads(layer_t **model, size_t modelSize, lossConfig_t los
                               ctx);
 }
 
+/* Return the two parameter_t* of a trainable layer (bias may be NULL).
+ * Non-trainable layers return false. */
+static bool layerParameters(layer_t *layer, parameter_t **weightOut, parameter_t **biasOut) {
+    switch (layer->type) {
+    case LINEAR:
+        *weightOut = layer->config->linear->weights;
+        *biasOut = layer->config->linear->bias;
+        return true;
+    case CONV1D:
+        *weightOut = layer->config->conv1d->weights;
+        *biasOut = layer->config->conv1d->bias; /* may be NULL */
+        return true;
+    case CONV1D_TRANSPOSED:
+        *weightOut = layer->config->conv1dTransposed->weights;
+        *biasOut = layer->config->conv1dTransposed->bias;
+        return true;
+    case LAYERNORM:
+        *weightOut = layer->config->layerNorm->gamma;
+        *biasOut = layer->config->layerNorm->beta;
+        return true;
+    default:
+        return false;
+    }
+}
+
+static void traceModelParams(layer_t **model, size_t modelSize, const char *tag, bool wantGrad,
+                             traceSink_t sink, void *ctx) {
+    char phase[64];
+    for (size_t i = 0; i < modelSize; i++) {
+        parameter_t *w = NULL, *b = NULL;
+        if (!layerParameters(model[i], &w, &b)) {
+            continue;
+        }
+        tensor_t *wt = wantGrad ? getGradFromParameter(w) : getParamFromParameter(w);
+        snprintf(phase, sizeof(phase), "%s.weight", tag);
+        sink(ctx, i, model[i]->type, phase, wt);
+        if (b != NULL) {
+            tensor_t *bt = wantGrad ? getGradFromParameter(b) : getParamFromParameter(b);
+            snprintf(phase, sizeof(phase), "%s.bias", tag);
+            sink(ctx, i, model[i]->type, phase, bt);
+        }
+    }
+}
+
+void traceModelWeights(layer_t **model, size_t modelSize, const char *tag, traceSink_t sink,
+                       void *ctx) {
+    traceModelParams(model, modelSize, tag, /*wantGrad=*/false, sink, ctx);
+}
+
+void traceModelGrads(layer_t **model, size_t modelSize, const char *tag, traceSink_t sink,
+                     void *ctx) {
+    traceModelParams(model, modelSize, tag, /*wantGrad=*/true, sink, ctx);
+}
+
 static void initLayerOutputs(tensor_t **layerOutputs, layer_t **model, size_t sizeNetwork) {
     for (size_t i = 0; i < sizeNetwork; i++) {
         layer_t *currentLayer = model[i];

--- a/src/userApi/training_loop/calculate_grads/CalculateGradsSequential.c
+++ b/src/userApi/training_loop/calculate_grads/CalculateGradsSequential.c
@@ -77,17 +77,16 @@ static trainingStats_t *calculateGradsImpl(layer_t **model, size_t modelSize,
     }
 
     for (int i = (int)backwardIndex; i >= 0; i--) {
+        layerType_t layerType = model[i]->type;
+        /* agrad@i = gradient w.r.t. layer i's OUTPUT (the wire grad entering layer i's
+         * backward), matching the PyTorch forward-hook activation.grad. */
+        if (sink != NULL) {
+            sink(sinkCtx, (size_t)i, layerType, "agrad", &gradNext);
+        }
         tensor_t gradCurr;
         initGradTensor(&gradCurr, layerOutputs[i]);
-
-        layerType_t layerType = model[i]->type;
         backwardFn_t backward = layerFunctions[layerType].backward;
-
         backward(model[i], layerOutputs[i], &gradNext, &gradCurr);
-        if (sink != NULL) {
-            sink(sinkCtx, (size_t)i, layerType, "agrad", &gradCurr);
-        }
-
         deInitGradTensor(&gradNext);
         gradNext = gradCurr;
     }

--- a/src/userApi/training_loop/calculate_grads/include/TraceApi.h
+++ b/src/userApi/training_loop/calculate_grads/include/TraceApi.h
@@ -4,7 +4,9 @@
 #include <stddef.h>
 
 #include "Layer.h"
+#include "LossFunction.h"
 #include "Tensor.h"
+#include "TrainingLoopApi.h"
 
 /*! Fired at every probe point of one traced training step. The framework hands
  *  a tensor to the sink and never opens a file; the sink (above the src/
@@ -18,8 +20,15 @@
 typedef void (*traceSink_t)(void *ctx, size_t layerIdx, layerType_t layerType, const char *phase,
                             tensor_t *tensor);
 
-/* tracedGrads(), traceModelWeights(), traceModelGrads() declarations are added
- * here in Tasks 2 and 3 — each declaration lands together with its failing test
+/*! Same forward+backward as calculateGradsSequential, but fires `sink` after
+ *  each layer's forward ("fwd"), after the loss backward ("lossgrad",
+ *  layerIdx == modelSize), and after each layer's backward ("agrad"). */
+trainingStats_t *tracedGrads(layer_t **model, size_t modelSize, lossConfig_t lossConfig,
+                             reduction_t forwardReduction, tensor_t *input, tensor_t *label,
+                             traceSink_t sink, void *ctx);
+
+/* traceModelWeights(), traceModelGrads() declarations are added here in Task 3
+ * — each declaration lands together with its failing test
  * (TDD-strict: no decl/stub before the test that drives it). */
 
 #endif /* TRACE_API_H */

--- a/src/userApi/training_loop/calculate_grads/include/TraceApi.h
+++ b/src/userApi/training_loop/calculate_grads/include/TraceApi.h
@@ -27,8 +27,14 @@ trainingStats_t *tracedGrads(layer_t **model, size_t modelSize, lossConfig_t los
                              reduction_t forwardReduction, tensor_t *input, tensor_t *label,
                              traceSink_t sink, void *ctx);
 
-/* traceModelWeights(), traceModelGrads() declarations are added here in Task 3
- * — each declaration lands together with its failing test
- * (TDD-strict: no decl/stub before the test that drives it). */
+/*! Fire `sink` for each trainable layer's weight and bias PARAM tensors, with
+ *  phase "<tag>.weight" / "<tag>.bias". Param-less layers and NULL bias are
+ *  skipped. (Trainable: LINEAR, CONV1D, CONV1D_TRANSPOSED, LAYERNORM.) */
+void traceModelWeights(layer_t **model, size_t modelSize, const char *tag, traceSink_t sink,
+                       void *ctx);
+
+/*! Same, for the GRAD tensor of each parameter_t. */
+void traceModelGrads(layer_t **model, size_t modelSize, const char *tag, traceSink_t sink,
+                     void *ctx);
 
 #endif /* TRACE_API_H */

--- a/src/userApi/training_loop/calculate_grads/include/TraceApi.h
+++ b/src/userApi/training_loop/calculate_grads/include/TraceApi.h
@@ -1,0 +1,25 @@
+#ifndef TRACE_API_H
+#define TRACE_API_H
+
+#include <stddef.h>
+
+#include "Layer.h"
+#include "Tensor.h"
+
+/*! Fired at every probe point of one traced training step. The framework hands
+ *  a tensor to the sink and never opens a file; the sink (above the src/
+ *  boundary) decides what to do with it.
+ *
+ *  - layerIdx:   model index of the layer; for the loss gradient, == modelSize.
+ *  - layerType:  the layer's type (for naming / dtype decisions).
+ *  - phase:      "fwd" | "agrad" | "lossgrad" for tracedGrads (Task 2);
+ *                "<tag>.weight" / "<tag>.bias" for traceModelWeights/Grads (Task 3).
+ *  - tensor:     borrowed; valid only for the duration of the call. */
+typedef void (*traceSink_t)(void *ctx, size_t layerIdx, layerType_t layerType, const char *phase,
+                            tensor_t *tensor);
+
+/* tracedGrads(), traceModelWeights(), traceModelGrads() declarations are added
+ * here in Tasks 2 and 3 — each declaration lands together with its failing test
+ * (TDD-strict: no decl/stub before the test that drives it). */
+
+#endif /* TRACE_API_H */

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -12,4 +12,4 @@ add_subdirectory(rng)
 add_subdirectory(serial)
 add_subdirectory(tensor)
 add_subdirectory(userAPI)
-
+add_subdirectory(training_loop)

--- a/test/unit/training_loop/CMakeLists.txt
+++ b/test/unit/training_loop/CMakeLists.txt
@@ -1,0 +1,28 @@
+add_elastic_ai_unit_test(
+        LIB_UNDER_TEST
+        CalculateGradsSequential
+        MORE_LIBS
+        CommonLayerLibs
+        LinearApi
+        SoftmaxApi
+        LayerQuant
+        LayerCommon
+        LayerWeightsApi
+        StateDictApi
+        QuantizationApi
+        Quantization
+        Rounding
+        TensorApi
+        Tensor
+        StorageApi
+        Common
+        Optimizer
+        TrainingLoopApi
+        InferenceApi
+        DataLoader
+        DataLoaderApi
+        LossFunction
+        CrossEntropy
+        Distributions
+        RNG
+)

--- a/test/unit/training_loop/UnitTestCalculateGradsSequential.c
+++ b/test/unit/training_loop/UnitTestCalculateGradsSequential.c
@@ -93,7 +93,9 @@ static void recordingSink(void *ctx, size_t layerIdx, layerType_t type, const ch
                           tensor_t *t) {
     (void)ctx;
     (void)type;
-    if (g_eventCount >= MAX_EVENTS) return;
+    if (g_eventCount >= MAX_EVENTS) {
+        return;
+    }
     g_events[g_eventCount].idx = layerIdx;
     snprintf(g_events[g_eventCount].phase, sizeof(g_events[g_eventCount].phase), "%s", phase);
     g_events[g_eventCount].ndim = t->shape->numberOfDimensions;
@@ -113,11 +115,11 @@ void testTracedGradsFiresInOrder() {
     tensor_t *x = makeRowVec2(1.0f, 1.0f);
     tensor_t *label = makeRowVec2(1.0f, 0.0f);
 
-    trainingStats_t *stats = tracedGrads(
-        model, 2,
-        (lossConfig_t){
-            .funcType = CROSS_ENTROPY, .backwardReduction = REDUCTION_MEAN, .classWeights = NULL},
-        REDUCTION_MEAN, x, label, recordingSink, NULL);
+    trainingStats_t *stats = tracedGrads(model, 2,
+                                         (lossConfig_t){.funcType = CROSS_ENTROPY,
+                                                        .backwardReduction = REDUCTION_MEAN,
+                                                        .classWeights = NULL},
+                                         REDUCTION_MEAN, x, label, recordingSink, NULL);
 
     /* fwd L0, fwd L1, lossgrad@2, agrad L0  (Softmax skipped under CE) */
     TEST_ASSERT_EQUAL_size_t(4, g_eventCount);
@@ -150,8 +152,8 @@ void testTraceModelParamsFiresPerTrainableParam() {
     tensor_t *x = makeRowVec2(1.0f, 1.0f), *label = makeRowVec2(1.0f, 0.0f);
     trainingStats_t *stats = calculateGradsSequential(
         model, 2,
-        (lossConfig_t){.funcType = CROSS_ENTROPY, .backwardReduction = REDUCTION_MEAN,
-                       .classWeights = NULL},
+        (lossConfig_t){
+            .funcType = CROSS_ENTROPY, .backwardReduction = REDUCTION_MEAN, .classWeights = NULL},
         REDUCTION_MEAN, x, label);
 
     traceModelWeights(model, 2, "w_before", recordingSink, NULL);

--- a/test/unit/training_loop/UnitTestCalculateGradsSequential.c
+++ b/test/unit/training_loop/UnitTestCalculateGradsSequential.c
@@ -1,5 +1,7 @@
 #define SOURCE_FILE "UnitTestCalculateGradsSequential"
 
+#include <stdio.h>
+
 #include "CalculateGradsSequential.h"
 #include "Common.h"
 #include "Layer.h"
@@ -12,6 +14,7 @@
 #include "StorageApi.h"
 #include "Tensor.h"
 #include "TensorApi.h"
+#include "TraceApi.h"
 #include "unity.h"
 
 void setUp() {}
@@ -77,8 +80,66 @@ void testCalculateGradsSequentialClosedForm() {
     freeSoftmaxLayer(model[1]);
 }
 
+#define MAX_EVENTS 64
+typedef struct {
+    size_t idx;
+    char phase[16];
+    size_t ndim;
+} traceEvent_t;
+static traceEvent_t g_events[MAX_EVENTS];
+static size_t g_eventCount;
+
+static void recordingSink(void *ctx, size_t layerIdx, layerType_t type, const char *phase,
+                          tensor_t *t) {
+    (void)ctx;
+    (void)type;
+    if (g_eventCount >= MAX_EVENTS) return;
+    g_events[g_eventCount].idx = layerIdx;
+    snprintf(g_events[g_eventCount].phase, sizeof(g_events[g_eventCount].phase), "%s", phase);
+    g_events[g_eventCount].ndim = t->shape->numberOfDimensions;
+    g_eventCount++;
+}
+
+void testTracedGradsFiresInOrder() {
+    g_eventCount = 0;
+    layerQuant_t lq;
+    layerQuantInitUniform(&lq, quantizationInitFloat());
+    layer_t *model[2];
+    model[0] = linearLayerInit(&(linearInit_t){.inFeatures = 2, .outFeatures = 2}, &lq);
+    model[1] = softmaxLayerInit(&lq);
+    float W[4] = {0.1f, 0.2f, 0.3f, 0.4f}, B[2] = {0};
+    modelLoadStateDict(model, 2,
+                       (stateDictEntry_t[]){{.name = "fc", .weightData = W, .biasData = B}}, 1);
+    tensor_t *x = makeRowVec2(1.0f, 1.0f);
+    tensor_t *label = makeRowVec2(1.0f, 0.0f);
+
+    trainingStats_t *stats = tracedGrads(
+        model, 2,
+        (lossConfig_t){
+            .funcType = CROSS_ENTROPY, .backwardReduction = REDUCTION_MEAN, .classWeights = NULL},
+        REDUCTION_MEAN, x, label, recordingSink, NULL);
+
+    /* fwd L0, fwd L1, lossgrad@2, agrad L0  (Softmax skipped under CE) */
+    TEST_ASSERT_EQUAL_size_t(4, g_eventCount);
+    TEST_ASSERT_EQUAL_size_t(0, g_events[0].idx);
+    TEST_ASSERT_EQUAL_STRING("fwd", g_events[0].phase);
+    TEST_ASSERT_EQUAL_size_t(1, g_events[1].idx);
+    TEST_ASSERT_EQUAL_STRING("fwd", g_events[1].phase);
+    TEST_ASSERT_EQUAL_size_t(2, g_events[2].idx);
+    TEST_ASSERT_EQUAL_STRING("lossgrad", g_events[2].phase);
+    TEST_ASSERT_EQUAL_size_t(0, g_events[3].idx);
+    TEST_ASSERT_EQUAL_STRING("agrad", g_events[3].phase);
+
+    freeTrainingStats(stats);
+    freeTensor(x);
+    freeTensor(label);
+    freeLinearLayer(model[0]);
+    freeSoftmaxLayer(model[1]);
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(testCalculateGradsSequentialClosedForm);
+    RUN_TEST(testTracedGradsFiresInOrder);
     return UNITY_END();
 }

--- a/test/unit/training_loop/UnitTestCalculateGradsSequential.c
+++ b/test/unit/training_loop/UnitTestCalculateGradsSequential.c
@@ -83,7 +83,7 @@ void testCalculateGradsSequentialClosedForm() {
 #define MAX_EVENTS 64
 typedef struct {
     size_t idx;
-    char phase[16];
+    char phase[32];
     size_t ndim;
 } traceEvent_t;
 static traceEvent_t g_events[MAX_EVENTS];
@@ -137,9 +137,44 @@ void testTracedGradsFiresInOrder() {
     freeSoftmaxLayer(model[1]);
 }
 
+void testTraceModelParamsFiresPerTrainableParam() {
+    g_eventCount = 0;
+    layerQuant_t lq;
+    layerQuantInitUniform(&lq, quantizationInitFloat());
+    layer_t *model[2];
+    model[0] = linearLayerInit(&(linearInit_t){.inFeatures = 2, .outFeatures = 2}, &lq);
+    model[1] = softmaxLayerInit(&lq);
+    float W[4] = {0.1f, 0.2f, 0.3f, 0.4f}, B[2] = {0};
+    modelLoadStateDict(model, 2,
+                       (stateDictEntry_t[]){{.name = "fc", .weightData = W, .biasData = B}}, 1);
+    tensor_t *x = makeRowVec2(1.0f, 1.0f), *label = makeRowVec2(1.0f, 0.0f);
+    trainingStats_t *stats = calculateGradsSequential(
+        model, 2,
+        (lossConfig_t){.funcType = CROSS_ENTROPY, .backwardReduction = REDUCTION_MEAN,
+                       .classWeights = NULL},
+        REDUCTION_MEAN, x, label);
+
+    traceModelWeights(model, 2, "w_before", recordingSink, NULL);
+    traceModelGrads(model, 2, "grad_raw", recordingSink, NULL);
+
+    /* weight+bias for the one Linear, then wgrad+bgrad */
+    TEST_ASSERT_EQUAL_size_t(4, g_eventCount);
+    TEST_ASSERT_EQUAL_STRING("w_before.weight", g_events[0].phase);
+    TEST_ASSERT_EQUAL_STRING("w_before.bias", g_events[1].phase);
+    TEST_ASSERT_EQUAL_STRING("grad_raw.weight", g_events[2].phase);
+    TEST_ASSERT_EQUAL_STRING("grad_raw.bias", g_events[3].phase);
+
+    freeTrainingStats(stats);
+    freeTensor(x);
+    freeTensor(label);
+    freeLinearLayer(model[0]);
+    freeSoftmaxLayer(model[1]);
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(testCalculateGradsSequentialClosedForm);
     RUN_TEST(testTracedGradsFiresInOrder);
+    RUN_TEST(testTraceModelParamsFiresPerTrainableParam);
     return UNITY_END();
 }

--- a/test/unit/training_loop/UnitTestCalculateGradsSequential.c
+++ b/test/unit/training_loop/UnitTestCalculateGradsSequential.c
@@ -38,6 +38,9 @@ static tensor_t *makeRowVec2(float a, float b) {
     return t;
 }
 
+/* Structural note: tracedGrads and calculateGradsSequential both call calculateGradsImpl
+ * internally; npyDumpSink (and any other sink) observes tensors but does not mutate them.
+ * This means the closed-form characterisation test pins both paths simultaneously. */
 void testCalculateGradsSequentialClosedForm() {
     layerQuant_t lq;
     layerQuantInitUniform(&lq, quantizationInitFloat());
@@ -125,12 +128,16 @@ void testTracedGradsFiresInOrder() {
     TEST_ASSERT_EQUAL_size_t(4, g_eventCount);
     TEST_ASSERT_EQUAL_size_t(0, g_events[0].idx);
     TEST_ASSERT_EQUAL_STRING("fwd", g_events[0].phase);
+    TEST_ASSERT_EQUAL_size_t(2, g_events[0].ndim);
     TEST_ASSERT_EQUAL_size_t(1, g_events[1].idx);
     TEST_ASSERT_EQUAL_STRING("fwd", g_events[1].phase);
+    TEST_ASSERT_EQUAL_size_t(2, g_events[1].ndim);
     TEST_ASSERT_EQUAL_size_t(2, g_events[2].idx);
     TEST_ASSERT_EQUAL_STRING("lossgrad", g_events[2].phase);
+    TEST_ASSERT_EQUAL_size_t(2, g_events[2].ndim);
     TEST_ASSERT_EQUAL_size_t(0, g_events[3].idx);
     TEST_ASSERT_EQUAL_STRING("agrad", g_events[3].phase);
+    TEST_ASSERT_EQUAL_size_t(2, g_events[3].ndim);
 
     freeTrainingStats(stats);
     freeTensor(x);

--- a/test/unit/training_loop/UnitTestCalculateGradsSequential.c
+++ b/test/unit/training_loop/UnitTestCalculateGradsSequential.c
@@ -1,0 +1,84 @@
+#define SOURCE_FILE "UnitTestCalculateGradsSequential"
+
+#include "CalculateGradsSequential.h"
+#include "Common.h"
+#include "Layer.h"
+#include "LayerQuant.h"
+#include "Linear.h"
+#include "LinearApi.h"
+#include "QuantizationApi.h"
+#include "SoftmaxApi.h"
+#include "StateDictApi.h"
+#include "StorageApi.h"
+#include "Tensor.h"
+#include "TensorApi.h"
+#include "unity.h"
+
+void setUp() {}
+void tearDown() {}
+
+/* Build a [1,2] float32 tensor from a stack buffer (data is copied into the tensor). */
+static tensor_t *makeRowVec2(float a, float b) {
+    size_t *dims = reserveMemory(2 * sizeof(size_t));
+    size_t *order = reserveMemory(2 * sizeof(size_t));
+    dims[0] = 1;
+    dims[1] = 2;
+    order[0] = 0;
+    order[1] = 1;
+    shape_t *shape = reserveMemory(sizeof(shape_t));
+    shape->dimensions = dims;
+    shape->orderOfDimensions = order;
+    shape->numberOfDimensions = 2;
+    tensor_t *t = initTensor(shape, quantizationInitFloat(), NULL);
+    float vals[2] = {a, b};
+    tensorFillFromFloatBuffer(t, vals, 2);
+    return t;
+}
+
+void testCalculateGradsSequentialClosedForm() {
+    layerQuant_t lq;
+    layerQuantInitUniform(&lq, quantizationInitFloat());
+
+    layer_t *model[2];
+    model[0] = linearLayerInit(&(linearInit_t){.inFeatures = 2, .outFeatures = 2}, &lq);
+    model[1] = softmaxLayerInit(&lq);
+
+    /* Set known weights/bias: W = {{0.1,0.2},{0.3,0.4}}, b = {0,0}. */
+    float W[4] = {0.1f, 0.2f, 0.3f, 0.4f};
+    float B[2] = {0.0f, 0.0f};
+    modelLoadStateDict(model, 2,
+                       (stateDictEntry_t[]){{.name = "fc", .weightData = W, .biasData = B}}, 1);
+
+    tensor_t *x = makeRowVec2(1.0f, 1.0f);
+    tensor_t *label = makeRowVec2(1.0f, 0.0f); /* one-hot class 0 */
+
+    trainingStats_t *stats = calculateGradsSequential(
+        model, 2,
+        (lossConfig_t){
+            .funcType = CROSS_ENTROPY, .backwardReduction = REDUCTION_MEAN, .classWeights = NULL},
+        REDUCTION_MEAN, x, label);
+
+    TEST_ASSERT_FLOAT_WITHIN(1e-4f, 0.91300f, stats->loss);
+
+    float *wg = (float *)getGradFromParameter(model[0]->config->linear->weights)->data;
+    TEST_ASSERT_FLOAT_WITHIN(1e-4f, -0.59869f, wg[0]);
+    TEST_ASSERT_FLOAT_WITHIN(1e-4f, -0.59869f, wg[1]);
+    TEST_ASSERT_FLOAT_WITHIN(1e-4f, 0.59869f, wg[2]);
+    TEST_ASSERT_FLOAT_WITHIN(1e-4f, 0.59869f, wg[3]);
+
+    float *bg = (float *)getGradFromParameter(model[0]->config->linear->bias)->data;
+    TEST_ASSERT_FLOAT_WITHIN(1e-4f, -0.59869f, bg[0]);
+    TEST_ASSERT_FLOAT_WITHIN(1e-4f, 0.59869f, bg[1]);
+
+    freeTrainingStats(stats);
+    freeTensor(x);
+    freeTensor(label);
+    freeLinearLayer(model[0]);
+    freeSoftmaxLayer(model[1]);
+}
+
+int main(void) {
+    UNITY_BEGIN();
+    RUN_TEST(testCalculateGradsSequentialClosedForm);
+    return UNITY_END();
+}


### PR DESCRIPTION
## Summary

Implements the per-layer activation/gradient **trace facility** from #257 — a mechanism to record each layer's forward activation and backward gradient on both the C and PyTorch sides and diff them layer-by-layer, to localize where the C framework and PyTorch diverge during training.

**Framework (`src/userApi`, production byte-identical):**
- `traceSink_t` callback + `tracedGrads` — fires per-layer forward activations, the loss-grad, and act-grads (∂L/∂ layer **output**, matching PyTorch forward-hook `activation.grad`).
- `traceModelWeights` / `traceModelGrads` — per-trainable-layer parameter + gradient dumps (Linear/Conv1d/ConvT1d/LayerNorm).
- Implemented by extracting `static calculateGradsImpl(...,sink,ctx)`; `calculateGradsSequential` becomes a `NULL`-sink wrapper, so the production training path is **unchanged** (every sink call is `NULL`-guarded; verified by a closed-form CE+softmax characterization test).

**Host tooling (`examples/`, all file I/O lives here — never in `src/`):**
- `_shared/npyDumpSink` — writes each fired FLOAT32 tensor to `.npy`.
- `kws_raw/trace_c.c` — controlled-step harness (loads the exported weights, runs one step on a **fully configurable batch**, dumps every probe).
- `kws_raw/trace_pytorch.py` — PyTorch mirror via hooks, with the ×B reconciliation (C's per-sample backward is unscaled; PyTorch's mean backward carries 1/B).
- `_shared/trace_compare.py` — depth-ordered localizer with an absolute-error gate.
- `_shared/trace_sweep.py` — multi-batch aggregator.

## First diagnostic result (kws_raw)

Controlled single step from identical loaded weights, 10-batch sweep: forward activations, inter-layer act-grads, loss, and the optimizer step are **clean on every batch**; the divergence is in the **early-layer parameter gradients, dominated by the first LayerNorm (`ln1`)**, and is batch-dependent. Per-step weight impact is tiny (≤ 5e-5). Root-cause (LayerNorm-backward formula vs amplified float noise; whether it compounds over training) is a follow-up the facility now enables.

## Verification

- Production path byte-identical (`NULL`-sink wrapper + closed-form characterization test).
- 63/63 unit tests; alloc-locality + clang-format-21 clean; examples build.
- Whole-branch reviewed (no Critical/Important findings); production-byte-identical, I/O-boundary, and act-grad/×B/effB constraints all verified.

Closes #257

🤖 Generated with [Claude Code](https://claude.com/claude-code)
