### PR TITLE
fix(tensor,serial): sub-byte primitives — copyQuantization arms + byte-ceiling class (PR2, #171/#172)

### DIFF
--- a/docs/conventions/tensor.md
+++ b/docs/conventions/tensor.md
@@ -26,6 +26,13 @@ hard-pinned `FLOAT32`, closing the gap described above by default. `SYM_INT32`
 parameter grads remain available and legitimate only via the explicit
 `weightGradStorage`/`biasGradStorage` knob on `layerQuant_t` (#261).
 
+## Packing / byte-count invariant (#172)
+
+- Payload sizing: byte counts for tensor data always ceiling-divide;
+  `calcNumberOfBytesForData(q, N)` is the single authority (allocation, copy,
+  zeroing, serialization). `calcBytesPerElement` is an unpacked per-element
+  stride — multiplying it by N over-counts packed sub-byte payloads (#172).
+
 ## SYM ↔ * conversion bridge (#227)
 
 `SYM` is the sub-byte bit-packed **storage** dtype; `SYM_INT32` is the int32-slot

--- a/src/optimizer/Sgd.c
+++ b/src/optimizer/Sgd.c
@@ -3,7 +3,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <tgmath.h>
 
 #include "Common.h"
 #include "Sgd.h"
@@ -167,8 +166,7 @@ void sgdZeroGrad(optimizer_t *optimizer) {
     for (size_t i = 0; i < optimizer->sizeStates; i++) {
         parameter_t *param = optimizer->parameter[i];
         size_t paramSize = calcNumberOfElementsByParameter(param);
-        size_t bitsPerElement = calcBitsPerElement(param->grad->quantization);
-        size_t totalNumberOfBytes = ceil(paramSize * bitsPerElement / 8);
+        size_t totalNumberOfBytes = calcNumberOfBytesForData(param->grad->quantization, paramSize);
 
         memset(param->grad->data, 0, totalNumberOfBytes);
 

--- a/src/serial/Deserialize.c
+++ b/src/serial/Deserialize.c
@@ -31,9 +31,10 @@ void deserializeTensor(tensor_t *tensor, FILE *f) {
     deserializeQuantization(tensor->quantization, f);
 
     size_t numberOfValues = calcNumberOfElementsByShape(tensor->shape);
-    size_t bytesPerValue = calcBytesPerElement(tensor->quantization);
+    /* Mirrors Serialize.c: payload length is the packed size. */
+    size_t dataBytes = calcNumberOfBytesForData(tensor->quantization, numberOfValues);
 
-    deserializeData(tensor->data, numberOfValues, bytesPerValue, f);
+    deserializeData(tensor->data, dataBytes, 1, f);
     deserializeSparsity();
 }
 

--- a/src/serial/Serialize.c
+++ b/src/serial/Serialize.c
@@ -31,11 +31,13 @@
 
 void serializeTensor(tensor_t *tensor, FILE *f) {
     size_t numberOfValues = calcNumberOfElementsByTensor(tensor);
-    size_t bytesPerValue = calcBytesPerElement(tensor->quantization);
+    /* Data payload = packed size (calcNumberOfBytesForData) -- byte-identical to
+     * N * elementSize for byte-aligned dtypes, packed-tight for sub-byte (#172). */
+    size_t dataBytes = calcNumberOfBytesForData(tensor->quantization, numberOfValues);
 
     serializeShape(tensor->shape, f);
     serializeQuantization(tensor->quantization, f);
-    serializeData(tensor->data, numberOfValues, bytesPerValue, f);
+    serializeData(tensor->data, dataBytes, 1, f);
     serializeSparsity();
 }
 

--- a/src/tensor/Tensor.c
+++ b/src/tensor/Tensor.c
@@ -76,15 +76,9 @@ size_t calcBitsPerElement(quantization_t *quantization) {
     }
 }
 
-size_t calcBitsPerTensor(tensor_t *tensor) {
-    size_t bitsPerElement = calcBitsPerElement(tensor->quantization);
-    size_t numElements = calcNumberOfElementsByShape(tensor->shape);
-    return bitsPerElement * numElements;
-}
-
 size_t calcBytesPerTensor(tensor_t *tensor) {
-    size_t bitsPerTensor = calcBitsPerTensor(tensor);
-    return bitsPerTensor / 8;
+    size_t numberOfElements = calcNumberOfElementsByShape(tensor->shape);
+    return calcNumberOfBytesForData(tensor->quantization, numberOfElements);
 }
 
 size_t calcNumberOfBytesForData(quantization_t *q, size_t numberOfElements) {

--- a/src/tensor/Tensor.c
+++ b/src/tensor/Tensor.c
@@ -418,17 +418,39 @@ void copyShape(shape_t *dest, shape_t *src) {
     dest->numberOfDimensions = src->numberOfDimensions;
 }
 
+/* Clones src's quantization into dest. Config-carrying dtypes (SYM_INT32/SYM/ASYM)
+ * copy INTO dest->qConfig -- the caller must have pre-allocated it for the same
+ * dtype (src/tensor never allocates). NULL-config dtypes (INT32/FLOAT32/BOOL)
+ * overwrite dest->qConfig with NULL; a heap config dest owned beforehand stays
+ * owned by the caller. */
+static void copyQConfigInto(quantization_t *dest, quantization_t *src, size_t qConfigSize,
+                            const char *typeName) {
+    if (dest->qConfig == NULL) {
+        PRINT_ERROR("copyQuantization: dest->qConfig for %s must be caller-allocated", typeName);
+        exit(1);
+    }
+    dest->type = src->type;
+    memcpy(dest->qConfig, src->qConfig, qConfigSize);
+}
+
 void copyQuantization(quantization_t *dest, quantization_t *src) {
     switch (src->type) {
+    case INT32:
+        dest->type = INT32;
+        dest->qConfig = NULL;
+        break;
     case FLOAT32:
         dest->type = FLOAT32;
         dest->qConfig = NULL;
         break;
     case SYM_INT32:
-        dest->type = SYM_INT32;
-        symInt32QConfig_t *destQC = dest->qConfig;
-        symInt32QConfig_t *srcQC = src->qConfig;
-        memcpy(destQC, srcQC, sizeof(symInt32QConfig_t));
+        copyQConfigInto(dest, src, sizeof(symInt32QConfig_t), "SYM_INT32");
+        break;
+    case SYM:
+        copyQConfigInto(dest, src, sizeof(symQConfig_t), "SYM");
+        break;
+    case ASYM:
+        copyQConfigInto(dest, src, sizeof(asymQConfig_t), "ASYM");
         break;
     case BOOL:
         dest->type = BOOL;

--- a/src/tensor/TensorConversion.c
+++ b/src/tensor/TensorConversion.c
@@ -516,23 +516,42 @@ conversionFunction_t conversionMatrix[6][6] = {
 
 static void convertTensorsWithSameType(tensor_t *inputTensor, tensor_t *outputTensor,
                                        qtype_t qType) {
+    size_t inputBits = calcBitsPerElement(inputTensor->quantization);
+    size_t outputBits = calcBitsPerElement(outputTensor->quantization);
+    if (inputBits != outputBits) {
+        /* Same-type conversion is a verbatim packed-byte copy; differing widths
+         * would reinterpret the packing (and overflow the output for wider inputs).
+         * Width-changing SYM/ASYM rewrites are real conversions (repack policy:
+         * PR3, #261). */
+        PRINT_ERROR("Same-type conversion requires equal element widths (%zu vs %zu bits)",
+                    inputBits, outputBits);
+        exit(1);
+    }
     size_t numberOfElements = calcNumberOfElementsByTensor(inputTensor);
     size_t numberOfBytes = calcNumberOfBytesForData(inputTensor->quantization, numberOfElements);
 
     memmove(outputTensor->data, inputTensor->data, numberOfBytes);
 
     switch (qType) {
-    case SYM_INT32:
+    case SYM_INT32: {
         symInt32QConfig_t *inputSymIntQC = inputTensor->quantization->qConfig;
         symInt32QConfig_t *outputSymIntQC = outputTensor->quantization->qConfig;
         outputSymIntQC->scale = inputSymIntQC->scale;
         break;
-    case ASYM:
+    }
+    case SYM: {
+        symQConfig_t *inputSymQC = inputTensor->quantization->qConfig;
+        symQConfig_t *outputSymQC = outputTensor->quantization->qConfig;
+        outputSymQC->scale = inputSymQC->scale;
+        break;
+    }
+    case ASYM: {
         asymQConfig_t *inputAsymQC = inputTensor->quantization->qConfig;
         asymQConfig_t *outputAsymQC = outputTensor->quantization->qConfig;
         outputAsymQC->scale = inputAsymQC->scale;
         outputAsymQC->zeroPoint = inputAsymQC->zeroPoint;
         break;
+    }
     default:
         break;
     }

--- a/src/tensor/TensorConversion.c
+++ b/src/tensor/TensorConversion.c
@@ -19,8 +19,7 @@ static void quantizeFloatToAsym(const float *values, size_t n, asymQConfig_t *ou
 
 void zeroTensorData(tensor_t *tensor) {
     size_t numberOfElements = calcNumberOfElementsByTensor(tensor);
-    size_t bytesPerElement = calcBytesPerElement(tensor->quantization);
-    memset(tensor->data, 0, numberOfElements * bytesPerElement);
+    memset(tensor->data, 0, calcNumberOfBytesForData(tensor->quantization, numberOfElements));
 }
 
 void convertInt32TensorToFloatTensor(tensor_t *inputTensor, tensor_t *outputTensor) {

--- a/test/unit/optimizer/UnitTestSgd.c
+++ b/test/unit/optimizer/UnitTestSgd.c
@@ -1,5 +1,6 @@
 #define SOURCE_FILE "SGD-UTEST"
 #include <stdlib.h>
+#include <string.h>
 
 #include "ArithmeticType.h"
 #include "DeathTest.h"
@@ -570,6 +571,53 @@ void testSgdStepSymInt32DoesNotRoundTripGrad(void) {
     TEST_ASSERT_FLOAT_WITHIN(1e-9f, 0.05f, gScale);
 }
 
+void testSgdZeroGradAsymSubByteZeroesAllPackedBytes(void) {
+    /* ASYM qBits=3, N=10 grad -> packed ceil(30/8) = 4 bytes. Pre-fix sizing
+     * (size_t division inside ceil()) truncated to 3, leaving stale grad bits in
+     * the last packed byte. Mutation guard: reverting to the old formula leaves
+     * byte 3 == 0xFF -> RED. */
+    size_t *pDims = reserveMemory(2 * sizeof(size_t));
+    pDims[0] = 2;
+    pDims[1] = 5;
+    size_t *pOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, pOrder);
+    shape_t *pShape = reserveMemory(sizeof(shape_t));
+    setShape(pShape, pDims, 2, pOrder);
+    tensor_t *p = initTensor(pShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(p, (float[]){0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f}, 10);
+    tensor_t *g = gradInitAsym(p, 3, HALF_AWAY, NULL);
+    parameter_t *param = parameterInit(p, g);
+    memset(g->data, 0xFF, 4); /* poison all packed grad bytes */
+
+    /* Hand-built optimizer: sgdMCreateOptim rejects sub-byte grad storage until
+     * PR3, but sgdZeroGrad reads only sizeStates/parameter — this characterizes
+     * the primitive PR3 will rely on. */
+    sgd_t sgd;
+    sgdInit(&sgd, 0.1f, 0.0f, 0.0f);
+    parameter_t *params[1] = {param};
+    optimImpl_t impl;
+    impl.sgd = &sgd;
+    optimizer_t optim;
+    optim.parameter = params;
+    optim.sizeStates = 1;
+    optim.qtype = FLOAT32;
+    optim.impl = &impl;
+
+    sgdZeroGrad(&optim);
+
+    /* CAPTURE -> free -> assert (file convention). */
+    uint8_t b0 = g->data[0];
+    uint8_t b1 = g->data[1];
+    uint8_t b2 = g->data[2];
+    uint8_t b3 = g->data[3];
+    freeParameter(param);
+
+    TEST_ASSERT_EQUAL_UINT8(0, b0);
+    TEST_ASSERT_EQUAL_UINT8(0, b1);
+    TEST_ASSERT_EQUAL_UINT8(0, b2);
+    TEST_ASSERT_EQUAL_UINT8(0, b3);
+}
+
 void testSgdMCreateOptimRejectsSubByteGradStorage(void) {
     /* FLOAT32 weight param whose grad is allocated sub-byte SYM (int8) — the
      * not-yet-supported storage PR3 adds. Optimizer construction must abort. */
@@ -620,5 +668,6 @@ int main() {
     RUN_TEST(testSgdMCreateOptimRegistersLayerNormGammaAndBeta);
     RUN_TEST(testSgdStepSymInt32DoesNotRoundTripGrad);
     RUN_TEST(testSgdMCreateOptimRejectsSubByteGradStorage);
+    RUN_TEST(testSgdZeroGradAsymSubByteZeroesAllPackedBytes);
     return UNITY_END();
 }

--- a/test/unit/serial/UnitTestSerialize.c
+++ b/test/unit/serial/UnitTestSerialize.c
@@ -1,4 +1,6 @@
+#include <stdbool.h>
 #include <stdio.h>
+#include <string.h>
 
 #include "AdaptiveAvgPool1d.h"
 #include "AdaptivePool1dApi.h"
@@ -1197,6 +1199,111 @@ static void testRoundTripQuantizationLayer(void) {
     TEST_ASSERT_EQUAL(capturedSerialPropLossZP, capturedDeserialPropLossZP);
 }
 
+/*! SYM sub-byte tensor DATA record: qBits=4, N=10 -> exactly ceil(40/8) = 5
+ *  packed data bytes on the wire. The u32 sentinel written right after the
+ *  record catches any sizing skew between writer and reader (one-sided
+ *  mutation -> misaligned sentinel).
+ *  Mutation guard: reverting BOTH sides to N * calcBytesPerElement makes
+ *  serialize fwrite 10 bytes from the 5-byte heap buffer and deserialize
+ *  fread 10 into it -> ASan RED (over-read + OOB write); reverting ONE side
+ *  misaligns the sentinel -> RED in plain debug too. */
+static void testSerializeTensorSymSubByteRoundTripsPackedData(void) {
+    size_t *dims = reserveMemory(2 * sizeof(size_t));
+    dims[0] = 2;
+    dims[1] = 5;
+    size_t *order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, order);
+    shape_t *shape = reserveMemory(sizeof(shape_t));
+    setShape(shape, dims, 2, order);
+    tensor_t *src = initTensor(shape, quantizationInitSym(4, HALF_AWAY), NULL);
+    tensorFillFromFloatBuffer(src, (float[]){1.f, -2.f, 3.f, -4.f, 5.f, -6.f, 7.f, -6.f, 5.f, -4.f},
+                              10);
+    float srcScale = ((symQConfig_t *)src->quantization->qConfig)->scale;
+    uint8_t srcBytes[5];
+    memcpy(srcBytes, src->data, 5);
+
+    FILE *f = fopen(FILE_PATH, "wb");
+    serializeTensor(src, f);
+    uint32_t sentinelOut = 0x53454E54u;
+    fwrite(&sentinelOut, sizeof(sentinelOut), 1, f);
+    fclose(f);
+
+    size_t *dDims = reserveMemory(2 * sizeof(size_t));
+    dDims[0] = 2;
+    dDims[1] = 5;
+    size_t *dOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, dOrder);
+    shape_t *dShape = reserveMemory(sizeof(shape_t));
+    setShape(dShape, dDims, 2, dOrder);
+    tensor_t *dst = initTensor(dShape, quantizationInitSym(4, HALF_AWAY), NULL);
+
+    f = fopen(FILE_PATH, "rb");
+    deserializeTensor(dst, f);
+    uint32_t sentinelIn = 0;
+    fread(&sentinelIn, sizeof(sentinelIn), 1, f);
+    fclose(f);
+
+    /* CAPTURE -> free -> assert (file convention). */
+    float dstScale = ((symQConfig_t *)dst->quantization->qConfig)->scale;
+    uint8_t dstBytes[5];
+    memcpy(dstBytes, dst->data, 5);
+    freeTensor(src);
+    freeTensor(dst);
+
+    TEST_ASSERT_EQUAL_HEX32(0x53454E54u, sentinelIn);
+    TEST_ASSERT_EQUAL_FLOAT(srcScale, dstScale);
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(srcBytes, dstBytes, 5);
+}
+
+/*! BOOL tensor DATA record: N=12 bools -> 2 packed bytes on the wire
+ *  (pre-fix: 12). Same sentinel discipline as the SYM round trip. */
+static void testSerializeTensorBoolRoundTripsPackedData(void) {
+    size_t *dims = reserveMemory(2 * sizeof(size_t));
+    dims[0] = 3;
+    dims[1] = 4;
+    size_t *order = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, order);
+    shape_t *shape = reserveMemory(sizeof(shape_t));
+    setShape(shape, dims, 2, order);
+    tensor_t *src = initTensor(shape, quantizationInitBool(), NULL);
+    bool pattern[12] = {true, false, true,  true, false, false,
+                        true, false, false, true, true,  false};
+    tensorFillFromBoolBuffer(src, pattern, 12);
+
+    FILE *f = fopen(FILE_PATH, "wb");
+    serializeTensor(src, f);
+    uint32_t sentinelOut = 0x53454E54u;
+    fwrite(&sentinelOut, sizeof(sentinelOut), 1, f);
+    fclose(f);
+
+    size_t *dDims = reserveMemory(2 * sizeof(size_t));
+    dDims[0] = 3;
+    dDims[1] = 4;
+    size_t *dOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, dOrder);
+    shape_t *dShape = reserveMemory(sizeof(shape_t));
+    setShape(dShape, dDims, 2, dOrder);
+    tensor_t *dst = initTensor(dShape, quantizationInitBool(), NULL);
+
+    f = fopen(FILE_PATH, "rb");
+    deserializeTensor(dst, f);
+    uint32_t sentinelIn = 0;
+    fread(&sentinelIn, sizeof(sentinelIn), 1, f);
+    fclose(f);
+
+    bool got[12];
+    for (size_t i = 0; i < 12; i++) {
+        got[i] = tensorBoolGet(dst, i);
+    }
+    freeTensor(src);
+    freeTensor(dst);
+
+    TEST_ASSERT_EQUAL_HEX32(0x53454E54u, sentinelIn);
+    for (size_t i = 0; i < 12; i++) {
+        TEST_ASSERT_EQUAL_INT(pattern[i], got[i]);
+    }
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(testRoundTripLinear);
@@ -1211,5 +1318,7 @@ int main(void) {
     RUN_TEST(testRoundTripDropout);
     RUN_TEST(testRoundTripLayerNorm);
     RUN_TEST(testRoundTripQuantizationLayer);
+    RUN_TEST(testSerializeTensorSymSubByteRoundTripsPackedData);
+    RUN_TEST(testSerializeTensorBoolRoundTripsPackedData);
     return UNITY_END();
 }

--- a/test/unit/tensor/CMakeLists.txt
+++ b/test/unit/tensor/CMakeLists.txt
@@ -13,6 +13,7 @@ add_elastic_ai_unit_test(
         Rounding
         Quantization
         StorageApi
+        odt_test_death
 )
 add_elastic_ai_unit_test(
         LIB_UNDER_TEST

--- a/test/unit/tensor/UnitTestTensor.c
+++ b/test/unit/tensor/UnitTestTensor.c
@@ -1,4 +1,5 @@
 #include "DTypes.h"
+#include "DeathTest.h"
 #include "StorageApi.h"
 #include "Tensor.h"
 #include "unity.h"
@@ -265,6 +266,143 @@ void test_calcNumberOfBytesForData_Sym_qBits5_N4() {
     TEST_ASSERT_EQUAL_size_t(3, calcNumberOfBytesForData(&q, 4));
 }
 
+void testCopyTensorInt32CarriesTypeAndData() {
+    /* Mutation guard: re-removing the INT32 arm makes copyQuantization exit(1)
+     * ("Unknown QType!"), killing the test run — RED. */
+    int32_t srcData[] = {7, -3, 2000000000, -2000000000};
+    size_t srcDims[] = {1, 4};
+    size_t srcOrder[] = {0, 1};
+    shape_t srcShape = {
+        .dimensions = srcDims, .numberOfDimensions = 2, .orderOfDimensions = srcOrder};
+    quantization_t qSrc;
+    initInt32Quantization(&qSrc);
+    tensor_t src;
+    setTensorValues(&src, (uint8_t *)srcData, &srcShape, &qSrc, NULL);
+
+    int32_t dstData[4] = {0};
+    size_t dstDims[2];
+    size_t dstOrder[2];
+    shape_t dstShape = {
+        .dimensions = dstDims, .numberOfDimensions = 2, .orderOfDimensions = dstOrder};
+    quantization_t qDst;
+    initFloat32Quantization(&qDst); /* NULL-config family: overwritten by copyQuantization */
+    tensor_t dst;
+    setTensorValues(&dst, (uint8_t *)dstData, &dstShape, &qDst, NULL);
+
+    copyTensor(&dst, &src);
+
+    TEST_ASSERT_EQUAL_INT(INT32, dst.quantization->type);
+    TEST_ASSERT_NULL(dst.quantization->qConfig);
+    TEST_ASSERT_EQUAL_INT32_ARRAY(srcData, (int32_t *)dst.data, 4);
+}
+
+void testCopyTensorSymCarriesConfigAndPackedBytes() {
+    /* 4 mantissas at qBits=6 -> ceil(24/8) = 3 packed bytes. Dest starts with a
+     * deliberately different config (scale 1.f, SR_HALF_AWAY): every field must be
+     * overwritten by the copy, INTO the caller's storage (no pointer swap).
+     * Mutation guard: re-removing the SYM arm exits the run ("Unknown QType!"). */
+    int32_t mantissas[] = {3, -3, 31, -32};
+    uint8_t srcData[3];
+    byteConversion((uint8_t *)mantissas, 32, srcData, 6, 4);
+    size_t srcDims[] = {1, 4};
+    size_t srcOrder[] = {0, 1};
+    shape_t srcShape = {
+        .dimensions = srcDims, .numberOfDimensions = 2, .orderOfDimensions = srcOrder};
+    symQConfig_t srcQC = {.scale = 0.25f, .qBits = 6, .roundingMode = HALF_AWAY};
+    quantization_t qSrc;
+    initSymQuantization(&srcQC, &qSrc);
+    tensor_t src;
+    setTensorValues(&src, srcData, &srcShape, &qSrc, NULL);
+
+    uint8_t dstData[3] = {0};
+    size_t dstDims[2];
+    size_t dstOrder[2];
+    shape_t dstShape = {
+        .dimensions = dstDims, .numberOfDimensions = 2, .orderOfDimensions = dstOrder};
+    symQConfig_t dstQC = {.scale = 1.f, .qBits = 6, .roundingMode = SR_HALF_AWAY};
+    quantization_t qDst;
+    initSymQuantization(&dstQC, &qDst);
+    tensor_t dst;
+    setTensorValues(&dst, dstData, &dstShape, &qDst, NULL);
+
+    copyTensor(&dst, &src);
+
+    TEST_ASSERT_EQUAL_INT(SYM, dst.quantization->type);
+    TEST_ASSERT_EQUAL_PTR(&dstQC, dst.quantization->qConfig);
+    TEST_ASSERT_EQUAL_FLOAT(0.25f, dstQC.scale);
+    TEST_ASSERT_EQUAL_UINT8(6, dstQC.qBits);
+    TEST_ASSERT_EQUAL_INT(HALF_AWAY, dstQC.roundingMode);
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(srcData, dstData, 3);
+}
+
+void testCopyTensorAsymCarriesConfigAndPackedBytes() {
+    /* 4 codes at qBits=5 -> ceil(20/8) = 3 packed bytes. Mutation guard: re-removing
+     * the ASYM arm exits the run ("Unknown QType!"). */
+    int32_t codes[] = {0, 10, 20, 31};
+    uint8_t srcData[3];
+    byteConversion((uint8_t *)codes, 32, srcData, 5, 4);
+    size_t srcDims[] = {1, 4};
+    size_t srcOrder[] = {0, 1};
+    shape_t srcShape = {
+        .dimensions = srcDims, .numberOfDimensions = 2, .orderOfDimensions = srcOrder};
+    asymQConfig_t srcQC = {.scale = 0.5f, .zeroPoint = -7, .qBits = 5, .roundingMode = HALF_AWAY};
+    quantization_t qSrc;
+    initAsymQuantization(&srcQC, &qSrc);
+    tensor_t src;
+    setTensorValues(&src, srcData, &srcShape, &qSrc, NULL);
+
+    uint8_t dstData[3] = {0};
+    size_t dstDims[2];
+    size_t dstOrder[2];
+    shape_t dstShape = {
+        .dimensions = dstDims, .numberOfDimensions = 2, .orderOfDimensions = dstOrder};
+    asymQConfig_t dstQC = {.scale = 1.f, .zeroPoint = 0, .qBits = 5, .roundingMode = SR_HALF_AWAY};
+    quantization_t qDst;
+    initAsymQuantization(&dstQC, &qDst);
+    tensor_t dst;
+    setTensorValues(&dst, dstData, &dstShape, &qDst, NULL);
+
+    copyTensor(&dst, &src);
+
+    TEST_ASSERT_EQUAL_INT(ASYM, dst.quantization->type);
+    TEST_ASSERT_EQUAL_FLOAT(0.5f, dstQC.scale);
+    TEST_ASSERT_EQUAL_INT16(-7, dstQC.zeroPoint);
+    TEST_ASSERT_EQUAL_UINT8(5, dstQC.qBits);
+    TEST_ASSERT_EQUAL_INT(HALF_AWAY, dstQC.roundingMode);
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(srcData, dstData, 3);
+}
+
+void testCopyTensorSymIntoNullConfigDestDies() {
+    /* Config-carrying src into a dest whose qConfig is NULL (FLOAT32-initialized)
+     * must fail fast, not memcpy through NULL. Mutation guard: without the NULL
+     * check the child dies by SIGSEGV (signal, not exit(1)) and
+     * ASSERT_EXITS_WITH_FAILURE flags the wrong termination kind. */
+    int32_t mantissas[] = {1, -1};
+    uint8_t srcData[2];
+    byteConversion((uint8_t *)mantissas, 32, srcData, 6, 2);
+    size_t srcDims[] = {1, 2};
+    size_t srcOrder[] = {0, 1};
+    shape_t srcShape = {
+        .dimensions = srcDims, .numberOfDimensions = 2, .orderOfDimensions = srcOrder};
+    symQConfig_t srcQC = {.scale = 1.f, .qBits = 6, .roundingMode = HALF_AWAY};
+    quantization_t qSrc;
+    initSymQuantization(&srcQC, &qSrc);
+    tensor_t src;
+    setTensorValues(&src, srcData, &srcShape, &qSrc, NULL);
+
+    uint8_t dstData[2] = {0};
+    size_t dstDims[2];
+    size_t dstOrder[2];
+    shape_t dstShape = {
+        .dimensions = dstDims, .numberOfDimensions = 2, .orderOfDimensions = dstOrder};
+    quantization_t qDst;
+    initFloat32Quantization(&qDst); /* qConfig == NULL on purpose */
+    tensor_t dst;
+    setTensorValues(&dst, dstData, &dstShape, &qDst, NULL);
+
+    ASSERT_EXITS_WITH_FAILURE(copyTensor(&dst, &src));
+}
+
 void setUp() {}
 void tearDown() {}
 
@@ -285,6 +423,10 @@ int main(void) {
     RUN_TEST(testReadByte);
 
     RUN_TEST(testCopyTensor);
+    RUN_TEST(testCopyTensorInt32CarriesTypeAndData);
+    RUN_TEST(testCopyTensorSymCarriesConfigAndPackedBytes);
+    RUN_TEST(testCopyTensorAsymCarriesConfigAndPackedBytes);
+    RUN_TEST(testCopyTensorSymIntoNullConfigDestDies);
 
     RUN_TEST(test_calcBitsPerElement_Sym_qBits3);
     RUN_TEST(test_calcBytesPerElement_Sym_qBits3);

--- a/test/unit/tensor/UnitTestTensor.c
+++ b/test/unit/tensor/UnitTestTensor.c
@@ -266,6 +266,32 @@ void test_calcNumberOfBytesForData_Sym_qBits5_N4() {
     TEST_ASSERT_EQUAL_size_t(3, calcNumberOfBytesForData(&q, 4));
 }
 
+void test_calcBytesPerTensor_SymQBits3N10_Ceils() {
+    /* 10 x 3 bits = 30 bits -> 4 bytes. Pre-fix truncation gave 30/8 = 3 (#172).
+     * Mutation guard: reverting to bits/8 truncation returns 3 -> RED. */
+    size_t dims[] = {1, 10};
+    size_t order[] = {0, 1};
+    shape_t shape = {.dimensions = dims, .numberOfDimensions = 2, .orderOfDimensions = order};
+    symQConfig_t cfg = {.scale = 1.0f, .qBits = 3, .roundingMode = HALF_AWAY};
+    quantization_t q;
+    initSymQuantization(&cfg, &q);
+    tensor_t t;
+    setTensorValues(&t, NULL, &shape, &q, NULL);
+    TEST_ASSERT_EQUAL_size_t(4, calcBytesPerTensor(&t));
+}
+
+void test_calcBytesPerTensor_BoolN3_CeilsTo1() {
+    /* 3 x 1 bit -> 1 byte; pre-fix truncation gave 0 (#172). */
+    size_t dims[] = {1, 3};
+    size_t order[] = {0, 1};
+    shape_t shape = {.dimensions = dims, .numberOfDimensions = 2, .orderOfDimensions = order};
+    quantization_t q;
+    initBoolQuantization(&q);
+    tensor_t t;
+    setTensorValues(&t, NULL, &shape, &q, NULL);
+    TEST_ASSERT_EQUAL_size_t(1, calcBytesPerTensor(&t));
+}
+
 void testCopyTensorInt32CarriesTypeAndData() {
     /* Mutation guard: re-removing the INT32 arm makes copyQuantization exit(1)
      * ("Unknown QType!"), killing the test run — RED. */
@@ -432,5 +458,7 @@ int main(void) {
     RUN_TEST(test_calcBytesPerElement_Sym_qBits3);
     RUN_TEST(test_calcNumberOfBytesForData_Sym_qBits3_N10);
     RUN_TEST(test_calcNumberOfBytesForData_Sym_qBits5_N4);
+    RUN_TEST(test_calcBytesPerTensor_SymQBits3N10_Ceils);
+    RUN_TEST(test_calcBytesPerTensor_BoolN3_CeilsTo1);
     return UNITY_END();
 }

--- a/test/unit/tensor/UnitTestTensorConversion.c
+++ b/test/unit/tensor/UnitTestTensorConversion.c
@@ -14,6 +14,10 @@
 #include <stdlib.h>
 #include <string.h>
 
+/* File-internal helper of TensorConversion.c (external linkage, no header entry);
+ * declared locally to characterize its packed-size memset. */
+void zeroTensorData(tensor_t *tensor);
+
 /* PR-C pack tests verify the packed SYM output by unpacking it here in-test:
  * byteConversion zero-fills on widen, so sign-extend each value from qBits.
  * (The SYM->* unpack cells live on the parallel PR-B branch, not here.) */
@@ -25,6 +29,29 @@ static void symTestUnpackSignExtend(const uint8_t *packed, size_t qBits, int32_t
         int32_t v = out[i] & mask;
         out[i] = (v ^ signBit) - signBit;
     }
+}
+
+void testZeroTensorDataSymSubByteZeroesOnlyPackedBytes() {
+    /* SYM qBits=3, N=10 -> packed 4 bytes; the guard byte behind them must survive.
+     * Mutation guard: the pre-fix N * calcBytesPerElement memset (10 bytes) clobbers
+     * the canary -> RED (and stack-buffer-overflow under ASan). */
+    uint8_t data[5];
+    memset(data, 0xFF, sizeof(data));
+    size_t dims[] = {1, 10};
+    size_t order[] = {0, 1};
+    shape_t shape = {.dimensions = dims, .numberOfDimensions = 2, .orderOfDimensions = order};
+    symQConfig_t cfg = {.scale = 1.0f, .qBits = 3, .roundingMode = HALF_AWAY};
+    quantization_t q;
+    initSymQuantization(&cfg, &q);
+    tensor_t t;
+    setTensorValues(&t, data, &shape, &q, NULL);
+
+    zeroTensorData(&t);
+
+    for (size_t i = 0; i < 4; i++) {
+        TEST_ASSERT_EQUAL_UINT8(0, data[i]);
+    }
+    TEST_ASSERT_EQUAL_UINT8(0xFF, data[4]);
 }
 
 void testConversionIntFloat() {
@@ -1484,6 +1511,7 @@ void tearDown() {}
 int main(void) {
     UNITY_BEGIN();
 
+    RUN_TEST(testZeroTensorDataSymSubByteZeroesOnlyPackedBytes);
     RUN_TEST(testConversionIntFloat);
     RUN_TEST(testConversionIntSymInt32);
     RUN_TEST(testConversionIntAsym);

--- a/test/unit/tensor/UnitTestTensorConversion.c
+++ b/test/unit/tensor/UnitTestTensorConversion.c
@@ -583,6 +583,93 @@ void testConversionSymInt32SameTypeCopyPropagatesScale() {
     TEST_ASSERT_EQUAL_FLOAT(0.03125f, outQC.scale);
 }
 
+void testConversionSymSameTypeCopyPropagatesScale() {
+    /* SYM -> SYM same width is a verbatim packed copy; the output's stale default
+     * scale (1.f) must be replaced by the input's, or every later dequant is wrong.
+     * Mutation guard: dropping the new `case SYM:` leaves scale == 1.f -> RED. */
+    int32_t mantissas[] = {3, -3, 31, -32};
+    size_t dims[] = {1, 4};
+    size_t order[] = {0, 1};
+    shape_t shape = {.dimensions = dims, .numberOfDimensions = 2, .orderOfDimensions = order};
+
+    symQConfig_t inQC = {.scale = 0.25f, .qBits = 6, .roundingMode = HALF_AWAY};
+    quantization_t inQ;
+    initSymQuantization(&inQC, &inQ);
+    uint8_t inData[3];
+    byteConversion((uint8_t *)mantissas, 32, inData, 6, 4);
+    tensor_t in;
+    setTensorValues(&in, inData, &shape, &inQ, NULL);
+
+    symQConfig_t outQC = {.scale = 1.f, .qBits = 6, .roundingMode = HALF_AWAY};
+    quantization_t outQ;
+    initSymQuantization(&outQC, &outQ);
+    uint8_t outData[4];
+    memset(outData, 0xAA,
+           sizeof(outData)); /* canary in byte 3: only 3 packed bytes may be written */
+    tensor_t out;
+    setTensorValues(&out, outData, &shape, &outQ, NULL);
+
+    convertTensor(&in, &out);
+
+    TEST_ASSERT_EQUAL_FLOAT(0.25f, outQC.scale);
+    TEST_ASSERT_EQUAL_UINT8(6, outQC.qBits);
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(inData, outData, 3);
+    TEST_ASSERT_EQUAL_UINT8(0xAA, outData[3]);
+}
+
+void testConversionSymSameTypeWidthMismatchDies() {
+    /* qBits 6 -> 4: a verbatim byte copy would reinterpret the packing (and for
+     * wider inputs overflow the output buffer). Width-changing SYM rewrites are
+     * real conversions (repack policy: PR3). Mutation guard: removing the width
+     * guard lets the child exit 0 -> RED. */
+    int32_t mantissas[] = {3, -3};
+    size_t dims[] = {1, 2};
+    size_t order[] = {0, 1};
+    shape_t shape = {.dimensions = dims, .numberOfDimensions = 2, .orderOfDimensions = order};
+
+    symQConfig_t inQC = {.scale = 0.25f, .qBits = 6, .roundingMode = HALF_AWAY};
+    quantization_t inQ;
+    initSymQuantization(&inQC, &inQ);
+    uint8_t inData[2];
+    byteConversion((uint8_t *)mantissas, 32, inData, 6, 2);
+    tensor_t in;
+    setTensorValues(&in, inData, &shape, &inQ, NULL);
+
+    symQConfig_t outQC = {.scale = 1.f, .qBits = 4, .roundingMode = HALF_AWAY};
+    quantization_t outQ;
+    initSymQuantization(&outQC, &outQ);
+    uint8_t outData[1] = {0};
+    tensor_t out;
+    setTensorValues(&out, outData, &shape, &outQ, NULL);
+
+    ASSERT_EXITS_WITH_FAILURE(convertTensor(&in, &out));
+}
+
+void testConversionAsymSameTypeWidthMismatchDies() {
+    /* ASYM variant of the width guard (qBits 5 -> 3). */
+    int32_t codes[] = {0, 10};
+    size_t dims[] = {1, 2};
+    size_t order[] = {0, 1};
+    shape_t shape = {.dimensions = dims, .numberOfDimensions = 2, .orderOfDimensions = order};
+
+    asymQConfig_t inQC = {.scale = 0.5f, .zeroPoint = -7, .qBits = 5, .roundingMode = HALF_AWAY};
+    quantization_t inQ;
+    initAsymQuantization(&inQC, &inQ);
+    uint8_t inData[2];
+    byteConversion((uint8_t *)codes, 32, inData, 5, 2);
+    tensor_t in;
+    setTensorValues(&in, inData, &shape, &inQ, NULL);
+
+    asymQConfig_t outQC = {.scale = 1.f, .zeroPoint = 0, .qBits = 3, .roundingMode = HALF_AWAY};
+    quantization_t outQ;
+    initAsymQuantization(&outQC, &outQ);
+    uint8_t outData[1] = {0};
+    tensor_t out;
+    setTensorValues(&out, outData, &shape, &outQ, NULL);
+
+    ASSERT_EXITS_WITH_FAILURE(convertTensor(&in, &out));
+}
+
 void testRequantDynamicAccumulatorRangeMatchesGold() {
     size_t dims[] = {input_requant_f1AccumRange_len};
     size_t orderOfDims[] = {0};
@@ -1540,6 +1627,9 @@ int main(void) {
     RUN_TEST(testRequantToScaleSharedBufferAliasMatchesGold);
     RUN_TEST(testConversionBoolBoolCopiesOnlyPackedBytes);
     RUN_TEST(testConversionSymInt32SameTypeCopyPropagatesScale);
+    RUN_TEST(testConversionSymSameTypeCopyPropagatesScale);
+    RUN_TEST(testConversionSymSameTypeWidthMismatchDies);
+    RUN_TEST(testConversionAsymSameTypeWidthMismatchDies);
     RUN_TEST(testQuantTypeToStringBool);
     RUN_TEST(testConversionSymSymInt32SignExtends);
     RUN_TEST(testConversionSymFloat32Dequantizes);


### PR DESCRIPTION
PR2 of the grad-storage series (spec §9 PR2 row / grad-storage spec §4): sub-byte tensors become first-class at the tensor layer. Pure tensor/serial-level gap-filling — **zero training-path wiring, zero numeric expectation changes** (the whole `test/` diff is additive; mixed_width example loss bit-identical: 2.292284 → 1.250560).

Closes #171
Closes #172

> Develop-merge: auto-close does not fire — close #171/#172 manually after merge. Relates: #210, #261.

## What changed

1. **`copyQuantization` — all 6 dtype arms (#171).** New INT32 (NULL-config family) + SYM/ASYM arms via a shared `copyQConfigInto` helper that fail-fasts (exit 1) when `dest->qConfig` is NULL instead of memcpy-through-NULL UB. src/tensor stays allocation-free; contract documented at the decision point.
2. **Byte-count truncation class retired (#172).** `calcBytesPerTensor` delegates to the single ceiling authority `calcNumberOfBytesForData` (dead `calcBitsPerTensor` deleted); `zeroTensorData` memsets the packed size (was: per-element-ceil × N over-count → latent OOB); `sgdZeroGrad` sizes via the authority (was: size_t division truncating before `ceil` saw it → stale grad bits in the last packed byte; flagged in the PR1a final review as "#172 class").
3. **Same-type conversion: equal-width guard + SYM scale propagation.** `convertTensorsWithSameType` now fail-fasts on element-width mismatch BEFORE the memmove (previously: silent bit-reinterpretation, buffer overflow for wider inputs) and propagates `scale` for SYM (previously: stale scale → wrong dequantization). No repack — width-changing SYM/ASYM rewrites remain real conversions (PR3 pack-policy territory).
4. **Serialization v1: packed data records.** `serializeTensor`/`deserializeTensor` size the data payload via the ceiling authority. Byte-aligned dtypes serialize **bit-identically** (no version bump); sub-byte payloads go from heap over-read (write) / OOB write (read) to well-defined packed records — SYM + BOOL data round-trip tests included (unblocks Dropout-mask serialization). Plus the payload-sizing invariant in `docs/conventions/tensor.md`.

## Scope decisions (veto welcome)

- **OUT: `addSym/AsymTensorsInplace`** (spec-PR2 bullet) — their repack step is exactly the fit-preserving-vs-requant pack-policy question reserved for the PR3 design round; building them now would pre-empt it (same throwaway-code logic as funnel-spec D5).
- **OUT: `getQLike`/`getDataLike` SYM arms + `gradInitSym`** — #269, declared a PR3 dependency; `src/userApi/tensor/TensorApi.c` is untouched.
- **IN: Serialize/Deserialize + `sgdZeroGrad`** — same `calcBytesPerElement × N` / truncation audit class the spec's PR2 bullet mandates auditing.

## Verification

- TDD throughout; every characterization test mutation-verified (evidence in commit bodies; the serial both-sides revert is the one ASan-caught case — one-sided reverts are debug-RED via the wire sentinel).
- Gates: debug + ASan + UBSan ctest 67/67; examples preset full build (85/85 targets); mixed_width gates pass, loss bit-identical; alloc-locality clean; format sweep clean; `calcBitsPerTensor` zero remaining references.
- Final whole-branch review: ready-to-merge, 0 Critical/Important. Reviewer-verified: single-sizing-site invariant in serial (all tensor payloads route through `serializeTensor`/`deserializeTensor`), no production path reaches the new guards with legitimate traffic (behavior change confined to previously-corrupt/unreached cases).

## PR3 watch-list (recorded, not in this PR)

- **ASYM grad zeroing semantics:** `sgdZeroGrad` zeroes *bytes*; for ASYM, dequant(code 0) = (0 − zeroPoint)·scale ≠ 0 unless zeroPoint == 0, and there is no zeroPoint/scale reset arm (SYM_INT32 has one). Unreachable today (PR1a ctor guard), but the new test characterizes byte-zeroing — the PR3 design round should decide value-vs-byte zeroing before opening the guard.
- **Same-type convert element-count guard:** the width guard doesn't compare element counts (pre-existing; needs shape comparison, belongs with PR3 conversion-contract work).
- **Deserializer trusted-file sizing:** fread length derives from file-read quantization into a caller-sized buffer (pre-existing class, unchanged here; worth stating once now that sizing is packed).

Review-noted minors (accepted as-is): ASYM copy-arm mutation inferred via the shared helper (removal provably hits default→exit); ASYM copy test asserts in-place copy transitively (stack-config field reads) rather than via EQUAL_PTR; serial-test shape boilerplate matches file-local style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011stYySaq1QzpETkmhwFfTm
