### PR TITLE
refactor: PR1b.2 — all forward paths + Conv backward through the executeOp funnel

### DIFF
--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -13,6 +13,24 @@ a defect. FLOAT32-twin comparisons are a **ballpark sanity check**, not a tight
 acceptance gate; SYM acceptance is "trains and converges to a useful model".
 This does not license UB — overflow/garbage is still a bug (hence the #189 guard).
 
+## Comment guidelines
+
+A good comment carries one of two things the code cannot say for itself:
+
+1. **Non-obvious rationale** — why this approach, not what it does (the code
+   already says what). Deviations from an obvious/expected design, tricky
+   invariants, or research-scope decisions belong here.
+2. **When-to-use guidance at a decision point** — where two or more
+   similar-looking alternatives exist (an `*Init` vs. `*InitOwning` factory
+   pair, a mode enum, a documented exception to a general rule) and picking
+   wrong is easy, say which one to reach for and why, right at the
+   declaration.
+
+What-narration ("this loop iterates over the array") drifts out of sync with
+the code it describes and carries no information a reader can't get by
+reading the next line. When you find it, delete it — don't rewrite it into
+something that will drift again.
+
 ## Subsystem conventions
 
 - [`conventions/tensor.md`](conventions/tensor.md) — `SYM_INT32` is a compute

--- a/docs/conventions/arithmetic-sym.md
+++ b/docs/conventions/arithmetic-sym.md
@@ -37,26 +37,56 @@ FLOAT kernels with identical loop nest + `SlidingWindow1d` geometry:
   Conv1dTransposed's forward in PR3.
 
 Both emit **raw accumulator-range int32 mantissas** at output scale `s_in·s_w`
-(NOT range-restored). As of PR1b the `executeOp` epilogue restores operand width at the
-**producer** on the migrated paths (the dx wire; Linear/LayerNorm backward; the Quantization
-layer itself — `OUT_WRITE` routes SYM→SYM through the conversionMatrix diagonal). SYM
-**forward** chains are not yet funnel-routed: an explicitly-chained Quantization layer after
-each SYM producer remains REQUIRED (enforced by `validateModelQuantization`) until the forward
-migration (PR1b.2), after which it becomes an optional storage node. Per-output-
+(NOT range-restored) — that's the *kernel's* contract. The `executeOp` epilogue
+restores operand width at the **producer**, on every migrated path (forward
+AND backward: Linear/Conv1d/Conv1dTransposed/LayerNorm forward; the dx wire;
+the Quantization layer itself — `OUT_WRITE` routes SYM→SYM through the
+conversionMatrix diagonal). A chained Quantization layer after a SYM producer
+is therefore **optional**, not required (`validateModelQuantization`'s old
+"next layer must be QUANTIZATION" rule is retired, PR1b.2/spec D3) — but
+"optional" does not mean "harmless to add anyway". The precise anti-pattern:
+**a Quant node with an IDENTICAL config directly consuming a funnel-restored
+producer wire** repeats the exact restoration the producer epilogue just
+did — under HALF_AWAY this is a redundant no-op computation; under SR it
+re-draws stochastic jitter, i.e. pure noise. Three uses of a following
+Quant/requant node stay legitimate single-requants, not double-requants:
+(a) **width change** `@W1 -> @W2` — though when the target width is known at
+the producer, prefer declaring it directly in `outputQ` and letting the
+`OUT_WRITE` epilogue requant straight to `@W2`, skipping the Quant node
+entirely; (b) **same-width re-normalization after a scale-transparent
+segment** (Relu/Dropout/Flatten forward are NOT funnel-routed by design —
+element-wise scale-transparent ops that copy/fold the input's scale rather
+than deriving a fresh one, `2026-07-03-pr1b2-forward-funnel-design.md` D2 —
+so they can leave a tensor underfilled, e.g. Relu zeroing the absmax element;
+a Quant node there is the *first* requant of that value, not a second one);
+(c) **dtype changes** (SYM -> FLOAT32 etc.). There is no runtime "was this wire already
+restored?" check — raw vs. restored isn't reliably detectable from the tensor
+alone, and requant legitimately re-normalizes underfilled tensors, so this is
+a design discipline for model authors, not an enforced invariant. Per-output-
 channel bias is refolded into the product scale via `rescaleIntoAccumulatorScale`
 (the #189 guarded helper); never raw-added.
 
 Conv1d backward declares **per-op arithmetic** (`weightGradMath`, `biasGradMath`,
-`propLossMath`, by-value `arithmetic_t`), like `linearBackward`:
+`propLossMath`, by-value `arithmetic_t`), like `linearBackward`, and — like
+forward (above) — routes all three through the `executeOp` funnel:
 
-- **weightGrad (SYM)** = strategy A: integer gather into a fresh `reserveMemory`
-  intermediate at scale `s_loss·s_in`, then `addSymInt32TensorsInplace` into the
-  SYM grad accumulator (fresh absmax scale).
+- **weightGrad (SYM)** = strategy A: integer gather into the funnel's Phase-2
+  intermediate (a stack-allocated, data-sized VLA scratch inside `executeOp` —
+  no `reserveMemory`) at scale `s_loss·s_in`, then the `OUT_ACC_DYNAMIC_RESCALE`
+  epilogue's `addSymInt32TensorsInplace` into the SYM grad accumulator (fresh
+  absmax scale).
 - **biasGrad (SYM)** = an int32 `(batch × outputLength)` accumulator per output
-  channel, then `rescaleIntoAccumulatorScale(sum, s_loss, s_bg, mode)` at the
-  bias-grad's fixed scale (the #218 scheme).
-- **dx / propLoss (SYM)** = `convTranspose1dKernelSymInt32(lossGrad, weights)`,
-  scale `s_loss·s_w`, guarded by the #187 fail-fast (produced propLoss tensor must be SYM).
+  channel, then the `OUT_ACC_FIXED_SCALE` epilogue's
+  `rescaleIntoAccumulatorScale(sum, s_loss, s_bg, mode)` at the bias-grad's
+  fixed scale (the #218 scheme).
+- **dx / propLoss (SYM)** = `convTranspose1dKernelSymInt32(lossGrad, weights)`
+  emits the raw `s_loss·s_w` mantissa into the funnel intermediate; the
+  `OUT_WRITE` epilogue then width-restores it at the producer through the
+  conversionMatrix diagonal — the dx wire gets the same treatment as every
+  other producer wire (above). The old #187 dtype fail-fast (produced propLoss
+  tensor must be SYM) is retired: superseded by the funnel's own
+  prologue/epilogue and a confirmed tautology post-#221 (zero test coverage
+  exercised it).
 
 ### Operand bit-width: int12, not int16 (int32-accumulator soundness)
 
@@ -126,11 +156,14 @@ cores — no new kernels:
 
 - **forward** = `convTranspose1dKernelSymInt32` (the scatter core; its internal
   per-channel bias-seed refold gives ConvT bias for free). Pass `outputPadding`.
-- **dx / propLoss** = `conv1dKernelSymInt32` (the gather core, the VALID adjoint),
-  guarded by the #187 fail-fast (produced propLoss tensor must be SYM).
+- **dx / propLoss** = `conv1dKernelSymInt32` (the gather core, the VALID adjoint);
+  the `OUT_WRITE` epilogue width-restores the raw mantissa at the producer,
+  same as Conv1d's dx wire above — the old #187 dtype fail-fast is retired
+  (superseded by the funnel, PR1b.2).
 - **weightGrad** = strategy A: a scatter-style integer gather (ConvT weight layout
-  `[Cin, Cout/groups, K]`, index `(ic·outChPerGroup + ocOffset)·K + k`) into a fresh
-  `reserveMemory` int32 intermediate at scale `s_in·s_loss`, then
+  `[Cin, Cout/groups, K]`, index `(ic·outChPerGroup + ocOffset)·K + k`) into the
+  funnel's Phase-2 stack-VLA intermediate (no `reserveMemory`) at scale
+  `s_in·s_loss`, then the `OUT_ACC_DYNAMIC_RESCALE` epilogue's
   `addSymInt32TensorsInplace` into the SYM grad accumulator.
 - **biasGrad** = the same fixed-scale refold as Conv1d (`rescaleIntoAccumulatorScale`
   over the `batch × outputLength` int32 sum).
