### PR TITLE
feat(userApi): memory-profiling facility core — heap counter + stack watermark + RSS anchor

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -43,7 +43,8 @@
       "displayName": "Unit-Test-Debug",
       "inherits": "host",
       "cacheVariables": {
-        "DEBUG_MODE_DEBUG": "ON"
+        "DEBUG_MODE_DEBUG": "ON",
+        "ODT_MEM_PROFILE": "ON"
       }
     },
     {
@@ -52,7 +53,8 @@
       "inherits": "host",
       "cacheVariables": {
         "CMAKE_C_FLAGS": "-fsanitize=address,undefined -fno-sanitize=function -fno-omit-frame-pointer -fno-sanitize-recover=all -g -O1",
-        "CMAKE_EXE_LINKER_FLAGS": "-fsanitize=address,undefined"
+        "CMAKE_EXE_LINKER_FLAGS": "-fsanitize=address,undefined",
+        "ODT_MEM_PROFILE": "ON"
       }
     },
     {

--- a/src/userApi/CMakeLists.txt
+++ b/src/userApi/CMakeLists.txt
@@ -35,6 +35,7 @@ target_link_libraries(InferenceApi PRIVATE
 
 add_library(StorageApi StorageApi.c)
 target_include_directories(StorageApi PUBLIC include)
+target_compile_definitions(StorageApi PUBLIC $<$<BOOL:${ODT_MEM_PROFILE}>:ODT_MEM_PROFILE>)
 target_link_libraries(StorageApi PRIVATE
         Tensor
         Rounding

--- a/src/userApi/CMakeLists.txt
+++ b/src/userApi/CMakeLists.txt
@@ -4,6 +4,11 @@ add_subdirectory(optimizer)
 add_subdirectory(tensor)
 add_subdirectory(training_loop)
 
+add_library(MemProfile MemProfile.c)
+target_include_directories(MemProfile PUBLIC include)
+find_package(Threads REQUIRED)
+target_link_libraries(MemProfile PUBLIC Threads::Threads)
+
 add_library(LayerCommon LayerCommon.c)
 target_include_directories(LayerCommon PUBLIC include)
 target_link_libraries(LayerCommon PRIVATE

--- a/src/userApi/CMakeLists.txt
+++ b/src/userApi/CMakeLists.txt
@@ -7,7 +7,7 @@ add_subdirectory(training_loop)
 add_library(MemProfile MemProfile.c)
 target_include_directories(MemProfile PUBLIC include)
 find_package(Threads REQUIRED)
-target_link_libraries(MemProfile PUBLIC Threads::Threads)
+target_link_libraries(MemProfile PRIVATE Threads::Threads)
 
 add_library(LayerCommon LayerCommon.c)
 target_include_directories(LayerCommon PUBLIC include)

--- a/src/userApi/MemProfile.c
+++ b/src/userApi/MemProfile.c
@@ -1,0 +1,66 @@
+#define SOURCE_FILE "MEM_PROFILE"
+
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "MemProfile.h"
+
+#define MEM_STACK_PAINT 0xA5u
+
+typedef struct stackThunk {
+    void (*fn)(void *);
+    void *arg;
+} stackThunk_t;
+
+static void *stackThunkRunner(void *p) {
+    stackThunk_t *t = (stackThunk_t *)p;
+    t->fn(t->arg);
+    return NULL;
+}
+
+size_t measurePeakStackBytes(void (*fn)(void *), void *arg, size_t stackBytes) {
+    /* raw malloc: measurement apparatus, deliberately not reserveMemory */
+    unsigned char *region = malloc(stackBytes);
+    if (region == NULL) {
+        fprintf(stderr, "MEM_PROFILE: malloc for the stack region failed — failing loud\n");
+        exit(1);
+    }
+    memset(region, (int)MEM_STACK_PAINT, stackBytes);
+
+    pthread_attr_t attr;
+    pthread_attr_init(&attr);
+    /* Fail loud on any pthread error: a rejected stack region (attr_setstack) would run the
+     * workload on the DEFAULT stack, leaving `region` fully painted -> a silent used==0
+     * measurement; a failed create would leave `th` uninitialized -> UB in join. Both are
+     * worse than a crash for a measurement apparatus. */
+    if (pthread_attr_setstack(&attr, region, stackBytes) != 0) {
+        fprintf(stderr, "MEM_PROFILE: pthread_attr_setstack rejected the stack region "
+                        "— failing loud (measurement would be wrong)\n");
+        exit(1);
+    }
+
+    stackThunk_t thunk = {.fn = fn, .arg = arg};
+    pthread_t th;
+    if (pthread_create(&th, &attr, stackThunkRunner, &thunk) != 0) {
+        fprintf(stderr, "MEM_PROFILE: pthread_create failed — failing loud\n");
+        exit(1);
+    }
+    if (pthread_join(th, NULL) != 0) {
+        fprintf(stderr, "MEM_PROFILE: pthread_join failed — failing loud\n");
+        exit(1);
+    }
+    pthread_attr_destroy(&attr);
+
+    /* Stack grows down from the high end of [region, region+stackBytes). The
+     * untouched (still-painted) bytes are the low prefix; scan from the low end
+     * for the first touched byte. used = stackBytes - firstTouchedIndex. */
+    size_t firstTouched = 0;
+    while (firstTouched < stackBytes && region[firstTouched] == MEM_STACK_PAINT) {
+        firstTouched++;
+    }
+    size_t used = stackBytes - firstTouched;
+    free(region);
+    return used;
+}

--- a/src/userApi/MemProfile.c
+++ b/src/userApi/MemProfile.c
@@ -69,6 +69,12 @@ size_t measurePeakStackBytes(void (*fn)(void *), void *arg, size_t stackBytes) {
 size_t memProfileRssPeakKb(void) {
     struct rusage ru;
     if (getrusage(RUSAGE_SELF, &ru) != 0) {
+        /* Soft-fail sentinel (0 = "unavailable"): RSS is a COARSE SECONDARY anchor,
+         * not a primary measurement like the heap counter / stack watermark. A 0
+         * (never a real RSS) is more useful to a consumer than crashing the whole
+         * run; contrast measurePeakStackBytes, which fails loud because a wrong
+         * stack number silently corrupts the primary result. getrusage(RUSAGE_SELF)
+         * essentially never fails in practice. */
         return 0;
     }
     /* ru_maxrss is KiB on Linux, bytes on macOS/Darwin. */

--- a/src/userApi/MemProfile.c
+++ b/src/userApi/MemProfile.c
@@ -4,6 +4,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/resource.h>
 
 #include "MemProfile.h"
 
@@ -63,4 +64,17 @@ size_t measurePeakStackBytes(void (*fn)(void *), void *arg, size_t stackBytes) {
     size_t used = stackBytes - firstTouched;
     free(region);
     return used;
+}
+
+size_t memProfileRssPeakKb(void) {
+    struct rusage ru;
+    if (getrusage(RUSAGE_SELF, &ru) != 0) {
+        return 0;
+    }
+    /* ru_maxrss is KiB on Linux, bytes on macOS/Darwin. */
+#if defined(__APPLE__)
+    return (size_t)ru.ru_maxrss / 1024u;
+#else
+    return (size_t)ru.ru_maxrss;
+#endif
 }

--- a/src/userApi/StorageApi.c
+++ b/src/userApi/StorageApi.c
@@ -4,10 +4,86 @@
 
 #include "StorageApi.h"
 
+#ifdef ODT_MEM_PROFILE
+#include <stdatomic.h>
+#include <stddef.h>
+#include <stdint.h>
+
+/* Prepended to every allocation; a union with max_align_t forces the user
+ * region (immediately after) to keep max alignment. Stores the user size so
+ * free() can decrement the exact byte count. */
+typedef union memHeader {
+    size_t size;
+    max_align_t align;
+} memHeader_t;
+
+static atomic_size_t g_currentBytes = 0;
+static atomic_size_t g_peakBytes = 0;
+
+static void bumpPeak(size_t cur) {
+    size_t prev = atomic_load_explicit(&g_peakBytes, memory_order_relaxed);
+    while (cur > prev && !atomic_compare_exchange_weak_explicit(
+                             &g_peakBytes, &prev, cur, memory_order_relaxed, memory_order_relaxed)) {
+        /* prev is reloaded by the CAS on failure */
+    }
+}
+
 void *reserveMemory(size_t numberOfBytes) {
-    return calloc(1, numberOfBytes);
+    if (numberOfBytes > SIZE_MAX - sizeof(memHeader_t)) {
+        return NULL; /* size_t wrap would under-allocate the payload */
+    }
+    memHeader_t *base = calloc(1, sizeof(memHeader_t) + numberOfBytes);
+    if (base == NULL) {
+        return NULL;
+    }
+    base->size = numberOfBytes;
+    size_t cur =
+        atomic_fetch_add_explicit(&g_currentBytes, numberOfBytes, memory_order_relaxed) +
+        numberOfBytes;
+    bumpPeak(cur);
+    return (void *)(base + 1);
 }
 
 void freeReservedMemory(void *ptr) {
+    if (ptr == NULL) {
+        return;
+    }
+    memHeader_t *base = (memHeader_t *)ptr - 1;
+    atomic_fetch_sub_explicit(&g_currentBytes, base->size, memory_order_relaxed);
+    free(base);
+}
+
+void memProfileReset(void) {
+    atomic_store_explicit(&g_currentBytes, 0, memory_order_relaxed);
+    atomic_store_explicit(&g_peakBytes, 0, memory_order_relaxed);
+}
+size_t memProfileCurrentBytes(void) {
+    return atomic_load_explicit(&g_currentBytes, memory_order_relaxed);
+}
+size_t memProfilePeakBytes(void) {
+    return atomic_load_explicit(&g_peakBytes, memory_order_relaxed);
+}
+size_t memProfileMark(void) {
+    return memProfileCurrentBytes();
+}
+
+#else /* !ODT_MEM_PROFILE — bit-identical to the pre-facility behavior */
+
+void *reserveMemory(size_t numberOfBytes) {
+    return calloc(1, numberOfBytes);
+}
+void freeReservedMemory(void *ptr) {
     free(ptr);
 }
+void memProfileReset(void) {}
+size_t memProfileCurrentBytes(void) {
+    return 0;
+}
+size_t memProfilePeakBytes(void) {
+    return 0;
+}
+size_t memProfileMark(void) {
+    return 0;
+}
+
+#endif

--- a/src/userApi/StorageApi.c
+++ b/src/userApi/StorageApi.c
@@ -22,8 +22,9 @@ static atomic_size_t g_peakBytes = 0;
 
 static void bumpPeak(size_t cur) {
     size_t prev = atomic_load_explicit(&g_peakBytes, memory_order_relaxed);
-    while (cur > prev && !atomic_compare_exchange_weak_explicit(
-                             &g_peakBytes, &prev, cur, memory_order_relaxed, memory_order_relaxed)) {
+    while (cur > prev &&
+           !atomic_compare_exchange_weak_explicit(&g_peakBytes, &prev, cur, memory_order_relaxed,
+                                                  memory_order_relaxed)) {
         /* prev is reloaded by the CAS on failure */
     }
 }
@@ -37,9 +38,8 @@ void *reserveMemory(size_t numberOfBytes) {
         return NULL;
     }
     base->size = numberOfBytes;
-    size_t cur =
-        atomic_fetch_add_explicit(&g_currentBytes, numberOfBytes, memory_order_relaxed) +
-        numberOfBytes;
+    size_t cur = atomic_fetch_add_explicit(&g_currentBytes, numberOfBytes, memory_order_relaxed) +
+                 numberOfBytes;
     bumpPeak(cur);
     return (void *)(base + 1);
 }

--- a/src/userApi/include/MemProfile.h
+++ b/src/userApi/include/MemProfile.h
@@ -9,4 +9,8 @@
  * reserveMemory, so it never enters the heap counter. */
 size_t measurePeakStackBytes(void (*fn)(void *), void *arg, size_t stackBytes);
 
+/* Peak resident set size (KiB) from getrusage(RUSAGE_SELF). Includes
+ * allocator/libc/dataset — a coarse process-level anchor, NOT the MCU number. */
+size_t memProfileRssPeakKb(void);
+
 #endif

--- a/src/userApi/include/MemProfile.h
+++ b/src/userApi/include/MemProfile.h
@@ -1,0 +1,12 @@
+#ifndef MEM_PROFILE_H
+#define MEM_PROFILE_H
+
+#include <stddef.h>
+
+/* Runs fn(arg) on a fresh pthread whose stack is a stackBytes region painted
+ * with a sentinel, then returns the peak bytes touched (stack high-water).
+ * Host-only measurement apparatus; the region uses raw malloc, NOT
+ * reserveMemory, so it never enters the heap counter. */
+size_t measurePeakStackBytes(void (*fn)(void *), void *arg, size_t stackBytes);
+
+#endif

--- a/src/userApi/include/StorageApi.h
+++ b/src/userApi/include/StorageApi.h
@@ -8,4 +8,13 @@ void *reserveMemory(size_t numberOfBytes);
 /* NULL-safe (mirrors free(NULL)). */
 void freeReservedMemory(void *ptr);
 
+/* Memory profiling (active only when ODT_MEM_PROFILE is defined; otherwise
+ * these are no-ops returning 0). Counts user bytes requested via
+ * reserveMemory, net of freeReservedMemory. memProfileMark returns the current
+ * live total for phase-boundary diffing. */
+void memProfileReset(void);
+size_t memProfileCurrentBytes(void);
+size_t memProfilePeakBytes(void);
+size_t memProfileMark(void);
+
 #endif // STORAGEAPI_H

--- a/test/unit/userAPI/CMakeLists.txt
+++ b/test/unit/userAPI/CMakeLists.txt
@@ -4,7 +4,7 @@ add_elastic_ai_unit_test(
 )
 
 
-add_elastic_ai_unit_test(LIB_UNDER_TEST MemProfile)
+add_elastic_ai_unit_test(LIB_UNDER_TEST MemProfile MORE_LIBS StorageApi)
 
 
 add_elastic_ai_unit_test(

--- a/test/unit/userAPI/CMakeLists.txt
+++ b/test/unit/userAPI/CMakeLists.txt
@@ -4,6 +4,9 @@ add_elastic_ai_unit_test(
 )
 
 
+add_elastic_ai_unit_test(LIB_UNDER_TEST MemProfile)
+
+
 add_elastic_ai_unit_test(
         LIB_UNDER_TEST
         LayerQuant

--- a/test/unit/userAPI/UnitTestMemProfile.c
+++ b/test/unit/userAPI/UnitTestMemProfile.c
@@ -1,0 +1,57 @@
+#define SOURCE_FILE "UnitTestMemProfile"
+
+#include "MemProfile.h"
+#include "unity.h"
+
+void setUp(void) {}
+void tearDown(void) {}
+
+static volatile unsigned char g_sink;
+
+/* Touches n bytes of a stack VLA end-to-end so the compiler cannot elide it.
+ * No framework calls — pure stack load. */
+static void stackConsumer(void *arg) {
+    size_t n = *(size_t *)arg;
+    volatile unsigned char buf[n];
+    for (size_t i = 0; i < n; i++) {
+        buf[i] = (unsigned char)(i & 0xFF);
+    }
+    g_sink += buf[n - 1];
+}
+
+/* Frame slack established from first principles: the ONLY non-VLA variation
+ * between calls is alignment padding of the VLA base. 256 bytes is a generous
+ * ceiling for that. This constant is NEVER raised to make a failing case pass
+ * (integrity rule) — a delta beyond it is a finding to investigate with Leo. */
+#define F_STACK_SLACK 256
+
+void testStackWatermarkTracksLoadRelativeAndMonotonic(void) {
+    size_t n16 = 16u * 1024, n64 = 64u * 1024, n256 = 256u * 1024;
+    size_t region = 1u << 20; /* 1 MiB */
+
+    size_t s16 = measurePeakStackBytes(stackConsumer, &n16, region);
+    size_t s64 = measurePeakStackBytes(stackConsumer, &n64, region);
+    size_t s256 = measurePeakStackBytes(stackConsumer, &n256, region);
+
+    /* Absolute sanity: each measurement is at least its own VLA load. */
+    TEST_ASSERT_GREATER_OR_EQUAL_size_t(n16, s16);
+    TEST_ASSERT_GREATER_OR_EQUAL_size_t(n64, s64);
+    TEST_ASSERT_GREATER_OR_EQUAL_size_t(n256, s256);
+
+    /* Monotonic in load. */
+    TEST_ASSERT_GREATER_THAN_size_t(s16, s64);
+    TEST_ASSERT_GREATER_THAN_size_t(s64, s256);
+
+    /* Deltas equal the load deltas within the fixed frame slack (absolute
+     * frame overhead cancels). This is the "genuinely tracks stack" claim. */
+    long d1 = (long)(s64 - s16) - (long)(n64 - n16);
+    long d2 = (long)(s256 - s64) - (long)(n256 - n64);
+    TEST_ASSERT_INT_WITHIN(F_STACK_SLACK, 0, (int)d1);
+    TEST_ASSERT_INT_WITHIN(F_STACK_SLACK, 0, (int)d2);
+}
+
+int main(void) {
+    UNITY_BEGIN();
+    RUN_TEST(testStackWatermarkTracksLoadRelativeAndMonotonic);
+    return UNITY_END();
+}

--- a/test/unit/userAPI/UnitTestMemProfile.c
+++ b/test/unit/userAPI/UnitTestMemProfile.c
@@ -1,7 +1,5 @@
 #define SOURCE_FILE "UnitTestMemProfile"
 
-#include <stdlib.h>
-
 #include "MemProfile.h"
 #include "StorageApi.h"
 #include "unity.h"

--- a/test/unit/userAPI/UnitTestMemProfile.c
+++ b/test/unit/userAPI/UnitTestMemProfile.c
@@ -1,11 +1,19 @@
 #define SOURCE_FILE "UnitTestMemProfile"
 
+#include <stdlib.h>
+
 #include "MemProfile.h"
+#include "StorageApi.h"
 #include "unity.h"
 
 void setUp(void) {}
 void tearDown(void) {}
 
+/* GT-2 drives measurePeakStackBytes, which runs the workload on a custom pthread
+ * stack (pthread_attr_setstack). ASan's thread instrumentation rejects a custom
+ * stack, so skip GT-2 under ASan — it runs under plain/debug/ubsan. The stack
+ * watermark is host measurement tooling and is never used under ASan in practice. */
+#ifndef __SANITIZE_ADDRESS__
 static volatile unsigned char g_sink;
 
 /* Touches n bytes of a stack VLA end-to-end so the compiler cannot elide it.
@@ -49,9 +57,27 @@ void testStackWatermarkTracksLoadRelativeAndMonotonic(void) {
     TEST_ASSERT_INT_WITHIN(F_STACK_SLACK, 0, (int)d1);
     TEST_ASSERT_INT_WITHIN(F_STACK_SLACK, 0, (int)d2);
 }
+#endif /* !__SANITIZE_ADDRESS__ */
+
+void testRssPeakIsPositiveAndGrows(void) {
+    size_t before = memProfileRssPeakKb();
+    TEST_ASSERT_GREATER_THAN_size_t(0, before); /* the process already uses RAM */
+    /* Force a large resident allocation and touch it. */
+    size_t big = 32u * 1024 * 1024;
+    volatile unsigned char *p = reserveMemory(big);
+    for (size_t i = 0; i < big; i += 4096) {
+        p[i] = 1;
+    }
+    size_t after = memProfileRssPeakKb();
+    TEST_ASSERT_GREATER_OR_EQUAL_size_t(before, after); /* peak is monotonic */
+    freeReservedMemory((void *)p);
+}
 
 int main(void) {
     UNITY_BEGIN();
+#ifndef __SANITIZE_ADDRESS__
     RUN_TEST(testStackWatermarkTracksLoadRelativeAndMonotonic);
+#endif
+    RUN_TEST(testRssPeakIsPositiveAndGrows);
     return UNITY_END();
 }

--- a/test/unit/userAPI/UnitTestStorageApi.c
+++ b/test/unit/userAPI/UnitTestStorageApi.c
@@ -1,3 +1,5 @@
+#define SOURCE_FILE "UnitTestStorageApi"
+
 #include <stddef.h>
 #include <stdint.h>
 
@@ -43,6 +45,53 @@ void testFreeReservedMemoryIsNullSafe(void) {
     freeReservedMemory(NULL);
 }
 
+#ifdef ODT_MEM_PROFILE
+/* GT-1: exact-integer heap accounting. No tolerance exists to fudge.
+ * Guarded by ODT_MEM_PROFILE: the counter is a no-op when the macro is
+ * undefined, so these tests only compile/run in profiling builds (the
+ * dedicated c-memprofile CI job). */
+void testHeapCounterExactCurrentAndPeak(void) {
+    memProfileReset();
+    TEST_ASSERT_EQUAL_size_t(0, memProfileCurrentBytes());
+    TEST_ASSERT_EQUAL_size_t(0, memProfilePeakBytes());
+
+    void *a = reserveMemory(1000);
+    TEST_ASSERT_EQUAL_size_t(1000, memProfileCurrentBytes());
+    TEST_ASSERT_EQUAL_size_t(1000, memProfilePeakBytes());
+
+    void *b = reserveMemory(500);
+    TEST_ASSERT_EQUAL_size_t(1500, memProfileCurrentBytes());
+    TEST_ASSERT_EQUAL_size_t(1500, memProfilePeakBytes());
+
+    freeReservedMemory(a);
+    TEST_ASSERT_EQUAL_size_t(500, memProfileCurrentBytes());
+    TEST_ASSERT_EQUAL_size_t(1500, memProfilePeakBytes()); /* peak holds */
+
+    void *c = reserveMemory(2000);
+    TEST_ASSERT_EQUAL_size_t(2500, memProfileCurrentBytes());
+    TEST_ASSERT_EQUAL_size_t(2500, memProfilePeakBytes()); /* new peak */
+
+    freeReservedMemory(b);
+    freeReservedMemory(c);
+    TEST_ASSERT_EQUAL_size_t(0, memProfileCurrentBytes());
+    TEST_ASSERT_EQUAL_size_t(2500, memProfilePeakBytes());
+}
+
+/* The size-header must preserve alignment + writability of the full request. */
+void testReservedRegionUsableAndAligned(void) {
+    memProfileReset();
+    size_t n = 777;
+    unsigned char *p = reserveMemory(n);
+    TEST_ASSERT_EQUAL_UINT(0, (uintptr_t)p % _Alignof(max_align_t));
+    for (size_t i = 0; i < n; i++) {
+        p[i] = (unsigned char)(i & 0xFF); /* full-range write; ASan guards OOB */
+    }
+    TEST_ASSERT_EQUAL_size_t(n, memProfileCurrentBytes());
+    freeReservedMemory(p);
+    TEST_ASSERT_EQUAL_size_t(0, memProfileCurrentBytes());
+}
+#endif /* ODT_MEM_PROFILE */
+
 void setUp() {}
 void tearDown() {}
 
@@ -51,5 +100,9 @@ int main(void) {
     RUN_TEST(testReserveMemoryReturnsZeroedWritablePayload);
     RUN_TEST(testReserveAndFreeRoundTrip);
     RUN_TEST(testFreeReservedMemoryIsNullSafe);
+#ifdef ODT_MEM_PROFILE
+    RUN_TEST(testHeapCounterExactCurrentAndPeak);
+    RUN_TEST(testReservedRegionUsableAndAligned);
+#endif
     return UNITY_END();
 }

--- a/test/unit/userAPI/UnitTestStorageApi.c
+++ b/test/unit/userAPI/UnitTestStorageApi.c
@@ -48,8 +48,8 @@ void testFreeReservedMemoryIsNullSafe(void) {
 #ifdef ODT_MEM_PROFILE
 /* GT-1: exact-integer heap accounting. No tolerance exists to fudge.
  * Guarded by ODT_MEM_PROFILE: the counter is a no-op when the macro is
- * undefined, so these tests only compile/run in profiling builds (the
- * dedicated c-memprofile CI job). */
+ * undefined, so these tests only compile/run in profiling builds — the
+ * ASan/UBSan CI presets (ODT_MEM_PROFILE=ON); plain unit_test has it OFF. */
 void testHeapCounterExactCurrentAndPeak(void) {
     memProfileReset();
     TEST_ASSERT_EQUAL_size_t(0, memProfileCurrentBytes());


### PR DESCRIPTION
## What & why

The dependency for the HAR float-vs-SYM training demo (the memory / runtime / accuracy example). Adds three **host** measurement primitives, each proven by a zero-fudge ground-truth test, so the example can report *honest* peak-RAM numbers instead of hand-waved ones.

## The three primitives

1. **Heap byte counter** (`StorageApi.c`, behind `#ifdef ODT_MEM_PROFILE`) — a `max_align_t`-sized header prepended to every `reserveMemory` allocation, plus C11 atomics tracking net-current / peak bytes. **Zero overhead when the macro is undefined**: the OFF path is bare `calloc`/`free` (byte-identical — the production / MCU build is unchanged). Proven by **GT-1** (exact-integer accounting, no tolerance to fudge).
2. **Stack high-water watermark** (`MemProfile.c` → `measurePeakStackBytes`) — pthread paint-and-scan on a custom stack. Fails loud on any pthread/malloc error (a rejected stack would otherwise silently mis-measure). Proven by **GT-2** (tracks a known VLA load *relatively* + *monotonically* within a first-principles frame slack `F=256`; measured deltas 0 / ±16 on macOS + Ubuntu).
3. **getrusage peak-RSS anchor** (`memProfileRssPeakKb`) — coarse *secondary* anchor (Linux KiB / Darwin bytes normalized).

## Integrity

GT-1 is exact-integer; GT-2's `F=256` is first-principles and is **never widened** to green a failing measurement — a discrepancy is a finding to investigate, not a tolerance to loosen. Both tests are mutation-verified RED when the mechanism is broken.

## Sanitizer wiring

`ODT_MEM_PROFILE` is ON in `unit_test_debug` / `unit_test_asan` / `unit_test_ubsan`, OFF in plain `unit_test` + `examples`. Consequences:
- The **whole suite's allocations flow through the size-header under ASan** — framework-wide proof that every `reserveMemory`/`freeReservedMemory` pairing round-trips with no alloc/dealloc mismatch or OOB.
- GT-1 runs under both ASan and UBSan.
- Plain `unit_test` proves the byte-identical OFF path.
- GT-2 is `#ifndef __SANITIZE_ADDRESS__`-guarded — its custom pthread stack is fundamentally ASan-incompatible; it runs under plain/debug/ubsan, skipped under ASan (verified: the RSS test still runs there, exit 0).

## Verification

- `unit_test_debug` **68/68** (profiling ON); plain `unit_test` OFF-path builds, GT excluded.
- Full unit suite under **ASan (clang-22) green** with the header active framework-wide.
- GT-1 + GT-2 mutation-verified; GT-2 cross-checked macOS + Ubuntu-Docker.
- `clang-format` clean; alloc-locality gate clean.
- Reviewed: three per-task spec+quality reviews + one whole-branch review (verdict **merge-ready**, all findings polish, folded in).

## Scope

Facility **core** only. The analytic per-category breakdown, the reconciliation cross-check, and the timeline trace hook are deferred — they're consumed by the HAR example, not part of the core.

## One note for review

`memProfileRssPeakKb` returns `0` (= "unavailable") on the near-impossible `getrusage` failure rather than `exit(1)`. Deliberate: RSS is a *coarse secondary* anchor, so a sentinel a consumer can branch on beats crashing a whole training run — unlike the *primary* stack/heap measurements, which fail loud. Easy to flip to fail-loud if you'd rather have consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
