### PR TITLE
PR1a: optimizer grad fixes — no grad round-trip (#203) + sub-byte grad-storage guard (#261)

### DIFF
--- a/src/optimizer/Sgd.c
+++ b/src/optimizer/Sgd.c
@@ -64,7 +64,6 @@ static void sgdStepSymInt32(optimizer_t *optim) {
         }
 
         convertTensor(&paramFloat, param->param);
-        convertTensor(&gradFloat, param->grad);
     }
 }
 

--- a/src/userApi/optimizer/SgdApi.c
+++ b/src/userApi/optimizer/SgdApi.c
@@ -163,6 +163,23 @@ optimizer_t *sgdMCreateOptim(float learningRate, float momentumFactor, float wei
             exit(1);
         }
     }
+    /* #261: grads may be stored FLOAT32 (default) or SYM_INT32 (legitimate
+     * low-level path until PR3). Sub-byte SYM/ASYM grad storage is not
+     * implemented yet - fail fast rather than silently misread packed bytes.
+     * Non-trainable params carry no grad: skip. */
+    for (size_t s = 0; s < optim->sizeStates; s++) {
+        tensor_t *grad = optim->parameter[s]->grad;
+        if (grad == NULL) {
+            continue;
+        }
+        qtype_t gradType = grad->quantization->type;
+        if (gradType != FLOAT32 && gradType != SYM_INT32) {
+            PRINT_ERROR("sgdMCreateOptim: gradient storage dtype %d not supported "
+                        "(only FLOAT32 / SYM_INT32; sub-byte grad storage lands in PR3, #261)",
+                        (int)gradType);
+            exit(1);
+        }
+    }
     return optim;
 }
 

--- a/test/unit/optimizer/CMakeLists.txt
+++ b/test/unit/optimizer/CMakeLists.txt
@@ -10,4 +10,5 @@ add_elastic_ai_unit_test(
         LinearApi
         ReluApi
         LayerQuant
+        odt_test_death
 )

--- a/test/unit/optimizer/UnitTestSgd.c
+++ b/test/unit/optimizer/UnitTestSgd.c
@@ -467,6 +467,53 @@ void testLayerNormContributesTwoOptimizerStates(void) {
     TEST_ASSERT_EQUAL_size_t(2, nStates);
 }
 