@@ -156,12 +189,16 @@ paths (ASYM, BOOL, SYM width-restore), unifying the Quantization layer into a pu
 conversion node (#266). This separation keeps arithmetic orthogonal to storage,
 enabling per-op compute-dtype divergence (#218 knobs) without ownership complexity.
 
-### Validator (PR3)
+### Validator retirement (PR1b.2)
 
-`isAccumulatorRangeSymProducer` (`ModelValidationApi.c`) now recognizes CONV1D and
-CONV1D_TRANSPOSED whose declared `layerForwardMath(layer).type` is `ARITH_SYM_INT32`,
-bringing SYM-producing conv layers under the int16 inter-layer contract: a SYM conv
-producer must be followed by a Quantization layer (or sit in the last position).
+`ModelValidationApi.c`'s `isAccumulatorRangeSymProducer` + `validateModelQuantization`'s
+"a SYM accumulator-range producer (LINEAR/LAYERNORM/CONV1D/CONV1D_TRANSPOSED) not in
+the last position must be followed by a QUANTIZATION layer" rule is **retired**: once
+every producer's forward restores width at its own wire (above), there is nothing left
+for that rule to catch — a following Quant layer is optional, and forcing one directly
+after a producer is the double-requant anti-pattern, not a requirement. `validateModelQuantization`
+stays as the model-wide validation entry point for future rules; today it only guards
+the model array shape (non-NULL model/elements).
 
 ### SYM training chains
 
@@ -171,8 +208,10 @@ every layer type — Linear/Conv/pools/Relu/Softmax/Dropout/LayerNorm/Quantizati
 all resolve through the same field; Flatten and the loss seed pass through the
 upstream dtype) — #221. Uniform chains behave exactly as before: a
 uniformly-SYM chain (every layer's `forwardMath` declaring `ARITH_SYM_INT32`)
-makes every grad tensor SYM_INT32 and every layer's `propLossQ` match — the #187
-guard passes. SYM-trainable conv layers are built via the low-level
+makes every grad tensor SYM_INT32 and every layer's `propLossQ` match — each
+producer's `OUT_WRITE` epilogue (above) width-restores its own dx wire
+independently, so the chain stays consistent without the retired #187
+cross-layer guard. SYM-trainable conv layers are built via the low-level
 `initConv1dTransposedConfigWithWeightsAndBias` with SYM `parameter_t`s (the
 high-level factory's KAIMING/uniform init still requires FLOAT32-native
 weight/bias storage; grad storage itself now follows `propLossQ`/the

--- a/examples/mixed_width_mlp/train_c.c
+++ b/examples/mixed_width_mlp/train_c.c
@@ -46,15 +46,20 @@
 #define LR 0.01f
 #define MOMENTUM 0.9f
 
-/* Flatten -> Linear0 -> Quant0 -> Relu -> Linear1 -> Quant1 -> Softmax = 7 layers */
-#define MODEL_SIZE 7
+/* Flatten -> Linear0 -> Relu -> Linear1 -> Quant1 -> Softmax = 6 layers.
+ * No Quant0 (spec D3): Linear0's forward funnel already restores width to
+ * SYM_INT32@12 at the wire (Linear0.outputQ), so a follow-up Quant node with
+ * the IDENTICAL @12 config would just repeat that restore for free noise
+ * (the double-requant anti-pattern, docs/conventions/arithmetic-sym.md).
+ * Quant1 stays: it's a genuine SYM_INT32@12 -> FLOAT32 dtype change, the
+ * legitimate single-requant case D3 carves out. */
+#define MODEL_SIZE 6
 #define FLATTEN_IDX 0
 #define LINEAR0_IDX 1
-#define QUANT0_IDX 2
-#define RELU_IDX 3
-#define LINEAR1_IDX 4
-#define QUANT1_IDX 5
-#define SOFTMAX_IDX 6
+#define RELU_IDX 2
+#define LINEAR1_IDX 3
+#define QUANT1_IDX 4
+#define SOFTMAX_IDX 5
 
 /* Pinned widths (spec §7). */
 #define WEIGHT_QMAXBITS 8
@@ -144,13 +149,13 @@ typedef struct mixedWidthQuant {
     quantization_t *weightQ;    /* SYM_INT32 @8  — weightStorage (post-construction fixup) */
     quantization_t *biasQ;      /* SYM_INT32 @16 — biasStorage   (post-construction fixup) */
     quantization_t *gradQ;      /* SYM_INT32 @16 — weightGradStorage/biasGradStorage knob */
-    quantization_t *operandQ;   /* SYM_INT32 @12 — Linear0/Linear1 outputQ (raw producer wire) */
-    quantization_t *wireQ;      /* SYM_INT32 @12 — Quant0/Relu outputQ + every layer's propLossQ */
-    quantization_t *floatQ;     /* FLOAT32 — Quant1/Softmax outputQ */
+    quantization_t *operandQ; /* SYM_INT32 @12 — Linear0/Linear1 outputQ (producer-restored wire) */
+    quantization_t *wireQ;    /* SYM_INT32 @12 — Relu outputQ + every layer's propLossQ */
+    quantization_t *floatQ;   /* FLOAT32 — Quant1/Softmax outputQ */
 } mixedWidthQuant_t;
 
 /* Flatten [1,28,28] -> [1,784] (the channel-1 acts as batch, mnist_mlp convention) -> Linear0
- * -> Quant0 -> Relu -> Linear1 -> Quant1 -> Softmax, CE loss (spec §7 topology). */
+ * -> Relu -> Linear1 -> Quant1 -> Softmax, CE loss (spec §7 topology). */
 static void buildModel(layer_t **model, mixedWidthQuant_t *mq) {
     model[FLATTEN_IDX] = flattenLayerInit();
 
@@ -201,14 +206,6 @@ static void buildModel(layer_t **model, mixedWidthQuant_t *mq) {
     model[LINEAR1_IDX] = linearLayerInit(
         &(linearInit_t){.inFeatures = HIDDEN, .outFeatures = NUM_CLASSES}, &lqLinear);
 
-    /* Quant0: pure conversion node (D4) — width restoration to SYM_INT32@12
-     * on both the forward wire and the dx wire it hands upstream. */
-    layerQuant_t lqQuant0 = {
-        .outputQ = mq->wireQ,
-        .propLossQ = mq->wireQ,
-    };
-    model[QUANT0_IDX] = quantLayerInit(&lqQuant0);
-
     layerQuant_t lqRelu = {
         .forwardMath = (arithmetic_t){ARITH_SYM_INT32, HALF_AWAY},
         .propLossMath = (arithmetic_t){ARITH_SYM_INT32, HALF_AWAY}, /* native on SYM wires */
@@ -245,23 +242,25 @@ typedef struct wireGateCtx {
     bool checked;
 } wireGateCtx_t;
 
-/* Fired via tracedGrads for the first training sample: asserts the
- * post-Quant0 forward wire is SYM_INT32@12. */
-static void quant0WireGateSink(void *ctxVoid, size_t layerIdx, layerType_t layerType,
-                               const char *phase, tensor_t *tensor) {
+/* Fired via tracedGrads for the first training sample: asserts Linear0's own
+ * forward wire is already SYM_INT32@12 (spec D3 — the funnel restores width
+ * at the producer directly; there is no separate Quant0 wire to probe
+ * anymore). */
+static void linear0WireGateSink(void *ctxVoid, size_t layerIdx, layerType_t layerType,
+                                const char *phase, tensor_t *tensor) {
     (void)layerType;
-    if (layerIdx != QUANT0_IDX || strcmp(phase, "fwd") != 0) {
+    if (layerIdx != LINEAR0_IDX || strcmp(phase, "fwd") != 0) {
         return;
     }
     wireGateCtx_t *ctx = ctxVoid;
     if (tensor->quantization->type != SYM_INT32) {
-        PRINT_ERROR("gate: Quant0 forward wire expected SYM_INT32, got qtype %d",
+        PRINT_ERROR("gate: Linear0 forward wire expected SYM_INT32, got qtype %d",
                     (int)tensor->quantization->type);
         exit(1);
     }
     symInt32QConfig_t *qc = tensor->quantization->qConfig;
     if (qc->qMaxBits != WIRE_QMAXBITS) {
-        PRINT_ERROR("gate: Quant0 forward wire expected qMaxBits %d, got %u", WIRE_QMAXBITS,
+        PRINT_ERROR("gate: Linear0 forward wire expected qMaxBits %d, got %u", WIRE_QMAXBITS,
                     (unsigned)qc->qMaxBits);
         exit(1);
     }
@@ -350,9 +349,9 @@ int main(void) {
 
         trainingStats_t *stats;
         if (i == 0) {
-            /* One traced step: also probes the post-Quant0 forward wire. */
+            /* One traced step: also probes Linear0's own forward wire. */
             stats = tracedGrads(model, MODEL_SIZE, lossCfg, REDUCTION_MEAN, smp->item, label,
-                                quant0WireGateSink, &wireCtx);
+                                linear0WireGateSink, &wireCtx);
         } else {
             stats = calculateGradsSequential(model, MODEL_SIZE, lossCfg, REDUCTION_MEAN, smp->item,
                                              label);
@@ -371,7 +370,7 @@ int main(void) {
             /* Hard gates (spec §7): after one training step, storage/wire
              * dtypes must already match the pinned config. */
             if (!wireCtx.checked) {
-                PRINT_ERROR("gate: Quant0 forward-wire probe never fired (layer index wrong?)");
+                PRINT_ERROR("gate: Linear0 forward-wire probe never fired (layer index wrong?)");
                 exit(1);
             }
 
@@ -393,7 +392,7 @@ int main(void) {
 
             fprintf(stdout,
                     "GATES PASS: weight=SYM_INT32@%d bias=SYM_INT32@%d grads=SYM_INT32@%d "
-                    "Quant0-wire=SYM_INT32@%d\n",
+                    "Linear0-wire=SYM_INT32@%d\n",
                     WEIGHT_QMAXBITS, BIAS_QMAXBITS, GRAD_QMAXBITS, WIRE_QMAXBITS);
         }
     }

--- a/src/arithmetic/CMakeLists.txt
+++ b/src/arithmetic/CMakeLists.txt
@@ -178,5 +178,6 @@ target_link_libraries(ExecuteOp PRIVATE
         ArithmeticType
         TensorConversion
         Add
+        Rounding
         Common
 )

--- a/src/arithmetic/ExecuteOp.c
+++ b/src/arithmetic/ExecuteOp.c
@@ -1,6 +1,5 @@
 #define SOURCE_FILE "EXECUTE-OP"
 
-#include <math.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
@@ -9,14 +8,18 @@
 #include "Common.h"
 #include "ExecuteOp.h"
 #include "Quantization.h"
+#include "Rounding.h"
 #include "Tensor.h"
 #include "TensorConversion.h"
 
 /* Maximum operands any in-tree op passes (matmul: 2). Bump deliberately. */
 #define EXECUTE_OP_MAX_INPUTS 2
 
-void executeOpIdentityKernel(tensor_t **operands, size_t nOperands, tensor_t *rawOut) {
+void executeOpIdentityKernel(tensor_t **operands, size_t nOperands, tensor_t *rawOut,
+                             tensor_t *auxOut, const void *ctx) {
     (void)nOperands;
+    (void)auxOut;
+    (void)ctx;
     tensor_t *src = operands[0];
     size_t n = calcNumberOfElementsByTensor(src);
     size_t bytes = calcNumberOfBytesForData(src->quantization, n);
@@ -49,8 +52,9 @@ void executeConvert(tensor_t *input, tensor_t *target) {
  * increment to operand width with the TARGET's roundingMode (reproduces the
  * former LayerNorm helper layerNormAccumulateGradSymInt32, deleted in PR1b;
  * semantics live here now). Fixed-scale reproduces the former
- * linearCalcBiasGradsSymInt32 behavior: raw roundf, no clamp, scale
- * never re-derived. */
+ * linearCalcBiasGradsSymInt32 behavior: rescale into the target's EXISTING
+ * scale via rescaleIntoAccumulatorScale (spec D4 — honors the TARGET's
+ * roundingMode; Conv1d.c:288 precedent), no clamp, scale never re-derived. */
 static void accumulateOut(tensor_t *intermediate, tensor_t *target, outputMode_t mode) {
     size_t n = calcNumberOfElementsByTensor(target);
 
@@ -89,7 +93,8 @@ static void accumulateOut(tensor_t *intermediate, tensor_t *target, outputMode_t
             int32_t *tg = (int32_t *)target->data;
             int32_t *in = (int32_t *)intermediate->data;
             for (size_t i = 0; i < n; i++) {
-                tg[i] += (int32_t)roundf((float)in[i] * intermScale / targetScale);
+                tg[i] += rescaleIntoAccumulatorScale(in[i], intermScale, targetScale,
+                                                     targetQC->roundingMode);
             }
             return;
         }
@@ -119,8 +124,11 @@ static void accumulateOut(tensor_t *intermediate, tensor_t *target, outputMode_t
     }
 }
 
-void executeOp(opKernelFn_t kernel, tensor_t **inputs, size_t nInputs, arithmetic_t arithmetic,
-               tensor_t *target, outputMode_t mode) {
+void executeOp(const opSpec_t *spec, tensor_t *target) {
+    tensor_t **inputs = spec->inputs;
+    size_t nInputs = spec->nInputs;
+    arithmetic_t arithmetic = spec->arithmetic;
+
     if (nInputs > EXECUTE_OP_MAX_INPUTS) {
         PRINT_ERROR("executeOp: %u inputs exceeds EXECUTE_OP_MAX_INPUTS (%u)", (unsigned)nInputs,
                     (unsigned)EXECUTE_OP_MAX_INPUTS);
@@ -192,17 +200,18 @@ void executeOp(opKernelFn_t kernel, tensor_t **inputs, size_t nInputs, arithmeti
     }
     setTensorValues(&raw, rawData, target->shape, &rawQ, target->sparsity);
 
-    /* Phase 3 — kernel emits raw. */
-    kernel(ops, nInputs, &raw);
+    /* Phase 3 — kernel emits raw; auxOut/ctx pass through untouched by the
+     * funnel (auxOut is NEVER funnel-converted). */
+    spec->kernel(ops, nInputs, &raw, spec->auxOut, spec->ctx);
 
-    /* Phase 4 — epilogue. */
-    switch (mode) {
+    /* Phase 4 — epilogue (target only; auxOut already final). */
+    switch (spec->mode) {
     case OUT_WRITE:
         writeOut(&raw, target);
         break;
     case OUT_ACC_DYNAMIC_RESCALE:
     case OUT_ACC_FIXED_SCALE:
-        accumulateOut(&raw, target, mode);
+        accumulateOut(&raw, target, spec->mode);
         break;
     }
 }

--- a/src/arithmetic/ExecuteOp.c
+++ b/src/arithmetic/ExecuteOp.c
@@ -12,8 +12,9 @@
 #include "Tensor.h"
 #include "TensorConversion.h"
 
-/* Maximum operands any in-tree op passes (matmul: 2). Bump deliberately. */
-#define EXECUTE_OP_MAX_INPUTS 2
+/* Maximum operands any in-tree op passes (Linear/LayerNorm forward: input +
+ * weights/gamma + bias/beta = 3). Bump deliberately. */
+#define EXECUTE_OP_MAX_INPUTS 3
 
 void executeOpIdentityKernel(tensor_t **operands, size_t nOperands, tensor_t *rawOut,
                              tensor_t *auxOut, const void *ctx) {

--- a/src/arithmetic/include/ExecuteOp.h
+++ b/src/arithmetic/include/ExecuteOp.h
@@ -6,19 +6,24 @@
 #include "ArithmeticType.h"
 #include "Tensor.h"
 
-/* The one conversion funnel (design spec 2026-07-02, §3-§4). Every op runs:
+/* The one conversion funnel (design spec 2026-07-03 PR1b.2, D1). Every op runs:
  *   prologue   — operands whose dtype != arithmetic are converted into
  *                transient stack scratch (sources are never mutated)
  *   kernel     — pure computation: operands (in arithmetic representation)
- *                -> raw intermediate (SYM kernels emit raw int32 mantissas)
+ *                -> raw intermediate (SYM kernels emit raw int32 mantissas);
+ *                also given auxOut (kernel-written verbatim, e.g. MaxPool's
+ *                argmax indices) and ctx (kernel geometry/config), neither of
+ *                which the funnel touches
  *   epilogue   — the intermediate is written/accumulated into the target,
  *                in the TARGET's own dtype. Persistent buffers are never
- *                pulled through the arithmetic.
+ *                pulled through the arithmetic. auxOut is NEVER funnel-
+ *                converted — the kernel writes it in its own storage format.
  * Escape hatch policy: the prologue/epilogue helpers stay static in
  * ExecuteOp.c. Opening one for an op that does not fit the n-inputs/1-output
  * shape requires a documented exception here. */
 
-typedef void (*opKernelFn_t)(tensor_t **operands, size_t nOperands, tensor_t *rawOut);
+typedef void (*opKernelFn_t)(tensor_t **operands, size_t nOperands, tensor_t *rawOut,
+                             tensor_t *auxOut, const void *ctx);
 
 typedef enum {
     OUT_WRITE,               /* overwrite target (wire / forward output); SYM->SYM
@@ -27,17 +32,35 @@ typedef enum {
     OUT_ACC_DYNAMIC_RESCALE, /* Strategy A: dequant both -> float-add -> fresh
                               * absmax scale (SYM targets); exact add (FLOAT32) */
     OUT_ACC_FIXED_SCALE      /* bias scheme: rescale increment into the target's
-                              * EXISTING scale, integer add, raw roundf, no clamp
-                              * (SYM targets); exact add (FLOAT32) */
+                              * EXISTING scale via rescaleIntoAccumulatorScale
+                              * (honors the TARGET's roundingMode), integer
+                              * add, no clamp (SYM targets); exact add (FLOAT32) */
 } outputMode_t;
 
-void executeOp(opKernelFn_t kernel, tensor_t **inputs, size_t nInputs, arithmetic_t arithmetic,
-               tensor_t *target, outputMode_t mode);
+/*! @brief Descriptor for a funnel op invocation (design spec D1).
+ * ctx: kernel geometry/config, opaque to the funnel, passed straight through
+ *      to the kernel; NULL for config-free kernels.
+ * auxOut: kernel-written verbatim, in ITS OWN storage format — never funnel-
+ *         converted; NULL for single-output ops (e.g. MaxPool1d's argmax
+ *         indices live here). */
+typedef struct opSpec {
+    opKernelFn_t kernel;
+    const void *ctx;
+    tensor_t **inputs;
+    size_t nInputs;
+    arithmetic_t arithmetic;
+    outputMode_t mode;
+    tensor_t *auxOut;
+} opSpec_t;
+
+void executeOp(const opSpec_t *spec, tensor_t *target);
 
 /* Copies operand 0 into rawOut (data + SYM scale if applicable). For ops whose
  * increment is produced inline (LayerNorm dgamma/dbeta only — the Quantization
- * layer is a pure conversion node routed through executeConvert instead). */
-void executeOpIdentityKernel(tensor_t **operands, size_t nOperands, tensor_t *rawOut);
+ * layer is a pure conversion node routed through executeConvert instead).
+ * Ignores auxOut/ctx. */
+void executeOpIdentityKernel(tensor_t **operands, size_t nOperands, tensor_t *rawOut,
+                             tensor_t *auxOut, const void *ctx);
 
 /* Kernel-less funnel form: storage-to-storage conversion (1 input,
  * OUT_WRITE semantics). SYM->SYM routes through the conversionMatrix

--- a/src/layer/AdaptiveAvgPool1d.c
+++ b/src/layer/AdaptiveAvgPool1d.c
@@ -5,6 +5,7 @@
 #include "AdaptiveWindow1d.h"
 #include "ArithmeticType.h"
 #include "Common.h"
+#include "ExecuteOp.h"
 #include "Layer.h"
 #include "Tensor.h"
 
@@ -21,23 +22,34 @@ void initAdaptiveAvgPool1dConfig(adaptiveAvgPool1dConfig_t *cfg, size_t outputSi
     cfg->propLossQ = propLossQ;
 }
 
-void adaptiveAvgPool1dForwardFloat(layer_t *layer, tensor_t *input, tensor_t *output) {
-    adaptiveAvgPool1dConfig_t *cfg = layer->config->adaptiveAvgPool1d;
+/* executeOp forward kernel adapter — ctx = adaptiveAvgPool1dConfig_t* (outputSize
+ * geometry, mirrors AvgPool1d's ctx convention, AvgPool1d.c); 1 input, no
+ * auxOut. Only a FLOAT32 arm exists (no SYM kernel body), but routing it
+ * through the funnel still gains real capability: the prologue now
+ * dequantizes a mismatched-dtype (e.g. SYM_INT32) input into FLOAT32 scratch
+ * first, where the pre-migration direct cast would have silently
+ * reinterpreted the producer's raw int32 bits as floats. */
+static void adaptiveAvgPool1dForwardKernel(tensor_t **ops, size_t n, tensor_t *rawOut,
+                                           tensor_t *auxOut, const void *ctx) {
+    (void)n;
+    (void)auxOut;
+    const adaptiveAvgPool1dConfig_t *cfg = ctx;
+    tensor_t *input = ops[0];
 
     size_t batch = input->shape->dimensions[0];
     size_t channels = input->shape->dimensions[1];
     size_t inputLength = input->shape->dimensions[2];
     size_t outputLength = cfg->outputSize;
 
-    if (output->shape->dimensions[2] != outputLength) {
+    if (rawOut->shape->dimensions[2] != outputLength) {
         PRINT_ERROR("AdaptiveAvgPool1d forward: output length (%zu) does not match "
                     "configured outputSize (%zu)",
-                    output->shape->dimensions[2], outputLength);
+                    rawOut->shape->dimensions[2], outputLength);
         exit(1);
     }
 
     float const *xArr = (float const *)input->data;
-    float *yArr = (float *)output->data;
+    float *yArr = (float *)rawOut->data;
 
     for (size_t b = 0; b < batch; b++) {
         for (size_t c = 0; c < channels; c++) {
@@ -60,7 +72,16 @@ void adaptiveAvgPool1dForward(layer_t *layer, tensor_t *input, tensor_t *output)
     adaptiveAvgPool1dConfig_t *cfg = layer->config->adaptiveAvgPool1d;
     switch (cfg->forwardMath.type) {
     case ARITH_FLOAT32:
-        adaptiveAvgPool1dForwardFloat(layer, input, output);
+        executeOp(
+            &(opSpec_t){
+                .kernel = adaptiveAvgPool1dForwardKernel,
+                .ctx = cfg,
+                .inputs = (tensor_t *[]){input},
+                .nInputs = 1,
+                .arithmetic = cfg->forwardMath,
+                .mode = OUT_WRITE,
+            },
+            output);
         break;
     default:
         PRINT_ERROR("AdaptiveAvgPool1d forward: quantization type not implemented");

--- a/src/layer/AvgPool1d.c
+++ b/src/layer/AvgPool1d.c
@@ -4,6 +4,7 @@
 
 #include "ArithmeticType.h"
 #include "Common.h"
+#include "ExecuteOp.h"
 #include "Layer.h"
 #include "SlidingWindow1d.h"
 #include "Tensor.h"
@@ -21,8 +22,19 @@ void initAvgPool1dConfig(avgPool1dConfig_t *cfg, kernel_t *kernel, quantization_
     cfg->propLossQ = propLossQ;
 }
 
-void avgPool1dForwardFloat(layer_t *layer, tensor_t *input, tensor_t *output) {
-    avgPool1dConfig_t *cfg = layer->config->avgPool1d;
+/* executeOp forward kernel adapter — ctx = avgPool1dConfig_t* for kernel_t
+ * geometry (mirrors Conv1d's ctx convention, Conv1d.c); 1 input, no auxOut.
+ * Only a FLOAT32 arm exists (no SYM kernel body), but routing it through the
+ * funnel still gains real capability: the prologue now dequantizes a
+ * mismatched-dtype (e.g. SYM_INT32) input into FLOAT32 scratch first, where
+ * the pre-migration direct cast would have silently reinterpreted the
+ * producer's raw int32 bits as floats. */
+static void avgPool1dForwardKernel(tensor_t **ops, size_t n, tensor_t *rawOut, tensor_t *auxOut,
+                                   const void *ctx) {
+    (void)n;
+    (void)auxOut;
+    const avgPool1dConfig_t *cfg = ctx;
+    tensor_t *input = ops[0];
 
     size_t batch = input->shape->dimensions[0];
     size_t channels = input->shape->dimensions[1];
@@ -31,15 +43,15 @@ void avgPool1dForwardFloat(layer_t *layer, tensor_t *input, tensor_t *output) {
     windowGeometry1d_t geom = windowGeometry1dCalc(inputLength, cfg->kernel);
     size_t outputLength = geom.outputLength;
 
-    if (output->shape->dimensions[2] != outputLength) {
+    if (rawOut->shape->dimensions[2] != outputLength) {
         PRINT_ERROR("AvgPool1d forward: output length (%zu) does not match "
                     "geometry-derived (%zu)",
-                    output->shape->dimensions[2], outputLength);
+                    rawOut->shape->dimensions[2], outputLength);
         exit(1);
     }
 
     float const *xArr = (float const *)input->data;
-    float *yArr = (float *)output->data;
+    float *yArr = (float *)rawOut->data;
     float divisor = (float)cfg->kernel->size; // count_include_pad=true: divisor = K always
 
     for (size_t b = 0; b < batch; b++) {
@@ -64,7 +76,16 @@ void avgPool1dForward(layer_t *layer, tensor_t *input, tensor_t *output) {
     avgPool1dConfig_t *cfg = layer->config->avgPool1d;
     switch (cfg->forwardMath.type) {
     case ARITH_FLOAT32:
-        avgPool1dForwardFloat(layer, input, output);
+        executeOp(
+            &(opSpec_t){
+                .kernel = avgPool1dForwardKernel,
+                .ctx = cfg,
+                .inputs = (tensor_t *[]){input},
+                .nInputs = 1,
+                .arithmetic = cfg->forwardMath,
+                .mode = OUT_WRITE,
+            },
+            output);
         break;
     default:
         PRINT_ERROR("AvgPool1d forward: quantization type not implemented");

--- a/src/layer/CMakeLists.txt
+++ b/src/layer/CMakeLists.txt
@@ -158,6 +158,7 @@ target_link_libraries(Softmax PRIVATE
         Tensor
         Arithmetic
         ArithmeticType
+        ExecuteOp
         Layer
         Common
 )

--- a/src/layer/CMakeLists.txt
+++ b/src/layer/CMakeLists.txt
@@ -5,11 +5,9 @@ target_link_libraries(Conv1d PRIVATE
         Tensor
         Arithmetic
         ArithmeticType
-        Add
+        ExecuteOp
         Mul
         Quantization
-        Rounding
-        StorageApi
         Common
         Kernel
         SlidingWindow1d
@@ -24,11 +22,9 @@ target_link_libraries(Conv1dTransposed PRIVATE
         Tensor
         Arithmetic
         ArithmeticType
-        Add
+        ExecuteOp
         Mul
         Quantization
-        Rounding
-        StorageApi
         Common
         Kernel
         SlidingWindow1d

--- a/src/layer/CMakeLists.txt
+++ b/src/layer/CMakeLists.txt
@@ -39,6 +39,7 @@ target_link_libraries(MaxPool1d PRIVATE
         Tensor
         Arithmetic
         ArithmeticType
+        ExecuteOp
         Common
         Kernel
         SlidingWindow1d
@@ -51,6 +52,7 @@ target_link_libraries(AvgPool1d PRIVATE
         Tensor
         Arithmetic
         ArithmeticType
+        ExecuteOp
         Common
         Kernel
         SlidingWindow1d
@@ -62,6 +64,7 @@ target_link_libraries(AdaptiveAvgPool1d PRIVATE
         DTypes
         Tensor
         ArithmeticType
+        ExecuteOp
         Common
         AdaptiveWindow1d
 )

--- a/src/layer/Conv1d.c
+++ b/src/layer/Conv1d.c
@@ -2,16 +2,16 @@
 
 #include "Conv1d.h"
 
-#include "Add.h"
+#include <string.h>
+
 #include "Common.h"
 #include "Conv1dKernel.h"
 #include "ConvTranspose1dKernel.h"
+#include "ExecuteOp.h"
 #include "Layer.h"
 #include "Mul.h"
 #include "Quantization.h"
-#include "Rounding.h"
 #include "SlidingWindow1d.h"
-#include "StorageApi.h"
 #include "Tensor.h"
 
 void initConv1dConfigWithWeightsAndBias(conv1dConfig_t *conv1dConfig, kernel_t *kernel,
@@ -70,8 +70,26 @@ void conv1dForward(layer_t *layer, tensor_t *input, tensor_t *output) {
     }
 }
 
-static void conv1dCalcWeightGradsFloat32(conv1dConfig_t *cfg, tensor_t *forwardInput,
-                                         tensor_t *lossGrad) {
+/* executeOp kernel adapters (ctx = conv1dConfig_t*, for kernel_t/groups
+ * geometry — recon-conv-backward §8: the fixed opKernelFn_t shape has no
+ * per-op-instance geometry slot other than ctx). Weight-grad kernels `+=`
+ * into the same weight cell across many (b, outPos) iterations, so they
+ * memset rawOut first (the executeOp Phase-2 scratch is an uninitialized
+ * VLA, unlike the reserveMemory-backed intermediate they replace — recon
+ * §2). Bias-grad kernels write each output-channel index exactly once (no
+ * zero-init hazard). SYM weight-grad sets the raw intermediate's scale
+ * itself (s_in*s_loss); SYM bias-grad emits the raw per-channel sum at the
+ * loss scale and lets the OUT_ACC_FIXED_SCALE epilogue's
+ * rescaleIntoAccumulatorScale (target roundingMode, spec D4) do the rescale
+ * that used to happen inline here. */
+static void weightGradKernelFloat(tensor_t **ops, size_t n, tensor_t *rawOut, tensor_t *auxOut,
+                                  const void *ctx) {
+    (void)n;
+    (void)auxOut;
+    const conv1dConfig_t *cfg = ctx;
+    tensor_t *forwardInput = ops[0];
+    tensor_t *lossGrad = ops[1];
+
     size_t batch = forwardInput->shape->dimensions[0];
     size_t inChannels = forwardInput->shape->dimensions[1];
     size_t inputLength = forwardInput->shape->dimensions[2];
@@ -107,7 +125,9 @@ static void conv1dCalcWeightGradsFloat32(conv1dConfig_t *cfg, tensor_t *forwardI
 
     float const *xArr = (float const *)forwardInput->data;
     float const *gyArr = (float const *)lossGrad->data;
-    float *gwArr = (float *)cfg->weights->grad->data;
+    float *gwArr = (float *)rawOut->data;
+    memset(gwArr, 0,
+           calcNumberOfBytesForData(rawOut->quantization, calcNumberOfElementsByTensor(rawOut)));
 
     for (size_t b = 0; b < batch; b++) {
         for (size_t g = 0; g < groups; g++) {
@@ -137,7 +157,27 @@ static void conv1dCalcWeightGradsFloat32(conv1dConfig_t *cfg, tensor_t *forwardI
     }
 }
 
-static void conv1dCalcBiasGradsFloat32(conv1dConfig_t *cfg, tensor_t *lossGrad) {
+static void conv1dCalcWeightGradsFloat32(conv1dConfig_t *cfg, tensor_t *forwardInput,
+                                         tensor_t *lossGrad) {
+    executeOp(
+        &(opSpec_t){
+            .kernel = weightGradKernelFloat,
+            .ctx = cfg,
+            .inputs = (tensor_t *[]){forwardInput, lossGrad},
+            .nInputs = 2,
+            .arithmetic = cfg->weightGradMath,
+            .mode = OUT_ACC_DYNAMIC_RESCALE,
+        },
+        cfg->weights->grad);
+}
+
+static void biasGradKernelFloat(tensor_t **ops, size_t n, tensor_t *rawOut, tensor_t *auxOut,
+                                const void *ctx) {
+    (void)n;
+    (void)auxOut;
+    const conv1dConfig_t *cfg = ctx;
+    tensor_t *lossGrad = ops[0];
+
     size_t batch = lossGrad->shape->dimensions[0];
     size_t outChannels = lossGrad->shape->dimensions[1];
     size_t outputLength = lossGrad->shape->dimensions[2];
@@ -151,7 +191,7 @@ static void conv1dCalcBiasGradsFloat32(conv1dConfig_t *cfg, tensor_t *lossGrad) 
     }
 
     float const *gyArr = (float const *)lossGrad->data;
-    float *gbArr = (float *)cfg->bias->grad->data;
+    float *rawArr = (float *)rawOut->data;
 
     for (size_t oc = 0; oc < outChannels; oc++) {
         float sum = 0.0f;
@@ -160,12 +200,31 @@ static void conv1dCalcBiasGradsFloat32(conv1dConfig_t *cfg, tensor_t *lossGrad) 
                 sum += gyArr[(b * outChannels + oc) * outputLength + outPos];
             }
         }
-        gbArr[oc] += sum;
+        rawArr[oc] = sum;
     }
 }
 
-void conv1dCalcWeightGradsSymInt32(conv1dConfig_t *cfg, tensor_t *forwardInput,
-                                   tensor_t *lossGrad) {
+static void conv1dCalcBiasGradsFloat32(conv1dConfig_t *cfg, tensor_t *lossGrad) {
+    executeOp(
+        &(opSpec_t){
+            .kernel = biasGradKernelFloat,
+            .ctx = cfg,
+            .inputs = (tensor_t *[]){lossGrad},
+            .nInputs = 1,
+            .arithmetic = cfg->biasGradMath,
+            .mode = OUT_ACC_FIXED_SCALE,
+        },
+        cfg->bias->grad);
+}
+
+static void weightGradKernelSym(tensor_t **ops, size_t n, tensor_t *rawOut, tensor_t *auxOut,
+                                const void *ctx) {
+    (void)n;
+    (void)auxOut;
+    const conv1dConfig_t *cfg = ctx;
+    tensor_t *forwardInput = ops[0];
+    tensor_t *lossGrad = ops[1];
+
     size_t batch = forwardInput->shape->dimensions[0];
     size_t inChannels = forwardInput->shape->dimensions[1];
     size_t inputLength = forwardInput->shape->dimensions[2];
@@ -202,23 +261,10 @@ void conv1dCalcWeightGradsSymInt32(conv1dConfig_t *cfg, tensor_t *forwardInput,
     float inScale = ((symInt32QConfig_t *)forwardInput->quantization->qConfig)->scale;
     float lossScale = ((symInt32QConfig_t *)lossGrad->quantization->qConfig)->scale;
 
-    tensor_t *weightGrad = cfg->weights->grad;
-    size_t numberOfWeights = calcNumberOfElementsByTensor(weightGrad);
-
-    /* Fresh int32 intermediate at scale s_in*s_loss, allocated via reserveMemory
-     * (allocation-locality rule — NOT a stack VLA). reserveMemory zero-inits. */
-    int32_t *interData = reserveMemory(numberOfWeights * sizeof(int32_t));
-
-    symInt32QConfig_t interQC;
-    initSymInt32QConfig(((symInt32QConfig_t *)weightGrad->quantization->qConfig)->roundingMode,
-                        &interQC);
-    interQC.scale = inScale * lossScale;
-    quantization_t interQ;
-    initSymInt32Quantization(&interQC, &interQ);
-    tensor_t intermediate;
-    /* intermediate borrows weightGrad->shape read-only (addSymInt32TensorsInplace
-     * only reads shapes); mirrors the pre-funnel Linear SYM backward. */
-    setTensorValues(&intermediate, (uint8_t *)interData, weightGrad->shape, &interQ, NULL);
+    int32_t *interData = (int32_t *)rawOut->data;
+    memset(interData, 0,
+           calcNumberOfBytesForData(rawOut->quantization, calcNumberOfElementsByTensor(rawOut)));
+    ((symInt32QConfig_t *)rawOut->quantization->qConfig)->scale = inScale * lossScale;
 
     int32_t const *xArr = (int32_t const *)forwardInput->data;
     int32_t const *gyArr = (int32_t const *)lossGrad->data;
@@ -249,12 +295,29 @@ void conv1dCalcWeightGradsSymInt32(conv1dConfig_t *cfg, tensor_t *forwardInput,
             }
         }
     }
-
-    addSymInt32TensorsInplace(weightGrad, &intermediate);
-    freeReservedMemory(interData);
 }
 
-void conv1dCalcBiasGradsSymInt32(conv1dConfig_t *cfg, tensor_t *lossGrad) {
+void conv1dCalcWeightGradsSymInt32(conv1dConfig_t *cfg, tensor_t *forwardInput,
+                                   tensor_t *lossGrad) {
+    executeOp(
+        &(opSpec_t){
+            .kernel = weightGradKernelSym,
+            .ctx = cfg,
+            .inputs = (tensor_t *[]){forwardInput, lossGrad},
+            .nInputs = 2,
+            .arithmetic = cfg->weightGradMath,
+            .mode = OUT_ACC_DYNAMIC_RESCALE,
+        },
+        cfg->weights->grad);
+}
+
+static void biasGradKernelSym(tensor_t **ops, size_t n, tensor_t *rawOut, tensor_t *auxOut,
+                              const void *ctx) {
+    (void)n;
+    (void)auxOut;
+    const conv1dConfig_t *cfg = ctx;
+    tensor_t *lossGrad = ops[0];
+
     size_t batch = lossGrad->shape->dimensions[0];
     size_t outChannels = lossGrad->shape->dimensions[1];
     size_t outputLength = lossGrad->shape->dimensions[2];
@@ -268,12 +331,8 @@ void conv1dCalcBiasGradsSymInt32(conv1dConfig_t *cfg, tensor_t *lossGrad) {
     }
 
     int32_t const *gyArr = (int32_t const *)lossGrad->data;
-    tensor_t *biasGrad = cfg->bias->grad;
-    int32_t *gbArr = (int32_t *)biasGrad->data;
-
+    int32_t *rawArr = (int32_t *)rawOut->data;
     float lossScale = ((symInt32QConfig_t *)lossGrad->quantization->qConfig)->scale;
-    symInt32QConfig_t *bgQC = (symInt32QConfig_t *)biasGrad->quantization->qConfig;
-    float bgScale = bgQC->scale;
 
     for (size_t oc = 0; oc < outChannels; oc++) {
         /* int32 accumulator (NO int64): loss mantissas are int12-range per the
@@ -285,22 +344,38 @@ void conv1dCalcBiasGradsSymInt32(conv1dConfig_t *cfg, tensor_t *lossGrad) {
                 sum += gyArr[(b * outChannels + oc) * outputLength + outPos];
             }
         }
-        gbArr[oc] += rescaleIntoAccumulatorScale(sum, lossScale, bgScale, bgQC->roundingMode);
+        rawArr[oc] = sum;
     }
+    ((symInt32QConfig_t *)rawOut->quantization->qConfig)->scale = lossScale;
 }
 
-void conv1dBackwardFloat(layer_t *layer, tensor_t *forwardInput, tensor_t *lossGrad,
-                         tensor_t *propLoss) {
-    conv1dConfig_t *cfg = layer->config->conv1d;
+void conv1dCalcBiasGradsSymInt32(conv1dConfig_t *cfg, tensor_t *lossGrad) {
+    executeOp(
+        &(opSpec_t){
+            .kernel = biasGradKernelSym,
+            .ctx = cfg,
+            .inputs = (tensor_t *[]){lossGrad},
+            .nInputs = 1,
+            .arithmetic = cfg->biasGradMath,
+            .mode = OUT_ACC_FIXED_SCALE,
+        },
+        cfg->bias->grad);
+}
 
-    conv1dCalcWeightGradsFloat32(cfg, forwardInput, lossGrad);
+static void propLossKernelFloat(tensor_t **ops, size_t n, tensor_t *rawOut, tensor_t *auxOut,
+                                const void *ctx) {
+    (void)n;
+    (void)auxOut;
+    const conv1dConfig_t *cfg = ctx;
+    convTranspose1dKernelFloat32(ops[0], ops[1], NULL, cfg->kernel, cfg->groups, 0u, rawOut);
+}
 
-    if (cfg->bias) {
-        conv1dCalcBiasGradsFloat32(cfg, lossGrad);
-    }
-
-    convTranspose1dKernelFloat32(lossGrad, cfg->weights->param, NULL, cfg->kernel, cfg->groups, 0u,
-                                 propLoss);
+static void propLossKernelSym(tensor_t **ops, size_t n, tensor_t *rawOut, tensor_t *auxOut,
+                              const void *ctx) {
+    (void)n;
+    (void)auxOut;
+    const conv1dConfig_t *cfg = ctx;
+    convTranspose1dKernelSymInt32(ops[0], ops[1], NULL, cfg->kernel, cfg->groups, 0u, rawOut);
 }
 
 void conv1dBackward(layer_t *layer, tensor_t *forwardInput, tensor_t *lossGrad,
@@ -335,19 +410,36 @@ void conv1dBackward(layer_t *layer, tensor_t *forwardInput, tensor_t *lossGrad,
         exit(1);
     }
 
+    /* propLoss (dx wire): OUT_WRITE. For a SYM_INT32 target this now requants
+     * through the conversionMatrix diagonal (width-restored at the producer,
+     * design D3) instead of the old direct kernel write of raw, unrestored
+     * accumulator-range mantissas — the #187 dtype guard is superseded by the
+     * funnel's own prologue/epilogue and is deleted (recon-conv-backward §4:
+     * zero test coverage, confirmed tautology post-#221). */
     switch (cfg->propLossMath.type) {
     case ARITH_FLOAT32:
-        convTranspose1dKernelFloat32(lossGrad, cfg->weights->param, NULL, cfg->kernel, cfg->groups,
-                                     0u, propLoss);
+        executeOp(
+            &(opSpec_t){
+                .kernel = propLossKernelFloat,
+                .ctx = cfg,
+                .inputs = (tensor_t *[]){lossGrad, cfg->weights->param},
+                .nInputs = 2,
+                .arithmetic = cfg->propLossMath,
+                .mode = OUT_WRITE,
+            },
+            propLoss);
         break;
     case ARITH_SYM_INT32:
-        if (propLoss->quantization->type != SYM_INT32) {
-            PRINT_ERROR("Conv1d backward: propLossQ is SYM_INT32 but the propLoss tensor is "
-                        "not (#187)");
-            exit(1);
-        }
-        convTranspose1dKernelSymInt32(lossGrad, cfg->weights->param, NULL, cfg->kernel, cfg->groups,
-                                      0u, propLoss);
+        executeOp(
+            &(opSpec_t){
+                .kernel = propLossKernelSym,
+                .ctx = cfg,
+                .inputs = (tensor_t *[]){lossGrad, cfg->weights->param},
+                .nInputs = 2,
+                .arithmetic = cfg->propLossMath,
+                .mode = OUT_WRITE,
+            },
+            propLoss);
         break;
     default:
         PRINT_ERROR("Conv1d backward (propLoss): quantization type not implemented");

--- a/src/layer/Conv1d.c
+++ b/src/layer/Conv1d.c
@@ -39,30 +39,57 @@ void initConv1dConfigWithWeightsAndBias(conv1dConfig_t *conv1dConfig, kernel_t *
     conv1dConfig->propLossQ = propLossQ;
 }
 
-void conv1dForwardFloat(layer_t *conv1dLayer, tensor_t *input, tensor_t *output) {
-    conv1dConfig_t *cfg = conv1dLayer->config->conv1d;
-    tensor_t *weightTensor = cfg->weights->param;
-    tensor_t *biasTensor = cfg->bias ? cfg->bias->param : NULL;
-
-    conv1dKernelFloat32(input, weightTensor, biasTensor, cfg->kernel, cfg->groups, output);
+/* executeOp forward kernel adapters — ctx = conv1dConfig_t* for kernel_t/
+ * groups geometry (mirrors the backward adapters below). operands are
+ * {input, weights} or {input, weights, bias} (bias omitted, not
+ * NULL-padded, when the layer has no bias) — same convention Linear's
+ * forward adapters use (Linear.c). */
+static void forwardKernelFloat(tensor_t **ops, size_t n, tensor_t *rawOut, tensor_t *auxOut,
+                               const void *ctx) {
+    (void)auxOut;
+    const conv1dConfig_t *cfg = ctx;
+    tensor_t *bias = (n > 2) ? ops[2] : NULL;
+    conv1dKernelFloat32(ops[0], ops[1], bias, cfg->kernel, cfg->groups, rawOut);
 }
-
-void conv1dForwardSymInt32(layer_t *conv1dLayer, tensor_t *input, tensor_t *output) {
-    conv1dConfig_t *cfg = conv1dLayer->config->conv1d;
-    tensor_t *weightTensor = cfg->weights->param;
-    tensor_t *biasTensor = cfg->bias ? cfg->bias->param : NULL;
-
-    conv1dKernelSymInt32(input, weightTensor, biasTensor, cfg->kernel, cfg->groups, output);
+static void forwardKernelSym(tensor_t **ops, size_t n, tensor_t *rawOut, tensor_t *auxOut,
+                             const void *ctx) {
+    (void)auxOut;
+    const conv1dConfig_t *cfg = ctx;
+    tensor_t *bias = (n > 2) ? ops[2] : NULL;
+    conv1dKernelSymInt32(ops[0], ops[1], bias, cfg->kernel, cfg->groups, rawOut);
 }
 
 void conv1dForward(layer_t *layer, tensor_t *input, tensor_t *output) {
     conv1dConfig_t *cfg = layer->config->conv1d;
+    tensor_t *weightTensor = cfg->weights->param;
+    tensor_t *biasTensor = cfg->bias ? cfg->bias->param : NULL;
+
     switch (cfg->forwardMath.type) {
     case ARITH_FLOAT32:
-        conv1dForwardFloat(layer, input, output);
+        executeOp(
+            &(opSpec_t){
+                .kernel = forwardKernelFloat,
+                .ctx = cfg,
+                .inputs = biasTensor != NULL ? (tensor_t *[]){input, weightTensor, biasTensor}
+                                             : (tensor_t *[]){input, weightTensor},
+                .nInputs = biasTensor != NULL ? 3 : 2,
+                .arithmetic = cfg->forwardMath,
+                .mode = OUT_WRITE,
+            },
+            output);
         break;
     case ARITH_SYM_INT32:
-        conv1dForwardSymInt32(layer, input, output);
+        executeOp(
+            &(opSpec_t){
+                .kernel = forwardKernelSym,
+                .ctx = cfg,
+                .inputs = biasTensor != NULL ? (tensor_t *[]){input, weightTensor, biasTensor}
+                                             : (tensor_t *[]){input, weightTensor},
+                .nInputs = biasTensor != NULL ? 3 : 2,
+                .arithmetic = cfg->forwardMath,
+                .mode = OUT_WRITE,
+            },
+            output);
         break;
     default:
         PRINT_ERROR("Conv1d forward: quantization type not implemented");

--- a/src/layer/Conv1dTransposed.c
+++ b/src/layer/Conv1dTransposed.c
@@ -2,16 +2,16 @@
 
 #include "Conv1dTransposed.h"
 
-#include "Add.h"
+#include <string.h>
+
 #include "Common.h"
 #include "Conv1dKernel.h"
 #include "ConvTranspose1dKernel.h"
+#include "ExecuteOp.h"
 #include "Layer.h"
 #include "Mul.h"
 #include "Quantization.h"
-#include "Rounding.h"
 #include "SlidingWindow1d.h"
-#include "StorageApi.h"
 #include "Tensor.h"
 
 void initConv1dTransposedConfigWithWeightsAndBias(
@@ -85,8 +85,22 @@ void conv1dTransposedForward(layer_t *layer, tensor_t *input, tensor_t *output) 
     }
 }
 
-static void conv1dTransposedCalcWeightGradsFloat32(conv1dTransposedConfig_t *cfg,
-                                                   tensor_t *forwardInput, tensor_t *lossGrad) {
+/* executeOp kernel adapters (ctx = conv1dTransposedConfig_t*, for
+ * kernel_t/groups geometry — mirrors Conv1d.c). Weight-grad kernels `+=`
+ * across many (b, inPos) iterations, so they memset rawOut first; bias-grad
+ * kernels write each output-channel index exactly once. SYM weight-grad
+ * sets the raw intermediate's scale itself (s_in*s_loss); SYM bias-grad
+ * emits the raw per-channel sum at the loss scale, letting the
+ * OUT_ACC_FIXED_SCALE epilogue's rescaleIntoAccumulatorScale (target
+ * roundingMode, spec D4) do the rescale that used to happen inline here. */
+static void weightGradKernelFloat(tensor_t **ops, size_t n, tensor_t *rawOut, tensor_t *auxOut,
+                                  const void *ctx) {
+    (void)n;
+    (void)auxOut;
+    const conv1dTransposedConfig_t *cfg = ctx;
+    tensor_t *forwardInput = ops[0];
+    tensor_t *lossGrad = ops[1];
+
     size_t batch = forwardInput->shape->dimensions[0];
     size_t inChannels = forwardInput->shape->dimensions[1];
     size_t inputLength = forwardInput->shape->dimensions[2];
@@ -128,7 +142,9 @@ static void conv1dTransposedCalcWeightGradsFloat32(conv1dTransposedConfig_t *cfg
 
     float const *xArr = (float const *)forwardInput->data;
     float const *gyArr = (float const *)lossGrad->data;
-    float *gwArr = (float *)cfg->weights->grad->data;
+    float *gwArr = (float *)rawOut->data;
+    memset(gwArr, 0,
+           calcNumberOfBytesForData(rawOut->quantization, calcNumberOfElementsByTensor(rawOut)));
 
     for (size_t b = 0; b < batch; b++) {
         for (size_t g = 0; g < groups; g++) {
@@ -159,8 +175,27 @@ static void conv1dTransposedCalcWeightGradsFloat32(conv1dTransposedConfig_t *cfg
     }
 }
 
-static void conv1dTransposedCalcBiasGradsFloat32(conv1dTransposedConfig_t *cfg,
-                                                 tensor_t *lossGrad) {
+static void conv1dTransposedCalcWeightGradsFloat32(conv1dTransposedConfig_t *cfg,
+                                                   tensor_t *forwardInput, tensor_t *lossGrad) {
+    executeOp(
+        &(opSpec_t){
+            .kernel = weightGradKernelFloat,
+            .ctx = cfg,
+            .inputs = (tensor_t *[]){forwardInput, lossGrad},
+            .nInputs = 2,
+            .arithmetic = cfg->weightGradMath,
+            .mode = OUT_ACC_DYNAMIC_RESCALE,
+        },
+        cfg->weights->grad);
+}
+
+static void biasGradKernelFloat(tensor_t **ops, size_t n, tensor_t *rawOut, tensor_t *auxOut,
+                                const void *ctx) {
+    (void)n;
+    (void)auxOut;
+    const conv1dTransposedConfig_t *cfg = ctx;
+    tensor_t *lossGrad = ops[0];
+
     size_t batch = lossGrad->shape->dimensions[0];
     size_t outChannels = lossGrad->shape->dimensions[1];
     size_t outputLength = lossGrad->shape->dimensions[2];
@@ -174,7 +209,7 @@ static void conv1dTransposedCalcBiasGradsFloat32(conv1dTransposedConfig_t *cfg,
     }
 
     float const *gyArr = (float const *)lossGrad->data;
-    float *gbArr = (float *)cfg->bias->grad->data;
+    float *rawArr = (float *)rawOut->data;
 
     for (size_t oc = 0; oc < outChannels; oc++) {
         float sum = 0.0f;
@@ -183,12 +218,32 @@ static void conv1dTransposedCalcBiasGradsFloat32(conv1dTransposedConfig_t *cfg,
                 sum += gyArr[(b * outChannels + oc) * outputLength + outPos];
             }
         }
-        gbArr[oc] += sum;
+        rawArr[oc] = sum;
     }
 }
 
-void conv1dTransposedCalcWeightGradsSymInt32(conv1dTransposedConfig_t *cfg, tensor_t *forwardInput,
-                                             tensor_t *lossGrad) {
+static void conv1dTransposedCalcBiasGradsFloat32(conv1dTransposedConfig_t *cfg,
+                                                 tensor_t *lossGrad) {
+    executeOp(
+        &(opSpec_t){
+            .kernel = biasGradKernelFloat,
+            .ctx = cfg,
+            .inputs = (tensor_t *[]){lossGrad},
+            .nInputs = 1,
+            .arithmetic = cfg->biasGradMath,
+            .mode = OUT_ACC_FIXED_SCALE,
+        },
+        cfg->bias->grad);
+}
+
+static void weightGradKernelSym(tensor_t **ops, size_t n, tensor_t *rawOut, tensor_t *auxOut,
+                                const void *ctx) {
+    (void)n;
+    (void)auxOut;
+    const conv1dTransposedConfig_t *cfg = ctx;
+    tensor_t *forwardInput = ops[0];
+    tensor_t *lossGrad = ops[1];
+
     size_t batch = forwardInput->shape->dimensions[0];
     size_t inChannels = forwardInput->shape->dimensions[1];
     size_t inputLength = forwardInput->shape->dimensions[2];
@@ -227,21 +282,10 @@ void conv1dTransposedCalcWeightGradsSymInt32(conv1dTransposedConfig_t *cfg, tens
     float inScale = ((symInt32QConfig_t *)forwardInput->quantization->qConfig)->scale;
     float lossScale = ((symInt32QConfig_t *)lossGrad->quantization->qConfig)->scale;
 
-    tensor_t *weightGrad = cfg->weights->grad;
-    size_t numberOfWeights = calcNumberOfElementsByTensor(weightGrad);
-
-    /* Fresh int32 intermediate at scale s_in*s_loss, allocated via reserveMemory
-     * (allocation-locality rule — NOT a stack VLA). reserveMemory zero-inits. */
-    int32_t *interData = reserveMemory(numberOfWeights * sizeof(int32_t));
-
-    symInt32QConfig_t interQC;
-    initSymInt32QConfig(((symInt32QConfig_t *)weightGrad->quantization->qConfig)->roundingMode,
-                        &interQC);
-    interQC.scale = inScale * lossScale;
-    quantization_t interQ;
-    initSymInt32Quantization(&interQC, &interQ);
-    tensor_t intermediate;
-    setTensorValues(&intermediate, (uint8_t *)interData, weightGrad->shape, &interQ, NULL);
+    int32_t *interData = (int32_t *)rawOut->data;
+    memset(interData, 0,
+           calcNumberOfBytesForData(rawOut->quantization, calcNumberOfElementsByTensor(rawOut)));
+    ((symInt32QConfig_t *)rawOut->quantization->qConfig)->scale = inScale * lossScale;
 
     int32_t const *xArr = (int32_t const *)forwardInput->data;
     int32_t const *gyArr = (int32_t const *)lossGrad->data;
@@ -278,12 +322,29 @@ void conv1dTransposedCalcWeightGradsSymInt32(conv1dTransposedConfig_t *cfg, tens
             }
         }
     }
-
-    addSymInt32TensorsInplace(weightGrad, &intermediate);
-    freeReservedMemory(interData);
 }
 
-void conv1dTransposedCalcBiasGradsSymInt32(conv1dTransposedConfig_t *cfg, tensor_t *lossGrad) {
+void conv1dTransposedCalcWeightGradsSymInt32(conv1dTransposedConfig_t *cfg, tensor_t *forwardInput,
+                                             tensor_t *lossGrad) {
+    executeOp(
+        &(opSpec_t){
+            .kernel = weightGradKernelSym,
+            .ctx = cfg,
+            .inputs = (tensor_t *[]){forwardInput, lossGrad},
+            .nInputs = 2,
+            .arithmetic = cfg->weightGradMath,
+            .mode = OUT_ACC_DYNAMIC_RESCALE,
+        },
+        cfg->weights->grad);
+}
+
+static void biasGradKernelSym(tensor_t **ops, size_t n, tensor_t *rawOut, tensor_t *auxOut,
+                              const void *ctx) {
+    (void)n;
+    (void)auxOut;
+    const conv1dTransposedConfig_t *cfg = ctx;
+    tensor_t *lossGrad = ops[0];
+
     size_t batch = lossGrad->shape->dimensions[0];
     size_t outChannels = lossGrad->shape->dimensions[1];
     size_t outputLength = lossGrad->shape->dimensions[2];
@@ -297,12 +358,8 @@ void conv1dTransposedCalcBiasGradsSymInt32(conv1dTransposedConfig_t *cfg, tensor
     }
 
     int32_t const *gyArr = (int32_t const *)lossGrad->data;
-    tensor_t *biasGrad = cfg->bias->grad;
-    int32_t *gbArr = (int32_t *)biasGrad->data;
-
+    int32_t *rawArr = (int32_t *)rawOut->data;
     float lossScale = ((symInt32QConfig_t *)lossGrad->quantization->qConfig)->scale;
-    symInt32QConfig_t *bgQC = (symInt32QConfig_t *)biasGrad->quantization->qConfig;
-    float bgScale = bgQC->scale;
 
     for (size_t oc = 0; oc < outChannels; oc++) {
         /* int32 accumulator (NO int64): loss mantissas are int12-range per the
@@ -314,24 +371,41 @@ void conv1dTransposedCalcBiasGradsSymInt32(conv1dTransposedConfig_t *cfg, tensor
                 sum += gyArr[(b * outChannels + oc) * outputLength + outPos];
             }
         }
-        gbArr[oc] += rescaleIntoAccumulatorScale(sum, lossScale, bgScale, bgQC->roundingMode);
+        rawArr[oc] = sum;
     }
+    ((symInt32QConfig_t *)rawOut->quantization->qConfig)->scale = lossScale;
 }
 
-void conv1dTransposedBackwardFloat(layer_t *layer, tensor_t *forwardInput, tensor_t *lossGrad,
-                                   tensor_t *propLoss) {
-    conv1dTransposedConfig_t *cfg = layer->config->conv1dTransposed;
+void conv1dTransposedCalcBiasGradsSymInt32(conv1dTransposedConfig_t *cfg, tensor_t *lossGrad) {
+    executeOp(
+        &(opSpec_t){
+            .kernel = biasGradKernelSym,
+            .ctx = cfg,
+            .inputs = (tensor_t *[]){lossGrad},
+            .nInputs = 1,
+            .arithmetic = cfg->biasGradMath,
+            .mode = OUT_ACC_FIXED_SCALE,
+        },
+        cfg->bias->grad);
+}
 
-    conv1dTransposedCalcWeightGradsFloat32(cfg, forwardInput, lossGrad);
+/* dL/dx via the adjoint: conv1d-correlation of lossGrad with weight. The
+ * kernel here uses VALID (Phase-1 contract); conv1dKernelFloat32/SymInt32
+ * accept the same weight tensor (no flip needed, per spec §5.2). */
+static void propLossKernelFloat(tensor_t **ops, size_t n, tensor_t *rawOut, tensor_t *auxOut,
+                                const void *ctx) {
+    (void)n;
+    (void)auxOut;
+    const conv1dTransposedConfig_t *cfg = ctx;
+    conv1dKernelFloat32(ops[0], ops[1], NULL, cfg->kernel, cfg->groups, rawOut);
+}
 
-    if (cfg->bias) {
-        conv1dTransposedCalcBiasGradsFloat32(cfg, lossGrad);
-    }
-
-    // dL/dx via the adjoint: conv1d-correlation of lossGrad with weight.
-    // The kernel here uses VALID (Phase-1 contract). conv1dKernelFloat32
-    // accepts the same weight tensor (no flip needed, per spec §5.2).
-    conv1dKernelFloat32(lossGrad, cfg->weights->param, NULL, cfg->kernel, cfg->groups, propLoss);
+static void propLossKernelSym(tensor_t **ops, size_t n, tensor_t *rawOut, tensor_t *auxOut,
+                              const void *ctx) {
+    (void)n;
+    (void)auxOut;
+    const conv1dTransposedConfig_t *cfg = ctx;
+    conv1dKernelSymInt32(ops[0], ops[1], NULL, cfg->kernel, cfg->groups, rawOut);
 }
 
 void conv1dTransposedBackward(layer_t *layer, tensor_t *forwardInput, tensor_t *lossGrad,
@@ -366,20 +440,36 @@ void conv1dTransposedBackward(layer_t *layer, tensor_t *forwardInput, tensor_t *
         exit(1);
     }
 
+    /* propLoss (dx wire): OUT_WRITE. For a SYM_INT32 target this now requants
+     * through the conversionMatrix diagonal (width-restored at the producer,
+     * design D3) instead of the old direct kernel write of raw, unrestored
+     * accumulator-range mantissas — the #187 dtype guard is superseded by the
+     * funnel's own prologue/epilogue and is deleted (recon-conv-backward §4:
+     * zero test coverage, confirmed tautology post-#221). */
     switch (cfg->propLossMath.type) {
     case ARITH_FLOAT32:
-        // dL/dx via the adjoint: conv1d-correlation of lossGrad with weight (VALID, Phase-1).
-        conv1dKernelFloat32(lossGrad, cfg->weights->param, NULL, cfg->kernel, cfg->groups,
-                            propLoss);
+        executeOp(
+            &(opSpec_t){
+                .kernel = propLossKernelFloat,
+                .ctx = cfg,
+                .inputs = (tensor_t *[]){lossGrad, cfg->weights->param},
+                .nInputs = 2,
+                .arithmetic = cfg->propLossMath,
+                .mode = OUT_WRITE,
+            },
+            propLoss);
         break;
     case ARITH_SYM_INT32:
-        if (propLoss->quantization->type != SYM_INT32) {
-            PRINT_ERROR("Conv1dTransposed backward: propLossQ is SYM_INT32 but the propLoss "
-                        "tensor is not (#187)");
-            exit(1);
-        }
-        conv1dKernelSymInt32(lossGrad, cfg->weights->param, NULL, cfg->kernel, cfg->groups,
-                             propLoss);
+        executeOp(
+            &(opSpec_t){
+                .kernel = propLossKernelSym,
+                .ctx = cfg,
+                .inputs = (tensor_t *[]){lossGrad, cfg->weights->param},
+                .nInputs = 2,
+                .arithmetic = cfg->propLossMath,
+                .mode = OUT_WRITE,
+            },
+            propLoss);
         break;
     default:
         PRINT_ERROR("Conv1dTransposed backward (propLoss): quantization type not implemented");

--- a/src/layer/Conv1dTransposed.c
+++ b/src/layer/Conv1dTransposed.c
@@ -52,32 +52,59 @@ void initConv1dTransposedConfigWithWeightsAndBias(
     cfg->propLossQ = propLossQ;
 }
 
-void conv1dTransposedForwardFloat(layer_t *layer, tensor_t *input, tensor_t *output) {
-    conv1dTransposedConfig_t *cfg = layer->config->conv1dTransposed;
-    tensor_t *weightTensor = cfg->weights->param;
-    tensor_t *biasTensor = cfg->bias ? cfg->bias->param : NULL;
-
-    convTranspose1dKernelFloat32(input, weightTensor, biasTensor, cfg->kernel, cfg->groups,
-                                 cfg->outputPadding, output);
+/* executeOp forward kernel adapters — ctx = conv1dTransposedConfig_t* for
+ * kernel_t/groups/outputPadding geometry (mirrors the backward adapters
+ * below and Conv1d.c's forward adapters). operands are {input, weights} or
+ * {input, weights, bias} (bias omitted, not NULL-padded, when the layer has
+ * no bias). */
+static void forwardKernelFloat(tensor_t **ops, size_t n, tensor_t *rawOut, tensor_t *auxOut,
+                               const void *ctx) {
+    (void)auxOut;
+    const conv1dTransposedConfig_t *cfg = ctx;
+    tensor_t *bias = (n > 2) ? ops[2] : NULL;
+    convTranspose1dKernelFloat32(ops[0], ops[1], bias, cfg->kernel, cfg->groups, cfg->outputPadding,
+                                 rawOut);
 }
-
-void conv1dTransposedForwardSymInt32(layer_t *layer, tensor_t *input, tensor_t *output) {
-    conv1dTransposedConfig_t *cfg = layer->config->conv1dTransposed;
-    tensor_t *weightTensor = cfg->weights->param;
-    tensor_t *biasTensor = cfg->bias ? cfg->bias->param : NULL;
-
-    convTranspose1dKernelSymInt32(input, weightTensor, biasTensor, cfg->kernel, cfg->groups,
-                                  cfg->outputPadding, output);
+static void forwardKernelSym(tensor_t **ops, size_t n, tensor_t *rawOut, tensor_t *auxOut,
+                             const void *ctx) {
+    (void)auxOut;
+    const conv1dTransposedConfig_t *cfg = ctx;
+    tensor_t *bias = (n > 2) ? ops[2] : NULL;
+    convTranspose1dKernelSymInt32(ops[0], ops[1], bias, cfg->kernel, cfg->groups,
+                                  cfg->outputPadding, rawOut);
 }
 
 void conv1dTransposedForward(layer_t *layer, tensor_t *input, tensor_t *output) {
     conv1dTransposedConfig_t *cfg = layer->config->conv1dTransposed;
+    tensor_t *weightTensor = cfg->weights->param;
+    tensor_t *biasTensor = cfg->bias ? cfg->bias->param : NULL;
+
     switch (cfg->forwardMath.type) {
     case ARITH_FLOAT32:
-        conv1dTransposedForwardFloat(layer, input, output);
+        executeOp(
+            &(opSpec_t){
+                .kernel = forwardKernelFloat,
+                .ctx = cfg,
+                .inputs = biasTensor != NULL ? (tensor_t *[]){input, weightTensor, biasTensor}
+                                             : (tensor_t *[]){input, weightTensor},
+                .nInputs = biasTensor != NULL ? 3 : 2,
+                .arithmetic = cfg->forwardMath,
+                .mode = OUT_WRITE,
+            },
+            output);
         break;
     case ARITH_SYM_INT32:
-        conv1dTransposedForwardSymInt32(layer, input, output);
+        executeOp(
+            &(opSpec_t){
+                .kernel = forwardKernelSym,
+                .ctx = cfg,
+                .inputs = biasTensor != NULL ? (tensor_t *[]){input, weightTensor, biasTensor}
+                                             : (tensor_t *[]){input, weightTensor},
+                .nInputs = biasTensor != NULL ? 3 : 2,
+                .arithmetic = cfg->forwardMath,
+                .mode = OUT_WRITE,
+            },
+            output);
         break;
     default:
         PRINT_ERROR("Conv1dTransposed forward: quantization type not implemented");

--- a/src/layer/LayerNorm.c
+++ b/src/layer/LayerNorm.c
@@ -186,26 +186,31 @@ static void layerNormGroupStatsSymInt32(tensor_t *t, size_t numNormDims, size_t 
  *            throughout" holds only while the rescaled seed leaves one worst-case
  *            int12xint12 product (2047*2047 ≈ 4.2e6, #227) of int32 headroom for the
  *            gamma-product, i.e. |beta| <~ absmax_n * absmax_gamma.)
- * gamma/beta are contiguous default-order rank-D tensors -> flat index j. */
-static void layerNormAffineSymInt32(layerNormConfig_t *cfg, tensor_t *output, float sNorm) {
+ * gamma/beta are contiguous default-order rank-D tensors -> flat index j. This
+ * writes a RAW, unrestored y_q (accumulator-range, same class as Linear/Conv's
+ * matmul output, spec D2/D3) into rawOut's own scale field — the executeOp
+ * OUT_WRITE epilogue (caller, layerNormForward) restores width at the
+ * producer via the SYM->SYM diagonal requant. */
+static void layerNormAffineSymInt32(size_t numNormDims, tensor_t *gamma, tensor_t *beta,
+                                    tensor_t *output, float sNorm) {
     int32_t *out = (int32_t *)output->data;
-    int32_t *gammaQ = (int32_t *)cfg->gamma->param->data;
-    int32_t *betaQ = (int32_t *)cfg->beta->param->data;
+    int32_t *gammaQ = (int32_t *)gamma->data;
+    int32_t *betaQ = (int32_t *)beta->data;
     symInt32QConfig_t *outQC = output->quantization->qConfig;
-    symInt32QConfig_t *gammaQC = cfg->gamma->param->quantization->qConfig;
-    symInt32QConfig_t *betaQC = cfg->beta->param->quantization->qConfig;
+    symInt32QConfig_t *gammaQC = gamma->quantization->qConfig;
+    symInt32QConfig_t *betaQC = beta->quantization->qConfig;
 
     float sY = sNorm * gammaQC->scale;
 
     size_t G, N;
-    layerNormGroupSizes(output, cfg->numNormDims, &G, &N);
+    layerNormGroupSizes(output, numNormDims, &G, &N);
 
     /* Seed-rescale + flag-gated int32-overflow guard live in the shared #189 helper
      * (rescaleIntoAccumulatorScale): beta is refolded from its own scale into the
      * output (gamma-product) scale sY per element. */
     for (size_t g = 0; g < G; g++) {
         for (size_t j = 0; j < N; j++) {
-            size_t off = layerNormPhysOffset(output, cfg->numNormDims, g, j);
+            size_t off = layerNormPhysOffset(output, numNormDims, g, j);
             int32_t seed =
                 rescaleIntoAccumulatorScale(betaQ[j], betaQC->scale, sY, outQC->roundingMode);
             out[off] = out[off] * gammaQ[j] + seed;
@@ -222,14 +227,17 @@ static void layerNormAffineSymInt32(layerNormConfig_t *cfg, tensor_t *output, fl
  * pass 2: recompute stats per group (recompute-over-store: no scratch at all,
  *         not even G floats — stateless and MCU-friendly), normalize, stretch
  *         by K = qMax/absmax, round-clamp.
- * Output scale s_norm = 1/K. Per-group reconstructed variance of the output is
- * var/(var+eps) — exactly PyTorch's eps behavior. The affine stage follows
- * separately (Task 3). */
-static void layerNormForwardSymInt32(layerNormConfig_t *cfg, tensor_t *input, tensor_t *output) {
+ * Output scale s_norm = 1/K, then the affine stage folds in gamma/beta and
+ * writes the (raw, unrestored) producer scale. gamma/beta are passed
+ * explicitly (funnel operands, PR1b.2) rather than read via cfg, mirroring
+ * Linear's weights/bias adapter pattern — cfg is retained only for
+ * eps/numNormDims/qMaxBits-independent geometry. */
+static void layerNormForwardSymInt32(layerNormConfig_t *cfg, tensor_t *gamma, tensor_t *beta,
+                                     tensor_t *input, tensor_t *output) {
     layerNormValidateSymTensor(input, "input");
     layerNormValidateSymTensor(output, "output");
-    layerNormValidateSymTensor(cfg->gamma->param, "gamma");
-    layerNormValidateSymTensor(cfg->beta->param, "beta");
+    layerNormValidateSymTensor(gamma, "gamma");
+    layerNormValidateSymTensor(beta, "beta");
 
     symInt32QConfig_t *inQC = input->quantization->qConfig;
     symInt32QConfig_t *outQC = output->quantization->qConfig;
@@ -322,47 +330,68 @@ static void layerNormForwardSymInt32(layerNormConfig_t *cfg, tensor_t *input, te
         }
     }
 
-    layerNormAffineSymInt32(cfg, output, sNorm);
+    layerNormAffineSymInt32(cfg->numNormDims, gamma, beta, output, sNorm);
 }
 
-static void layerNormForwardFloat(layerNormConfig_t *cfg, tensor_t *input, tensor_t *output) {
+static void layerNormForwardFloat(layerNormConfig_t *cfg, tensor_t *gamma, tensor_t *beta,
+                                  tensor_t *input, tensor_t *output) {
     float *in = (float *)input->data;
     float *out = (float *)output->data;
-    float *gamma = (float *)cfg->gamma->param->data;
-    float *beta = (float *)cfg->beta->param->data;
+    float *g = (float *)gamma->data;
+    float *b = (float *)beta->data;
 
     size_t G, N;
     layerNormGroupSizes(input, cfg->numNormDims, &G, &N);
 
-    for (size_t g = 0; g < G; g++) {
+    for (size_t grp = 0; grp < G; grp++) {
         float mean;
         float invSigma;
-        layerNormGroupStats(input, cfg->numNormDims, g, N, cfg->eps, &mean, &invSigma);
+        layerNormGroupStats(input, cfg->numNormDims, grp, N, cfg->eps, &mean, &invSigma);
 
         for (size_t j = 0; j < N; j++) {
-            size_t off = layerNormPhysOffset(input, cfg->numNormDims, g, j);
+            size_t off = layerNormPhysOffset(input, cfg->numNormDims, grp, j);
             float nval = (in[off] - mean) * invSigma;
-            size_t outOff = layerNormPhysOffset(output, cfg->numNormDims, g, j);
-            out[outOff] = gamma[j] * nval + beta[j];
+            size_t outOff = layerNormPhysOffset(output, cfg->numNormDims, grp, j);
+            out[outOff] = g[j] * nval + b[j];
         }
     }
+}
+
+/* executeOp forward kernel adapters — operands {input, gamma, beta}; ctx =
+ * cfg (eps/normalizedShape/numNormDims geometry, not a tensor so it cannot
+ * travel through the funnel's operand array). The SYM kernel emits a RAW,
+ * unrestored producer scale (Finding A/D2/D3): the OUT_WRITE epilogue
+ * (layerNormForward) restores width via the SYM->SYM diagonal requant, same
+ * as Linear/Conv1d's matmul-family forwards. */
+static void layerNormForwardKernelFloat(tensor_t **ops, size_t n, tensor_t *rawOut,
+                                        tensor_t *auxOut, const void *ctx) {
+    (void)n;
+    (void)auxOut;
+    layerNormForwardFloat((layerNormConfig_t *)ctx, ops[1], ops[2], ops[0], rawOut);
+}
+static void layerNormForwardKernelSym(tensor_t **ops, size_t n, tensor_t *rawOut, tensor_t *auxOut,
+                                      const void *ctx) {
+    (void)n;
+    (void)auxOut;
+    layerNormForwardSymInt32((layerNormConfig_t *)ctx, ops[1], ops[2], ops[0], rawOut);
 }
 
 void layerNormForward(layer_t *layer, tensor_t *input, tensor_t *output) {
     layerNormConfig_t *cfg = layer->config->layerNorm;
     layerNormValidateInputShape(cfg, input);
-    switch (cfg->forwardMath.type) {
-    case ARITH_FLOAT32:
-        layerNormForwardFloat(cfg, input, output);
-        break;
-    case ARITH_SYM_INT32:
-        layerNormForwardSymInt32(cfg, input, output);
-        break;
-    default:
-        PRINT_ERROR(
-            "LayerNorm forward: quantization type not implemented (FLOAT32/SYM_INT32 only)");
-        exit(1);
-    }
+
+    executeOp(
+        &(opSpec_t){
+            .kernel = cfg->forwardMath.type == ARITH_SYM_INT32 ? layerNormForwardKernelSym
+                                                               : layerNormForwardKernelFloat,
+            .ctx = cfg,
+            .inputs = (tensor_t *[]){input, getParamFromParameter(cfg->gamma),
+                                     getParamFromParameter(cfg->beta)},
+            .nInputs = 3,
+            .arithmetic = cfg->forwardMath,
+            .mode = OUT_WRITE,
+        },
+        output);
 }
 
 static void layerNormBackwardFloat(layerNormConfig_t *cfg, tensor_t *forwardInput, tensor_t *loss,

--- a/src/layer/LayerNorm.c
+++ b/src/layer/LayerNorm.c
@@ -502,12 +502,24 @@ static void layerNormBackwardSymInt32(layerNormConfig_t *cfg, tensor_t *forwardI
     tensor_t dbetaT;
     setTensorValues(&dbetaT, (uint8_t *)dbetaInc, cfg->beta->grad->shape, &incQ,
                     cfg->beta->grad->sparsity);
-    executeOp(executeOpIdentityKernel, (tensor_t *[]){&dgammaT}, 1,
-              (arithmetic_t){.type = ARITH_FLOAT32, .roundingMode = HALF_AWAY}, cfg->gamma->grad,
-              OUT_ACC_DYNAMIC_RESCALE);
-    executeOp(executeOpIdentityKernel, (tensor_t *[]){&dbetaT}, 1,
-              (arithmetic_t){.type = ARITH_FLOAT32, .roundingMode = HALF_AWAY}, cfg->beta->grad,
-              OUT_ACC_DYNAMIC_RESCALE);
+    executeOp(
+        &(opSpec_t){
+            .kernel = executeOpIdentityKernel,
+            .inputs = (tensor_t *[]){&dgammaT},
+            .nInputs = 1,
+            .arithmetic = (arithmetic_t){.type = ARITH_FLOAT32, .roundingMode = HALF_AWAY},
+            .mode = OUT_ACC_DYNAMIC_RESCALE,
+        },
+        cfg->gamma->grad);
+    executeOp(
+        &(opSpec_t){
+            .kernel = executeOpIdentityKernel,
+            .inputs = (tensor_t *[]){&dbetaT},
+            .nInputs = 1,
+            .arithmetic = (arithmetic_t){.type = ARITH_FLOAT32, .roundingMode = HALF_AWAY},
+            .mode = OUT_ACC_DYNAMIC_RESCALE,
+        },
+        cfg->beta->grad);
 
     /* dx requant: convertFloatTensorToSymInt32Tensor idiom (whole-tensor
      * absmax -> scale -> round-clamp). NO integer dy==0 pre-check is needed

--- a/src/layer/Linear.c
+++ b/src/layer/Linear.c
@@ -119,29 +119,47 @@ void linearCalcPropLossSymInt32(tensor_t *weights, tensor_t *loss, tensor_t *pro
 }
 
 /* executeOp kernel adapters — ops convention: weight-grad {loss, fwdIn},
- * bias-grad {loss}, propLoss {loss, weightsParam}. */
-static void weightGradKernelFloat(tensor_t **ops, size_t n, tensor_t *rawOut) {
+ * bias-grad {loss}, propLoss {loss, weightsParam}. auxOut/ctx unused here. */
+static void weightGradKernelFloat(tensor_t **ops, size_t n, tensor_t *rawOut, tensor_t *auxOut,
+                                  const void *ctx) {
     (void)n;
+    (void)auxOut;
+    (void)ctx;
     linearCalcWeightGradsFloat32(ops[1], ops[0], rawOut);
 }
-static void weightGradKernelSym(tensor_t **ops, size_t n, tensor_t *rawOut) {
+static void weightGradKernelSym(tensor_t **ops, size_t n, tensor_t *rawOut, tensor_t *auxOut,
+                                const void *ctx) {
     (void)n;
+    (void)auxOut;
+    (void)ctx;
     linearCalcWeightGradsSymInt32(ops[0], ops[1], rawOut);
 }
-static void biasGradKernelFloat(tensor_t **ops, size_t n, tensor_t *rawOut) {
+static void biasGradKernelFloat(tensor_t **ops, size_t n, tensor_t *rawOut, tensor_t *auxOut,
+                                const void *ctx) {
     (void)n;
+    (void)auxOut;
+    (void)ctx;
     linearCalcBiasGradsFloat32(ops[0], rawOut);
 }
-static void biasGradKernelSym(tensor_t **ops, size_t n, tensor_t *rawOut) {
+static void biasGradKernelSym(tensor_t **ops, size_t n, tensor_t *rawOut, tensor_t *auxOut,
+                              const void *ctx) {
     (void)n;
+    (void)auxOut;
+    (void)ctx;
     linearCalcBiasGradsSymInt32(rawOut, ops[0]);
 }
-static void propLossKernelFloat(tensor_t **ops, size_t n, tensor_t *rawOut) {
+static void propLossKernelFloat(tensor_t **ops, size_t n, tensor_t *rawOut, tensor_t *auxOut,
+                                const void *ctx) {
     (void)n;
+    (void)auxOut;
+    (void)ctx;
     linearCalcPropLossFloat32(ops[0], ops[1], rawOut);
 }
-static void propLossKernelSym(tensor_t **ops, size_t n, tensor_t *rawOut) {
+static void propLossKernelSym(tensor_t **ops, size_t n, tensor_t *rawOut, tensor_t *auxOut,
+                              const void *ctx) {
     (void)n;
+    (void)auxOut;
+    (void)ctx;
     linearCalcPropLossSymInt32(ops[1], ops[0], rawOut);
 }
 
@@ -149,21 +167,40 @@ void linearBackward(layer_t *linearLayer, tensor_t *forwardInput, tensor_t *loss
                     tensor_t *propLoss) {
     linearConfig_t *cfg = linearLayer->config->linear;
 
-    executeOp(cfg->weightGradMath.type == ARITH_SYM_INT32 ? weightGradKernelSym
-                                                          : weightGradKernelFloat,
-              (tensor_t *[]){loss, forwardInput}, 2, cfg->weightGradMath,
-              getGradFromParameter(cfg->weights), OUT_ACC_DYNAMIC_RESCALE);
+    executeOp(
+        &(opSpec_t){
+            .kernel = cfg->weightGradMath.type == ARITH_SYM_INT32 ? weightGradKernelSym
+                                                                  : weightGradKernelFloat,
+            .inputs = (tensor_t *[]){loss, forwardInput},
+            .nInputs = 2,
+            .arithmetic = cfg->weightGradMath,
+            .mode = OUT_ACC_DYNAMIC_RESCALE,
+        },
+        getGradFromParameter(cfg->weights));
 
     if (cfg->bias != NULL) {
-        executeOp(cfg->biasGradMath.type == ARITH_SYM_INT32 ? biasGradKernelSym
-                                                            : biasGradKernelFloat,
-                  (tensor_t *[]){loss}, 1, cfg->biasGradMath, getGradFromParameter(cfg->bias),
-                  OUT_ACC_FIXED_SCALE);
+        executeOp(
+            &(opSpec_t){
+                .kernel = cfg->biasGradMath.type == ARITH_SYM_INT32 ? biasGradKernelSym
+                                                                    : biasGradKernelFloat,
+                .inputs = (tensor_t *[]){loss},
+                .nInputs = 1,
+                .arithmetic = cfg->biasGradMath,
+                .mode = OUT_ACC_FIXED_SCALE,
+            },
+            getGradFromParameter(cfg->bias));
     }
 
-    executeOp(cfg->propLossMath.type == ARITH_SYM_INT32 ? propLossKernelSym : propLossKernelFloat,
-              (tensor_t *[]){loss, getParamFromParameter(cfg->weights)}, 2, cfg->propLossMath,
-              propLoss, OUT_WRITE);
+    executeOp(
+        &(opSpec_t){
+            .kernel =
+                cfg->propLossMath.type == ARITH_SYM_INT32 ? propLossKernelSym : propLossKernelFloat,
+            .inputs = (tensor_t *[]){loss, getParamFromParameter(cfg->weights)},
+            .nInputs = 2,
+            .arithmetic = cfg->propLossMath,
+            .mode = OUT_WRITE,
+        },
+        propLoss);
 }
 
 void linearCalcOutputShape(layer_t *linearLayer, shape_t *inputShape, shape_t *outputShape) {

--- a/src/layer/Linear.c
+++ b/src/layer/Linear.c
@@ -40,23 +40,41 @@ void linearForwardSymInt32(tensor_t *w, tensor_t *b, tensor_t *input, tensor_t *
     transposeTensor(w, 0, 1);
 }
 
+/* executeOp forward kernel adapters — operands are {input, weights} or
+ * {input, weights, bias} (bias omitted, not NULL-padded, when the layer has
+ * no bias); ctx unused (matmul infers geometry from the tensors themselves). */
+static void linearForwardKernelFloat(tensor_t **ops, size_t n, tensor_t *rawOut, tensor_t *auxOut,
+                                     const void *ctx) {
+    (void)auxOut;
+    (void)ctx;
+    tensor_t *bias = (n > 2) ? ops[2] : NULL;
+    linearForwardFloat(ops[1], bias, ops[0], rawOut);
+}
+static void linearForwardKernelSym(tensor_t **ops, size_t n, tensor_t *rawOut, tensor_t *auxOut,
+                                   const void *ctx) {
+    (void)auxOut;
+    (void)ctx;
+    tensor_t *bias = (n > 2) ? ops[2] : NULL;
+    linearForwardSymInt32(ops[1], bias, ops[0], rawOut);
+}
+
 void linearForward(layer_t *linearLayer, tensor_t *input, tensor_t *output) {
     linearConfig_t *linearConfig = linearLayer->config->linear;
 
     tensor_t *weights = getParamFromParameter(linearConfig->weights);
-    tensor_t *bias = getParamFromParameter(linearConfig->bias);
+    tensor_t *bias = linearConfig->bias != NULL ? getParamFromParameter(linearConfig->bias) : NULL;
 
-    switch (linearConfig->forwardMath.type) {
-    case ARITH_FLOAT32:
-        linearForwardFloat(weights, bias, input, output);
-        break;
-    case ARITH_SYM_INT32:
-        linearForwardSymInt32(weights, bias, input, output);
-        break;
-    default:
-        PRINT_ERROR("Unknown QType!");
-        exit(1);
-    }
+    executeOp(
+        &(opSpec_t){
+            .kernel = linearConfig->forwardMath.type == ARITH_SYM_INT32 ? linearForwardKernelSym
+                                                                        : linearForwardKernelFloat,
+            .inputs = bias != NULL ? (tensor_t *[]){input, weights, bias}
+                                   : (tensor_t *[]){input, weights},
+            .nInputs = bias != NULL ? 3 : 2,
+            .arithmetic = linearConfig->forwardMath,
+            .mode = OUT_WRITE,
+        },
+        output);
 }
 
 void linearCalcWeightGradsFloat32(tensor_t *forwardInput, tensor_t *loss, tensor_t *weightGrads) {

--- a/src/layer/MaxPool1d.c
+++ b/src/layer/MaxPool1d.c
@@ -6,6 +6,7 @@
 
 #include "ArithmeticType.h"
 #include "Common.h"
+#include "ExecuteOp.h"
 #include "Layer.h"
 #include "SlidingWindow1d.h"
 #include "Tensor.h"
@@ -24,8 +25,19 @@ void initMaxPool1dConfig(maxPool1dConfig_t *cfg, kernel_t *kernel, tensor_t *arg
     cfg->propLossQ = propLossQ;
 }
 
-void maxPool1dForwardFloat(layer_t *layer, tensor_t *input, tensor_t *output) {
-    maxPool1dConfig_t *cfg = layer->config->maxPool1d;
+/* executeOp forward kernel adapter — ctx = maxPool1dConfig_t* for kernel_t
+ * geometry (mirrors AvgPool1d/Conv1d's ctx convention). auxOut = the layer's
+ * pre-allocated argmaxIndices tensor (opSpec_t.auxOut, spec D1): the funnel
+ * never converts it (kernel-written verbatim, in ITS OWN storage format,
+ * INT32) — this is exactly the dual-output shape auxOut was added for (D1's
+ * "MaxPool argmaxIndices lives here"). Only a FLOAT32 arm exists (no SYM
+ * kernel body); routing the data output through the funnel still gains real
+ * capability, same as AvgPool1d/AdaptiveAvgPool1d — see those files' comments. */
+static void maxPool1dForwardKernel(tensor_t **ops, size_t n, tensor_t *rawOut, tensor_t *auxOut,
+                                   const void *ctx) {
+    (void)n;
+    const maxPool1dConfig_t *cfg = ctx;
+    tensor_t *input = ops[0];
 
     size_t batch = input->shape->dimensions[0];
     size_t channels = input->shape->dimensions[1];
@@ -34,22 +46,22 @@ void maxPool1dForwardFloat(layer_t *layer, tensor_t *input, tensor_t *output) {
     windowGeometry1d_t geom = windowGeometry1dCalc(inputLength, cfg->kernel);
     size_t outputLength = geom.outputLength;
 
-    if (output->shape->dimensions[2] != outputLength) {
+    if (rawOut->shape->dimensions[2] != outputLength) {
         PRINT_ERROR("MaxPool1d forward: output length (%zu) does not match "
                     "geometry-derived (%zu)",
-                    output->shape->dimensions[2], outputLength);
+                    rawOut->shape->dimensions[2], outputLength);
         exit(1);
     }
-    if (cfg->argmaxIndices->shape->dimensions[2] != outputLength) {
+    if (auxOut->shape->dimensions[2] != outputLength) {
         PRINT_ERROR("MaxPool1d forward: argmaxIndices length (%zu) does not match "
                     "geometry-derived (%zu)",
-                    cfg->argmaxIndices->shape->dimensions[2], outputLength);
+                    auxOut->shape->dimensions[2], outputLength);
         exit(1);
     }
 
     float const *xArr = (float const *)input->data;
-    float *yArr = (float *)output->data;
-    int32_t *argmaxArr = (int32_t *)cfg->argmaxIndices->data;
+    float *yArr = (float *)rawOut->data;
+    int32_t *argmaxArr = (int32_t *)auxOut->data;
 
     for (size_t b = 0; b < batch; b++) {
         for (size_t c = 0; c < channels; c++) {
@@ -88,7 +100,17 @@ void maxPool1dForward(layer_t *layer, tensor_t *input, tensor_t *output) {
     maxPool1dConfig_t *cfg = layer->config->maxPool1d;
     switch (cfg->forwardMath.type) {
     case ARITH_FLOAT32:
-        maxPool1dForwardFloat(layer, input, output);
+        executeOp(
+            &(opSpec_t){
+                .kernel = maxPool1dForwardKernel,
+                .ctx = cfg,
+                .inputs = (tensor_t *[]){input},
+                .nInputs = 1,
+                .arithmetic = cfg->forwardMath,
+                .mode = OUT_WRITE,
+                .auxOut = cfg->argmaxIndices,
+            },
+            output);
         break;
     default:
         PRINT_ERROR("MaxPool1d forward: quantization type not implemented");

--- a/src/layer/Softmax.c
+++ b/src/layer/Softmax.c
@@ -9,6 +9,7 @@
 
 #include "ArithmeticType.h"
 #include "Common.h"
+#include "ExecuteOp.h"
 #include "Softmax.h"
 #include "TensorConversion.h"
 
@@ -25,15 +26,26 @@ void softmaxInitLayer(layerConfig_t *softmaxConfig, layer_t *softmaxLayer) {
     softmaxLayer->config = softmaxConfig;
 }
 
-static void softmaxForwardFloat(tensor_t *input, tensor_t *output) {
-    size_t n = calcNumberOfElementsByTensor(input);
+/* Softmax's real compute is always float (numerically stable max-shifted exp);
+ * SYM_INT32 forwardMath only ever meant "convert in, compute in float, convert
+ * out" (never native SYM arithmetic like Linear/Conv), so the funnel's
+ * prologue/epilogue perform that conversion automatically. Arithmetic is
+ * hardcoded ARITH_FLOAT32 here on purpose — forwardMath no longer selects a
+ * compute path, it only declares the layer's storage dtype. */
+static void softmaxForwardKernel(tensor_t **ops, size_t n, tensor_t *rawOut, tensor_t *auxOut,
+                                 const void *ctx) {
+    (void)n;
+    (void)auxOut;
+    (void)ctx;
+    tensor_t *input = ops[0];
+    size_t count = calcNumberOfElementsByTensor(input);
 
     float *x = (float *)input->data;
-    float *y = (float *)output->data;
+    float *y = (float *)rawOut->data;
 
     // 1. find max
     float max = x[0];
-    for (size_t i = 1; i < n; i++) {
+    for (size_t i = 1; i < count; i++) {
         if (x[i] > max) {
             max = x[i];
         }
@@ -41,78 +53,29 @@ static void softmaxForwardFloat(tensor_t *input, tensor_t *output) {
 
     // 2. exp and sum
     float sum = 0.f;
-    for (size_t i = 0; i < n; i++) {
+    for (size_t i = 0; i < count; i++) {
         float e = expf(x[i] - max);
         y[i] = e;
         sum += e;
     }
 
     // 3. normalize
-    for (size_t i = 0; i < n; i++) {
+    for (size_t i = 0; i < count; i++) {
         y[i] /= sum;
     }
 }
 
-/*static void softmaxForwardFloat(tensor_t *input, tensor_t *output) {
-    size_t inputSize = calcNumberOfElementsByTensor(input);
-
-    float *inputFloat = (float *)input->data;
-    float *outputFloat = (float *)output->data;
-
-    float sum = 0;
-    for (size_t i = 0; i < inputSize; i++) {
-        sum += expf(inputFloat[i]);
-    }
-
-    for (size_t i = 0; i < inputSize; i++) {
-        outputFloat[i] = expf(inputFloat[i]) / sum;
-    }
-}*/
-
-static void softmaxForwardSymInt32(tensor_t *input, tensor_t *output) {
-    size_t inputSize = calcNumberOfElementsByTensor(input);
-
-    tensor_t inputFloat;
-    quantization_t inputFloatQ;
-    initFloat32Quantization(&inputFloatQ);
-    uint8_t inputFloatData[inputSize * sizeof(float)];
-    setTensorValuesForConversion(inputFloatData, &inputFloatQ, input, &inputFloat);
-    convertTensor(input, &inputFloat);
-
-    tensor_t outputFloat;
-    quantization_t outputFloatQ;
-    initFloat32Quantization(&outputFloatQ);
-    uint8_t outputFloatData[inputSize * sizeof(float)];
-    setTensorValuesForConversion(outputFloatData, &outputFloatQ, output, &outputFloat);
-    convertTensor(output, &outputFloat);
-
-    float *inputFloatArr = (float *)inputFloat.data;
-    float *outputFloatArr = (float *)outputFloat.data;
-
-    float sum = 0;
-    for (size_t i = 0; i < inputSize; i++) {
-        sum += expf(inputFloatArr[i]);
-    }
-
-    for (size_t i = 0; i < inputSize; i++) {
-        outputFloatArr[i] = expf(inputFloatArr[i]) / sum;
-    }
-
-    convertTensor(&outputFloat, output);
-}
-
 void softmaxForward(layer_t *softmaxLayer, tensor_t *input, tensor_t *output) {
-    switch (softmaxLayer->config->softmax->forwardMath.type) {
-    case ARITH_FLOAT32:
-        softmaxForwardFloat(input, output);
-        break;
-    case ARITH_SYM_INT32:
-        softmaxForwardSymInt32(input, output);
-        break;
-    default:
-        PRINT_ERROR("Unknown QType!");
-        exit(1);
-    }
+    (void)softmaxLayer;
+    executeOp(
+        &(opSpec_t){
+            .kernel = softmaxForwardKernel,
+            .inputs = (tensor_t *[]){input},
+            .nInputs = 1,
+            .arithmetic = (arithmetic_t){.type = ARITH_FLOAT32, .roundingMode = HALF_AWAY},
+            .mode = OUT_WRITE,
+        },
+        output);
 }
 
 static void softmaxBackwardFloat(tensor_t *input, tensor_t *loss, tensor_t *propLoss) {

--- a/src/layer/Softmax.c
+++ b/src/layer/Softmax.c
@@ -1,7 +1,5 @@
 #define SOURCE_FILE "SOFTMAX"
 
-#define EULER_APPROX = 2.71828
-
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/layer/include/AdaptiveAvgPool1d.h
+++ b/src/layer/include/AdaptiveAvgPool1d.h
@@ -21,7 +21,6 @@ void initAdaptiveAvgPool1dConfig(adaptiveAvgPool1dConfig_t *cfg, size_t outputSi
                                  quantization_t *forwardQ, quantization_t *propLossQ);
 
 void adaptiveAvgPool1dForward(layer_t *layer, tensor_t *input, tensor_t *output);
-void adaptiveAvgPool1dForwardFloat(layer_t *layer, tensor_t *input, tensor_t *output);
 
 void adaptiveAvgPool1dBackward(layer_t *layer, tensor_t *forwardInput, tensor_t *lossGrad,
                                tensor_t *propLoss);

--- a/src/layer/include/AvgPool1d.h
+++ b/src/layer/include/AvgPool1d.h
@@ -22,7 +22,6 @@ void initAvgPool1dConfig(avgPool1dConfig_t *cfg, kernel_t *kernel, quantization_
                          quantization_t *propLossQ);
 
 void avgPool1dForward(layer_t *layer, tensor_t *input, tensor_t *output);
-void avgPool1dForwardFloat(layer_t *layer, tensor_t *input, tensor_t *output);
 
 void avgPool1dBackward(layer_t *layer, tensor_t *forwardInput, tensor_t *lossGrad,
                        tensor_t *propLoss);

--- a/src/layer/include/Conv1d.h
+++ b/src/layer/include/Conv1d.h
@@ -33,8 +33,6 @@ void initConv1dConfigWithWeightsAndBias(conv1dConfig_t *conv1dConfig, kernel_t *
                                         quantization_t *biasGradQ, quantization_t *propLossQ);
 
 void conv1dForward(layer_t *layer, tensor_t *input, tensor_t *output);
-void conv1dForwardFloat(layer_t *layer, tensor_t *input, tensor_t *output);
-void conv1dForwardSymInt32(layer_t *layer, tensor_t *input, tensor_t *output);
 
 void conv1dBackward(layer_t *layer, tensor_t *forwardInput, tensor_t *lossGrad, tensor_t *propLoss);
 

--- a/src/layer/include/Conv1d.h
+++ b/src/layer/include/Conv1d.h
@@ -37,8 +37,6 @@ void conv1dForwardFloat(layer_t *layer, tensor_t *input, tensor_t *output);
 void conv1dForwardSymInt32(layer_t *layer, tensor_t *input, tensor_t *output);
 
 void conv1dBackward(layer_t *layer, tensor_t *forwardInput, tensor_t *lossGrad, tensor_t *propLoss);
-void conv1dBackwardFloat(layer_t *layer, tensor_t *forwardInput, tensor_t *lossGrad,
-                         tensor_t *propLoss);
 
 void conv1dCalcWeightGradsSymInt32(conv1dConfig_t *cfg, tensor_t *forwardInput, tensor_t *lossGrad);
 void conv1dCalcBiasGradsSymInt32(conv1dConfig_t *cfg, tensor_t *lossGrad);

--- a/src/layer/include/Conv1dTransposed.h
+++ b/src/layer/include/Conv1dTransposed.h
@@ -34,8 +34,6 @@ void initConv1dTransposedConfigWithWeightsAndBias(
     quantization_t *biasGradQ, quantization_t *propLossQ);
 
 void conv1dTransposedForward(layer_t *layer, tensor_t *input, tensor_t *output);
-void conv1dTransposedForwardFloat(layer_t *layer, tensor_t *input, tensor_t *output);
-void conv1dTransposedForwardSymInt32(layer_t *layer, tensor_t *input, tensor_t *output);
 
 void conv1dTransposedBackward(layer_t *layer, tensor_t *forwardInput, tensor_t *lossGrad,
                               tensor_t *propLoss);

--- a/src/layer/include/Conv1dTransposed.h
+++ b/src/layer/include/Conv1dTransposed.h
@@ -39,8 +39,6 @@ void conv1dTransposedForwardSymInt32(layer_t *layer, tensor_t *input, tensor_t *
 
 void conv1dTransposedBackward(layer_t *layer, tensor_t *forwardInput, tensor_t *lossGrad,
                               tensor_t *propLoss);
-void conv1dTransposedBackwardFloat(layer_t *layer, tensor_t *forwardInput, tensor_t *lossGrad,
-                                   tensor_t *propLoss);
 
 void conv1dTransposedCalcWeightGradsSymInt32(conv1dTransposedConfig_t *cfg, tensor_t *forwardInput,
                                              tensor_t *lossGrad);

--- a/src/layer/include/MaxPool1d.h
+++ b/src/layer/include/MaxPool1d.h
@@ -23,7 +23,6 @@ void initMaxPool1dConfig(maxPool1dConfig_t *cfg, kernel_t *kernel, tensor_t *arg
                          quantization_t *forwardQ, quantization_t *propLossQ);
 
 void maxPool1dForward(layer_t *layer, tensor_t *input, tensor_t *output);
-void maxPool1dForwardFloat(layer_t *layer, tensor_t *input, tensor_t *output);
 
 void maxPool1dBackward(layer_t *layer, tensor_t *forwardInput, tensor_t *lossGrad,
                        tensor_t *propLoss);

--- a/src/userApi/CMakeLists.txt
+++ b/src/userApi/CMakeLists.txt
@@ -88,10 +88,8 @@ target_link_libraries(LayerConfigAccess PRIVATE
 add_library(ModelValidationApi ModelValidationApi.c)
 target_include_directories(ModelValidationApi PUBLIC include)
 target_link_libraries(ModelValidationApi PRIVATE
-        ArithmeticType
         Common
         Layer
-        LayerConfigAccess
         Quantization
         Rounding
         Tensor

--- a/src/userApi/ModelValidationApi.c
+++ b/src/userApi/ModelValidationApi.c
@@ -3,28 +3,17 @@
 #include <stdbool.h>
 #include <stddef.h>
 
-#include "ArithmeticType.h"
 #include "Common.h"
 #include "Layer.h"
-#include "LayerConfigAccess.h"
 #include "ModelValidationApi.h"
 
-/* True for accumulator-range producers (layers whose SYM forward emits raw
- * matmul/post-affine mantissas beyond the int16 norm) that ALSO declared
- * ARITH_SYM_INT32 as their forward compute representation; false for every
- * other layer type or arithmetic. */
-static bool isAccumulatorRangeSymProducer(layer_t *layer) {
-    switch (layer->type) {
-    case LINEAR:
-    case LAYERNORM:
-    case CONV1D:
-    case CONV1D_TRANSPOSED:
-        return layerForwardMath(layer).type == ARITH_SYM_INT32;
-    default:
-        return false;
-    }
-}
-
+/* RETIRED (PR1b.2, spec D3): this validator used to reject a SYM_INT32
+ * accumulator-range producer (Linear/LayerNorm/Conv1d/Conv1dTransposed) not
+ * immediately followed by a QUANTIZATION layer — the forward funnel now
+ * restores width at the producer's own wire, so that rule has nothing left
+ * to catch (a following Quant layer is optional, not required; see
+ * docs/conventions/arithmetic-sym.md). The entry point stays for future
+ * model-wide rules; today it only guards the model array shape itself. */
 bool validateModelQuantization(layer_t **model, size_t modelSize) {
     if (model == NULL) {
         PRINT_ERROR("validateModelQuantization: model is NULL");
@@ -34,21 +23,6 @@ bool validateModelQuantization(layer_t **model, size_t modelSize) {
     for (size_t i = 0; i < modelSize; i++) {
         if (model[i] == NULL) {
             PRINT_ERROR("validateModelQuantization: model[%zu] is NULL", i);
-            valid = false;
-            continue;
-        }
-        if (!isAccumulatorRangeSymProducer(model[i])) {
-            continue; /* not a SYM accumulator-range producer */
-        }
-        if (i + 1 == modelSize) {
-            continue; /* producer in last position: loss boundary, allowed */
-        }
-        if (model[i + 1] == NULL || model[i + 1]->type != QUANTIZATION) {
-            PRINT_ERROR("validateModelQuantization: layer %zu (type %d) emits SYM_INT32 "
-                        "accumulator-range output but layer %zu (type %d) is not a "
-                        "QUANTIZATION layer — insert a Quant layer to restore the int16 "
-                        "inter-layer contract",
-                        i, (int)model[i]->type, i + 1, model[i + 1] ? (int)model[i + 1]->type : -1);
             valid = false;
         }
     }

--- a/src/userApi/include/ModelValidationApi.h
+++ b/src/userApi/include/ModelValidationApi.h
@@ -8,12 +8,12 @@
 
 /*! Opt-in model-quantization validator (NOT wired into the training loop).
  *
- *  Walks the layer array and checks the int16 inter-layer contract: a layer
- *  whose declared forward arithmetic (layerForwardMath(layer).type) is
- *  ARITH_SYM_INT32 and whose type is an accumulator-range producer (LINEAR,
- *  LAYERNORM, CONV1D, CONV1D_TRANSPOSED) must be followed by a QUANTIZATION
- *  layer that requantizes the raw accumulator mantissas. A producer in the
- *  last position is allowed (loss boundary).
+ *  Walks the layer array and validates its shape (non-NULL model, non-NULL
+ *  elements). The int16-inter-layer "SYM producer must be followed by a
+ *  QUANTIZATION layer" rule this once enforced is RETIRED (PR1b.2, spec D3):
+ *  the forward funnel now restores width at the producer's own wire, so a
+ *  following Quant layer is optional, not required. This entry point is kept
+ *  as the place future model-wide rules attach to.
  *
  *  Diagnostics: logs every violation (PRINT_ERROR-style, visible with
  *  DLEVEL >= 1) and returns false if at least one violation was found.

--- a/src/userApi/layer/include/AdaptivePool1dApi.h
+++ b/src/userApi/layer/include/AdaptivePool1dApi.h
@@ -18,10 +18,16 @@ typedef struct adaptiveAvgPool1dInit {
 } adaptiveAvgPool1dInit_t;
 
 /*! Borrowing variant — stores lq->outputQ in outputQ and lq->propLossQ
- *  in propLossQ verbatim (ownsQuantizations = false). */
+ *  in propLossQ verbatim (ownsQuantizations = false).
+ *  Use when: outputQ/propLossQ are shared/long-lived (e.g. reused across
+ *  several layers) and the caller manages their lifetime — they must
+ *  outlive the layer. */
 layer_t *adaptiveAvgPool1dLayerInit(adaptiveAvgPool1dInit_t *init, layerQuant_t *lq);
 
-/*! Owning variant — deep-copies outputQ / propLossQ (ownsQuantizations = true). */
+/*! Owning variant — deep-copies outputQ / propLossQ (ownsQuantizations = true).
+ *  Use when: outputQ/propLossQ are stack-locals or one-off configs and you
+ *  want fire-and-forget teardown (freeAdaptiveAvgPool1dLayer tears them down
+ *  too). */
 layer_t *adaptiveAvgPool1dLayerInitOwning(adaptiveAvgPool1dInit_t *init, layerQuant_t *lq);
 
 /*! Tears down everything the factory allocated; frees the two math quantizations

--- a/src/userApi/layer/include/Conv1dApi.h
+++ b/src/userApi/layer/include/Conv1dApi.h
@@ -37,12 +37,17 @@ typedef struct conv1dInit {
 /*! Borrowing variant — factory allocates weights/bias/kernel internally
  *  and stores the four math `quantization_t*` from `lq` verbatim. Caller
  *  retains ownership of `lq` and the quantizations; `lq` may be a
- *  compound literal. */
+ *  compound literal.
+ *  Use when: the quantizations are shared/long-lived (e.g. reused across
+ *  several layers) and the caller manages their lifetime — they must
+ *  outlive the layer. */
 layer_t *conv1dLayerInit(conv1dInit_t *init, layerQuant_t *lq);
 
 /*! Owning variant — same as `conv1dLayerInit`, but additionally
  *  `deepCopyQuantization`s each of the four math quantizations. Caller
- *  can drop `lq` and the quantization_t's immediately. */
+ *  can drop `lq` and the quantization_t's immediately.
+ *  Use when: the quantizations are stack-locals or one-off configs and you
+ *  want fire-and-forget teardown (freeConv1dLayer tears them down too). */
 layer_t *conv1dLayerInitOwning(conv1dInit_t *init, layerQuant_t *lq);
 
 /*! Tears down everything the factory allocated. Reads

--- a/src/userApi/layer/include/Conv1dTransposedApi.h
+++ b/src/userApi/layer/include/Conv1dTransposedApi.h
@@ -37,11 +37,17 @@ typedef struct conv1dTransposedInit {
 } conv1dTransposedInit_t;
 
 /*! Borrowing variant — allocates kernel, weights, bias; stores the four
- *  lq math quantizations verbatim. Caller retains ownership of lq. */
+ *  lq math quantizations verbatim. Caller retains ownership of lq.
+ *  Use when: the quantizations are shared/long-lived (e.g. reused across
+ *  several layers) and the caller manages their lifetime — they must
+ *  outlive the layer. */
 layer_t *conv1dTransposedLayerInit(conv1dTransposedInit_t *init, layerQuant_t *lq);
 
 /*! Owning variant — additionally deep-copies the four math quantizations
- *  via deepCopyQuantization. */
+ *  via deepCopyQuantization.
+ *  Use when: the quantizations are stack-locals or one-off configs and you
+ *  want fire-and-forget teardown (freeConv1dTransposedLayer tears them down
+ *  too). */
 layer_t *conv1dTransposedLayerInitOwning(conv1dTransposedInit_t *init, layerQuant_t *lq);
 
 /*! Tears down everything the factory allocated. Reads

--- a/src/userApi/layer/include/LayerNormApi.h
+++ b/src/userApi/layer/include/LayerNormApi.h
@@ -20,13 +20,18 @@ typedef struct layerNormInit {
  *  (storage dtype = lq->weightStorage / lq->biasStorage) and their grads via
  *  gradInit(param, lq->weightGradStorage ?: lq->propLossQ, NULL) (resp.
  *  biasGradStorage for beta). Copies normalizedShape into factory-owned
- *  memory. */
+ *  memory.
+ *  Use when: outputQ/propLossQ are shared/long-lived (e.g. reused across
+ *  several layers) and the caller manages their lifetime — they must
+ *  outlive the layer. */
 layer_t *layerNormLayerInit(layerNormInit_t *init, layerQuant_t *lq);
 
 /*! Owning factory — deep-copies lq->outputQ / lq->propLossQ into the
  *  config (ownsQuantizations=true; the caller may drop its outputQ/propLossQ
  *  pointers immediately). Identical gamma/beta allocation + normalizedShape copy
- *  as the Borrowing variant. Mirrors linearLayerInitOwning. */
+ *  as the Borrowing variant. Mirrors linearLayerInitOwning.
+ *  Use when: outputQ/propLossQ are stack-locals or one-off configs and you
+ *  want fire-and-forget teardown (freeLayerNormLayer tears them down too). */
 layer_t *layerNormLayerInitOwning(layerNormInit_t *init, layerQuant_t *lq);
 
 /*! Frees the parameter_t (gamma/beta + grads + shapes), the copied

--- a/src/userApi/layer/include/LinearApi.h
+++ b/src/userApi/layer/include/LinearApi.h
@@ -16,12 +16,17 @@ typedef struct linearInit {
 
 /*! Borrowing variant — factory stores the four quantization_t* pointers from
  *  `lq` directly. Caller retains ownership of `lq` and the quantizations;
- *  `lq` itself can be a compound literal that dies after the call. */
+ *  `lq` itself can be a compound literal that dies after the call.
+ *  Use when: the quantizations are shared/long-lived (e.g. reused across
+ *  several layers) and the caller manages their lifetime — they must
+ *  outlive the layer. */
 layer_t *linearLayerInit(linearInit_t *init, layerQuant_t *lq);
 
 /*! Owning variant — factory deep-copies everything reachable from `lq`.
  *  Caller can free `lq` and all four quantization_t* immediately after
- *  the factory returns. free*Layer will tear down the copies. */
+ *  the factory returns. free*Layer will tear down the copies.
+ *  Use when: the quantizations are stack-locals or one-off configs and you
+ *  want fire-and-forget teardown (freeLinearLayer tears them down too). */
 layer_t *linearLayerInitOwning(linearInit_t *init, layerQuant_t *lq);
 
 /*! Tears down everything the factory allocated (parameters, kernel if any,

--- a/src/userApi/layer/include/Pool1dApi.h
+++ b/src/userApi/layer/include/Pool1dApi.h
@@ -48,12 +48,17 @@ typedef struct avgPool1dInit {
 
 /*! Borrowing variant — allocates kernel and (for MaxPool) the argmax
  *  tensor; stores lq->outputQ in outputQ and lq->propLossQ in
- *  propLossQ verbatim. */
+ *  propLossQ verbatim.
+ *  Use when: outputQ/propLossQ are shared/long-lived (e.g. reused across
+ *  several layers) and the caller manages their lifetime — they must
+ *  outlive the layer. */
 layer_t *maxPool1dLayerInit(maxPool1dInit_t *init, layerQuant_t *lq);
 layer_t *avgPool1dLayerInit(avgPool1dInit_t *init, layerQuant_t *lq);
 
 /*! Owning variant — additionally deep-copies outputQ and
- *  propLossQ via deepCopyQuantization. */
+ *  propLossQ via deepCopyQuantization.
+ *  Use when: outputQ/propLossQ are stack-locals or one-off configs and you
+ *  want fire-and-forget teardown (free*Pool1dLayer tears them down too). */
 layer_t *maxPool1dLayerInitOwning(maxPool1dInit_t *init, layerQuant_t *lq);
 layer_t *avgPool1dLayerInitOwning(avgPool1dInit_t *init, layerQuant_t *lq);
 

--- a/src/userApi/layer/include/QuantLayerApi.h
+++ b/src/userApi/layer/include/QuantLayerApi.h
@@ -11,12 +11,17 @@
  *  literal that dies after the call. outputQ = dtype/qConfig target of the
  *  forward output; propLossQ = dtype/qConfig target of the backward propLoss.
  *  weightStorage/biasStorage are ignored (the Quantization layer has no
- *  parameters). */
+ *  parameters).
+ *  Use when: outputQ/propLossQ are shared/long-lived (e.g. reused across
+ *  several layers) and the caller manages their lifetime — they must
+ *  outlive the layer. */
 layer_t *quantLayerInit(layerQuant_t *lq);
 
 /*! Owning variant — factory deep-copies outputQ and propLossQ.
  *  Caller can free `lq` and both quantization_t* immediately after the
- *  factory returns. freeQuantLayer will tear down the copies. */
+ *  factory returns. freeQuantLayer will tear down the copies.
+ *  Use when: outputQ/propLossQ are stack-locals or one-off configs and you
+ *  want fire-and-forget teardown (freeQuantLayer tears them down too). */
 layer_t *quantLayerInitOwning(layerQuant_t *lq);
 
 /*! Tears down everything the factory allocated (internal config, layer).

--- a/src/userApi/layer/include/ReluApi.h
+++ b/src/userApi/layer/include/ReluApi.h
@@ -5,11 +5,16 @@
 #include "LayerQuant.h"
 
 /*! Borrowing variant — stores lq->outputQ and lq->propLossQ as the
- *  layer's outputQ / propLossQ pointers. Caller retains ownership of lq. */
+ *  layer's outputQ / propLossQ pointers. Caller retains ownership of lq.
+ *  Use when: the quantizations are shared/long-lived (e.g. reused across
+ *  several layers) and the caller manages their lifetime — they must
+ *  outlive the layer. */
 layer_t *reluLayerInit(layerQuant_t *lq);
 
 /*! Owning variant — deep-copies lq->outputQ and lq->propLossQ.
- *  Caller can drop lq + quantizations immediately. */
+ *  Caller can drop lq + quantizations immediately.
+ *  Use when: the quantizations are stack-locals or one-off configs and you
+ *  want fire-and-forget teardown (freeReluLayer tears them down too). */
 layer_t *reluLayerInitOwning(layerQuant_t *lq);
 
 /*! Tears down the layer. Reads config->ownsQuantizations to decide whether

--- a/src/userApi/layer/include/SoftmaxApi.h
+++ b/src/userApi/layer/include/SoftmaxApi.h
@@ -6,11 +6,16 @@
 #include "Tensor.h"
 
 /*! Borrowing variant — stores lq->outputQ in outputQ and
- *  lq->propLossQ in propLossQ verbatim. */
+ *  lq->propLossQ in propLossQ verbatim.
+ *  Use when: outputQ/propLossQ are shared/long-lived (e.g. reused across
+ *  several layers) and the caller manages their lifetime — they must
+ *  outlive the layer. */
 layer_t *softmaxLayerInit(layerQuant_t *lq);
 
 /*! Owning variant — deep-copies outputQ + propLossQ via
- *  deepCopyQuantization. */
+ *  deepCopyQuantization.
+ *  Use when: outputQ/propLossQ are stack-locals or one-off configs and you
+ *  want fire-and-forget teardown (freeSoftmaxLayer tears them down too). */
 layer_t *softmaxLayerInitOwning(layerQuant_t *lq);
 
 /*! Tears down the layer. Reads config->ownsQuantizations to decide

--- a/test/unit/arithmetic/CMakeLists.txt
+++ b/test/unit/arithmetic/CMakeLists.txt
@@ -178,6 +178,7 @@ add_elastic_ai_unit_test(
         Arithmetic
         ArithmeticType
         Rounding
+        RNG
         StorageApi
         Common
         odt_test_death

--- a/test/unit/arithmetic/UnitTestExecuteOp.c
+++ b/test/unit/arithmetic/UnitTestExecuteOp.c
@@ -9,6 +9,8 @@
 #include "ExecuteOp.h"
 #include "Quantization.h"
 #include "QuantizationApi.h"
+#include "RNG.h"
+#include "Rounding.h"
 #include "StorageApi.h"
 #include "Tensor.h"
 #include "TensorApi.h"
@@ -59,8 +61,15 @@ void testProloguePassesMatchingOperandThroughUntouched(void) {
     initSymInt32QConfig(HALF_AWAY, &arithQC);
     initSymInt32Quantization(&arithQC, &arith);
 
-    executeOp(executeOpIdentityKernel, (tensor_t *[]){in}, 1, arithmeticFromQuantization(&arith),
-              out, OUT_WRITE);
+    executeOp(
+        &(opSpec_t){
+            .kernel = executeOpIdentityKernel,
+            .inputs = (tensor_t *[]){in},
+            .nInputs = 1,
+            .arithmetic = arithmeticFromQuantization(&arith),
+            .mode = OUT_WRITE,
+        },
+        out);
 
     int32_t srcM0 = ((int32_t *)in->data)[0];
     float srcScale = ((symInt32QConfig_t *)in->quantization->qConfig)->scale;
@@ -81,8 +90,15 @@ void testPrologueConvertsFloatOperandIntoSymArithmetic(void) {
     initSymInt32QConfig(HALF_AWAY, &arithQC);
     initSymInt32Quantization(&arithQC, &arith);
 
-    executeOp(executeOpIdentityKernel, (tensor_t *[]){in}, 1, arithmeticFromQuantization(&arith),
-              out, OUT_WRITE);
+    executeOp(
+        &(opSpec_t){
+            .kernel = executeOpIdentityKernel,
+            .inputs = (tensor_t *[]){in},
+            .nInputs = 1,
+            .arithmetic = arithmeticFromQuantization(&arith),
+            .mode = OUT_WRITE,
+        },
+        out);
 
     /* Reference: quantize the float input to int12 SYM directly, then requant
      * to the target exactly as the epilogue's OUT_WRITE diagonal does. */
@@ -120,8 +136,15 @@ void testOutWriteSymToSymBitEqualsDiagonalRequant(void) {
     initSymInt32QConfig(HALF_AWAY, &arithQC);
     initSymInt32Quantization(&arithQC, &arith);
 
-    executeOp(executeOpIdentityKernel, (tensor_t *[]){in}, 1, arithmeticFromQuantization(&arith),
-              out, OUT_WRITE);
+    executeOp(
+        &(opSpec_t){
+            .kernel = executeOpIdentityKernel,
+            .inputs = (tensor_t *[]){in},
+            .nInputs = 1,
+            .arithmetic = arithmeticFromQuantization(&arith),
+            .mode = OUT_WRITE,
+        },
+        out);
 
     tensor_t *ref = buildSym(3, (int32_t[]){0, 0, 0}, 1.0f);
     conversionMatrix[SYM_INT32][SYM_INT32](in, ref);
@@ -150,8 +173,15 @@ void testOutWriteSymToFloatEqualsConvertTensor(void) {
     initSymInt32QConfig(HALF_AWAY, &arithQC);
     initSymInt32Quantization(&arithQC, &arith);
 
-    executeOp(executeOpIdentityKernel, (tensor_t *[]){in}, 1, arithmeticFromQuantization(&arith),
-              out, OUT_WRITE);
+    executeOp(
+        &(opSpec_t){
+            .kernel = executeOpIdentityKernel,
+            .inputs = (tensor_t *[]){in},
+            .nInputs = 1,
+            .arithmetic = arithmeticFromQuantization(&arith),
+            .mode = OUT_WRITE,
+        },
+        out);
 
     float got0 = ((float *)out->data)[0];
     float got1 = ((float *)out->data)[1];
@@ -169,10 +199,24 @@ void testAccDynamicIntoFloatIsExactAndAccumulates(void) {
     quantization_t floatArith;
     initFloat32Quantization(&floatArith);
 
-    executeOp(executeOpIdentityKernel, (tensor_t *[]){inc}, 1,
-              arithmeticFromQuantization(&floatArith), grad, OUT_ACC_DYNAMIC_RESCALE);
-    executeOp(executeOpIdentityKernel, (tensor_t *[]){inc}, 1,
-              arithmeticFromQuantization(&floatArith), grad, OUT_ACC_DYNAMIC_RESCALE);
+    executeOp(
+        &(opSpec_t){
+            .kernel = executeOpIdentityKernel,
+            .inputs = (tensor_t *[]){inc},
+            .nInputs = 1,
+            .arithmetic = arithmeticFromQuantization(&floatArith),
+            .mode = OUT_ACC_DYNAMIC_RESCALE,
+        },
+        grad);
+    executeOp(
+        &(opSpec_t){
+            .kernel = executeOpIdentityKernel,
+            .inputs = (tensor_t *[]){inc},
+            .nInputs = 1,
+            .arithmetic = arithmeticFromQuantization(&floatArith),
+            .mode = OUT_ACC_DYNAMIC_RESCALE,
+        },
+        grad);
 
     float g0 = ((float *)grad->data)[0];
     float g1 = ((float *)grad->data)[1];
@@ -191,8 +235,15 @@ void testAccFixedIntoFloatCollapsesToExactAdd(void) {
     quantization_t floatArith;
     initFloat32Quantization(&floatArith);
 
-    executeOp(executeOpIdentityKernel, (tensor_t *[]){inc}, 1,
-              arithmeticFromQuantization(&floatArith), grad, OUT_ACC_FIXED_SCALE);
+    executeOp(
+        &(opSpec_t){
+            .kernel = executeOpIdentityKernel,
+            .inputs = (tensor_t *[]){inc},
+            .nInputs = 1,
+            .arithmetic = arithmeticFromQuantization(&floatArith),
+            .mode = OUT_ACC_FIXED_SCALE,
+        },
+        grad);
 
     float g0 = ((float *)grad->data)[0];
     float g1 = ((float *)grad->data)[1];
@@ -213,8 +264,15 @@ void testAccDynamicSymIntoSymBitEqualsAddSymInplace(void) {
     initSymInt32QConfig(HALF_AWAY, &arithQC);
     initSymInt32Quantization(&arithQC, &arith);
 
-    executeOp(executeOpIdentityKernel, (tensor_t *[]){inc}, 1, arithmeticFromQuantization(&arith),
-              grad, OUT_ACC_DYNAMIC_RESCALE);
+    executeOp(
+        &(opSpec_t){
+            .kernel = executeOpIdentityKernel,
+            .inputs = (tensor_t *[]){inc},
+            .nInputs = 1,
+            .arithmetic = arithmeticFromQuantization(&arith),
+            .mode = OUT_ACC_DYNAMIC_RESCALE,
+        },
+        grad);
     addSymInt32TensorsInplace(refGrad, refInc);
 
     int32_t got[3];
@@ -243,8 +301,15 @@ void testAccDynamicFloatIncIntoSymTargetMatchesLayerNormReference(void) {
     quantization_t floatArith;
     initFloat32Quantization(&floatArith);
 
-    executeOp(executeOpIdentityKernel, (tensor_t *[]){inc}, 1,
-              arithmeticFromQuantization(&floatArith), grad, OUT_ACC_DYNAMIC_RESCALE);
+    executeOp(
+        &(opSpec_t){
+            .kernel = executeOpIdentityKernel,
+            .inputs = (tensor_t *[]){inc},
+            .nInputs = 1,
+            .arithmetic = arithmeticFromQuantization(&floatArith),
+            .mode = OUT_ACC_DYNAMIC_RESCALE,
+        },
+        grad);
 
     /* Reference: exact LayerNorm.c:446-463 sequence on a twin. */
     tensor_t *refGrad = buildSym(3, (int32_t[]){40, -80, 120}, 0.02f);
@@ -270,11 +335,14 @@ void testAccDynamicFloatIncIntoSymTargetMatchesLayerNormReference(void) {
     TEST_ASSERT_EQUAL_FLOAT(wantScale, gotScale);
 }
 
-/* Fixed-scale SYM+SYM reproduces linearCalcBiasGradsSymInt32's semantics:
- * target[i] += roundf(interm[i] * intermScale / targetScale), NO clamp.
- * Hand-computed: interm {700, -300} @ 0.01 into target {5, -5} @ 0.02:
- * roundf(700*0.01/0.02) = 350 -> 355; roundf(-300*0.5) = -150 -> -155.
- * Target scale must stay EXACTLY 0.02 (never re-derived). */
+/* Fixed-scale SYM+SYM reproduces linearCalcBiasGradsSymInt32's semantics via
+ * rescaleIntoAccumulatorScale(interm[i], intermScale, targetScale, HALF_AWAY),
+ * NO clamp; the target's roundingMode here is HALF_AWAY (default of buildSym),
+ * so this pins the D4 bit-identical-to-old-behavior case (roundHalfAway ==
+ * the pre-migration bare roundf for these inputs). Hand-computed: interm
+ * {700, -300} @ 0.01 into target {5, -5} @ 0.02: 700*0.01/0.02 = 350 (exact)
+ * -> 355; -300*0.01/0.02 = -150 (exact) -> -155. Target scale must stay
+ * EXACTLY 0.02 (never re-derived). */
 void testAccFixedSymIntoSymRescalesIntoExistingScale(void) {
     tensor_t *inc = buildSym(2, (int32_t[]){700, -300}, 0.01f);
     tensor_t *grad = buildSym(2, (int32_t[]){5, -5}, 0.02f);
@@ -283,8 +351,15 @@ void testAccFixedSymIntoSymRescalesIntoExistingScale(void) {
     initSymInt32QConfig(HALF_AWAY, &arithQC);
     initSymInt32Quantization(&arithQC, &arith);
 
-    executeOp(executeOpIdentityKernel, (tensor_t *[]){inc}, 1, arithmeticFromQuantization(&arith),
-              grad, OUT_ACC_FIXED_SCALE);
+    executeOp(
+        &(opSpec_t){
+            .kernel = executeOpIdentityKernel,
+            .inputs = (tensor_t *[]){inc},
+            .nInputs = 1,
+            .arithmetic = arithmeticFromQuantization(&arith),
+            .mode = OUT_ACC_FIXED_SCALE,
+        },
+        grad);
 
     int32_t g0 = ((int32_t *)grad->data)[0];
     int32_t g1 = ((int32_t *)grad->data)[1];
@@ -309,9 +384,15 @@ void testAccIntoSubByteTargetAborts(void) {
     quantization_t floatArith;
     initFloat32Quantization(&floatArith);
 
-    ASSERT_EXITS_WITH_FAILURE(executeOp(executeOpIdentityKernel, (tensor_t *[]){inc}, 1,
-                                        arithmeticFromQuantization(&floatArith), grad,
-                                        OUT_ACC_DYNAMIC_RESCALE));
+    ASSERT_EXITS_WITH_FAILURE(executeOp(
+        &(opSpec_t){
+            .kernel = executeOpIdentityKernel,
+            .inputs = (tensor_t *[]){inc},
+            .nInputs = 1,
+            .arithmetic = arithmeticFromQuantization(&floatArith),
+            .mode = OUT_ACC_DYNAMIC_RESCALE,
+        },
+        grad));
 
     freeTensor(grad);
     freeTensor(inc);
@@ -326,12 +407,174 @@ void testAccIntoTooWideSymTargetAborts(void) {
     quantization_t floatArith;
     initFloat32Quantization(&floatArith);
 
-    ASSERT_EXITS_WITH_FAILURE(executeOp(executeOpIdentityKernel, (tensor_t *[]){inc}, 1,
-                                        arithmeticFromQuantization(&floatArith), grad,
-                                        OUT_ACC_DYNAMIC_RESCALE));
+    ASSERT_EXITS_WITH_FAILURE(executeOp(
+        &(opSpec_t){
+            .kernel = executeOpIdentityKernel,
+            .inputs = (tensor_t *[]){inc},
+            .nInputs = 1,
+            .arithmetic = arithmeticFromQuantization(&floatArith),
+            .mode = OUT_ACC_DYNAMIC_RESCALE,
+        },
+        grad));
 
     freeTensor(grad);
     freeTensor(inc);
+}
+
+/* ---- opSpec_t: ctx / auxOut / FIXED_SCALE roundingMode (spec D1+D4) --- */
+
+typedef struct {
+    float addend;
+} testCtx_t;
+
+/* Adapter proving ctx actually reaches the kernel: adds ctx->addend to every
+ * element of operand 0 into rawOut. If the funnel dropped/NULLed ctx this
+ * would crash (NULL deref) or - if silently defaulted - would leave the
+ * output un-added; the pinned +10 catches either regression. */
+static void kernelAddsCtx(tensor_t **ops, size_t nOps, tensor_t *rawOut, tensor_t *auxOut,
+                          const void *ctx) {
+    (void)nOps;
+    (void)auxOut;
+    const testCtx_t *c = (const testCtx_t *)ctx;
+    size_t n = calcNumberOfElementsByTensor(ops[0]);
+    float *src = (float *)ops[0]->data;
+    float *dst = (float *)rawOut->data;
+    for (size_t i = 0; i < n; i++) {
+        dst[i] = src[i] + c->addend;
+    }
+}
+
+void testCtxReachesKernel(void) {
+    tensor_t *in = buildFloat(2, (float[]){1.0f, -2.0f});
+    tensor_t *out = buildFloat(2, (float[]){0.f, 0.f});
+    quantization_t floatArith;
+    initFloat32Quantization(&floatArith);
+    testCtx_t ctx = {.addend = 10.0f};
+
+    executeOp(
+        &(opSpec_t){
+            .kernel = kernelAddsCtx,
+            .ctx = &ctx,
+            .inputs = (tensor_t *[]){in},
+            .nInputs = 1,
+            .arithmetic = arithmeticFromQuantization(&floatArith),
+            .mode = OUT_WRITE,
+        },
+        out);
+
+    float got0 = ((float *)out->data)[0];
+    float got1 = ((float *)out->data)[1];
+    freeTensor(out);
+    freeTensor(in);
+    TEST_ASSERT_EQUAL_FLOAT(11.0f, got0); /* 1.0 + ctx->addend(10) */
+    TEST_ASSERT_EQUAL_FLOAT(8.0f, got1);  /* -2.0 + 10 */
+}
+
+/* Adapter writing distinct values into rawOut and auxOut, plus a sentinel SYM
+ * scale on auxOut that no funnel machinery would ever produce on its own
+ * (0.777f). auxOut is a DIFFERENT dtype (SYM_INT32) from the FLOAT32
+ * arithmetic/target here specifically so that, if a future edit accidentally
+ * routed auxOut through writeOut/accumulateOut (funnel-converting it), the
+ * requant would recompute its scale from the data's absmax and destroy the
+ * sentinel - this test would then fail. */
+static void kernelWritesAuxVerbatim(tensor_t **ops, size_t nOps, tensor_t *rawOut, tensor_t *auxOut,
+                                    const void *ctx) {
+    (void)nOps;
+    (void)ctx;
+    size_t n = calcNumberOfElementsByTensor(ops[0]);
+    float *src = (float *)ops[0]->data;
+    float *dst = (float *)rawOut->data;
+    int32_t *aux = (int32_t *)auxOut->data;
+    for (size_t i = 0; i < n; i++) {
+        dst[i] = src[i];
+        aux[i] = (int32_t)(i + 7); /* sentinel indices, unrelated to op values */
+    }
+    ((symInt32QConfig_t *)auxOut->quantization->qConfig)->scale = 0.777f;
+}
+
+void testAuxOutIsKernelWrittenVerbatimAndNeverFunnelConverted(void) {
+    tensor_t *in = buildFloat(2, (float[]){3.0f, -4.0f});
+    tensor_t *out = buildFloat(2, (float[]){0.f, 0.f});
+    tensor_t *aux = buildSym(2, (int32_t[]){0, 0}, 1.0f);
+    quantization_t floatArith;
+    initFloat32Quantization(&floatArith);
+
+    executeOp(
+        &(opSpec_t){
+            .kernel = kernelWritesAuxVerbatim,
+            .inputs = (tensor_t *[]){in},
+            .nInputs = 1,
+            .arithmetic = arithmeticFromQuantization(&floatArith),
+            .mode = OUT_WRITE,
+            .auxOut = aux,
+        },
+        out);
+
+    float outGot0 = ((float *)out->data)[0];
+    float outGot1 = ((float *)out->data)[1];
+    int32_t auxGot0 = ((int32_t *)aux->data)[0];
+    int32_t auxGot1 = ((int32_t *)aux->data)[1];
+    float auxScale = ((symInt32QConfig_t *)aux->quantization->qConfig)->scale;
+    freeTensor(aux);
+    freeTensor(out);
+    freeTensor(in);
+    TEST_ASSERT_EQUAL_FLOAT(3.0f, outGot0); /* target: untouched by auxOut content */
+    TEST_ASSERT_EQUAL_FLOAT(-4.0f, outGot1);
+    TEST_ASSERT_EQUAL_INT32(7, auxGot0); /* auxOut: kernel's verbatim write survives */
+    TEST_ASSERT_EQUAL_INT32(8, auxGot1);
+    TEST_ASSERT_FLOAT_WITHIN(1e-9f, 0.777f, auxScale); /* sentinel scale untouched */
+}
+
+/* OUT_ACC_FIXED_SCALE must consult the TARGET's roundingMode (spec D4) via
+ * rescaleIntoAccumulatorScale, not a bare roundf (which is HALF_AWAY-only and
+ * ignores SR jitter entirely). Values are chosen so the pre-rescale ratio
+ * lands exactly on a HALF_AWAY tie (705*0.01/0.02 = 352.5, -705*... = -352.5)
+ * so the two rounding modes provably diverge for ANY jitter draw that lands
+ * before the tie boundary.
+ *
+ * Derivation (verified by compiling Rounding.c+RNG.c standalone against
+ * rngSetSeed(99) — see task-1-report.md): with the module-global RNG seeded
+ * to 99, the two draws consumed by roundSRHalfAway (one per element, in
+ * element order) are jitter0=0.005865..., jitter1=0.558617... :
+ *   HALF_AWAY:   round(352.5)  = 353 ;  round(-352.5) = -353  (the OLD bare-
+ *                roundf behavior this test would still show if the epilogue
+ *                ignored the target's roundingMode - anti-vacuity)
+ *   SR_HALF_AWAY: round(352.5 + jitter0 - 0.5) = round(352.005...) = 352
+ *                 round(-352.5 + jitter1 - 0.5) = round(-352.44...) = -352
+ * Target scale must stay EXACTLY 0.02 (never re-derived), matching
+ * testAccFixedSymIntoSymRescalesIntoExistingScale's HALF_AWAY pin (D4's
+ * "bit-identical for HALF_AWAY" case). */
+void testAccFixedScaleHonorsTargetSrRoundingMode(void) {
+    tensor_t *inc = buildSym(2, (int32_t[]){705, -705}, 0.01f);
+    tensor_t *grad = buildSym(2, (int32_t[]){0, 0}, 0.02f);
+    ((symInt32QConfig_t *)grad->quantization->qConfig)->roundingMode = SR_HALF_AWAY;
+    quantization_t arith;
+    symInt32QConfig_t arithQC;
+    initSymInt32QConfig(HALF_AWAY, &arithQC); /* arithmetic's own roundingMode is
+                                               * irrelevant to FIXED_SCALE's
+                                               * epilogue rescale (target's is
+                                               * what counts, per D4) */
+    initSymInt32Quantization(&arithQC, &arith);
+
+    rngSetSeed(99);
+    executeOp(
+        &(opSpec_t){
+            .kernel = executeOpIdentityKernel,
+            .inputs = (tensor_t *[]){inc},
+            .nInputs = 1,
+            .arithmetic = arithmeticFromQuantization(&arith),
+            .mode = OUT_ACC_FIXED_SCALE,
+        },
+        grad);
+
+    int32_t g0 = ((int32_t *)grad->data)[0];
+    int32_t g1 = ((int32_t *)grad->data)[1];
+    float gScale = ((symInt32QConfig_t *)grad->quantization->qConfig)->scale;
+    freeTensor(grad);
+    freeTensor(inc);
+    TEST_ASSERT_EQUAL_INT(352, g0);
+    TEST_ASSERT_EQUAL_INT(-352, g1);
+    TEST_ASSERT_FLOAT_WITHIN(1e-9f, 0.02f, gScale);
 }
 
 /* executeConvert SYM->SYM must requant through the conversionMatrix diagonal
@@ -399,6 +642,9 @@ int main(void) {
     RUN_TEST(testAccFixedSymIntoSymRescalesIntoExistingScale);
     RUN_TEST(testAccIntoSubByteTargetAborts);
     RUN_TEST(testAccIntoTooWideSymTargetAborts);
+    RUN_TEST(testCtxReachesKernel);
+    RUN_TEST(testAuxOutIsKernelWrittenVerbatimAndNeverFunnelConverted);
+    RUN_TEST(testAccFixedScaleHonorsTargetSrRoundingMode);
     RUN_TEST(testExecuteConvertSymToSymRequantsThroughDiagonal);
     RUN_TEST(testExecuteConvertFloatToSymMatchesConvertTensor);
     return UNITY_END();

--- a/test/unit/layer/UnitTestAdaptiveAvgPool1d.c
+++ b/test/unit/layer/UnitTestAdaptiveAvgPool1d.c
@@ -262,6 +262,45 @@ void testCalcOutputShapeFixedRegardlessOfInput(void) {
     freeQuantization(q);
 }
 
+// Smoke test for the funnel's new SYM-input capability (spec Testing list) —
+// same rationale as AvgPool1d's twin test (UnitTestAvgPool1d.c): forwardMath
+// stays FLOAT32 (no SYM kernel body), but a SYM_INT32 producer tensor must
+// now be dequantized by the executeOp prologue rather than reinterpreted as
+// raw float bits. absMax(1,2,3,4)=4.0 -> scale=4/2047; per-element error
+// <= 0.5*scale ~ 9.8e-4 -> 5e-3 leaves a >5x margin.
+void testAdaptiveAvgPool1dForwardWithSymInt32Input(void) {
+    size_t inDims[] = {1, 1, 4};
+    size_t outDims[] = {1, 1, 2};
+
+    static adaptiveAvgPool1dConfig_t cfgStore;
+    static layer_t layerStore;
+    static layerConfig_t lcStore;
+
+    quantization_t *floatQ = quantizationInitFloat();
+    initAdaptiveAvgPool1dConfig(&cfgStore, 2, floatQ, floatQ);
+    lcStore.adaptiveAvgPool1d = &cfgStore;
+    layerStore.config = &lcStore;
+
+    size_t *ownedDims = reserveMemory(3 * sizeof(size_t));
+    memcpy(ownedDims, inDims, 3 * sizeof(size_t));
+    size_t *order = reserveMemory(3 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(3, order);
+    shape_t *shape = reserveMemory(sizeof(shape_t));
+    setShape(shape, ownedDims, 3, order);
+    tensor_t *symInput = initTensor(shape, quantizationInitSymInt32WithBits(HALF_AWAY, 12), NULL);
+    tensorFillFromFloatBuffer(symInput, input_adaptiveAvgPool1d_basic,
+                              calcNumberOfElementsByTensor(symInput));
+
+    tensor_t *output = makeFloatTensor(outDims, 3, NULL);
+
+    adaptiveAvgPool1dForward(&layerStore, symInput, output);
+
+    for (size_t i = 0; i < expectedForward_adaptiveAvgPool1d_basic_len; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(5e-3f, expectedForward_adaptiveAvgPool1d_basic[i],
+                                 ((float *)output->data)[i]);
+    }
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(testForwardBasic);
@@ -276,5 +315,6 @@ int main(void) {
     RUN_TEST(testBackwardMultiBatch);
     RUN_TEST(testBackwardGlobal);
     RUN_TEST(testBackwardUpsample);
+    RUN_TEST(testAdaptiveAvgPool1dForwardWithSymInt32Input);
     return UNITY_END();
 }

--- a/test/unit/layer/UnitTestAvgPool1d.c
+++ b/test/unit/layer/UnitTestAvgPool1d.c
@@ -240,6 +240,52 @@ void testAvgPool1dEdgeCases(void) {
     }
 }
 
+// Smoke test for the funnel's new SYM-input capability (spec Testing list):
+// the layer's own forwardMath stays FLOAT32 (no SYM kernel body exists for
+// this op), but a SYM_INT32-typed *producer* tensor feeding it must now be
+// dequantized by the executeOp prologue rather than silently reinterpreted
+// as raw float bits (the pre-migration direct-cast hazard). Tolerance is
+// widened relative to the FLOAT32 fixture tests above: it must cover the
+// SYM_INT32@12 quantization step (qMax=2047) on top of the exact average,
+// not just float rounding noise. absMax(1,4,2,3)=4.0 -> scale=4/2047;
+// per-element error <= 0.5*scale ~ 9.8e-4, unchanged by the K=2 average
+// (linear in the elements) -> 5e-3 leaves a >5x margin, not vacuous.
+void testAvgPool1dForwardWithSymInt32Input(void) {
+    size_t inputDims[] = {1, 1, 4};
+    size_t outputDims[] = {1, 1, 3};
+
+    static kernel_t kernelStore;
+    static avgPool1dConfig_t cfgStore;
+    static layer_t layerStore;
+    static layerConfig_t lcStore;
+
+    initKernel(&kernelStore, 2, VALID, 1, 1);
+    quantization_t *floatQ = quantizationInitFloat();
+    initAvgPool1dConfig(&cfgStore, &kernelStore, floatQ, floatQ);
+    layerStore.type = AVGPOOL1D;
+    lcStore.avgPool1d = &cfgStore;
+    layerStore.config = &lcStore;
+
+    size_t *ownedDims = reserveMemory(3 * sizeof(size_t));
+    memcpy(ownedDims, inputDims, 3 * sizeof(size_t));
+    size_t *order = reserveMemory(3 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(3, order);
+    shape_t *shape = reserveMemory(sizeof(shape_t));
+    setShape(shape, ownedDims, 3, order);
+    tensor_t *symInput = initTensor(shape, quantizationInitSymInt32WithBits(HALF_AWAY, 12), NULL);
+    tensorFillFromFloatBuffer(symInput, input_avgPool1d_basic,
+                              calcNumberOfElementsByTensor(symInput));
+
+    tensor_t *output = makeFloatTensor(outputDims, 3, NULL);
+
+    avgPool1dForward(&layerStore, symInput, output);
+
+    for (size_t i = 0; i < expectedForward_avgPool1d_basic_len; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(5e-3f, expectedForward_avgPool1d_basic[i],
+                                 ((float *)output->data)[i]);
+    }
+}
+
 void setUp(void) {}
 void tearDown(void) {}
 
@@ -252,5 +298,6 @@ int main(void) {
     RUN_TEST(testAvgPool1dWithStrideAndDilation);
     RUN_TEST(testAvgPool1dWithSamePadding);
     RUN_TEST(testAvgPool1dEdgeCases);
+    RUN_TEST(testAvgPool1dForwardWithSymInt32Input);
     return UNITY_END();
 }

--- a/test/unit/layer/UnitTestConv1d.c
+++ b/test/unit/layer/UnitTestConv1d.c
@@ -1042,6 +1042,24 @@ void testConv1dCalcBiasGradsSymPointwise() {
     }
 }
 
+/* Re-gold (spec D5): conv1dBackward's dx wire (propLoss) is a *produced*
+ * wire, not a passthrough — convTranspose1dKernelSymInt32 emits the raw
+ * s_loss*s_w scatter-adjoint mantissa (characterized unrestored above by
+ * testConv1dKernelSymScatterStrideDilation), and executeOp's OUT_WRITE
+ * epilogue then requants it through the conversionMatrix diagonal to
+ * propLossQ's declared width (int12) before conv1dBackward returns it — the
+ * same restoration every other producer wire gets (forward output,
+ * weightGrad, biasGrad). The propLoss expectations below are therefore
+ * POST-restoration values, not the kernel's raw output; the old #187
+ * fail-fast (produced propLoss tensor must be SYM) this file used to lean on
+ * is retired along with the raw-wire validator
+ * (docs/conventions/arithmetic-sym.md). Dequant-equivalence: restored
+ * mantissa*restoredScale == raw mantissa*rawScale within representation
+ * tolerance — verified by generate_expected_conv1d.py's `emulate_sym_conv`
+ * dx section (`_requant_absmax_i12_f32`, dx_err <= dx_tol against the
+ * float64 PyTorch-autograd reference, computed on the RESTORED
+ * dx_deq/dx_scale). Same re-gold class as this file's forward pins above.
+ * Applies identically to the 2 other testConv1dBackwardSym* tests below. */
 void testConv1dBackwardSymExplicitPadding() {
     size_t weightDims[] = {3, 2, 7};
     size_t biasDims[] = {3};

--- a/test/unit/layer/UnitTestConv1d.c
+++ b/test/unit/layer/UnitTestConv1d.c
@@ -970,19 +970,24 @@ void testConv1dKernelSymScatterStrideDilation() {
     kernel_t kernel;
     initKernel(&kernel, 2, VALID, 2, 3); /* size=2, VALID, dilation=2, stride=3 */
 
+    /* Direct low-level kernel call — bypasses conv1dBackward's executeOp
+     * funnel entirely, so this characterizes convTranspose1dKernelSymInt32's
+     * own raw, unrestored output (the RawKernel fixtures), not the
+     * funnel-restored propLoss wire conv1dBackward now produces (design D3;
+     * see testConv1dBackwardSymStrideDilation for that). */
     convTranspose1dKernelSymInt32(lossGrad, weight, NULL, &kernel, 1, 0, propLoss);
 
     int32_t *m = (int32_t *)propLoss->data;
-    for (size_t i = 0; i < expectedPropLoss_conv1dSym_strideDilationSym_len; i++) {
-        TEST_ASSERT_INT_WITHIN(propLossMantissaTol_conv1dSym_strideDilationSym,
-                               expectedPropLoss_conv1dSym_strideDilationSym[i], m[i]);
+    for (size_t i = 0; i < expectedPropLossRawKernel_conv1dSym_strideDilationSym_len; i++) {
+        TEST_ASSERT_INT_WITHIN(propLossRawKernelMantissaTol_conv1dSym_strideDilationSym,
+                               expectedPropLossRawKernel_conv1dSym_strideDilationSym[i], m[i]);
     }
     float scale = symScaleOf(propLoss);
-    TEST_ASSERT_FLOAT_WITHIN(expectedPropLossScale_conv1dSym_strideDilationSym * 1e-4f,
-                             expectedPropLossScale_conv1dSym_strideDilationSym, scale);
-    for (size_t i = 0; i < expectedPropLossDequant_conv1dSym_strideDilationSym_len; i++) {
-        TEST_ASSERT_FLOAT_WITHIN(propLossDequantTol_conv1dSym_strideDilationSym,
-                                 expectedPropLossDequant_conv1dSym_strideDilationSym[i],
+    TEST_ASSERT_FLOAT_WITHIN(expectedPropLossRawKernelScale_conv1dSym_strideDilationSym * 1e-4f,
+                             expectedPropLossRawKernelScale_conv1dSym_strideDilationSym, scale);
+    for (size_t i = 0; i < expectedPropLossRawKernelDequant_conv1dSym_strideDilationSym_len; i++) {
+        TEST_ASSERT_FLOAT_WITHIN(propLossRawKernelDequantTol_conv1dSym_strideDilationSym,
+                                 expectedPropLossRawKernelDequant_conv1dSym_strideDilationSym[i],
                                  (float)m[i] * scale);
     }
 }

--- a/test/unit/layer/UnitTestConv1d.c
+++ b/test/unit/layer/UnitTestConv1d.c
@@ -794,6 +794,20 @@ void testConv1dBackwardExplicitPadding() {
     }
 }
 
+/* Re-gold (spec D5): conv1dForward now routes SYM through executeOp's
+ * OUT_WRITE epilogue, which requants the raw s_in*s_w accumulator wire
+ * through the conversionMatrix diagonal (requantSymInt32Tensor) instead of
+ * writing it unrestored (pre-PR1b.2 behavior — the fixture this test asserted
+ * against was the raw wire, characterizing exactly what a downstream
+ * Quantization layer used to restore). Dequant-equivalence: restored
+ * mantissa*restoredScale == raw mantissa*rawScale within representation
+ * tolerance (both are exact re-expressions of the same real value at a
+ * different int12 scale) — verified by generate_expected_conv1d.py's
+ * `emulate_sym_conv` self-check (fwd_err <= fwd_tol against the float64
+ * PyTorch-autograd reference, computed on the RESTORED fwd_deq/fwd_scale).
+ * Same re-gold class as Task 2's propLoss/Task 3's LayerNorm forward pins
+ * (ratified spec D5 principle, controller 2026-07-03). Applies identically
+ * to the 3 other testConv1dForwardSym* tests below. */
 void testConv1dForwardSymSingleChannelSingleBatch() {
     size_t weightDims[] = {1, 1, 2};
     size_t inputDims[] = {1, 1, 4};
@@ -816,7 +830,8 @@ void testConv1dForwardSymSingleChannelSingleBatch() {
                                expectedForward_conv1dSym_singleChannelSingleBatch[i], m[i]);
     }
     float scale = symScaleOf(output);
-    TEST_ASSERT_FLOAT_WITHIN(expectedForwardScale_conv1dSym_singleChannelSingleBatch * 1e-4f,
+    TEST_ASSERT_FLOAT_WITHIN(expectedForwardScale_conv1dSym_singleChannelSingleBatch *
+                                 forwardScaleTol_conv1dSym_singleChannelSingleBatch,
                              expectedForwardScale_conv1dSym_singleChannelSingleBatch, scale);
     for (size_t i = 0; i < expectedForwardDequant_conv1dSym_singleChannelSingleBatch_len; i++) {
         TEST_ASSERT_FLOAT_WITHIN(forwardDequantTol_conv1dSym_singleChannelSingleBatch,
@@ -849,7 +864,8 @@ void testConv1dForwardSymSingleChannelWithBias() {
                                expectedForward_conv1dSym_singleChannelWithBias[i], m[i]);
     }
     float scale = symScaleOf(output);
-    TEST_ASSERT_FLOAT_WITHIN(expectedForwardScale_conv1dSym_singleChannelWithBias * 1e-4f,
+    TEST_ASSERT_FLOAT_WITHIN(expectedForwardScale_conv1dSym_singleChannelWithBias *
+                                 forwardScaleTol_conv1dSym_singleChannelWithBias,
                              expectedForwardScale_conv1dSym_singleChannelWithBias, scale);
     for (size_t i = 0; i < expectedForwardDequant_conv1dSym_singleChannelWithBias_len; i++) {
         TEST_ASSERT_FLOAT_WITHIN(forwardDequantTol_conv1dSym_singleChannelWithBias,
@@ -882,7 +898,8 @@ void testConv1dForwardSymPointwise() {
                                expectedForward_conv1dSym_pointwise[i], m[i]);
     }
     float scale = symScaleOf(output);
-    TEST_ASSERT_FLOAT_WITHIN(expectedForwardScale_conv1dSym_pointwise * 1e-4f,
+    TEST_ASSERT_FLOAT_WITHIN(expectedForwardScale_conv1dSym_pointwise *
+                                 forwardScaleTol_conv1dSym_pointwise,
                              expectedForwardScale_conv1dSym_pointwise, scale);
     for (size_t i = 0; i < expectedForwardDequant_conv1dSym_pointwise_len; i++) {
         TEST_ASSERT_FLOAT_WITHIN(forwardDequantTol_conv1dSym_pointwise,
@@ -915,7 +932,8 @@ void testConv1dForwardSymExplicitPadding() {
                                expectedForward_conv1dSym_explicitPadding[i], m[i]);
     }
     float scale = symScaleOf(output);
-    TEST_ASSERT_FLOAT_WITHIN(expectedForwardScale_conv1dSym_explicitPadding * 1e-4f,
+    TEST_ASSERT_FLOAT_WITHIN(expectedForwardScale_conv1dSym_explicitPadding *
+                                 forwardScaleTol_conv1dSym_explicitPadding,
                              expectedForwardScale_conv1dSym_explicitPadding, scale);
     for (size_t i = 0; i < expectedForwardDequant_conv1dSym_explicitPadding_len; i++) {
         TEST_ASSERT_FLOAT_WITHIN(forwardDequantTol_conv1dSym_explicitPadding,

--- a/test/unit/layer/UnitTestConv1dTransposed.c
+++ b/test/unit/layer/UnitTestConv1dTransposed.c
@@ -100,6 +100,20 @@ static float symScaleOf(tensor_t *t) {
     return ((symInt32QConfig_t *)t->quantization->qConfig)->scale;
 }
 
+/* Re-gold (spec D5): conv1dTransposedForward now routes SYM through
+ * executeOp's OUT_WRITE epilogue, which requants the raw s_in*s_w
+ * accumulator wire through the conversionMatrix diagonal
+ * (requantSymInt32Tensor) instead of writing it unrestored (pre-PR1b.2
+ * behavior — the fixture this test asserted against was the raw wire).
+ * Dequant-equivalence: restored mantissa*restoredScale == raw
+ * mantissa*rawScale within representation tolerance (same real value
+ * re-expressed at a different int12 scale) — verified by
+ * generate_expected_conv1d_transposed.py's `emulate_sym_convT` self-check
+ * (fwd_err <= fwd_tol against the float64 PyTorch-autograd reference,
+ * computed on the RESTORED fwd_deq/fwd_scale). Same re-gold class as Task 2's
+ * propLoss/Task 3's LayerNorm/Conv1d's own forward pins (ratified spec D5
+ * principle). Applies identically to the 3 other
+ * testConv1dTransposedForwardSym* tests below. */
 void testConv1dTransposedForwardSymSingleChannelSingleBatch() {
     size_t weightDims[] = {1, 1, 2};
     size_t inputDims[] = {1, 1, 3};
@@ -129,7 +143,8 @@ void testConv1dTransposedForwardSymSingleChannelSingleBatch() {
                                expectedForward_convT1dSym_singleChannelSingleBatch[i], m[i]);
     }
     float scale = symScaleOf(output);
-    TEST_ASSERT_FLOAT_WITHIN(expectedForwardScale_convT1dSym_singleChannelSingleBatch * 1e-4f,
+    TEST_ASSERT_FLOAT_WITHIN(expectedForwardScale_convT1dSym_singleChannelSingleBatch *
+                                 forwardScaleTol_convT1dSym_singleChannelSingleBatch,
                              expectedForwardScale_convT1dSym_singleChannelSingleBatch, scale);
     for (size_t i = 0; i < expectedForwardDequant_convT1dSym_singleChannelSingleBatch_len; i++) {
         TEST_ASSERT_FLOAT_WITHIN(forwardDequantTol_convT1dSym_singleChannelSingleBatch,
@@ -520,7 +535,8 @@ void testConv1dTransposedForwardSymSingleChannelWithBias() {
                                expectedForward_convT1dSym_singleChannelWithBias[i], m[i]);
     }
     float scale = symScaleOf(output);
-    TEST_ASSERT_FLOAT_WITHIN(expectedForwardScale_convT1dSym_singleChannelWithBias * 1e-4f,
+    TEST_ASSERT_FLOAT_WITHIN(expectedForwardScale_convT1dSym_singleChannelWithBias *
+                                 forwardScaleTol_convT1dSym_singleChannelWithBias,
                              expectedForwardScale_convT1dSym_singleChannelWithBias, scale);
     for (size_t i = 0; i < expectedForwardDequant_convT1dSym_singleChannelWithBias_len; i++) {
         TEST_ASSERT_FLOAT_WITHIN(forwardDequantTol_convT1dSym_singleChannelWithBias,
@@ -558,7 +574,8 @@ void testConv1dTransposedForwardSymStride2() {
                                expectedForward_convT1dSym_stride2Sym[i], m[i]);
     }
     float scale = symScaleOf(output);
-    TEST_ASSERT_FLOAT_WITHIN(expectedForwardScale_convT1dSym_stride2Sym * 1e-4f,
+    TEST_ASSERT_FLOAT_WITHIN(expectedForwardScale_convT1dSym_stride2Sym *
+                                 forwardScaleTol_convT1dSym_stride2Sym,
                              expectedForwardScale_convT1dSym_stride2Sym, scale);
     for (size_t i = 0; i < expectedForwardDequant_convT1dSym_stride2Sym_len; i++) {
         TEST_ASSERT_FLOAT_WITHIN(forwardDequantTol_convT1dSym_stride2Sym,
@@ -598,7 +615,8 @@ void testConv1dTransposedForwardSymStride2OutputPadding() {
                                expectedForward_convT1dSym_stride2OutputPaddingSym[i], m[i]);
     }
     float scale = symScaleOf(output);
-    TEST_ASSERT_FLOAT_WITHIN(expectedForwardScale_convT1dSym_stride2OutputPaddingSym * 1e-4f,
+    TEST_ASSERT_FLOAT_WITHIN(expectedForwardScale_convT1dSym_stride2OutputPaddingSym *
+                                 forwardScaleTol_convT1dSym_stride2OutputPaddingSym,
                              expectedForwardScale_convT1dSym_stride2OutputPaddingSym, scale);
     for (size_t i = 0; i < expectedForwardDequant_convT1dSym_stride2OutputPaddingSym_len; i++) {
         TEST_ASSERT_FLOAT_WITHIN(forwardDequantTol_convT1dSym_stride2OutputPaddingSym,

--- a/test/unit/layer/UnitTestConv1dTransposed.c
+++ b/test/unit/layer/UnitTestConv1dTransposed.c
@@ -693,6 +693,23 @@ void testConv1dTransposedCalcBiasGradsSymMultiChannel() {
     }
 }
 
+/* Re-gold (spec D5): conv1dTransposedBackward's dx wire (propLoss) is a
+ * *produced* wire, not a passthrough — conv1dKernelSymInt32 (the VALID
+ * gather adjoint) emits the raw s_loss*s_w mantissa, and executeOp's
+ * OUT_WRITE epilogue then requants it through the conversionMatrix diagonal
+ * to propLossQ's declared width (int12) before conv1dTransposedBackward
+ * returns it — the same restoration every other producer wire gets (forward
+ * output, weightGrad, biasGrad). The propLoss expectations below are
+ * therefore POST-restoration values, not the kernel's raw output; the old
+ * #187 fail-fast (produced propLoss tensor must be SYM) is retired along
+ * with the raw-wire validator (docs/conventions/arithmetic-sym.md).
+ * Dequant-equivalence: restored mantissa*restoredScale == raw
+ * mantissa*rawScale within representation tolerance — verified by
+ * generate_expected_conv1d_transposed.py's `emulate_sym_convT` dx section
+ * (`_requant_absmax_i12_f32`, dx_err <= dx_tol against the float64
+ * PyTorch-autograd reference, computed on the RESTORED dx_deq/dx_scale).
+ * Same re-gold class as this file's forward pins above. Applies identically
+ * to the 2 other testConv1dTransposedBackwardSym* tests below. */
 void testConv1dTransposedBackwardSymStride2OutputPadding() {
     size_t weightDims[] = {1, 1, 2};
     size_t biasDims[] = {1};

--- a/test/unit/layer/UnitTestLayerNorm.c
+++ b/test/unit/layer/UnitTestLayerNorm.c
@@ -850,18 +850,32 @@ static void runGoldBackward(size_t numDims, const size_t *dims, const float *xVa
 /* SYM gold runner: forward over generated fixtures, then assert
  * (a) mantissas within +-mantissaTol of the float64 emulation (float32 stats
  *     noise can flip a rounding boundary; tol = 2*max|gamma_q|+1),
- * (b) output scale within 1e-4 relative of the emulated s_y,
+ * (b) output scale within scaleRelTol relative of the emulated s_y,
  * (c) dequantized output within dequantTol of F.layer_norm on the same
  *     dequantized inputs,
  * (d) for gamma=1/beta=0 fixtures: dequant within 3e-5 of PyTorch xhat (the
  *     spec-verified tolerance; generator guarantees absmax(xhat) <= 1.9), and
- * (e) per-group dequant variance within 5e-3 of var/(var+eps). */
+ * (e) per-group dequant variance within 5e-3 of var/(var+eps).
+ *
+ * PR1b.2 (Task 3): expMantissas/expScale/mantissaTol are now the RESTORED
+ * (post-executeOp-OUT_WRITE) values, not the affine stage's raw producer
+ * output — LayerNorm's SYM forward is an accumulator-range producer (same
+ * class as Linear/Conv1d's matmul, Finding A), so the funnel's mandatory
+ * SYM->SYM diagonal requant (requantSymInt32Tensor) now restores width at the
+ * producer instead of leaving it to a downstream Quantization layer. scaleTol
+ * widens beyond the old fixed 1e-4f: the restored scale is itself derived
+ * from an absmax over the (float32, C-vs-Python-noisy) mantissas, so it
+ * inherits the SAME per-element rounding-boundary noise the mantissas do,
+ * unlike the old raw sY (a direct product of two independently-computed
+ * scales, insensitive to mantissa noise). See
+ * generate_expected_layernorm_sym.py's `_restore_tolerances` for the
+ * empirical (perturbation-based) derivation of both. */
 static void runSymGoldForward(size_t numDims, const size_t *dims, size_t numNormDims,
                               const size_t *normShapeIn, const float *xVals, const float *gammaVals,
                               const float *betaVals, const int32_t *expMantissas, float expScale,
                               int32_t mantissaTol, const float *expDequant, float dequantTol,
-                              const float *expXhat, const float *expGroupVarRatio, size_t groups,
-                              size_t count) {
+                              float scaleRelTol, const float *expXhat,
+                              const float *expGroupVarRatio, size_t groups, size_t count) {
     TEST_ASSERT_TRUE_MESSAGE(count > 0 && count <= 64, "fixture exceeds capture buffer");
     size_t normCount = count / groups;
 
@@ -899,7 +913,7 @@ static void runSymGoldForward(size_t numDims, const size_t *dims, size_t numNorm
     for (size_t i = 0; i < count; i++) {
         TEST_ASSERT_INT_WITHIN(mantissaTol, expMantissas[i], m[i]);
     }
-    TEST_ASSERT_FLOAT_WITHIN(expScale * 1e-4f, expScale, scale);
+    TEST_ASSERT_FLOAT_WITHIN(expScale * scaleRelTol, expScale, scale);
     for (size_t i = 0; i < count; i++) {
         float deq = (float)m[i] * scale;
         TEST_ASSERT_FLOAT_WITHIN(dequantTol, expDequant[i], deq);
@@ -1091,7 +1105,7 @@ void testSymGoldParityMultiGroup(void) {
                       beta_layerNormSym_symParity, expectedMantissas_layerNormSym_symParity,
                       expectedScale_layerNormSym_symParity, mantissaTol_layerNormSym_symParity,
                       expectedDequant_layerNormSym_symParity, dequantTol_layerNormSym_symParity,
-                      expectedXhat_layerNormSym_symParity,
+                      scaleTol_layerNormSym_symParity, expectedXhat_layerNormSym_symParity,
                       expectedGroupVarRatio_layerNormSym_symParity, 3,
                       expectedMantissas_layerNormSym_symParity_len);
 }
@@ -1103,7 +1117,8 @@ void testSymGoldAffine(void) {
                       beta_layerNormSym_symAffine, expectedMantissas_layerNormSym_symAffine,
                       expectedScale_layerNormSym_symAffine, mantissaTol_layerNormSym_symAffine,
                       expectedDequant_layerNormSym_symAffine, dequantTol_layerNormSym_symAffine,
-                      NULL, NULL, 2, expectedMantissas_layerNormSym_symAffine_len);
+                      scaleTol_layerNormSym_symAffine, NULL, NULL, 2,
+                      expectedMantissas_layerNormSym_symAffine_len);
 }
 
 void testSymGoldSigmaRatio10x(void) {
@@ -1114,8 +1129,9 @@ void testSymGoldSigmaRatio10x(void) {
         beta_layerNormSym_symSigmaRatio, expectedMantissas_layerNormSym_symSigmaRatio,
         expectedScale_layerNormSym_symSigmaRatio, mantissaTol_layerNormSym_symSigmaRatio,
         expectedDequant_layerNormSym_symSigmaRatio, dequantTol_layerNormSym_symSigmaRatio,
-        expectedXhat_layerNormSym_symSigmaRatio, expectedGroupVarRatio_layerNormSym_symSigmaRatio,
-        2, expectedMantissas_layerNormSym_symSigmaRatio_len);
+        scaleTol_layerNormSym_symSigmaRatio, expectedXhat_layerNormSym_symSigmaRatio,
+        expectedGroupVarRatio_layerNormSym_symSigmaRatio, 2,
+        expectedMantissas_layerNormSym_symSigmaRatio_len);
 }
 
 /* Small-variance fixture: var (1.25e-6) is comparable to eps (1e-5), so this
@@ -1251,16 +1267,25 @@ void testSymForwardConstantInputEmitsZeros(void) {
 }
 
 /* The affine with gamma=ones multiplies every normalized mantissa by exactly
- * the gamma operand qMax. At int12 operands (#227) gamma=ones quantizes to
- * qMax=2047 (absmax=1 -> every gamma_q = 2047) and beta=zeros -> seed=0, so
- * y_q = qNorm * 2047 EXACTLY. Recover qNorm = y_q/2047 (remainder must be 0 —
- * pins that the gamma multiply actually happened) and assert the
- * normalization-stage invariants: full-range stretch (max |qNorm| == 2047, the
- * normalized output also saturates to the int12 qMax) and near-zero per-group
+ * the gamma operand qMax (2047 at int12, #227) and beta=zeros -> seed=0, so
+ * the affine's RAW output is qNorm*2047 EXACTLY at scale sNorm/2047.
+ *
+ * PR1b.2 (Task 3, re-gold — LayerNorm is an accumulator-range producer,
+ * Finding A, same class as Linear/Conv1d's matmul): executeOp's OUT_WRITE
+ * epilogue now restores width via the SYM->SYM diagonal requant
+ * (requantSymInt32Tensor) instead of leaving the raw qNorm*2047 mantissas for
+ * a downstream Quantization layer. Because the requant's absmax is computed
+ * from the SAME dequantized values (qNorm*2047 * sNorm/2047 == qNorm*sNorm),
+ * the restored scale becomes EXACTLY sNorm and the restored mantissas become
+ * EXACTLY qNorm again — the gamma-multiply and the requant's own divide
+ * cancel algebraically (qNorm*2047 * (sNorm/2047) / sNorm == qNorm). This
+ * fixture is therefore a lossless round-trip BACK to the normalization
+ * stage's own mantissas; assert the SAME normalization-stage invariants
+ * directly on the (now-restored) output: full-range stretch (max |m| == 2047,
+ * the normalized output saturates to the int12 qMax) and near-zero per-group
  * mantissa sums (Σ n == 0 exactly in real arithmetic; rounding adds <= 0.5/
  * element, so |Σ qNorm| <= N/2 = 2, asserted within the width-independent
- * [-4, 4]). Pure width substitution from the int16 era (32767 -> 2047); the
- * structural invariant is unchanged. */
+ * [-4, 4]). */
 void testSymForwardMantissaInvariantsViaOnesGamma(void) {
     size_t dims[] = {2, 4};
     tensor_t *in =
@@ -1295,12 +1320,9 @@ void testSymForwardMantissaInvariantsViaOnesGamma(void) {
     freeTensor(out);
     freeTensor(in);
 
-    int32_t qNorm[8];
     int32_t maxAbs = 0;
     for (size_t i = 0; i < 8; i++) {
-        TEST_ASSERT_EQUAL_INT(0, m[i] % 2047);
-        qNorm[i] = m[i] / 2047;
-        int32_t a = (qNorm[i] < 0) ? -qNorm[i] : qNorm[i];
+        int32_t a = (m[i] < 0) ? -m[i] : m[i];
         if (a > maxAbs) {
             maxAbs = a;
         }
@@ -1309,7 +1331,7 @@ void testSymForwardMantissaInvariantsViaOnesGamma(void) {
     for (size_t g = 0; g < 2; g++) {
         int32_t sum = 0;
         for (size_t j = 0; j < 4; j++) {
-            sum += qNorm[g * 4 + j];
+            sum += m[g * 4 + j];
         }
         TEST_ASSERT_TRUE(sum >= -4 && sum <= 4);
     }
@@ -1318,8 +1340,19 @@ void testSymForwardMantissaInvariantsViaOnesGamma(void) {
 /* Constant input + nonzero beta: y = gamma*0 + beta. Pins (a) the affine runs
  * AFTER the constant guard, (b) the beta-rescale idiom (raw beta_q would
  * dequantize to 2x the right value here since s_beta = 0.5/2047 != s_y), and
- * (c) the post-affine output scale s_y = s_norm * s_gamma = 1/2047 (int12
- * operand gamma=ones quantizes to qMax=2047 with scale 1/2047, #227). */
+ * (c) PR1b.2's producer-restored output scale (LayerNorm's affine output is an
+ * accumulator-range producer, Finding A — executeOp's OUT_WRITE epilogue
+ * restores width via the SYM->SYM diagonal requant, same as Linear/Conv1d).
+ *
+ * Derivation of the restored scale: betaScale = absmax(beta)/2047 = 0.5/2047;
+ * betaQ = round(beta/betaScale) = round(beta*4094) = [2047, -1024, 512]
+ * (half-away: -1023.5 -> -1024). Pre-restoration affine raw output is
+ * seed_j = round(betaQ_j * betaScale/sY) with the raw producer scale
+ * sY = sNorm*gammaScale = 1.0*(1/2047) (constant input -> sNorm=1, gamma=ones
+ * -> gammaScale=1/2047): seed = round(betaQ_j * 0.5) = [1024, -512, 256] (all
+ * exact, no .5 ties). The requant's absmax over these raw mantissas is 1024
+ * (at scale sY), so the restored scale is max(|seed_j|)/2047 * sY =
+ * 1024/2047 * (1/2047). */
 void testSymForwardConstantInputAppliesBeta(void) {
     size_t dims[] = {2, 3};
     tensor_t *in = buildSymInt32TensorND(2, dims, (float[]){7.f, 7.f, 7.f, 7.f, 7.f, 7.f});
@@ -1354,7 +1387,7 @@ void testSymForwardConstantInputAppliesBeta(void) {
     freeTensor(out);
     freeTensor(in);
 
-    float expectedScale = 1.0f / 2047.0f;
+    float expectedScale = (1024.0f / 2047.0f) / 2047.0f;
     TEST_ASSERT_FLOAT_WITHIN(expectedScale * 1e-4f, expectedScale, scale);
     float expBeta[] = {0.5f, -0.25f, 0.125f};
     for (size_t g = 0; g < 2; g++) {

--- a/test/unit/layer/UnitTestLinear.c
+++ b/test/unit/layer/UnitTestLinear.c
@@ -1482,6 +1482,37 @@ void testLinearBackwardWithoutBiasDoesNotCrash(void) {
     TEST_ASSERT_EQUAL_FLOAT(0.5f, wg00); /* loss[0,0]*fwdIn[0,0] = 0.5*1 */
 }
 
+/* Regression net for the bias-NULL-deref fix bundled into the forward funnel
+ * migration (Task 3 of PR1b.2): pre-migration, linearForward unconditionally
+ * called getParamFromParameter(cfg->bias) even when bias == NULL, crashing on
+ * any bias-disabled layer's forward call — untested until the funnel's
+ * operand-array construction forced the NULL check to be added. Mirrors
+ * testLinearBackwardWithoutBiasDoesNotCrash's fixture shape. */
+void testLinearForwardWithoutBiasDoesNotCrash(void) {
+    quantization_t *q = quantizationInitFloat();
+    layerQuant_t lq;
+    layerQuantInitUniform(&lq, q);
+    layer_t *layer = linearLayerInit(
+        &(linearInit_t){.inFeatures = 3, .outFeatures = 2, .bias = BIAS_FALSE}, &lq);
+    layerLoadWeights(layer, (float[]){-1.f, 2.f, -3.f, 4.f, 5.f, -6.f}, NULL);
+
+    tensor_t *input = buildFloatTensor2d(1, 3, (float[]){0.f, 1.f, 2.f});
+    tensor_t *output = buildFloatTensor2d(1, 2, (float[]){0.f, 0.f});
+
+    layerFunctions[LINEAR].forward(layer, input, output);
+
+    bool biasIsNull = (layer->config->linear->bias == NULL);
+    float out0 = ((float *)output->data)[0];
+    float out1 = ((float *)output->data)[1];
+    freeTensor(output);
+    freeTensor(input);
+    freeLinearLayer(layer);
+    freeQuantization(q);
+    TEST_ASSERT_TRUE(biasIsNull);
+    TEST_ASSERT_EQUAL_FLOAT(-4.f, out0); /* -1*0 + 2*1 + -3*2 = -4 */
+    TEST_ASSERT_EQUAL_FLOAT(-7.f, out1); /*  4*0 + 5*1 + -6*2 = -7 */
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(testLinearForwardFloat);
@@ -1512,5 +1543,6 @@ int main(void) {
     RUN_TEST(testLinearLayerInitDefaultWeightsWithinPyTorchBound);
     RUN_TEST(testLinearLayerInitXavierUniformOverrideUsesGlorotBound);
     RUN_TEST(testLinearBackwardWithoutBiasDoesNotCrash);
+    RUN_TEST(testLinearForwardWithoutBiasDoesNotCrash);
     return UNITY_END();
 }

--- a/test/unit/layer/UnitTestMaxPool1d.c
+++ b/test/unit/layer/UnitTestMaxPool1d.c
@@ -296,6 +296,16 @@ void testMaxPool1dWithStrideAndDilation(void) {
                                  ((float *)r.output->data)[i]);
     }
 
+    // auxOut integration (spec Testing list): argmaxIndices now flows through
+    // opSpec_t.auxOut (kernel-written verbatim, never funnel-converted) —
+    // assert it is byte-identical to this pre-migration, unregenerated
+    // fixture (a non-trivial dilation/stride pattern, unlike the other
+    // argmax-checking tests' simpler geometries).
+    int32_t const *argmaxActual = (int32_t const *)r.argmax->data;
+    for (size_t i = 0; i < expectedArgmax_maxPool1d_withStrideAndDilation_len; i++) {
+        TEST_ASSERT_EQUAL_INT32(expectedArgmax_maxPool1d_withStrideAndDilation[i], argmaxActual[i]);
+    }
+
     // Use the gold-emitted random lossGrad (NOT ones), so positional mutations
     // on the backward path are non-vacuous (codebase_uniform_lossgrad_mutation_vacuity).
     tensor_t *lossGrad = makeFloatTensor(outputDims, 3, lossGrad_maxPool1d_withStrideAndDilation);

--- a/test/unit/layer/generate_expected_conv1d.py
+++ b/test/unit/layer/generate_expected_conv1d.py
@@ -393,6 +393,22 @@ def _requant_absmax_f32(mac_int: torch.Tensor, in_scale: float):
     return q.to(torch.int32), scale.item()
 
 
+def _requant_absmax_i12_f32(mac_int: torch.Tensor, in_scale: float):
+    """PR1b.2 (design D3): propLoss now routes through executeOp's OUT_WRITE
+    epilogue; for a SYM_INT32 target this hits the conversionMatrix diagonal
+    (requantSymInt32Tensor, TensorConversion.c) instead of a raw direct write.
+    Mirrors _requant_absmax_f32 above but at propLossQ's declared qMaxBits=12
+    (int12) instead of the grad contract's 16 — same dequant(f32) -> absmax(f32)
+    -> scale=absmax/2047(f32) -> round_half_away(clamp(...)) sequence."""
+    deq = mac_int.to(torch.float32) * torch.tensor(in_scale, dtype=torch.float32)
+    absmax = deq.abs().max().to(torch.float32)
+    if absmax.item() == 0.0:
+        return torch.zeros_like(mac_int, dtype=torch.int32), 1.0
+    scale = (absmax / QMAX_I12)
+    q = round_half_away(torch.clamp(deq / scale, QMIN_I12, QMAX_I12))
+    return q.to(torch.int32), scale.item()
+
+
 def _autograd_ref_f64(q, p):
     """float64 torch-autograd on the EXACT dequantized inputs (q*s in f64) — the true
     grads the SYM dequants must track within analytic bounds."""
@@ -421,7 +437,7 @@ def emulate_sym_conv(fx):
     q = _quant_inputs(fx)
     fwd_mac, dw_mac, dx_mac = _int_mac(q, p)
     out_scale = f32_mul(q["s_in"], q["s_w"])          # forward output scale
-    dx_scale = f32_mul(q["s_loss"], q["s_w"])         # propLoss scale = s_loss * s_w
+    dx_scale_raw = f32_mul(q["s_loss"], q["s_w"])     # propLoss RAW scatter scale (pre-PR1b.2)
     inter_scale = f32_mul(q["s_loss"], q["s_in"])     # weightGrad intermediate scale
 
     # forward: int MAC + per-channel bias seed (float32 refold)
@@ -437,8 +453,19 @@ def emulate_sym_conv(fx):
         fwd_mtol = 0
     fwd_deq = fwd_q.to(torch.float32) * torch.tensor(out_scale, dtype=torch.float32)
 
-    # dx (propLoss): raw scatter, no requant, no bias
-    dx_q = dx_mac.to(torch.int32)
+    # dx (propLoss): PR1b.2 (design D3) routes propLoss through executeOp's
+    # OUT_WRITE epilogue; for a SYM_INT32 target this requants through the
+    # conversionMatrix diagonal (requantSymInt32Tensor) instead of writing the
+    # raw, unrestored accumulator-range scatter directly (pre-PR1b.2 behavior).
+    # Mirrors weightGrad's existing Strategy-A requant (_requant_absmax_f32)
+    # but at propLossQ's declared qMaxBits=12 (int12), not the grad qMaxBits=16.
+    # dx_raw_* keeps the pre-restoration values: testConv1dKernelSymScatterStrideDilation
+    # calls convTranspose1dKernelSymInt32 directly (the low-level scatter
+    # kernel, not conv1dBackward), so it must keep pinning the kernel's own
+    # raw, unrestored output.
+    dx_raw_q = dx_mac.to(torch.int32)
+    dx_raw_deq = dx_raw_q.to(torch.float32) * torch.tensor(dx_scale_raw, dtype=torch.float32)
+    dx_q, dx_scale = _requant_absmax_i12_f32(dx_mac, dx_scale_raw)
     dx_deq = dx_q.to(torch.float32) * torch.tensor(dx_scale, dtype=torch.float32)
 
     # weightGrad: strategy A requant of the int gather from a zero grad
@@ -466,6 +493,7 @@ def emulate_sym_conv(fx):
     _eps32 = float(torch.finfo(torch.float32).eps)
     fwd_f32_prec = fwd_q.abs().max().item() * out_scale * _eps32
     dx_f32_prec = dx_q.abs().max().item() * dx_scale * _eps32
+    dx_raw_f32_prec = dx_raw_q.abs().max().item() * dx_scale_raw * _eps32
 
     # forward dequant tracks the true (quantized-input) conv within quantization noise + f32 ULP
     fwd_err = (fwd_deq.to(torch.float64) - ref_y).abs().max().item()
@@ -475,6 +503,11 @@ def emulate_sym_conv(fx):
     dx_err = (dx_deq.to(torch.float64) - ref_dx).abs().max().item()
     dx_tol = 8.0 * dx_scale + dx_f32_prec + 1e-9
     assert dx_err <= dx_tol, f"{fx['name']}: dx emulation err {dx_err} > tol {dx_tol}"
+    # dx_raw (pre-restoration, direct-kernel characterization) tracks the same autograd dx
+    dx_raw_err = (dx_raw_deq.to(torch.float64) - ref_dx).abs().max().item()
+    dx_raw_tol = 8.0 * dx_scale_raw + dx_raw_f32_prec + 1e-9
+    assert dx_raw_err <= dx_raw_tol, \
+        f"{fx['name']}: dx_raw emulation err {dx_raw_err} > tol {dx_raw_tol}"
     # weightGrad dequant tracks autograd dw (increment-quant + requant + drift)
     dw_err = (dw_q.to(torch.float64) * dw_scale - ref_dw.reshape(-1).reshape(dw_q.shape)
               ).abs().max().item()
@@ -492,6 +525,8 @@ def emulate_sym_conv(fx):
         fwd_mtol=fwd_mtol, fwd_dtol=8.0 * out_scale + fwd_f32_prec + 1e-6,
         dx_q=dx_q, dx_scale=dx_scale, dx_deq=ref_dx.to(torch.float32),
         dx_mtol=0, dx_dtol=8.0 * dx_scale + dx_f32_prec + 1e-6,
+        dx_raw_q=dx_raw_q, dx_raw_scale=dx_scale_raw, dx_raw_deq=ref_dx.to(torch.float32),
+        dx_raw_mtol=0, dx_raw_dtol=8.0 * dx_scale_raw + dx_raw_f32_prec + 1e-6,
         dw_q=dw_q, dw_scale=dw_scale, dw_deq=ref_dw.to(torch.float32),
         dw_mtol=2, dw_dtol=(0.5 * inter_scale + 2.5 * dw_scale) * 1.5 + 1e-6,
         db_q=db_q, db_scale=db_scale,
@@ -530,12 +565,22 @@ def emit_sym_fixture(parts, fx):
     parts.append(emit_int32_scalar(f"forwardMantissaTol_{pre}", g["fwd_mtol"]))
     parts.append(emit_float_array(f"expectedForwardDequant_{pre}", g["fwd_deq"]))
     parts.append(emit_float_scalar(f"forwardDequantTol_{pre}", g["fwd_dtol"]))
-    # dx / propLoss
+    # dx / propLoss (width-restored, as conv1dBackward now writes it — design D3)
     parts.append(emit_int32_array(f"expectedPropLoss_{pre}", g["dx_q"]))
     parts.append(emit_float_scalar(f"expectedPropLossScale_{pre}", g["dx_scale"]))
     parts.append(emit_int32_scalar(f"propLossMantissaTol_{pre}", g["dx_mtol"]))
     parts.append(emit_float_array(f"expectedPropLossDequant_{pre}", g["dx_deq"]))
     parts.append(emit_float_scalar(f"propLossDequantTol_{pre}", g["dx_dtol"]))
+    # dx / propLoss RAW (pre-restoration): for tests that call
+    # convTranspose1dKernelSymInt32/conv1dKernelSymInt32 directly, bypassing
+    # conv1dBackward's executeOp funnel entirely (e.g.
+    # testConv1dKernelSymScatterStrideDilation) — these still characterize the
+    # low-level kernel's own raw, unrestored output.
+    parts.append(emit_int32_array(f"expectedPropLossRawKernel_{pre}", g["dx_raw_q"]))
+    parts.append(emit_float_scalar(f"expectedPropLossRawKernelScale_{pre}", g["dx_raw_scale"]))
+    parts.append(emit_int32_scalar(f"propLossRawKernelMantissaTol_{pre}", g["dx_raw_mtol"]))
+    parts.append(emit_float_array(f"expectedPropLossRawKernelDequant_{pre}", g["dx_raw_deq"]))
+    parts.append(emit_float_scalar(f"propLossRawKernelDequantTol_{pre}", g["dx_raw_dtol"]))
     # weightGrad
     parts.append(emit_int32_array(f"expectedWeightGrad_{pre}", g["dw_q"]))
     parts.append(emit_float_scalar(f"expectedWeightGradScale_{pre}", g["dw_scale"]))

--- a/test/unit/layer/generate_expected_conv1d.py
+++ b/test/unit/layer/generate_expected_conv1d.py
@@ -11,6 +11,7 @@ explicit-padding fixtures (and all SYM grad fixtures) use a random
 (torch.randn) lossGrad to avoid output-channel vacuity in the gradients.
 """
 import argparse
+import math
 import sys
 from pathlib import Path
 
@@ -409,6 +410,47 @@ def _requant_absmax_i12_f32(mac_int: torch.Tensor, in_scale: float):
     return q.to(torch.int32), scale.item()
 
 
+def _restore_tolerances(raw_q, raw_scale, mtol_before, base_q, base_scale):
+    """Empirically DERIVE (not hand-guess) the restored (mantissa,
+    scale-relative) tolerances for a raw producer wire PR1b.2 now restores via
+    _requant_absmax_i12_f32 — mirrors the LayerNorm forward precedent
+    (generate_expected_layernorm_sym.py::_restore_tolerances, PR1b.2 Task 3).
+    Perturb the RAW pre-restoration mantissas by their own worst-case
+    C-vs-emulation noise band (+-mtol_before — the bias-seed rounding-
+    boundary ambiguity the forward fixture already carries pre-restoration),
+    applied elementwise AND concentrated at the argmax element (which drives
+    the requant's absmax renormalization), and measure how far the restored
+    mantissas/scale actually move under the SAME transform. A fixed 1.5x
+    safety margin is applied to the observed worst case; no independent C run
+    is available at generation time, so this calibrates against the real
+    transform instead of trusting an analytic closed-form propagation."""
+    # Floor at 1e-4 relative: the pre-existing (pre-PR1b.2) convention for
+    # every SYM scale assertion in this file, kept as a defensive margin
+    # against ordinary float32 noise even when no bias-seed ambiguity exists
+    # (mtol_before == 0) to perturb against.
+    floor = 1e-4
+    if mtol_before == 0:
+        return 0, floor
+    idx = int(raw_q.abs().reshape(-1).argmax().item())
+    variants = [raw_q + mtol_before, raw_q - mtol_before]
+    for delta in (mtol_before, -mtol_before):
+        v = raw_q.clone()
+        v.reshape(-1)[idx] += delta
+        variants.append(v)
+    max_mdiff = 0
+    max_sdiff = 0.0
+    for variant in variants:
+        vq, vs = _requant_absmax_i12_f32(variant, raw_scale)
+        mdiff = int((vq.to(torch.int64) - base_q.to(torch.int64)).abs().max().item())
+        sdiff = abs(vs - base_scale) / base_scale
+        max_mdiff = max(max_mdiff, mdiff)
+        max_sdiff = max(max_sdiff, sdiff)
+    margin = 1.5
+    mantissa_tol_r = int(math.ceil(max_mdiff * margin)) + 1
+    scale_rel_tol_r = max(max_sdiff * margin, floor)
+    return mantissa_tol_r, scale_rel_tol_r
+
+
 def _autograd_ref_f64(q, p):
     """float64 torch-autograd on the EXACT dequantized inputs (q*s in f64) — the true
     grads the SYM dequants must track within analytic bounds."""
@@ -436,22 +478,39 @@ def emulate_sym_conv(fx):
     p = _conv_params(fx)
     q = _quant_inputs(fx)
     fwd_mac, dw_mac, dx_mac = _int_mac(q, p)
-    out_scale = f32_mul(q["s_in"], q["s_w"])          # forward output scale
+    out_scale = f32_mul(q["s_in"], q["s_w"])          # RAW forward accumulator scale (s_in*s_w)
     dx_scale_raw = f32_mul(q["s_loss"], q["s_w"])     # propLoss RAW scatter scale (pre-PR1b.2)
     inter_scale = f32_mul(q["s_loss"], q["s_in"])     # weightGrad intermediate scale
 
-    # forward: int MAC + per-channel bias seed (float32 refold)
+    # forward: int MAC + per-channel bias seed (float32 refold), at the RAW
+    # s_in*s_w accumulator scale — matches conv1dKernelSymInt32's own direct
+    # output today (pre-PR1b.2: this raw wire is what a downstream
+    # Quantization layer used to restore).
     out_channels = fwd_mac.shape[1]
     if q["bq"] is not None:
         seed = _round_away_f32(q["bq"].to(torch.float32)
                                * torch.tensor(q["s_b"], dtype=torch.float32)
                                / torch.tensor(out_scale, dtype=torch.float32)).to(torch.int64)
-        fwd_q = (fwd_mac + seed.reshape(1, out_channels, 1)).to(torch.int32)
-        fwd_mtol = 1
+        fwd_raw_q = (fwd_mac + seed.reshape(1, out_channels, 1)).to(torch.int32)
+        fwd_mtol_raw = 1
     else:
-        fwd_q = fwd_mac.to(torch.int32)
-        fwd_mtol = 0
-    fwd_deq = fwd_q.to(torch.float32) * torch.tensor(out_scale, dtype=torch.float32)
+        fwd_raw_q = fwd_mac.to(torch.int32)
+        fwd_mtol_raw = 0
+    # PR1b.2 (design D3): conv1dForward now routes through executeOp's
+    # OUT_WRITE epilogue; a SYM_INT32 target hits the conversionMatrix
+    # diagonal (requantSymInt32Tensor) instead of the raw direct kernel write
+    # above (pre-PR1b.2 behavior) — the same restoration propLoss already got
+    # in Task 2, at the same declared qMaxBits=12 (_requant_absmax_i12_f32).
+    fwd_q, fwd_scale = _requant_absmax_i12_f32(fwd_raw_q, out_scale)
+    fwd_deq = fwd_q.to(torch.float32) * torch.tensor(fwd_scale, dtype=torch.float32)
+    # The restored scale is now itself derived from an absmax over the
+    # (float32, C-vs-Python-noisy) mantissas — sensitive to the same
+    # bias-seed rounding-boundary noise the mantissas are, unlike the old raw
+    # out_scale (a direct product of two independently-computed scales,
+    # insensitive to that noise). Empirically derive both tolerances instead
+    # of trusting the pre-restoration fwd_mtol_raw/hardcoded 1e-4 relative.
+    fwd_mtol, fwd_scale_tol = _restore_tolerances(fwd_raw_q, out_scale, fwd_mtol_raw, fwd_q,
+                                                  fwd_scale)
 
     # dx (propLoss): PR1b.2 (design D3) routes propLoss through executeOp's
     # OUT_WRITE epilogue; for a SYM_INT32 target this requants through the
@@ -491,13 +550,13 @@ def emulate_sym_conv(fx):
     # loses low bits. The C dequant (int32_val * scale) in float32 has the same precision
     # as our emulation, so the tolerance must include this f32 ULP term.
     _eps32 = float(torch.finfo(torch.float32).eps)
-    fwd_f32_prec = fwd_q.abs().max().item() * out_scale * _eps32
+    fwd_f32_prec = fwd_q.abs().max().item() * fwd_scale * _eps32
     dx_f32_prec = dx_q.abs().max().item() * dx_scale * _eps32
     dx_raw_f32_prec = dx_raw_q.abs().max().item() * dx_scale_raw * _eps32
 
     # forward dequant tracks the true (quantized-input) conv within quantization noise + f32 ULP
     fwd_err = (fwd_deq.to(torch.float64) - ref_y).abs().max().item()
-    fwd_tol = 8.0 * out_scale + fwd_f32_prec + 1e-9
+    fwd_tol = 8.0 * fwd_scale + fwd_f32_prec + 1e-9
     assert fwd_err <= fwd_tol, f"{fx['name']}: fwd emulation err {fwd_err} > tol {fwd_tol}"
     # dx dequant tracks autograd dx (+ f32 ULP term for large mantissas)
     dx_err = (dx_deq.to(torch.float64) - ref_dx).abs().max().item()
@@ -521,8 +580,9 @@ def emulate_sym_conv(fx):
     return dict(
         name=fx["name"], has_bias=q["bq"] is not None,
         x_deq=q["x_deq"], w_deq=q["w_deq"], b_deq=q["b_deq"], gy_deq=q["gy_deq"],
-        fwd_q=fwd_q, fwd_scale=out_scale, fwd_deq=ref_y.to(torch.float32),
-        fwd_mtol=fwd_mtol, fwd_dtol=8.0 * out_scale + fwd_f32_prec + 1e-6,
+        fwd_q=fwd_q, fwd_scale=fwd_scale, fwd_deq=ref_y.to(torch.float32),
+        fwd_mtol=fwd_mtol, fwd_dtol=8.0 * fwd_scale + fwd_f32_prec + 1e-6,
+        fwd_scale_tol=fwd_scale_tol,
         dx_q=dx_q, dx_scale=dx_scale, dx_deq=ref_dx.to(torch.float32),
         dx_mtol=0, dx_dtol=8.0 * dx_scale + dx_f32_prec + 1e-6,
         dx_raw_q=dx_raw_q, dx_raw_scale=dx_scale_raw, dx_raw_deq=ref_dx.to(torch.float32),
@@ -559,12 +619,13 @@ def emit_sym_fixture(parts, fx):
     if g["has_bias"]:
         parts.append(emit_float_array(f"bias_{pre}", g["b_deq"]))
     parts.append(emit_float_array(f"lossGrad_{pre}", g["gy_deq"]))
-    # forward
+    # forward (width-restored, as conv1dForward now writes it — design D3)
     parts.append(emit_int32_array(f"expectedForward_{pre}", g["fwd_q"]))
     parts.append(emit_float_scalar(f"expectedForwardScale_{pre}", g["fwd_scale"]))
     parts.append(emit_int32_scalar(f"forwardMantissaTol_{pre}", g["fwd_mtol"]))
     parts.append(emit_float_array(f"expectedForwardDequant_{pre}", g["fwd_deq"]))
     parts.append(emit_float_scalar(f"forwardDequantTol_{pre}", g["fwd_dtol"]))
+    parts.append(emit_float_scalar(f"forwardScaleTol_{pre}", g["fwd_scale_tol"]))
     # dx / propLoss (width-restored, as conv1dBackward now writes it — design D3)
     parts.append(emit_int32_array(f"expectedPropLoss_{pre}", g["dx_q"]))
     parts.append(emit_float_scalar(f"expectedPropLossScale_{pre}", g["dx_scale"]))

--- a/test/unit/layer/generate_expected_conv1d_transposed.py
+++ b/test/unit/layer/generate_expected_conv1d_transposed.py
@@ -239,6 +239,22 @@ def _requant_absmax_f32(mac_int: torch.Tensor, in_scale: float):
     return q.to(torch.int32), scale.item()
 
 
+def _requant_absmax_i12_f32(mac_int: torch.Tensor, in_scale: float):
+    """PR1b.2 (design D3): propLoss now routes through executeOp's OUT_WRITE
+    epilogue; for a SYM_INT32 target this hits the conversionMatrix diagonal
+    (requantSymInt32Tensor, TensorConversion.c) instead of a raw direct write.
+    Mirrors _requant_absmax_f32 above but at propLossQ's declared qMaxBits=12
+    (int12) instead of the grad contract's 16 — same dequant(f32) -> absmax(f32)
+    -> scale=absmax/2047(f32) -> round_half_away(clamp(...)) sequence."""
+    deq = mac_int.to(torch.float32) * torch.tensor(in_scale, dtype=torch.float32)
+    absmax = deq.abs().max().to(torch.float32)
+    if absmax.item() == 0.0:
+        return torch.zeros_like(mac_int, dtype=torch.int32), 1.0
+    scale = (absmax / QMAX_I12)
+    q = round_half_away(torch.clamp(deq / scale, QMIN_I12, QMAX_I12))
+    return q.to(torch.int32), scale.item()
+
+
 def _autograd_ref_f64(q, p):
     """float64 torch-autograd on the EXACT dequantized inputs (q*s in f64) — the true grads."""
     x64 = (q["xq"].to(torch.float64) * q["s_in"]).requires_grad_(True)
@@ -263,7 +279,7 @@ def emulate_sym_convT(fx):
     q = _quant_inputs(fx)
     fwd_mac, dw_mac, dx_mac = _int_mac(q, p)
     out_scale = f32_mul(q["s_in"], q["s_w"])          # forward output scale
-    dx_scale = f32_mul(q["s_loss"], q["s_w"])         # propLoss scale = s_loss * s_w
+    dx_scale_raw = f32_mul(q["s_loss"], q["s_w"])     # propLoss RAW gather-adjoint scale (pre-PR1b.2)
     inter_scale = f32_mul(q["s_loss"], q["s_in"])     # weightGrad intermediate scale
 
     # forward: int MAC + per-channel bias seed (float32 refold)
@@ -279,8 +295,13 @@ def emulate_sym_convT(fx):
         fwd_mtol = 0
     fwd_deq = fwd_q.to(torch.float32) * torch.tensor(out_scale, dtype=torch.float32)
 
-    # dx (propLoss): raw gather adjoint, no requant, no bias
-    dx_q = dx_mac.to(torch.int32)
+    # dx (propLoss): PR1b.2 (design D3) routes propLoss through executeOp's
+    # OUT_WRITE epilogue; for a SYM_INT32 target this requants through the
+    # conversionMatrix diagonal (requantSymInt32Tensor) instead of writing the
+    # raw, unrestored accumulator-range gather-adjoint directly (pre-PR1b.2
+    # behavior). Mirrors weightGrad's Strategy-A requant (_requant_absmax_f32)
+    # but at propLossQ's declared qMaxBits=12 (int12), not the grad qMaxBits=16.
+    dx_q, dx_scale = _requant_absmax_i12_f32(dx_mac, dx_scale_raw)
     dx_deq = dx_q.to(torch.float32) * torch.tensor(dx_scale, dtype=torch.float32)
 
     # weightGrad: strategy A requant of the int scatter-gather from a zero grad

--- a/test/unit/layer/generate_expected_conv1d_transposed.py
+++ b/test/unit/layer/generate_expected_conv1d_transposed.py
@@ -9,6 +9,7 @@ ConvTranspose1d weight shape: [Cin, Cout/groups, K] — note the order
 vs. Conv1d's [Cout, Cin/groups, K].
 """
 import argparse
+import math
 import sys
 from pathlib import Path
 
@@ -255,6 +256,47 @@ def _requant_absmax_i12_f32(mac_int: torch.Tensor, in_scale: float):
     return q.to(torch.int32), scale.item()
 
 
+def _restore_tolerances(raw_q, raw_scale, mtol_before, base_q, base_scale):
+    """Empirically DERIVE (not hand-guess) the restored (mantissa,
+    scale-relative) tolerances for a raw producer wire PR1b.2 now restores via
+    _requant_absmax_i12_f32 — mirrors generate_expected_conv1d.py's
+    identically-named helper (same forward-restoration hazard applies to
+    ConvT1d) and the LayerNorm forward precedent
+    (generate_expected_layernorm_sym.py::_restore_tolerances, PR1b.2 Task 3).
+    Perturb the RAW pre-restoration mantissas by their own worst-case
+    C-vs-emulation noise band (+-mtol_before — the bias-seed rounding-
+    boundary ambiguity the forward fixture already carries pre-restoration),
+    applied elementwise AND concentrated at the argmax element (which drives
+    the requant's absmax renormalization), and measure how far the restored
+    mantissas/scale actually move under the SAME transform. A fixed 1.5x
+    safety margin is applied to the observed worst case."""
+    # Floor at 1e-4 relative: the pre-existing (pre-PR1b.2) convention for
+    # every SYM scale assertion in this file, kept as a defensive margin
+    # against ordinary float32 noise even when no bias-seed ambiguity exists
+    # (mtol_before == 0) to perturb against.
+    floor = 1e-4
+    if mtol_before == 0:
+        return 0, floor
+    idx = int(raw_q.abs().reshape(-1).argmax().item())
+    variants = [raw_q + mtol_before, raw_q - mtol_before]
+    for delta in (mtol_before, -mtol_before):
+        v = raw_q.clone()
+        v.reshape(-1)[idx] += delta
+        variants.append(v)
+    max_mdiff = 0
+    max_sdiff = 0.0
+    for variant in variants:
+        vq, vs = _requant_absmax_i12_f32(variant, raw_scale)
+        mdiff = int((vq.to(torch.int64) - base_q.to(torch.int64)).abs().max().item())
+        sdiff = abs(vs - base_scale) / base_scale
+        max_mdiff = max(max_mdiff, mdiff)
+        max_sdiff = max(max_sdiff, sdiff)
+    margin = 1.5
+    mantissa_tol_r = int(math.ceil(max_mdiff * margin)) + 1
+    scale_rel_tol_r = max(max_sdiff * margin, floor)
+    return mantissa_tol_r, scale_rel_tol_r
+
+
 def _autograd_ref_f64(q, p):
     """float64 torch-autograd on the EXACT dequantized inputs (q*s in f64) — the true grads."""
     x64 = (q["xq"].to(torch.float64) * q["s_in"]).requires_grad_(True)
@@ -278,22 +320,40 @@ def emulate_sym_convT(fx):
     p = _conv_params(fx)
     q = _quant_inputs(fx)
     fwd_mac, dw_mac, dx_mac = _int_mac(q, p)
-    out_scale = f32_mul(q["s_in"], q["s_w"])          # forward output scale
+    out_scale = f32_mul(q["s_in"], q["s_w"])          # RAW forward accumulator scale (s_in*s_w)
     dx_scale_raw = f32_mul(q["s_loss"], q["s_w"])     # propLoss RAW gather-adjoint scale (pre-PR1b.2)
     inter_scale = f32_mul(q["s_loss"], q["s_in"])     # weightGrad intermediate scale
 
-    # forward: int MAC + per-channel bias seed (float32 refold)
+    # forward: int MAC + per-channel bias seed (float32 refold), at the RAW
+    # s_in*s_w accumulator scale — matches convTranspose1dKernelSymInt32's own
+    # direct output today (pre-PR1b.2: this raw wire is what a downstream
+    # Quantization layer used to restore).
     out_channels = fwd_mac.shape[1]
     if q["bq"] is not None:
         seed = _round_away_f32(q["bq"].to(torch.float32)
                                * torch.tensor(q["s_b"], dtype=torch.float32)
                                / torch.tensor(out_scale, dtype=torch.float32)).to(torch.int64)
-        fwd_q = (fwd_mac + seed.reshape(1, out_channels, 1)).to(torch.int32)
-        fwd_mtol = 1
+        fwd_raw_q = (fwd_mac + seed.reshape(1, out_channels, 1)).to(torch.int32)
+        fwd_mtol_raw = 1
     else:
-        fwd_q = fwd_mac.to(torch.int32)
-        fwd_mtol = 0
-    fwd_deq = fwd_q.to(torch.float32) * torch.tensor(out_scale, dtype=torch.float32)
+        fwd_raw_q = fwd_mac.to(torch.int32)
+        fwd_mtol_raw = 0
+    # PR1b.2 (design D3): conv1dTransposedForward now routes through
+    # executeOp's OUT_WRITE epilogue; a SYM_INT32 target hits the
+    # conversionMatrix diagonal (requantSymInt32Tensor) instead of the raw
+    # direct kernel write above (pre-PR1b.2 behavior) — the same restoration
+    # propLoss already got in Task 2, at the same declared qMaxBits=12
+    # (_requant_absmax_i12_f32).
+    fwd_q, fwd_scale = _requant_absmax_i12_f32(fwd_raw_q, out_scale)
+    fwd_deq = fwd_q.to(torch.float32) * torch.tensor(fwd_scale, dtype=torch.float32)
+    # The restored scale is now itself derived from an absmax over the
+    # (float32, C-vs-Python-noisy) mantissas — sensitive to the same
+    # bias-seed rounding-boundary noise the mantissas are, unlike the old raw
+    # out_scale (a direct product of two independently-computed scales,
+    # insensitive to that noise). Empirically derive both tolerances instead
+    # of trusting the pre-restoration fwd_mtol_raw/hardcoded 1e-4 relative.
+    fwd_mtol, fwd_scale_tol = _restore_tolerances(fwd_raw_q, out_scale, fwd_mtol_raw, fwd_q,
+                                                  fwd_scale)
 
     # dx (propLoss): PR1b.2 (design D3) routes propLoss through executeOp's
     # OUT_WRITE epilogue; for a SYM_INT32 target this requants through the
@@ -320,11 +380,11 @@ def emulate_sym_convT(fx):
 
     # ---- self-checks (fail at generation time, not in C) ----
     _eps32 = float(torch.finfo(torch.float32).eps)
-    fwd_f32_prec = fwd_q.abs().max().item() * out_scale * _eps32
+    fwd_f32_prec = fwd_q.abs().max().item() * fwd_scale * _eps32
     dx_f32_prec = dx_q.abs().max().item() * dx_scale * _eps32
 
     fwd_err = (fwd_deq.to(torch.float64) - ref_y).abs().max().item()
-    fwd_tol = 8.0 * out_scale + fwd_f32_prec + 1e-9
+    fwd_tol = 8.0 * fwd_scale + fwd_f32_prec + 1e-9
     assert fwd_err <= fwd_tol, f"{fx['name']}: fwd emulation err {fwd_err} > tol {fwd_tol}"
     dx_err = (dx_deq.to(torch.float64) - ref_dx).abs().max().item()
     dx_tol = 8.0 * dx_scale + dx_f32_prec + 1e-9
@@ -341,8 +401,9 @@ def emulate_sym_convT(fx):
     return dict(
         name=fx["name"], has_bias=q["bq"] is not None,
         x_deq=q["x_deq"], w_deq=q["w_deq"], b_deq=q["b_deq"], gy_deq=q["gy_deq"],
-        fwd_q=fwd_q, fwd_scale=out_scale, fwd_deq=ref_y.to(torch.float32),
-        fwd_mtol=fwd_mtol, fwd_dtol=8.0 * out_scale + fwd_f32_prec + 1e-6,
+        fwd_q=fwd_q, fwd_scale=fwd_scale, fwd_deq=ref_y.to(torch.float32),
+        fwd_mtol=fwd_mtol, fwd_dtol=8.0 * fwd_scale + fwd_f32_prec + 1e-6,
+        fwd_scale_tol=fwd_scale_tol,
         dx_q=dx_q, dx_scale=dx_scale, dx_deq=ref_dx.to(torch.float32),
         dx_mtol=0, dx_dtol=8.0 * dx_scale + dx_f32_prec + 1e-6,
         dw_q=dw_q, dw_scale=dw_scale, dw_deq=ref_dw.to(torch.float32),
@@ -451,12 +512,13 @@ def emit_sym_fixture(parts, fx):
     if g["has_bias"]:
         parts.append(emit_float_array(f"bias_{pre}", g["b_deq"]))
     parts.append(emit_float_array(f"lossGrad_{pre}", g["gy_deq"]))
-    # forward
+    # forward (width-restored, as conv1dTransposedForward now writes it — design D3)
     parts.append(emit_int32_array(f"expectedForward_{pre}", g["fwd_q"]))
     parts.append(emit_float_scalar(f"expectedForwardScale_{pre}", g["fwd_scale"]))
     parts.append(emit_int32_scalar(f"forwardMantissaTol_{pre}", g["fwd_mtol"]))
     parts.append(emit_float_array(f"expectedForwardDequant_{pre}", g["fwd_deq"]))
     parts.append(emit_float_scalar(f"forwardDequantTol_{pre}", g["fwd_dtol"]))
+    parts.append(emit_float_scalar(f"forwardScaleTol_{pre}", g["fwd_scale_tol"]))
     # dx / propLoss
     parts.append(emit_int32_array(f"expectedPropLoss_{pre}", g["dx_q"]))
     parts.append(emit_float_scalar(f"expectedPropLossScale_{pre}", g["dx_scale"]))

--- a/test/unit/layer/generate_expected_layernorm_sym.py
+++ b/test/unit/layer/generate_expected_layernorm_sym.py
@@ -6,12 +6,25 @@ inputs -> per-group stats from mantissas -> global absmax stretch -> separate
 affine with beta rescale) and emits the expected output mantissas + scale,
 plus the true PyTorch xhat for dequant-domain parity, per fixture.
 
+PR1b.2 (Task 3): the affine stage's raw producer output (Finding A — same
+accumulator-range class as Linear/Conv1d's matmul, NOT self-restoring as an
+earlier recon pass mistakenly assumed) now routes through executeOp's
+OUT_WRITE epilogue; for a SYM_INT32 target this hits the conversionMatrix
+diagonal (requantSymInt32Tensor) instead of a raw direct write. The emitted
+mantissas/scale below are therefore the RESTORED (post-requant) values, not
+the raw affine output — see `_requant_i12_f32` and its call in `_run_fixture`.
+
 Self-checks:
  - emitted float fixtures are dequantization-STABLE: re-quantizing them
    reproduces the mantissas bit-exactly (so the C side's
    tensorFillFromFloatBuffer lands on the same input mantissas);
- - the emulated dequantized output matches F.layer_norm on the dequantized
-   inputs within the analytic quantization bound;
+ - the emulated dequantized output (both raw AND restored) matches
+   F.layer_norm on the dequantized inputs within the analytic quantization
+   bound;
+ - the restored mantissa/scale tolerances are DERIVED (not just asserted) by
+   perturbing the raw emulation by its own worst-case C-vs-emulation noise
+   band and re-running the SAME requant, taking the observed worst case plus
+   a safety margin (see `_restore_tolerances`);
  - parity fixtures keep absmax(xhat) <= 1.9, which guarantees the documented
    5e-4 C-side xhat tolerance: at int12 operands (qMaxBits=12, #227) the
    normalized output LSB is s_norm <= 1.9/2047, so s_norm/2 <= 4.64e-4 < 5e-4
@@ -25,6 +38,7 @@ half-to-even, which diverges on ties like 16382.5).
 Run via `uv run` (CMake wires this automatically).
 """
 import argparse
+import math
 import sys
 from pathlib import Path
 
@@ -129,6 +143,53 @@ def emulate_sym_forward(xq, sx, gq, sg, bq, sb, normalized_shape, eps):
     return yq.to(torch.int32).reshape(xq.shape), s_y, s_norm, var_ratio
 
 
+def _requant_i12_f32(mantissas: torch.Tensor, scale: float):
+    """PR1b.2 (Task 3): mirrors requantSymInt32Tensor's exact float32 sequence
+    (TensorConversion.c) applied to the funnel's raw affine-stage output:
+    dequant (f32) -> absmax (f32) -> scale=absmax/qMax (f32) ->
+    round_half_away(clamp(...)). Returns (restored int32 mantissas, restored
+    scale)."""
+    deq = mantissas.to(torch.float32) * torch.tensor(scale, dtype=torch.float32)
+    absmax = deq.abs().max().to(torch.float32)
+    if absmax.item() == 0.0:
+        return torch.zeros_like(mantissas, dtype=torch.int32), 1.0
+    new_scale = (absmax / QMAX).item()
+    q = round_half_away(
+        torch.clamp(deq / torch.tensor(new_scale, dtype=torch.float32), QMIN, QMAX))
+    return q.to(torch.int32), new_scale
+
+
+def _restore_tolerances(yq, s_y, mantissa_tol, yq_r, s_y_r):
+    """Empirically DERIVE (not just assert) the restored (mantissa, scale)
+    tolerances: no independent C run is available at generation time, so
+    perturb the raw emulation by its own worst-case C-vs-emulation noise band
+    (+-mantissa_tol, applied elementwise AND concentrated at the argmax
+    element, which drives the requant's absmax renormalization) and measure
+    how far the restored mantissas/scale actually move under the SAME requant
+    transform. This calibrates the propagated tolerance directly against the
+    real transform instead of trusting an analytic (and easy-to-get-wrong)
+    closed-form propagation, then applies a fixed safety margin on the
+    observed worst case."""
+    idx = int(yq.abs().reshape(-1).argmax().item())
+    variants = [yq + mantissa_tol, yq - mantissa_tol]
+    for delta in (mantissa_tol, -mantissa_tol):
+        v = yq.clone()
+        v.reshape(-1)[idx] += delta
+        variants.append(v)
+    max_mdiff = 0
+    max_sdiff = 0.0
+    for variant in variants:
+        vq, vs = _requant_i12_f32(variant, s_y)
+        mdiff = int((vq.to(torch.int64) - yq_r.to(torch.int64)).abs().max().item())
+        sdiff = abs(vs - s_y_r) / s_y_r
+        max_mdiff = max(max_mdiff, mdiff)
+        max_sdiff = max(max_sdiff, sdiff)
+    margin = 1.5
+    mantissa_tol_r = int(math.ceil(max_mdiff * margin)) + 1
+    scale_rel_tol_r = max_sdiff * margin
+    return mantissa_tol_r, scale_rel_tol_r
+
+
 def _run_fixture(name, x, gamma, beta, normalized_shape, *, eps=1e-5,
                  require_parity=False):
     xq, sx, x_deq = stable_dequant(x)
@@ -161,11 +222,29 @@ def _run_fixture(name, x, gamma, beta, normalized_shape, *, eps=1e-5,
     mantissa_tol = 2 * int(gq.abs().max().item()) + 1
     dequant_tol = bound + mantissa_tol * s_y
 
+    # PR1b.2 (Task 3): the affine's raw output no longer lands in `output`
+    # directly — executeOp's OUT_WRITE epilogue restores width via the
+    # SYM->SYM conversionMatrix diagonal (requantSymInt32Tensor). Restore the
+    # SAME way here so the emitted fixture matches what the funnel produces.
+    yq_r, s_y_r = _requant_i12_f32(yq, s_y)
+
+    # Restored dequant tracks the SAME F.layer_norm reference: restoration is
+    # a pure width-renormalization of the identical underlying value, adding
+    # at most one more rounding pass (+-0.5 LSB of the NEW scale; 4x margin
+    # for the requant's own absmax-recompute float32 noise).
+    restored_bound = dequant_tol + 4.0 * s_y_r + 1e-9
+    restored_err = (yq_r.to(torch.float64) * s_y_r - ref).abs().max().item()
+    assert restored_err <= restored_bound, \
+        f"{name}: restored dequant vs F.layer_norm {restored_err} > {restored_bound}"
+
+    mantissa_tol_r, scale_rel_tol_r = _restore_tolerances(yq, s_y, mantissa_tol, yq_r, s_y_r)
+
     return {
         "name": name,
         "x": x_deq, "gamma": g_deq, "beta": b_deq,
-        "mantissas": yq, "scale": s_y,
-        "mantissa_tol": mantissa_tol, "dequant_tol": dequant_tol,
+        "mantissas": yq_r, "scale": s_y_r,
+        "mantissa_tol": mantissa_tol_r, "dequant_tol": restored_bound,
+        "scale_tol": scale_rel_tol_r,
         "dequant": ref.to(torch.float32),
         "xhat": xhat.to(torch.float32) if require_parity else None,
         "var_ratio": var_ratio.to(torch.float32),
@@ -217,6 +296,7 @@ def emit_fixture(parts, fx):
     parts.append(emit_int32_scalar(f"mantissaTol_{pre}", fx["mantissa_tol"]))
     parts.append(emit_float_array(f"expectedDequant_{pre}", fx["dequant"]))
     parts.append(emit_float_scalar(f"dequantTol_{pre}", fx["dequant_tol"]))
+    parts.append(emit_float_scalar(f"scaleTol_{pre}", fx["scale_tol"]))
     if fx["xhat"] is not None:
         parts.append(emit_float_array(f"expectedXhat_{pre}", fx["xhat"]))
     parts.append(emit_float_array(f"expectedGroupVarRatio_{pre}", fx["var_ratio"]))

--- a/test/unit/userAPI/CMakeLists.txt
+++ b/test/unit/userAPI/CMakeLists.txt
@@ -363,7 +363,6 @@ add_elastic_ai_unit_test(
         MORE_LIBS
         ArithmeticType
         CommonLayerLibs
-        QuantizationLayer
         LinearApi
         LayerCommon
         LayerQuant

--- a/test/unit/userAPI/UnitTestLayerNormIntegration.c
+++ b/test/unit/userAPI/UnitTestLayerNormIntegration.c
@@ -142,10 +142,10 @@ void testLinearLayerNormLinearOneTrainingStep(void) {
 
 /* Full-SYM single-LayerNorm training step through the public training APIs:
  * calculateGradsSequential (MSE — the only SYM-capable loss backward) + SGD-M
- * step on SYM gamma/beta with SYM grads. Explicit Quantization (requant) layers
- * between SYM producers are still REQUIRED: the forward wire carries raw
- * accumulator mantissas until the forward migration (PR1b.2); as of PR1b only
- * the backward/dx side is funnel-restored at the producer (OUT_WRITE epilogue).
+ * step on SYM gamma/beta with SYM grads. Single-layer model: LayerNorm sits at
+ * the loss boundary, so there's no downstream layer to feed regardless of
+ * whether its forward wire is producer-restored (PR1b.2) or not — a chained
+ * Quantization layer was never required here even before that migration.
  * Test behavior unchanged: validates the full SYM end-to-end path.
  * A FLOAT32 twin trained on the same data is the reference; 5e-3 absolute
  * dequant tolerance absorbs input quantization + strategy-A grad noise

--- a/test/unit/userAPI/UnitTestModelValidationApi.c
+++ b/test/unit/userAPI/UnitTestModelValidationApi.c
@@ -3,14 +3,11 @@
 #include <stdbool.h>
 
 #include "ArithmeticType.h"
-#include "Conv1d.h"
-#include "Conv1dTransposed.h"
 #include "Layer.h"
 #include "LayerNorm.h"
 #include "Linear.h"
 #include "ModelValidationApi.h"
 #include "QuantizationApi.h"
-#include "QuantizationLayer.h"
 #include "Rounding.h"
 #include "StorageApi.h"
 #include "Tensor.h"
@@ -20,10 +17,11 @@
 void setUp(void) {}
 void tearDown(void) {}
 
-/* The validator reads ONLY layer->type + layerForwardMath(layer) (which reads
- * config->...->forwardMath), so a parameter-free stub suffices — same shape
- * as buildConv1dStub/buildLayerNormStub below (the deleted linearLayerInitLegacy
- * used to store forwardMath without dereferencing weights/bias). */
+/* The validator only walks layer->type + array shape now (the SYM-producer
+ * rule below buildLayerNormStub was retired, PR1b.2/spec D3), so a
+ * parameter-free stub suffices — same shape as buildLayerNormStub below (the
+ * deleted linearLayerInitLegacy used to store forwardMath without
+ * dereferencing weights/bias). */
 static layer_t *buildLinearStub(quantization_t *fq) {
     linearConfig_t *cfg = reserveMemory(sizeof(linearConfig_t));
     cfg->weights = NULL;
@@ -67,79 +65,8 @@ static layer_t *buildLayerNormStub(quantization_t *fq) {
     return layer;
 }
 
-static layer_t *buildQuantStub(quantization_t *fq) {
-    quantizationConfig_t *cfg = reserveMemory(sizeof(quantizationConfig_t));
-    cfg->outputQ = fq;
-    cfg->propLossQ = fq;
-    cfg->ownsQuantizations = false;
-    layerConfig_t *lc = reserveMemory(sizeof(layerConfig_t));
-    lc->quantization = cfg;
-    layer_t *layer = reserveMemory(sizeof(layer_t));
-    initLayer(layer, QUANTIZATION, lc);
-    return layer;
-}
-
 static void freeLayerNormStub(layer_t *layer) {
     freeReservedMemory(layer->config->layerNorm);
-    freeReservedMemory(layer->config);
-    freeReservedMemory(layer);
-}
-
-static layer_t *buildConv1dStub(quantization_t *fq) {
-    conv1dConfig_t *cfg = reserveMemory(sizeof(conv1dConfig_t));
-    cfg->kernel = NULL;
-    cfg->weights = NULL;
-    cfg->bias = NULL;
-    cfg->groups = 1;
-    cfg->forwardMath = arithmeticFromQuantization(fq);
-    cfg->weightGradMath = arithmeticFromQuantization(fq);
-    cfg->biasGradMath = arithmeticFromQuantization(fq);
-    cfg->propLossMath = arithmeticFromQuantization(fq);
-    cfg->outputQ = fq;
-    cfg->propLossQ = fq;
-    cfg->ownsQuantizations = false;
-    layerConfig_t *lc = reserveMemory(sizeof(layerConfig_t));
-    lc->conv1d = cfg;
-    layer_t *layer = reserveMemory(sizeof(layer_t));
-    initLayer(layer, CONV1D, lc);
-    return layer;
-}
-
-static void freeConv1dStub(layer_t *layer) {
-    freeReservedMemory(layer->config->conv1d);
-    freeReservedMemory(layer->config);
-    freeReservedMemory(layer);
-}
-
-static layer_t *buildConv1dTransposedStub(quantization_t *fq) {
-    conv1dTransposedConfig_t *cfg = reserveMemory(sizeof(conv1dTransposedConfig_t));
-    cfg->kernel = NULL;
-    cfg->weights = NULL;
-    cfg->bias = NULL;
-    cfg->groups = 1;
-    cfg->outputPadding = 0;
-    cfg->forwardMath = arithmeticFromQuantization(fq);
-    cfg->weightGradMath = arithmeticFromQuantization(fq);
-    cfg->biasGradMath = arithmeticFromQuantization(fq);
-    cfg->propLossMath = arithmeticFromQuantization(fq);
-    cfg->outputQ = fq;
-    cfg->propLossQ = fq;
-    cfg->ownsQuantizations = false;
-    layerConfig_t *lc = reserveMemory(sizeof(layerConfig_t));
-    lc->conv1dTransposed = cfg;
-    layer_t *layer = reserveMemory(sizeof(layer_t));
-    initLayer(layer, CONV1D_TRANSPOSED, lc);
-    return layer;
-}
-
-static void freeConv1dTransposedStub(layer_t *layer) {
-    freeReservedMemory(layer->config->conv1dTransposed);
-    freeReservedMemory(layer->config);
-    freeReservedMemory(layer);
-}
-
-static void freeQuantStub(layer_t *layer) {
-    freeReservedMemory(layer->config->quantization);
     freeReservedMemory(layer->config);
     freeReservedMemory(layer);
 }
@@ -172,7 +99,14 @@ void testValidatorRejectsNullElementMidArray(void) {
     TEST_ASSERT_FALSE_MESSAGE(valid, "NULL element in model array should be rejected");
 }
 
-void testValidatorRejectsSymProducerFollowedByNonQuantLayer(void) {
+/* Documents the retired rule's replacement contract (PR1b.2, spec D3): a SYM
+ * accumulator-range producer (Linear) feeding a non-QUANTIZATION layer
+ * (LayerNorm) used to be REJECTED (no chained Quant layer restoring width);
+ * the forward funnel now restores width at the producer's own wire, so this
+ * is a perfectly ordinary, ACCEPTED chain — a Quant layer here would just be
+ * a redundant identical-config requant (the double-requant anti-pattern
+ * `docs/conventions/arithmetic-sym.md` warns about), not a requirement. */
+void testValidatorAcceptsSymProducerFollowedByNonQuantLayer(void) {
     quantization_t *symQ = quantizationInitSymInt32(HALF_AWAY);
     layer_t *linear = buildLinearStub(symQ);
     layer_t *norm = buildLayerNormStub(symQ);
@@ -184,42 +118,9 @@ void testValidatorRejectsSymProducerFollowedByNonQuantLayer(void) {
     freeLinearStub(linear);
     freeQuantization(symQ);
 
-    TEST_ASSERT_FALSE_MESSAGE(valid, "Linear-SYM feeding LayerNorm-SYM without a Quant layer "
-                                     "violates the int16 inter-layer contract");
-}
-
-void testValidatorAcceptsChainWithQuantLayersBetweenProducers(void) {
-    quantization_t *symQ = quantizationInitSymInt32(HALF_AWAY);
-    layer_t *linear0 = buildLinearStub(symQ);
-    layer_t *quant1 = buildQuantStub(symQ);
-    layer_t *norm = buildLayerNormStub(symQ);
-    layer_t *quant2 = buildQuantStub(symQ);
-    layer_t *linear1 = buildLinearStub(symQ); /* producer in last position: allowed */
-    layer_t *model[5] = {linear0, quant1, norm, quant2, linear1};
-
-    bool valid = validateModelQuantization(model, 5);
-
-    freeLinearStub(linear1);
-    freeQuantStub(quant2);
-    freeLayerNormStub(norm);
-    freeQuantStub(quant1);
-    freeLinearStub(linear0);
-    freeQuantization(symQ);
-
-    TEST_ASSERT_TRUE(valid);
-}
-
-void testValidatorAcceptsSymProducerInLastPosition(void) {
-    quantization_t *symQ = quantizationInitSymInt32(HALF_AWAY);
-    layer_t *linear = buildLinearStub(symQ);
-    layer_t *model[1] = {linear};
-
-    bool valid = validateModelQuantization(model, 1);
-
-    freeLinearStub(linear);
-    freeQuantization(symQ);
-
-    TEST_ASSERT_TRUE_MESSAGE(valid, "producer at the loss boundary is allowed");
+    TEST_ASSERT_TRUE_MESSAGE(valid, "Linear-SYM feeding LayerNorm-SYM directly is accepted: "
+                                    "the forward funnel already restored width at the wire, "
+                                    "a Quant layer here is optional, not required");
 }
 
 void testValidatorAcceptsFloatOnlyModel(void) {
@@ -237,62 +138,12 @@ void testValidatorAcceptsFloatOnlyModel(void) {
     TEST_ASSERT_TRUE(valid);
 }
 
-void testValidatorRejectsConv1dSymProducerFollowedByNonQuantLayer(void) {
-    quantization_t *symQ = quantizationInitSymInt32(HALF_AWAY);
-    layer_t *conv = buildConv1dStub(symQ);
-    layer_t *norm = buildLayerNormStub(symQ);
-    layer_t *model[2] = {conv, norm};
-
-    bool valid = validateModelQuantization(model, 2);
-
-    freeLayerNormStub(norm);
-    freeConv1dStub(conv);
-    freeQuantization(symQ);
-
-    TEST_ASSERT_FALSE_MESSAGE(valid, "Conv1d-SYM feeding a non-Quant layer violates the "
-                                     "int16 inter-layer contract");
-}
-
-void testValidatorAcceptsConv1dTransposedSymProducerInLastPosition(void) {
-    quantization_t *symQ = quantizationInitSymInt32(HALF_AWAY);
-    layer_t *convT = buildConv1dTransposedStub(symQ);
-    layer_t *model[1] = {convT};
-
-    bool valid = validateModelQuantization(model, 1);
-
-    freeConv1dTransposedStub(convT);
-    freeQuantization(symQ);
-
-    TEST_ASSERT_TRUE_MESSAGE(valid, "a SYM producer in the last position is allowed");
-}
-
-void testValidatorRejectsConv1dTransposedSymProducerFollowedByNonQuantLayer(void) {
-    quantization_t *symQ = quantizationInitSymInt32(HALF_AWAY);
-    layer_t *convT = buildConv1dTransposedStub(symQ);
-    layer_t *norm = buildLayerNormStub(symQ);
-    layer_t *model[2] = {convT, norm};
-
-    bool valid = validateModelQuantization(model, 2);
-
-    freeLayerNormStub(norm);
-    freeConv1dTransposedStub(convT);
-    freeQuantization(symQ);
-
-    TEST_ASSERT_FALSE_MESSAGE(valid, "Conv1dTransposed-SYM feeding a non-Quant layer violates "
-                                     "the int16 inter-layer contract");
-}
-
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(testValidatorAcceptsEmptyModel);
     RUN_TEST(testValidatorRejectsNullModel);
     RUN_TEST(testValidatorRejectsNullElementMidArray);
-    RUN_TEST(testValidatorRejectsSymProducerFollowedByNonQuantLayer);
-    RUN_TEST(testValidatorAcceptsChainWithQuantLayersBetweenProducers);
-    RUN_TEST(testValidatorAcceptsSymProducerInLastPosition);
+    RUN_TEST(testValidatorAcceptsSymProducerFollowedByNonQuantLayer);
     RUN_TEST(testValidatorAcceptsFloatOnlyModel);
-    RUN_TEST(testValidatorRejectsConv1dSymProducerFollowedByNonQuantLayer);
-    RUN_TEST(testValidatorAcceptsConv1dTransposedSymProducerInLastPosition);
-    RUN_TEST(testValidatorRejectsConv1dTransposedSymProducerFollowedByNonQuantLayer);
     return UNITY_END();
 }

--- a/test/unit/userAPI/UnitTestQuantLayerIntegration.c
+++ b/test/unit/userAPI/UnitTestQuantLayerIntegration.c
@@ -425,6 +425,15 @@ void testFullSymChainTrainingStepMatchesFloatTwin(void) {
     }
 }
 
+/* The Quant layer in this chain (ConvT -> Quant -> MSE) is deliberately
+ * RETAINED, not required: ConvT1d's forward already restores its output wire
+ * to `symQ`'s width at the producer (executeOp's OUT_WRITE epilogue,
+ * PR1b.2), so a same-config Quant node consuming it straight after is the
+ * documented double-requant anti-pattern (docs/conventions/arithmetic-sym.md
+ * — "a Quant node with an IDENTICAL config directly consuming a
+ * funnel-restored producer wire"), i.e. REDUNDANT on this wire post-PR1b.2.
+ * It is kept here to exercise the Quantization layer inside a real training
+ * loop (loop-integration coverage), not as a model an author should copy. */
 void testConv1dTransposedSymChainTrains(void) {
     /* Tiny uniform-SYM chain: ConvT(1->1, K=2) -> Quant -> MSE. int12 operands keep
      * int12*int12 products inside int32; the loop forces int16 grad accumulators.
@@ -491,7 +500,13 @@ void testConv1dTransposedSymChainTrains(void) {
     TEST_ASSERT_TRUE_MESSAGE(decreased, "SYM ConvT chain must train (loss must decrease)");
 }
 
-void testValidatorRejectsChainWithoutQuantLayers(void) {
+/* Retired-rule contract update (PR1b.2, spec D3): a SYM-producer chain with
+ * no Quant layers between producers used to be REJECTED by
+ * validateModelQuantization; the forward funnel now restores width at each
+ * producer's own wire, so this exact chain is a perfectly ordinary, ACCEPTED
+ * model — a Quant layer here would be a redundant identical-config requant,
+ * not a requirement. */
+void testValidatorAcceptsChainWithoutQuantLayers(void) {
     quantization_t *symQ = quantizationInitSymInt32(HALF_AWAY);
     layerQuant_t lqSym;
     layerQuantInitUniform(&lqSym, symQ);
@@ -502,7 +517,8 @@ void testValidatorRejectsChainWithoutQuantLayers(void) {
     layer_t *lin1 = buildTrainableLinear(3, 2, W1_VALS, B1_VALS, symQ, true);
     layer_t *model[3] = {lin0, ln, lin1};
 
-    /* Linear-SYM raw accumulator would feed LayerNorm directly — do NOT train. */
+    /* Linear-SYM's forward already restores width before feeding LayerNorm-SYM
+     * directly — no Quant layer needed between them. */
     bool valid = validateModelQuantization(model, 3);
 
     freeParameter(lin1->config->linear->weights);
@@ -514,7 +530,9 @@ void testValidatorRejectsChainWithoutQuantLayers(void) {
     freeLinearLayerShell(lin0);
     freeQuantization(symQ);
 
-    TEST_ASSERT_FALSE_MESSAGE(valid, "missing Quant layers must be rejected by the validator");
+    TEST_ASSERT_TRUE_MESSAGE(valid, "a SYM-producer chain without Quant layers between "
+                                    "producers is accepted: the forward funnel already "
+                                    "restored width at each producer's wire");
 }
 
 int main(void) {
@@ -523,7 +541,7 @@ int main(void) {
     RUN_TEST(testTrainingStepLinearSymThenQuantRequantsOutputAndFiniteLoss);
     RUN_TEST(testInferenceLinearSymThenQuantOutputsInt16RangeMantissas);
     RUN_TEST(testFullSymChainTrainingStepMatchesFloatTwin);
-    RUN_TEST(testValidatorRejectsChainWithoutQuantLayers);
+    RUN_TEST(testValidatorAcceptsChainWithoutQuantLayers);
     RUN_TEST(testConv1dTransposedSymChainTrains);
     return UNITY_END();
 }


### PR DESCRIPTION
## Summary

Completes the funnel migration deferred by PR1b (funnel spec §9, PR1b.2 row), against the final \`arithmetic_t\` API from #267:

- **\`opSpec_t\` descriptor API** for \`executeOp\` (kernel/ctx/inputs/arithmetic/mode/auxOut) — one stable extension point; \`ctx\` carries kernel geometry, \`auxOut\` is kernel-written verbatim (MaxPool argmax). \`OUT_ACC_FIXED_SCALE\` now honors the target's roundingMode via \`rescaleIntoAccumulatorScale\` (bit-identical for HALF_AWAY; preserves Conv's SR bias-grad behavior; new SR pin test).
- **Conv1d/ConvT1d backward** through the funnel (per-op adapters; FLOAT32 weight-grad restructured off the persistent-grad write; #187 guards deleted — untested tautologies, superseded by the general prologue).
- **All non-scale-transparent forwards migrated**: Linear, Conv1d, ConvT1d, LayerNorm, Softmax (net deletion of its hand-rolled funnel), AvgPool, AdaptiveAvgPool, MaxPool (auxOut). **Relu/Dropout/Flatten stay unmigrated by design** — element-wise scale-transparent ops; the OUT_WRITE requant would corrupt exactly that property.
- **Double requant eliminated structurally** (design D3): producers restore width at the wire; a same-config Quant node on a restored wire is a documented anti-pattern (HALF_AWAY bit-latches; SR re-draws jitter = noise). SYM→SYM requant stays fully supported for its three legitimate uses (width change — declarable directly at the producer's \`outputQ\`; re-normalization after scale-transparent segments; dtype change). \`mixed_width_mlp\` drops its now-redundant Quant0; the raw-wire validator rule (producer-must-feed-Quant) is retired with its tests.
- Docs: \`docs/conventions/arithmetic-sym.md\` rewritten to producer-restored semantics; **new "Comment guidelines" in \`docs/CONVENTIONS.md\`** + when-to-use one-liners on all \`*LayerInit\`/\`*LayerInitOwning\` pairs.
- Bundled fix: latent NULL-deref in \`linearForward\` with \`bias == NULL\` (+ regression test).

## Acceptance evidence

- Debug/ASan/UBSan ctest: **67/67 each** on the push tip; examples preset builds; \`mixed_width_mlp\` hard gates pass.
- **Re-gold discipline (spec D5, twice controller-ratified):** every numeric expectation change on the branch is a verified raw-wire pin of a migrated producer (8 Conv/ConvT forward + 6 propLoss backward + 5 LayerNorm sites), each with a dequant-equivalence derivation comment and mutation check; the final whole-branch review independently enumerated the full set and found no stray change. Everything else byte-exact.
- **Gold-parity CI unaffected**: all six parity examples are FLOAT32 and BIT_PARITY mode is inference-only; HAR was additionally verified locally at tip — int32 predictions bit-identical (2947 elements).

## Notes for reviewers (residual risks)

- \`mixed_width_mlp\` final_loss shifted 1.836059 → 1.250560 after dropping Quant0: **forward is bit-identical** (initial_loss unchanged at 2.292284); the shift is purely the removal of Quant0's backward requant hop on the dx path (post-Relu dx tensors can be underfilled → that hop renormalized). One lossy rounding pass less; single-seed observation, no quality claim.
- Conv/ConvT FLOAT32 weight-grad accumulation order changed for macro-batches (per-sample partial sums in zeroed scratch, then one add) — float-rounding-level drift vs. the old term-by-term \`+=\`; no gate pins training trajectories.
- SYM dx wires are now width-restored at the producer — out-of-tree consumers of raw accumulator-range propLoss mantissas would see restored values.
- OUT_ACC_FIXED_SCALE under SR now honors the target roundingMode (previously bare roundf); no in-tree config used SR bias grads.
- One integration fixture deliberately retains a redundant Quant hop as loop coverage (documented as such, not an example to copy).

Refs the funnel spec §9 (PR1b.2); supersedes #187's guard approach. Follow-up after merge: none required by this PR; PR1c (grad-default flip) is next in the series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHXkmS6X8FkEdQCMqMHs6K