### PR TITLE
feat!: PR1c — grad-storage default flips to FLOAT32 (SYM via explicit knob)

### DIFF
--- a/docs/conventions/arithmetic-sym.md
+++ b/docs/conventions/arithmetic-sym.md
@@ -208,14 +208,18 @@ every layer type — Linear/Conv/pools/Relu/Softmax/Dropout/LayerNorm/Quantizati
 all resolve through the same field; Flatten and the loss seed pass through the
 upstream dtype) — #221. Uniform chains behave exactly as before: a
 uniformly-SYM chain (every layer's `forwardMath` declaring `ARITH_SYM_INT32`)
-makes every grad tensor SYM_INT32 and every layer's `propLossQ` match — each
-producer's `OUT_WRITE` epilogue (above) width-restores its own dx wire
-independently, so the chain stays consistent without the retired #187
-cross-layer guard. SYM-trainable conv layers are built via the low-level
+keeps every layer's `propLossQ` match consistent — each producer's
+`OUT_WRITE` epilogue (above) width-restores its own dx wire independently,
+so the chain stays consistent without the retired #187 cross-layer guard.
+As of PR1c, grad *tensor* dtype is decoupled from this: the factory's
+grad-storage default is `FLOAT32` regardless of how uniformly SYM the
+chain's forward/propLoss path is; a uniform-SYM chain only gets `SYM_INT32`
+parameter grads if each layer's `weightGradStorage`/`biasGradStorage` knob is
+set explicitly. SYM-trainable conv layers are built via the low-level
 `initConv1dTransposedConfigWithWeightsAndBias` with SYM `parameter_t`s (the
 high-level factory's KAIMING/uniform init still requires FLOAT32-native
-weight/bias storage; grad storage itself now follows `propLossQ`/the
-grad-storage knob like Linear, #261).
+weight/bias storage; grad storage there is a hard-pinned FLOAT32 default too,
+overridable by the same knob, #261).
 `Conv1dTransposed → Quant → MSE` trains under
 `calculateGradsSequential` + `sgdStepM(SYM_INT32)`.
 

--- a/docs/conventions/tensor.md
+++ b/docs/conventions/tensor.md
@@ -18,9 +18,13 @@ This bites hardest for **gradients**. Persistent parameter grads should be store
 `FLOAT32` (fidelity, same size) or `SYM`/`ASYM` (real compression); the integer
 step stays transient `SYM_INT32`. The only legitimate `SYM_INT32` grads are the
 transient dx/agrad operand-wires during backprop (int12, freed after the pass).
-That today's parameter grads are stored `SYM_INT32` (`gradInitSymInt32`, and the
-SGD SYM path that dequantizes → steps in float → requantizes for no gain) is a
-known conceptual gap under redesign — #261 (subsumes #203).
+
+As of PR1c, the factory default for parameter grads (Linear/LayerNorm/Conv1d/
+Conv1dTransposed) IS `FLOAT32` — the NULL-knob fallback that used to derive from
+`propLossQ` (silently landing on `SYM_INT32` for a uniform-SYM profile) is now a
+hard-pinned `FLOAT32`, closing the gap described above by default. `SYM_INT32`
+parameter grads remain available and legitimate only via the explicit
+`weightGradStorage`/`biasGradStorage` knob on `layerQuant_t` (#261).
 
 ## SYM ↔ * conversion bridge (#227)
 

--- a/src/arithmetic/ExecuteOp.c
+++ b/src/arithmetic/ExecuteOp.c
@@ -119,7 +119,8 @@ static void accumulateOut(tensor_t *intermediate, tensor_t *target, outputMode_t
     }
     default:
         PRINT_ERROR("executeOp: accumulate target dtype %d not supported "
-                    "(FLOAT32/SYM_INT32; sub-byte arms land in PR3, #261)",
+                    "(accepted: FLOAT32, SYM_INT32; INT32/SYM/ASYM/BOOL arms "
+                    "land in PR3, #261)",
                     (int)target->quantization->type);
         exit(1);
     }

--- a/src/userApi/layer/LayerNormApi.c
+++ b/src/userApi/layer/LayerNormApi.c
@@ -167,15 +167,18 @@ static layer_t *layerNormLayerInitCommon(layerNormInit_t *init, layerQuant_t *lq
     layerCfg->layerNorm = cfg;
     layer->config = layerCfg;
 
-    /* Grad storage knob (#261): NULL falls back to lq->propLossQ (bit-identical
-     * to the pre-split lq->backwardMath source in every in-tree profile). */
-    quantization_t *gammaGradQ =
-        lq->weightGradStorage != NULL ? lq->weightGradStorage : lq->propLossQ;
-    quantization_t *betaGradQ = lq->biasGradStorage != NULL ? lq->biasGradStorage : lq->propLossQ;
+    /* Grad storage knob (#261, PR1c): NULL falls back to a hard-pinned FLOAT32
+     * default (parameter grads are persistent state — SYM_INT32 is a compute
+     * format, not storage); a non-NULL weightGradStorage/biasGradStorage
+     * overrides it explicitly to opt back into SYM_INT32 (or another dtype). */
+    quantization_t *floatGradQ = quantizationInitFloat();
+    quantization_t *gammaGradQ = lq->weightGradStorage != NULL ? lq->weightGradStorage : floatGradQ;
+    quantization_t *betaGradQ = lq->biasGradStorage != NULL ? lq->biasGradStorage : floatGradQ;
     parameter_t *gamma = allocateLayerNormGamma(init->normalizedShape, init->numNormDims,
                                                 lq->weightStorage, gammaGradQ);
     parameter_t *beta =
         allocateLayerNormBeta(init->normalizedShape, init->numNormDims, lq->biasStorage, betaGradQ);
+    freeQuantization(floatGradQ);
 
     /* Factory-owned copy of normalizedShape (caller may free its own array). */
     size_t *normShapeCopy = reserveMemory(init->numNormDims * sizeof(size_t));

--- a/src/userApi/layer/LinearApi.c
+++ b/src/userApi/layer/LinearApi.c
@@ -128,16 +128,20 @@ layer_t *linearLayerInit(linearInit_t *init, layerQuant_t *lq) {
     layerCfg->linear = cfg;
     layer->config = layerCfg;
 
-    /* Grad storage knob (#261): NULL falls back to lq->propLossQ (bit-identical
-     * to the pre-split lq->backwardMath source in every in-tree profile). */
+    /* Grad storage knob (#261, PR1c): NULL falls back to a hard-pinned FLOAT32
+     * default (parameter grads are persistent state — SYM_INT32 is a compute
+     * format, not storage); a non-NULL weightGradStorage/biasGradStorage
+     * overrides it explicitly to opt back into SYM_INT32 (or another dtype). */
+    quantization_t *floatGradQ = quantizationInitFloat();
     quantization_t *weightGradQ =
-        lq->weightGradStorage != NULL ? lq->weightGradStorage : lq->propLossQ;
-    quantization_t *biasGradQ = lq->biasGradStorage != NULL ? lq->biasGradStorage : lq->propLossQ;
+        lq->weightGradStorage != NULL ? lq->weightGradStorage : floatGradQ;
+    quantization_t *biasGradQ = lq->biasGradStorage != NULL ? lq->biasGradStorage : floatGradQ;
     cfg->weights = allocateLinearWeights(init->inFeatures, init->outFeatures, init->weightInit,
                                          lq->weightStorage, weightGradQ);
     cfg->bias = hasBias ? allocateLinearBias(init->outFeatures, init->inFeatures, lq->biasStorage,
                                              biasGradQ)
                         : NULL;
+    freeQuantization(floatGradQ);
 
     /* Borrowing: store the forward-wire/dx-wire storage configs verbatim, no copy.
      * Arithmetic slots are plain by-value copies of the profile's declared math. */
@@ -169,15 +173,21 @@ layer_t *linearLayerInitOwning(linearInit_t *init, layerQuant_t *lq) {
      * SOURCE of the tensor's owned quantization.  The allocator helpers (from
      * T12) internally clone via getQLike, so the parameter tensors hold their
      * own quantization_t copies — the caller can immediately drop the lq's
-     * weightStorage/biasStorage pointers without breaking the parameters. */
+     * weightStorage/biasStorage pointers without breaking the parameters.
+     * Grad storage knob (#261, PR1c): NULL falls back to a hard-pinned FLOAT32
+     * default (parameter grads are persistent state — SYM_INT32 is a compute
+     * format, not storage); a non-NULL weightGradStorage/biasGradStorage
+     * overrides it explicitly to opt back into SYM_INT32 (or another dtype). */
+    quantization_t *floatGradQ = quantizationInitFloat();
     quantization_t *weightGradQ =
-        lq->weightGradStorage != NULL ? lq->weightGradStorage : lq->propLossQ;
-    quantization_t *biasGradQ = lq->biasGradStorage != NULL ? lq->biasGradStorage : lq->propLossQ;
+        lq->weightGradStorage != NULL ? lq->weightGradStorage : floatGradQ;
+    quantization_t *biasGradQ = lq->biasGradStorage != NULL ? lq->biasGradStorage : floatGradQ;
     cfg->weights = allocateLinearWeights(init->inFeatures, init->outFeatures, init->weightInit,
                                          lq->weightStorage, weightGradQ);
     cfg->bias = hasBias ? allocateLinearBias(init->outFeatures, init->inFeatures, lq->biasStorage,
                                              biasGradQ)
                         : NULL;
+    freeQuantization(floatGradQ);
 
     /* Owning: same arithmetic as Borrowing; deep-copy the two storage configs
      * (outputQ, propLossQ) into fresh allocations — 2 allocs, not 3. */

--- a/src/userApi/layer/include/LayerNormApi.h
+++ b/src/userApi/layer/include/LayerNormApi.h
@@ -18,8 +18,9 @@ typedef struct layerNormInit {
  *  into the config (ownsQuantizations=false; caller retains ownership of the
  *  storage quantizations). Allocates gamma (init 1) and beta (init 0) parameter_t
  *  (storage dtype = lq->weightStorage / lq->biasStorage) and their grads via
- *  gradInit(param, lq->weightGradStorage ?: lq->propLossQ, NULL) (resp.
- *  biasGradStorage for beta). Copies normalizedShape into factory-owned
+ *  gradInit(param, lq->weightGradStorage ?: FLOAT32, NULL) (resp.
+ *  biasGradStorage for beta) — PR1c: the NULL-knob default is a hard-pinned
+ *  FLOAT32, not lq->propLossQ. Copies normalizedShape into factory-owned
  *  memory.
  *  Use when: outputQ/propLossQ are shared/long-lived (e.g. reused across
  *  several layers) and the caller manages their lifetime — they must

--- a/src/userApi/optimizer/SgdApi.c
+++ b/src/userApi/optimizer/SgdApi.c
@@ -163,10 +163,11 @@ optimizer_t *sgdMCreateOptim(float learningRate, float momentumFactor, float wei
             exit(1);
         }
     }
-    /* #261: grads may be stored FLOAT32 (default) or SYM_INT32 (legitimate
-     * low-level path until PR3). Sub-byte SYM/ASYM grad storage is not
-     * implemented yet - fail fast rather than silently misread packed bytes.
-     * Non-trainable params carry no grad: skip. */
+    /* #261, PR1c: grads may be stored FLOAT32 (default) or SYM_INT32
+     * (legitimate low-level path via the explicit grad-storage knob). INT32/
+     * SYM/ASYM/BOOL grad storage is not implemented yet - fail fast rather
+     * than silently misread bytes in an unsupported layout. Non-trainable
+     * params carry no grad: skip. */
     for (size_t s = 0; s < optim->sizeStates; s++) {
         tensor_t *grad = optim->parameter[s]->grad;
         if (grad == NULL) {
@@ -175,7 +176,8 @@ optimizer_t *sgdMCreateOptim(float learningRate, float momentumFactor, float wei
         qtype_t gradType = grad->quantization->type;
         if (gradType != FLOAT32 && gradType != SYM_INT32) {
             PRINT_ERROR("sgdMCreateOptim: gradient storage dtype %d not supported "
-                        "(only FLOAT32 / SYM_INT32; sub-byte grad storage lands in PR3, #261)",
+                        "(accepted: FLOAT32, SYM_INT32; INT32/SYM/ASYM/BOOL grad storage "
+                        "lands in PR3, #261)",
                         (int)gradType);
             exit(1);
         }

--- a/test/unit/layer/UnitTestLayerNorm.c
+++ b/test/unit/layer/UnitTestLayerNorm.c
@@ -1856,12 +1856,11 @@ void testSymBackwardDivergentLayoutsBitIdentical(void) {
     }
 }
 
-/* Full-SYM profile (forwardMath = backwardMath = storage = SYM_INT32) through
- * the Borrowing factory: gradInit must yield SYM_INT32 grads (PR-0 plumbing),
- * and a vtable backward on factory-built params must accumulate into them.
- * (The new validation rules are death paths — liveness-checked in this task's
- * inversion step, not Unity-testable.) */
-void testFactoryFullSymProfileTrainsSymGrads(void) {
+/* PR1c: default grads are FLOAT32; SYM via knob. A full-SYM profile
+ * (forwardMath = propLossMath = storage = SYM_INT32) with the grad-storage
+ * knob left NULL must no longer fall back to SYM_INT32 gamma/beta grads — the
+ * factory default is now a hard-pinned FLOAT32, independent of propLossQ. */
+void testFactoryDefaultGradStorageIsFloat32DespiteFullSymProfile(void) {
     size_t normShape[] = {4};
     layerNormInit_t init = {.normalizedShape = normShape, .numNormDims = 1, .eps = 1e-5f};
 
@@ -1872,6 +1871,41 @@ void testFactoryFullSymProfileTrainsSymGrads(void) {
                        .propLossQ = symQ,
                        .weightStorage = symQ,
                        .biasStorage = symQ};
+    layer_t *layer = layerNormLayerInit(&init, &lq);
+    layerNormConfig_t *cfg = layer->config->layerNorm;
+
+    int gammaGradType = cfg->gamma->grad->quantization->type;
+    int betaGradType = cfg->beta->grad->quantization->type;
+
+    freeLayerNormLayer(layer);
+    freeQuantization(symQ);
+
+    TEST_ASSERT_EQUAL_INT_MESSAGE(FLOAT32, gammaGradType,
+                                  "PR1c: default (NULL knob) gamma grad storage must be FLOAT32");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(FLOAT32, betaGradType,
+                                  "PR1c: default (NULL knob) beta grad storage must be FLOAT32");
+}
+
+/* Full-SYM profile (forwardMath = backwardMath = storage = SYM_INT32) through
+ * the Borrowing factory with the grad-storage knob explicitly set: gradInit
+ * must yield SYM_INT32 grads when the caller opts in (PR1c: this is no longer
+ * the factory default — see testFactoryDefaultGradStorageIsFloat32DespiteFullSymProfile
+ * above), and a vtable backward on factory-built params must accumulate into
+ * them. (The new validation rules are death paths — liveness-checked in this
+ * task's inversion step, not Unity-testable.) */
+void testFactoryFullSymProfileTrainsSymGrads(void) {
+    size_t normShape[] = {4};
+    layerNormInit_t init = {.normalizedShape = normShape, .numNormDims = 1, .eps = 1e-5f};
+
+    quantization_t *symQ = quantizationInitSymInt32(HALF_AWAY);
+    layerQuant_t lq = {.forwardMath = arithmeticFromQuantization(symQ),
+                       .propLossMath = arithmeticFromQuantization(symQ),
+                       .outputQ = symQ,
+                       .propLossQ = symQ,
+                       .weightStorage = symQ,
+                       .biasStorage = symQ,
+                       .weightGradStorage = symQ,
+                       .biasGradStorage = symQ};
     layer_t *layer = layerNormLayerInit(&init, &lq);
     layerNormConfig_t *cfg = layer->config->layerNorm;
 
@@ -1900,8 +1934,10 @@ void testFactoryFullSymProfileTrainsSymGrads(void) {
     freeLayerNormLayer(layer);
     freeQuantization(symQ);
 
-    TEST_ASSERT_TRUE(gradsSym);
-    TEST_ASSERT_TRUE_MESSAGE(dbSum > 0, "backward must accumulate into the factory SYM grads");
+    TEST_ASSERT_TRUE_MESSAGE(
+        gradsSym, "explicit weightGradStorage/biasGradStorage knob must yield SYM_INT32 grads");
+    TEST_ASSERT_TRUE_MESSAGE(dbSum > 0,
+                             "backward must accumulate into the explicit-knob SYM grads");
     TEST_ASSERT_TRUE(dxScale > 0.0f && dxScale != 1.0f);
 }
 
@@ -1988,6 +2024,7 @@ int main(void) {
     RUN_TEST(testSymBackwardGradsAccumulateAcrossCalls);
     RUN_TEST(testSymBackwardVarNearEpsGold);
     RUN_TEST(testSymBackwardDivergentLayoutsBitIdentical);
+    RUN_TEST(testFactoryDefaultGradStorageIsFloat32DespiteFullSymProfile);
     RUN_TEST(testFactoryFullSymProfileTrainsSymGrads);
     RUN_TEST(testLayerNormSymRejectsOperandWiderThanInt12);
     return UNITY_END();

--- a/test/unit/layer/UnitTestLinear.c
+++ b/test/unit/layer/UnitTestLinear.c
@@ -1035,9 +1035,10 @@ void testLinearLayerInitBorrowingBiasFalseLeavesBiasNull(void) {
     freeLinearLayer(layer);
 }
 
-void testLinearLayerInitSymInt32BackwardMathYieldsSymInt32Grad(void) {
-    /* Regression for the "config lies" bug: a Linear built with a SYM_INT32
-     * backwardMath must store SYM_INT32 parameter gradients, not FLOAT32. */
+void testLinearLayerInitDefaultGradStorageIsFloat32DespiteSymPropLossQ(void) {
+    /* PR1c: default grads are FLOAT32; SYM via knob. A SYM propLossQ with the
+     * grad-storage knob left NULL must NOT fall back to SYM_INT32 anymore —
+     * the factory default is a hard-pinned FLOAT32, independent of propLossQ. */
     quantization_t *fwd = quantizationInitFloat();             /* FLOAT32 forward + storage */
     quantization_t *bwd = quantizationInitSymInt32(HALF_AWAY); /* SYM_INT32 backward */
     layerQuant_t lq = {
@@ -1049,6 +1050,50 @@ void testLinearLayerInitSymInt32BackwardMathYieldsSymInt32Grad(void) {
         .propLossQ = bwd,
         .weightStorage = fwd, /* KAIMING init requires FLOAT32 weight storage */
         .biasStorage = fwd,
+        /* weightGradStorage / biasGradStorage deliberately left NULL. */
+    };
+
+    layer_t *layer = linearLayerInit(
+        &(linearInit_t){
+            .inFeatures = 3,
+            .outFeatures = 2,
+            .bias = BIAS_TRUE,
+        },
+        &lq);
+
+    linearConfig_t *cfg = layer->config->linear;
+    int weightGradType = cfg->weights->grad->quantization->type;
+    int biasGradType = cfg->bias->grad->quantization->type;
+
+    freeLinearLayer(layer);
+    freeQuantization(bwd);
+    freeQuantization(fwd);
+
+    TEST_ASSERT_EQUAL_INT_MESSAGE(FLOAT32, weightGradType,
+                                  "PR1c: default (NULL knob) weight grad storage must be FLOAT32");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(FLOAT32, biasGradType,
+                                  "PR1c: default (NULL knob) bias grad storage must be FLOAT32");
+}
+
+void testLinearLayerInitSymInt32BackwardMathYieldsSymInt32Grad(void) {
+    /* Regression for the "config lies" bug: a Linear built with a SYM_INT32
+     * backwardMath must store SYM_INT32 parameter gradients when the caller
+     * opts in via the grad-storage knob. PR1c: default grads are FLOAT32; SYM
+     * via knob — the explicit weightGradStorage/biasGradStorage below is what
+     * keeps this test exercising the SYM path post-flip. */
+    quantization_t *fwd = quantizationInitFloat();             /* FLOAT32 forward + storage */
+    quantization_t *bwd = quantizationInitSymInt32(HALF_AWAY); /* SYM_INT32 backward */
+    layerQuant_t lq = {
+        .forwardMath = arithmeticFromQuantization(fwd),
+        .weightGradMath = arithmeticFromQuantization(bwd),
+        .biasGradMath = arithmeticFromQuantization(bwd),
+        .propLossMath = arithmeticFromQuantization(bwd),
+        .outputQ = fwd,
+        .propLossQ = bwd,
+        .weightStorage = fwd, /* KAIMING init requires FLOAT32 weight storage */
+        .biasStorage = fwd,
+        .weightGradStorage = bwd,
+        .biasGradStorage = bwd,
     };
 
     layer_t *layer = linearLayerInit(
@@ -1132,9 +1177,11 @@ void testLinearLayerInitOwningFreesAllAllocationsWithoutLeak(void) {
  * ========================================================================== */
 
 void testLinearLayerInitOwningWeightGradStorageKnobOverridesPropLossQDefault(void) {
-    /* Default (knob == NULL) grad storage derives from propLossQ; a non-NULL
-     * weightGradStorage config must override that default end-to-end, through
-     * the same getQLike path gradInit already uses. */
+    /* PR1c: default (knob == NULL) grad storage is a hard-pinned FLOAT32; a
+     * non-NULL weightGradStorage config must override that default end-to-end,
+     * through the same getQLike path gradInit already uses. (This test's own
+     * propLossQ is already FLOAT32, so the flip doesn't change its outcome —
+     * only the comment's claim about what NULL falls back to.) */
     quantization_t *q = quantizationInitFloat();
     layerQuant_t lq;
     layerQuantInitUniform(&lq, q);
@@ -1238,7 +1285,10 @@ static tensor_t *e2eMakeSym1x3(void) {
 
 void testLinearSymInt32GradAccumulatesOverTwoMicrobatchesAndSteps(void) {
     /* outFeatures=2, inFeatures=3. forward input [1,2,3], loss [0.5, -0.25].
-     * Two identical microbatches => accumulated weight grad ~= 2 * (loss^T @ input). */
+     * Two identical microbatches => accumulated weight grad ~= 2 * (loss^T @ input).
+     * PR1c: default grads are FLOAT32; SYM via knob — weightGradStorage/
+     * biasGradStorage below opt this layer back into the SYM_INT32 grad path
+     * so the test keeps exercising SYM accumulation parity, not float-vs-float. */
     const float inputVals[3] = {1.0f, 2.0f, 3.0f};
     const float lossVals[2] = {0.5f, -0.25f};
 
@@ -1252,7 +1302,9 @@ void testLinearSymInt32GradAccumulatesOverTwoMicrobatchesAndSteps(void) {
                           .outputQ = fwd,
                           .propLossQ = bwd,
                           .weightStorage = fwd,
-                          .biasStorage = fwd};
+                          .biasStorage = fwd,
+                          .weightGradStorage = bwd,
+                          .biasGradStorage = bwd};
     layer_t *symLayer = linearLayerInit(
         &(linearInit_t){.inFeatures = 3, .outFeatures = 2, .bias = BIAS_TRUE}, &lqSym);
 
@@ -1533,6 +1585,7 @@ int main(void) {
     RUN_TEST(testLinearLayerInitBorrowingZeroInChannelsAbortsViaPrintError);
     RUN_TEST(testLinearLayerInitBorrowingBiasDefaultResolvesToTrue);
     RUN_TEST(testLinearLayerInitBorrowingBiasFalseLeavesBiasNull);
+    RUN_TEST(testLinearLayerInitDefaultGradStorageIsFloat32DespiteSymPropLossQ);
     RUN_TEST(testLinearLayerInitSymInt32BackwardMathYieldsSymInt32Grad);
     RUN_TEST(testLinearSymInt32GradAccumulatesOverTwoMicrobatchesAndSteps);
 

--- a/test/unit/optimizer/UnitTestSgd.c
+++ b/test/unit/optimizer/UnitTestSgd.c
@@ -371,6 +371,9 @@ void testSGDZeroGrad() {
 }
 
 void testSgdZeroGradOnSymInt32GradZeroesMantissasAndResetsScale(void) {
+    /* PR1c: default grads are FLOAT32; SYM via knob. weightGradStorage/
+     * biasGradStorage opt this layer's grads back into SYM_INT32 so this test
+     * keeps exercising the SYM zero+scale-reset path it's named for. */
     quantization_t *fwd = quantizationInitFloat();
     quantization_t *bwd = quantizationInitSymInt32(HALF_AWAY);
     layerQuant_t lq = {.forwardMath = arithmeticFromQuantization(fwd),
@@ -380,7 +383,9 @@ void testSgdZeroGradOnSymInt32GradZeroesMantissasAndResetsScale(void) {
                        .outputQ = fwd,
                        .propLossQ = bwd,
                        .weightStorage = fwd,
-                       .biasStorage = fwd};
+                       .biasStorage = fwd,
+                       .weightGradStorage = bwd,
+                       .biasGradStorage = bwd};
     layer_t *layer =
         linearLayerInit(&(linearInit_t){.inFeatures = 3, .outFeatures = 2, .bias = BIAS_TRUE}, &lq);
 

--- a/test/unit/userAPI/UnitTestLayerNormIntegration.c
+++ b/test/unit/userAPI/UnitTestLayerNormIntegration.c
@@ -156,6 +156,9 @@ void testLayerNormSymInt32SingleLayerTrainingStep(void) {
     size_t normShape[] = {4};
 
     /* ---- SYM model (under test) ---- */
+    /* PR1c: default grads are FLOAT32; SYM via knob. weightGradStorage/
+     * biasGradStorage opt gamma/beta grads back into SYM_INT32 so this test
+     * keeps exercising the full SYM training step it's named for. */
     layerNormInit_t initSym = {.normalizedShape = normShape, .numNormDims = 1, .eps = 1e-5f};
     quantization_t *symQ = quantizationInitSymInt32(HALF_AWAY);
     layerQuant_t lqSym = {.forwardMath = arithmeticFromQuantization(symQ),
@@ -163,7 +166,9 @@ void testLayerNormSymInt32SingleLayerTrainingStep(void) {
                           .outputQ = symQ,
                           .propLossQ = symQ,
                           .weightStorage = symQ,
-                          .biasStorage = symQ};
+                          .biasStorage = symQ,
+                          .weightGradStorage = symQ,
+                          .biasGradStorage = symQ};
     layer_t *lnSym = layerNormLayerInit(&initSym, &lqSym);
     layer_t *modelSym[1] = {lnSym};
 
@@ -227,7 +232,8 @@ void testLayerNormSymInt32SingleLayerTrainingStep(void) {
 
     TEST_ASSERT_TRUE(symStatsNotNull);
     TEST_ASSERT_TRUE_MESSAGE(isfinite(symLoss), "SYM loss must be finite");
-    TEST_ASSERT_TRUE_MESSAGE(gradSymDtype, "factory must produce SYM_INT32 grads");
+    TEST_ASSERT_TRUE_MESSAGE(
+        gradSymDtype, "explicit weightGradStorage/biasGradStorage knob must yield SYM_INT32 grads");
     for (size_t i = 0; i < 4; i++) {
         /* gamma init 1.0 / beta init 0.0: both twins must move, and the SYM
          * twin must land near the float twin. */


### PR DESCRIPTION
## Summary

**STACKED on #272** (base = \`pr1b2-forward-funnel\`; GitHub auto-retargets to \`develop\` once #272 merges and its branch is deleted).

Completes the #261 principle (SYM_INT32 = compute format, not storage): the factory grad-storage **NULL-knob default becomes FLOAT32 everywhere**. Linear and LayerNorm previously derived default grad storage from \`propLossQ\` (SYM-uniform profile → SYM_INT32 grads); they now mirror Conv1d/ConvT1d's hard-pinned FLOAT32 default. SYM grads remain fully available via the explicit \`weightGradStorage\`/\`biasGradStorage\` knob.

- 2 new default-FLOAT32 pins (RED→GREEN, mutation-verified — independently reproduced in review).
- All 5 tests that consumed the old default **keep their SYM coverage** via the explicit knob set to the same pointer the default used — pre-flip semantics bit-for-bit, zero numeric expectation changes.
- Guard messages (SgdApi, ExecuteOp) reworded to name the admitted set (FLOAT32/SYM_INT32) — the old "sub-byte" wording also rejected INT32 (PR1a review carry-over); condition byte-identical.
- Docs: \`docs/conventions/tensor.md\` #261 paragraph + \`arithmetic-sym.md\` updated; no stale default-SYM claim left (grep-verified).

## Evidence

Debug/ASan/UBSan ctest 67/67; examples preset builds; \`mixed_width_mlp\` (sets the knob explicitly) bit-identical: initial 2.292284 / final 1.250560, grads SYM_INT32@16. Review verdict: Approved, zero findings — all claims independently reproduced in a throwaway clone.

Refs #261 (this PR completes its storage-default half; packed-SYM/ASYM grad storage lands in PR3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHXkmS6X8FkEdQCMqMHs6K