+void testSgdStepSymInt32DoesNotRoundTripGrad(void) {
+    /* Manual SYM param+grad (low-level path — heap shape per file convention). */
+    size_t *pDims = reserveMemory(1 * sizeof(size_t));
+    pDims[0] = 3;
+    size_t *pOrder = reserveMemory(1 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(1, pOrder);
+    shape_t *pShape = reserveMemory(sizeof(shape_t));
+    setShape(pShape, pDims, 1, pOrder);
+    tensor_t *p = initTensor(pShape, quantizationInitSymInt32(HALF_AWAY), NULL);
+    tensorFillFromFloatBuffer(p, (float[]){0.1f, -0.2f, 0.3f}, 3);
+    tensor_t *g = gradInitSymInt32(p, HALF_AWAY, NULL);
+    parameter_t *param = parameterInit(p, g);
+
+    /* Pre-load known grad mantissas + a non-1.0 scale. */
+    ((int32_t *)g->data)[0] = 10;
+    ((int32_t *)g->data)[1] = -20;
+    ((int32_t *)g->data)[2] = 30;
+    ((symInt32QConfig_t *)g->quantization->qConfig)->scale = 0.05f;
+
+    /* Minimal stack optimizer around one parameter; plain SGD, SYM_INT32 qtype.
+     * sgdStep dispatches on qtype; the plain-SGD SYM step reads only
+     * impl/sizeStates/parameter (+ sgd learningRate/weightDecay). */
+    sgd_t sgd;
+    sgdInit(&sgd, 0.1f, 0.0f, 0.0f);
+    parameter_t *params[1] = {param};
+    optimizer_t optim;
+    optim.parameter = params;
+    optim.sizeStates = 1;
+    optim.qtype = SYM_INT32;
+    optim.impl = (optimImpl_t *)&sgd;
+
+    sgdStep(&optim);
+
+    /* CAPTURE -> free -> assert: grad mantissas + scale must be untouched. */
+    int32_t m0 = ((int32_t *)g->data)[0];
+    int32_t m1 = ((int32_t *)g->data)[1];
+    int32_t m2 = ((int32_t *)g->data)[2];
+    float gScale = ((symInt32QConfig_t *)g->quantization->qConfig)->scale;
+
+    freeParameter(param);
+
+    TEST_ASSERT_EQUAL_INT(10, m0);
+    TEST_ASSERT_EQUAL_INT(-20, m1);
+    TEST_ASSERT_EQUAL_INT(30, m2);
+    TEST_ASSERT_FLOAT_WITHIN(1e-9f, 0.05f, gScale);
+}
+
 int main() {
     UNITY_BEGIN();
     RUN_TEST(testSgdMCreateOptim);
@@ -475,5 +522,6 @@ int main() {
     RUN_TEST(testSgdZeroGradOnSymInt32GradZeroesMantissasAndResetsScale);
     RUN_TEST(testLayerNormContributesTwoOptimizerStates);
     RUN_TEST(testSgdMCreateOptimRegistersLayerNormGammaAndBeta);
+    RUN_TEST(testSgdStepSymInt32DoesNotRoundTripGrad);
     return UNITY_END();
 }

--- a/test/unit/optimizer/UnitTestSgd.c
+++ b/test/unit/optimizer/UnitTestSgd.c
@@ -1,6 +1,7 @@
 #define SOURCE_FILE "SGD-UTEST"
 #include <stdlib.h>
 
+#include "DeathTest.h"
 #include "Layer.h"
 #include "LayerNorm.h"
 #include "LayerQuant.h"
@@ -514,6 +515,46 @@ void testSgdStepSymInt32DoesNotRoundTripGrad(void) {
     TEST_ASSERT_FLOAT_WITHIN(1e-9f, 0.05f, gScale);
 }
 
+void testSgdMCreateOptimRejectsSubByteGradStorage(void) {
+    /* FLOAT32 weight param whose grad is allocated sub-byte SYM (int8) — the
+     * not-yet-supported storage PR3 adds. Optimizer construction must abort. */
+    size_t *wDims = reserveMemory(2 * sizeof(size_t));
+    wDims[0] = 2;
+    wDims[1] = 3;
+    size_t *wOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, wOrder);
+    shape_t *wShape = reserveMemory(sizeof(shape_t));
+    setShape(wShape, wDims, 2, wOrder);
+    tensor_t *wParam = initTensor(wShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(wParam, (float[]){0.f, 0.f, 0.f, 0.f, 0.f, 0.f}, 6);
+    tensor_t *wGrad =
+        initTensor(getShapeLike(wParam->shape), quantizationInitSym(8, HALF_AWAY), NULL);
+    parameter_t *weights = parameterInit(wParam, wGrad);
+
+    size_t *bDims = reserveMemory(1 * sizeof(size_t));
+    bDims[0] = 2;
+    size_t *bOrder = reserveMemory(1 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(1, bOrder);
+    shape_t *bShape = reserveMemory(sizeof(shape_t));
+    setShape(bShape, bDims, 1, bOrder);
+    tensor_t *bParam = initTensor(bShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(bParam, (float[]){0.f, 0.f}, 2);
+    tensor_t *bGrad = gradInitFloat(bParam, NULL);
+    parameter_t *bias = parameterInit(bParam, bGrad);
+
+    quantization_t *fQ = quantizationInitFloat();
+    layer_t *layer = linearLayerInitLegacy(weights, bias, fQ, fQ, fQ, fQ);
+    layer_t *model[1] = {layer};
+
+    ASSERT_EXITS_WITH_FAILURE(sgdMCreateOptim(0.1f, 0.0f, 0.0f, model, 1, FLOAT32));
+
+    /* Teardown (parent continues after the fork-based assert; file convention). */
+    freeLinearLayerLegacy(layer);
+    freeParameter(weights);
+    freeParameter(bias);
+    freeQuantization(fQ);
+}
+
 int main() {
     UNITY_BEGIN();
     RUN_TEST(testSgdMCreateOptim);
@@ -523,5 +564,6 @@ int main() {
     RUN_TEST(testLayerNormContributesTwoOptimizerStates);
     RUN_TEST(testSgdMCreateOptimRegistersLayerNormGammaAndBeta);
     RUN_TEST(testSgdStepSymInt32DoesNotRoundTripGrad);
+    RUN_TEST(testSgdMCreateOptimRejectsSubByteGradStorage);
     return UNITY_END();
 }


### PR DESCRIPTION
First slice (PR1a) of the executeOp dtype-vs-arithmetic contract (spec: `docs/superpowers/specs/2026-07-02-executeop-dtype-arithmetic-contract-design.md`, §9).

## What

1. **`sgdStepSymInt32` no longer round-trips the grad** — deletes the dead dequant→requant write-back to `param->grad` (one line in `src/optimizer/Sgd.c`). The grad is never mutated by the step; the write-back was a pure lossy requantization of resident state. Plain and momentum SYM_INT32 steps are now consistent. Regression test pins grad mantissas AND scale across a step (RED verified pre-fix: mantissa 10 → ~10922 under the absmax requant).
2. **Fail-fast guard on unsupported grad-storage dtypes** — `sgdMCreateOptim` (the sole optimizer constructor) aborts with a clear message when a registered parameter's grad tensor is stored in a dtype outside {FLOAT32, SYM_INT32}; NULL grads (non-trainable params) are skipped. Fork-based death test (`UnitTestSgd` now links `odt_test_death`).

## Recorded spec deviation

The guard admits **SYM_INT32 in addition to FLOAT32** — stricter "not FLOAT32 → exit" wording in the grad-storage spec would abort the legitimate low-level SYM-grad paths that remain supported until PR3 (sub-byte grad storage). Recorded in the executeOp spec §7.

## Verification

- Debug suite: 63/63; ASan+UBSan suite (`unit_test_asan`): 63/63.
- TDD RED→GREEN evidence per task; both tests non-vacuous (task + final whole-branch review).
- Final review checked whole-branch risks: no in-tree code relies on the deleted write-back (grad dumps trace before `step()`); all in-tree `sgdMCreateOptim` callers (7 examples + tests) are admit-set-compatible; guard runs after full parameter registration.
- clang-format clean; no header/API changes.

## Follow-ups (from final review, deferred by scope)

- Guard error message over-narrows the rejection reason (INT32 is also rejected but the message speaks of sub-byte storage) → reword in PR1c.
- Pre-existing `Sgd.c` impl-access inconsistency (plain steps cast `optim->impl` directly, momentum steps use the union member) → PR1b territory / follow-up issue.

Closes #203
Refs #261 (resolved fully by PR1a + PR1c)

Note: auto-close fires only on `main` merges — close #203 manually after the develop merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
