### PR TITLE
feat(optimizer): route SGD update through executeOp — per-param dtype (#278), SRHTE dead-zone escape (#279), own momentum config (#277)

### DIFF
--- a/examples/ecg_anomaly_ae/train_c.c
+++ b/examples/ecg_anomaly_ae/train_c.c
@@ -316,8 +316,8 @@ int main(void) {
                                                  /*shuffle*/ false, /*shuffleSeed*/ 0,
                                                  /*dropLast*/ true);
 
-        optimizer_t *sgd =
-            sgdMCreateOptim(LR, MOMENTUM, /*weightDecay*/ 0.0f, model, MODEL_SIZE, FLOAT32);
+        optimizer_t *sgd = sgdMCreateOptim(LR, MOMENTUM, /*weightDecay*/ 0.0f, model, MODEL_SIZE,
+                                           FLOAT32, quantizationInitFloat());
 
         g_log_file = fopen("examples/ecg_anomaly_ae/logs/c.json", "w");
         if (!g_log_file) {

--- a/examples/har_classifier/train_c.c
+++ b/examples/har_classifier/train_c.c
@@ -313,8 +313,8 @@ int main(void) {
                                                  /*shuffle*/ false, /*shuffleSeed*/ 0,
                                                  /*dropLast*/ true);
 
-        optimizer_t *sgd =
-            sgdMCreateOptim(LR, MOMENTUM, /*weightDecay*/ 0.0f, model, MODEL_SIZE, FLOAT32);
+        optimizer_t *sgd = sgdMCreateOptim(LR, MOMENTUM, /*weightDecay*/ 0.0f, model, MODEL_SIZE,
+                                           FLOAT32, quantizationInitFloat());
 
         g_log_file = fopen("examples/har_classifier/logs/c.json", "w");
         if (!g_log_file) {

--- a/examples/kws_mfcc/train_c.c
+++ b/examples/kws_mfcc/train_c.c
@@ -322,8 +322,8 @@ int main(void) {
                                                  /*shuffle*/ false, /*shuffleSeed*/ 0,
                                                  /*dropLast*/ true);
 
-        optimizer_t *sgd =
-            sgdMCreateOptim(LR, MOMENTUM, /*weightDecay*/ 0.0f, model, MODEL_SIZE, FLOAT32);
+        optimizer_t *sgd = sgdMCreateOptim(LR, MOMENTUM, /*weightDecay*/ 0.0f, model, MODEL_SIZE,
+                                           FLOAT32, quantizationInitFloat());
 
         char logPath[300];
         snprintf(logPath, sizeof(logPath), "%s/c.json", logsDir);

--- a/examples/kws_raw/trace_c.c
+++ b/examples/kws_raw/trace_c.c
@@ -338,8 +338,8 @@ int main(int argc, char **argv) {
         return 1;
     }
 
-    optimizer_t *sgd =
-        sgdMCreateOptim(LR, MOMENTUM, /*weightDecay*/ 0.0f, model, MODEL_SIZE, FLOAT32);
+    optimizer_t *sgd = sgdMCreateOptim(LR, MOMENTUM, /*weightDecay*/ 0.0f, model, MODEL_SIZE,
+                                       FLOAT32, quantizationInitFloat());
     optimizerFunctions_t optimFns = optimizerFunctions[sgd->type];
 
     lossConfig_t lossCfg = {

--- a/examples/kws_raw/train_c.c
+++ b/examples/kws_raw/train_c.c
@@ -364,8 +364,8 @@ int main(void) {
                                                  /*shuffle*/ false, /*shuffleSeed*/ 0,
                                                  /*dropLast*/ true);
 
-        optimizer_t *sgd =
-            sgdMCreateOptim(LR, MOMENTUM, /*weightDecay*/ 0.0f, model, MODEL_SIZE, FLOAT32);
+        optimizer_t *sgd = sgdMCreateOptim(LR, MOMENTUM, /*weightDecay*/ 0.0f, model, MODEL_SIZE,
+                                           FLOAT32, quantizationInitFloat());
 
         char logPath[300];
         snprintf(logPath, sizeof(logPath), "%s/c.json", logsDir);

--- a/examples/mixed_width_mlp/train_c.c
+++ b/examples/mixed_width_mlp/train_c.c
@@ -388,8 +388,8 @@ int main(void) {
         requantizeTensorInPlace(cfg->bias->param, mq.biasQ);
     }
 
-    optimizer_t *sgd =
-        sgdMCreateOptim(LR, MOMENTUM, /*weightDecay*/ 0.0f, model, MODEL_SIZE, SYM_INT32);
+    optimizer_t *sgd = sgdMCreateOptim(LR, MOMENTUM, /*weightDecay*/ 0.0f, model, MODEL_SIZE,
+                                       SYM_INT32, quantizationInitFloat());
     optimizerFunctions_t optimFns = optimizerFunctions[sgd->type];
 
     lossConfig_t lossCfg = defaultLossConfig(CROSS_ENTROPY);

--- a/examples/mnist_cnn/train_c.c
+++ b/examples/mnist_cnn/train_c.c
@@ -287,8 +287,8 @@ int main(void) {
                                                  /*shuffle*/ false, /*shuffleSeed*/ 0,
                                                  /*dropLast*/ true);
 
-        optimizer_t *sgd =
-            sgdMCreateOptim(LR, MOMENTUM, /*weightDecay*/ 0.0f, model, MODEL_SIZE, FLOAT32);
+        optimizer_t *sgd = sgdMCreateOptim(LR, MOMENTUM, /*weightDecay*/ 0.0f, model, MODEL_SIZE,
+                                           FLOAT32, quantizationInitFloat());
 
         g_log_file = fopen("examples/mnist_cnn/logs/c.json", "w");
         if (!g_log_file) {

--- a/examples/mnist_mlp/train_c.c
+++ b/examples/mnist_mlp/train_c.c
@@ -237,8 +237,8 @@ int main(void) {
                                                  /*shuffle*/ false, /*shuffleSeed*/ 0,
                                                  /*dropLast*/ true);
 
-        optimizer_t *sgd =
-            sgdMCreateOptim(LR, MOMENTUM, /*weightDecay*/ 0.0f, model, MODEL_SIZE, FLOAT32);
+        optimizer_t *sgd = sgdMCreateOptim(LR, MOMENTUM, /*weightDecay*/ 0.0f, model, MODEL_SIZE,
+                                           FLOAT32, quantizationInitFloat());
 
         g_log_file = fopen("examples/mnist_mlp/logs/c.json", "w");
         if (!g_log_file) {

--- a/src/optimizer/CMakeLists.txt
+++ b/src/optimizer/CMakeLists.txt
@@ -14,6 +14,8 @@ target_link_libraries(Sgd PRIVATE
         DTypes
         Tensor
         Arithmetic
+        ArithmeticType
+        ExecuteOp
         Layer
         Common
 )

--- a/src/optimizer/Sgd.c
+++ b/src/optimizer/Sgd.c
@@ -1,13 +1,14 @@
+#define SOURCE_FILE "SGD"
+
 #include <stddef.h>
 #include <stdint.h>
-#include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
 
+#include "ArithmeticType.h"
 #include "Common.h"
+#include "ExecuteOp.h"
 #include "Sgd.h"
 #include "Tensor.h"
-#include "TensorConversion.h"
 
 void sgdInit(sgd_t *sgd, float learningRate, float momentumFactor, float weightDecay) {
     sgd->learningRate = learningRate;
@@ -15,185 +16,120 @@ void sgdInit(sgd_t *sgd, float learningRate, float momentumFactor, float weightD
     sgd->weightDecay = weightDecay;
 }
 
-static void sgdStepFloatCore(sgd_t *sgd, const float *gradArr, float *dataArr,
-                             size_t numberOfValues) {
-    for (size_t elementIndex = 0; elementIndex < numberOfValues; ++elementIndex) {
-        float grad = gradArr[elementIndex] + sgd->weightDecay * dataArr[elementIndex];
-        dataArr[elementIndex] -= sgd->learningRate * grad;
+typedef struct {
+    float lr, weightDecay;
+} sgdUpdateCtx_t; /* plain SGD */
+typedef struct {
+    float momentum, weightDecay;
+} sgdMStateCtx_t; /* momentum: state */
+typedef struct {
+    float lr;
+} sgdMParamCtx_t; /* momentum: param */
+
+/* executeOp update kernels (design spec 2026-07-03 PR1b.2, D1): arithmetic is
+ * always ARITH_FLOAT32, so the funnel prologue dequants every operand to
+ * float and the epilogue requants rawOut into the target's own dtype
+ * (OUT_WRITE) -- this is what gives the SGD update per-parameter dtype
+ * dispatch without a qtype switch here. */
+
+/* operands {param, grad} -> rawOut = param - lr*(grad + wd*param) */
+static void sgdUpdateKernel(tensor_t **op, size_t n, tensor_t *rawOut, tensor_t *aux,
+                            const void *ctxv) {
+    (void)n;
+    (void)aux;
+    const sgdUpdateCtx_t *ctx = ctxv;
+    size_t numberOfValues = calcNumberOfElementsByTensor(rawOut);
+    float *param = (float *)op[0]->data;
+    float *grad = (float *)op[1]->data;
+    float *out = (float *)rawOut->data;
+    for (size_t i = 0; i < numberOfValues; i++) {
+        float g = grad[i] + ctx->weightDecay * param[i];
+        out[i] = param[i] - ctx->lr * g;
     }
 }
 
-static void sgdStepFloat(optimizer_t *optim) {
-    sgd_t *sgd = optim->impl->sgd;
-
-    for (size_t stateIndex = 0; stateIndex < optim->sizeStates; stateIndex++) {
-        parameter_t *param = optim->parameter[stateIndex];
-        size_t numberOfValues = calcNumberOfElementsByParameter(param);
-        float *dataArr = (float *)param->param->data;
-
-        /* Grad-dtype-generic read (PR3, #261): FLOAT32 keeps the raw-cast fast
-         * path (no conversion, no scratch); any other admitted grad dtype
-         * (SYM_INT32/SYM/ASYM) is dequantized into a float VLA scoped to this
-         * branch only, mirroring the SYM_INT32 step arms below. */
-        if (param->grad->quantization->type == FLOAT32) {
-            sgdStepFloatCore(sgd, (float *)param->grad->data, dataArr, numberOfValues);
-        } else {
-            tensor_t gradFloat;
-            quantization_t gradFloatQ;
-            initFloat32Quantization(&gradFloatQ);
-            float gradFloatData[numberOfValues];
-            uint8_t *gradFloatDataBytes = (uint8_t *)gradFloatData;
-            setTensorValuesForConversion(gradFloatDataBytes, &gradFloatQ, param->grad, &gradFloat);
-            convertTensor(param->grad, &gradFloat);
-            sgdStepFloatCore(sgd, (float *)gradFloat.data, dataArr, numberOfValues);
-        }
+/* operands {state, grad, param} -> rawOut = mom*state + grad + wd*param */
+static void sgdMStateKernel(tensor_t **op, size_t n, tensor_t *rawOut, tensor_t *aux,
+                            const void *ctxv) {
+    (void)n;
+    (void)aux;
+    const sgdMStateCtx_t *ctx = ctxv;
+    size_t numberOfValues = calcNumberOfElementsByTensor(rawOut);
+    float *state = (float *)op[0]->data;
+    float *grad = (float *)op[1]->data;
+    float *param = (float *)op[2]->data;
+    float *out = (float *)rawOut->data;
+    for (size_t i = 0; i < numberOfValues; i++) {
+        float g = grad[i] + ctx->weightDecay * param[i];
+        out[i] = ctx->momentum * state[i] + g;
     }
 }
 
-static void sgdStepSymInt32(optimizer_t *optim) {
-    sgd_t *sgd = optim->impl->sgd;
-
-    for (size_t stateIndex = 0; stateIndex < optim->sizeStates; stateIndex++) {
-        parameter_t *param = optim->parameter[stateIndex];
-        size_t numberOfValues = calcNumberOfElementsByParameter(param);
-
-        tensor_t paramFloat;
-        quantization_t paramFloatQ;
-        initFloat32Quantization(&paramFloatQ);
-        uint8_t paramFloatData[numberOfValues * sizeof(float)];
-        setTensorValuesForConversion(paramFloatData, &paramFloatQ, param->param, &paramFloat);
-        convertTensor(param->param, &paramFloat);
-
-        float *paramFloatArr = (float *)paramFloat.data;
-
-        tensor_t gradFloat;
-        quantization_t gradFloatQ;
-        initFloat32Quantization(&gradFloatQ);
-        float gradFloatData[numberOfValues];
-        uint8_t *gradFloatDataBytes = (uint8_t *)gradFloatData;
-        setTensorValuesForConversion(gradFloatDataBytes, &gradFloatQ, param->grad, &gradFloat);
-        convertTensor(param->grad, &gradFloat);
-
-        float *gradFloatArr = (float *)gradFloat.data;
-
-        for (size_t j = 0; j < numberOfValues; ++j) {
-            float grad = gradFloatArr[j] + sgd->weightDecay * paramFloatArr[j];
-            paramFloatArr[j] -= sgd->learningRate * grad;
-        }
-
-        convertTensor(&paramFloat, param->param);
+/* operands {param, state} -> rawOut = param - lr*state */
+static void sgdMParamKernel(tensor_t **op, size_t n, tensor_t *rawOut, tensor_t *aux,
+                            const void *ctxv) {
+    (void)n;
+    (void)aux;
+    const sgdMParamCtx_t *ctx = ctxv;
+    size_t numberOfValues = calcNumberOfElementsByTensor(rawOut);
+    float *param = (float *)op[0]->data;
+    float *state = (float *)op[1]->data;
+    float *out = (float *)rawOut->data;
+    for (size_t i = 0; i < numberOfValues; i++) {
+        out[i] = param[i] - ctx->lr * state[i];
     }
 }
 
-void sgdStep(optimizer_t *optimizer) {
-    switch (optimizer->qtype) {
-    case FLOAT32:
-        sgdStepFloat(optimizer);
-        break;
-    case SYM_INT32:
-        sgdStepSymInt32(optimizer);
-        break;
-    default:
-        PRINT_ERROR("Unknown Layer Type!");
-        exit(1);
-    }
-}
-
-static void sgdStepMFloatCore(sgd_t *sgd, const float *gradArr, float *paramArr, float *stateArr,
-                              size_t numberOfValues) {
-    for (size_t elementIndex = 0; elementIndex < numberOfValues; ++elementIndex) {
-        float grad = gradArr[elementIndex] + sgd->weightDecay * paramArr[elementIndex];
-        stateArr[elementIndex] = sgd->momentumFactor * stateArr[elementIndex] + grad;
-        paramArr[elementIndex] -= sgd->learningRate * stateArr[elementIndex];
-    }
-}
-
-static void sgdStepMFloat(optimizer_t *optim) {
+void sgdStep(optimizer_t *optim) {
     sgd_t *sgd = optim->impl->sgd;
     for (size_t i = 0; i < optim->sizeStates; i++) {
-        parameter_t *param = optim->parameter[i];
-        size_t numberOfValues = calcNumberOfElementsByParameter(param);
-        float *paramArr = (float *)param->param->data;
-
-        states_t *states = optim->states[i];
-        tensor_t *state = states->stateBuffers[0];
-        float *stateArr = (float *)state->data;
-
-        /* Grad-dtype-generic read (PR3, #261) - see sgdStepFloat for the
-         * fast-path/VLA rationale. */
-        if (param->grad->quantization->type == FLOAT32) {
-            sgdStepMFloatCore(sgd, (float *)param->grad->data, paramArr, stateArr, numberOfValues);
-        } else {
-            tensor_t gradFloat;
-            quantization_t gradFloatQ;
-            initFloat32Quantization(&gradFloatQ);
-            float gradFloatData[numberOfValues];
-            uint8_t *gradFloatDataBytes = (uint8_t *)gradFloatData;
-            setTensorValuesForConversion(gradFloatDataBytes, &gradFloatQ, param->grad, &gradFloat);
-            convertTensor(param->grad, &gradFloat);
-            sgdStepMFloatCore(sgd, (float *)gradFloat.data, paramArr, stateArr, numberOfValues);
-        }
+        parameter_t *p = optim->parameter[i];
+        sgdUpdateCtx_t ctx = {.lr = sgd->learningRate, .weightDecay = sgd->weightDecay};
+        executeOp(
+            &(opSpec_t){
+                .kernel = sgdUpdateKernel,
+                .ctx = &ctx,
+                .inputs = (tensor_t *[]){p->param, p->grad},
+                .nInputs = 2,
+                .arithmetic = (arithmetic_t){.type = ARITH_FLOAT32, .roundingMode = HALF_AWAY},
+                .mode = OUT_WRITE,
+                .auxOut = NULL,
+            },
+            p->param);
     }
 }
 
-static void sgdStepMSymInt32(optimizer_t *optim) {
+void sgdStepM(optimizer_t *optim) {
     sgd_t *sgd = optim->impl->sgd;
-
     for (size_t i = 0; i < optim->sizeStates; i++) {
-        parameter_t *param = optim->parameter[i];
-        size_t numberOfValues = calcNumberOfElementsByParameter(param);
+        parameter_t *p = optim->parameter[i];
+        tensor_t *state = optim->states[i]->stateBuffers[0];
 
-        tensor_t paramFloat;
-        quantization_t paramFloatQ;
-        initFloat32Quantization(&paramFloatQ);
-        uint8_t paramFloatData[numberOfValues * sizeof(float)];
-        setTensorValuesForConversion(paramFloatData, &paramFloatQ, param->param, &paramFloat);
-        convertTensor(param->param, &paramFloat);
-        float *paramFloatArr = (float *)paramFloat.data;
+        sgdMStateCtx_t sc = {.momentum = sgd->momentumFactor, .weightDecay = sgd->weightDecay};
+        executeOp(
+            &(opSpec_t){
+                .kernel = sgdMStateKernel,
+                .ctx = &sc,
+                .inputs = (tensor_t *[]){state, p->grad, p->param},
+                .nInputs = 3,
+                .arithmetic = (arithmetic_t){.type = ARITH_FLOAT32, .roundingMode = HALF_AWAY},
+                .mode = OUT_WRITE,
+                .auxOut = NULL,
+            },
+            state);
 
-        tensor_t gradFloat;
-        quantization_t gradFloatQ;
-        initFloat32Quantization(&gradFloatQ);
-        float gradFloatData[numberOfValues];
-        uint8_t *gradFloatDataBytes = (uint8_t *)gradFloatData;
-        setTensorValuesForConversion(gradFloatDataBytes, &gradFloatQ, param->grad, &gradFloat);
-        convertTensor(param->grad, &gradFloat);
-        float *gradFloatArr = (float *)gradFloat.data;
-
-        states_t *states = optim->states[i];
-
-        tensor_t *state = states->stateBuffers[0];
-
-        tensor_t stateFloat;
-        quantization_t stateFloatQ;
-        initFloat32Quantization(&stateFloatQ);
-        uint8_t stateFloatData[numberOfValues * sizeof(float)];
-        setTensorValuesForConversion(stateFloatData, &stateFloatQ, state, &stateFloat);
-        convertTensor(state, &stateFloat);
-        float *stateFloatArr = (float *)stateFloat.data;
-
-        for (size_t j = 0; j < numberOfValues; ++j) {
-            float grad = gradFloatArr[j] + sgd->weightDecay * paramFloatArr[j];
-            stateFloatArr[j] = sgd->momentumFactor * stateFloatArr[j] + grad;
-            paramFloatArr[j] -= sgd->learningRate * stateFloatArr[j];
-        }
-
-        convertTensor(&stateFloat, state);
-        convertTensor(&paramFloat, param->param);
-    }
-}
-
-void sgdStepM(optimizer_t *optimizer) {
-    switch (optimizer->qtype) {
-    case FLOAT32:
-        sgdStepMFloat(optimizer);
-        break;
-    case SYM_INT32:
-        sgdStepMSymInt32(optimizer);
-        break;
-    default:
-        PRINT_ERROR("Unknown Layer Type!");
-        exit(1);
+        sgdMParamCtx_t pc = {.lr = sgd->learningRate};
+        executeOp(
+            &(opSpec_t){
+                .kernel = sgdMParamKernel,
+                .ctx = &pc,
+                .inputs = (tensor_t *[]){p->param, state},
+                .nInputs = 2,
+                .arithmetic = (arithmetic_t){.type = ARITH_FLOAT32, .roundingMode = HALF_AWAY},
+                .mode = OUT_WRITE,
+                .auxOut = NULL,
+            },
+            p->param);
     }
 }
 

--- a/src/userApi/optimizer/SgdApi.c
+++ b/src/userApi/optimizer/SgdApi.c
@@ -14,9 +14,16 @@
 #include "Tensor.h"
 #include "TensorApi.h"
 
-// IMPORTANT: Currently, the quantization for states are the same as the corresponding parameter
+/*! Builds a momentum-state tensor at `param`'s shape but with its OWN
+ * quantization (`momentumQuant`, deep-cloned via getQLike) -- decouples the
+ * accumulator's dtype from the parameter's storage dtype (#277 Task 2). */
+static tensor_t *momentumStateInit(tensor_t *param, quantization_t *momentumQuant) {
+    return initTensor(getShapeLike(param->shape), getQLike(momentumQuant), NULL);
+}
+
 optimizer_t *sgdMCreateOptim(float learningRate, float momentumFactor, float weightDecay,
-                             layer_t **model, size_t sizeModel, qtype_t qType) {
+                             layer_t **model, size_t sizeModel, qtype_t qType,
+                             quantization_t *momentumQuant) {
     optimizer_t *optim = reserveMemory(sizeof(optimizer_t));
     optim->type = SGD_M;
     optim->qtype = qType;
@@ -47,11 +54,11 @@ optimizer_t *sgdMCreateOptim(float learningRate, float momentumFactor, float wei
             parameter_t *weights = linearConfig->weights;
 
             optim->parameter[paramSlot] = weights;
-            tensor_t *weightStateBuffer = getTensorLike(weights->param);
+            tensor_t *weightStateBuffer = momentumStateInit(weights->param, momentumQuant);
 
             parameter_t *bias = linearConfig->bias;
             optim->parameter[paramSlot + 1] = bias;
-            tensor_t *biasStateBuffer = getTensorLike(bias->param);
+            tensor_t *biasStateBuffer = momentumStateInit(bias->param, momentumQuant);
 
             states_t *weightStates = reserveMemory(sizeof(states_t));
             weightStates->statesPerParameter = statesPerParam;
@@ -73,11 +80,11 @@ optimizer_t *sgdMCreateOptim(float learningRate, float momentumFactor, float wei
 
             parameter_t *cWeights = conv1dCfg->weights;
             optim->parameter[paramSlot] = cWeights;
-            tensor_t *cWeightStateBuffer = getTensorLike(cWeights->param);
+            tensor_t *cWeightStateBuffer = momentumStateInit(cWeights->param, momentumQuant);
 
             parameter_t *cBias = conv1dCfg->bias;
             optim->parameter[paramSlot + 1] = cBias;
-            tensor_t *cBiasStateBuffer = getTensorLike(cBias->param);
+            tensor_t *cBiasStateBuffer = momentumStateInit(cBias->param, momentumQuant);
 
             states_t *cWeightStates = reserveMemory(sizeof(states_t));
             cWeightStates->statesPerParameter = statesPerParam;
@@ -100,11 +107,11 @@ optimizer_t *sgdMCreateOptim(float learningRate, float momentumFactor, float wei
 
             parameter_t *ctWeights = ctCfg->weights;
             optim->parameter[paramSlot] = ctWeights;
-            tensor_t *ctWeightStateBuffer = getTensorLike(ctWeights->param);
+            tensor_t *ctWeightStateBuffer = momentumStateInit(ctWeights->param, momentumQuant);
 
             parameter_t *ctBias = ctCfg->bias;
             optim->parameter[paramSlot + 1] = ctBias;
-            tensor_t *ctBiasStateBuffer = getTensorLike(ctBias->param);
+            tensor_t *ctBiasStateBuffer = momentumStateInit(ctBias->param, momentumQuant);
 
             states_t *ctWeightStates = reserveMemory(sizeof(states_t));
             ctWeightStates->statesPerParameter = statesPerParam;
@@ -127,11 +134,11 @@ optimizer_t *sgdMCreateOptim(float learningRate, float momentumFactor, float wei
 
             parameter_t *lnGamma = lnCfg->gamma;
             optim->parameter[paramSlot] = lnGamma;
-            tensor_t *lnGammaStateBuffer = getTensorLike(lnGamma->param);
+            tensor_t *lnGammaStateBuffer = momentumStateInit(lnGamma->param, momentumQuant);
 
             parameter_t *lnBeta = lnCfg->beta;
             optim->parameter[paramSlot + 1] = lnBeta;
-            tensor_t *lnBetaStateBuffer = getTensorLike(lnBeta->param);
+            tensor_t *lnBetaStateBuffer = momentumStateInit(lnBeta->param, momentumQuant);
 
             states_t *lnGammaStates = reserveMemory(sizeof(states_t));
             lnGammaStates->statesPerParameter = statesPerParam;

--- a/src/userApi/optimizer/include/OptimizerApi.h
+++ b/src/userApi/optimizer/include/OptimizerApi.h
@@ -3,7 +3,10 @@
 
 #include "Optimizer.h"
 
-optimizer_t *optimizerInit(optimizerType_t type, void *optimizerConfig);
+/* No standalone `SGD` factory: sgdMCreateOptim() with momentumFactor == 0
+ * is numerically identical to plain SGD (the momentum-state kernel reduces
+ * to `state = grad + wd*param`, same as the plain-SGD kernel), at the cost
+ * of one extra momentum-state tensor per parameter. See SgdApi.h (#277). */
 
 /* Scales every gradient field of every parameter tracked by the optimizer
  * by the given factor in-place.

--- a/src/userApi/optimizer/include/SgdApi.h
+++ b/src/userApi/optimizer/include/SgdApi.h
@@ -3,8 +3,22 @@
 
 #include "Sgd.h"
 
+/*! Builds an SGD(+momentum) optimizer over a model's trainable parameters.
+ *
+ * Each parameter's momentum state buffer is allocated at the PARAMETER'S
+ * SHAPE but with its OWN quantization config (`momentumQuant`, deep-cloned
+ * per state via getQLike) -- decoupled from the parameter's own dtype.
+ * Pass quantizationInitFloat() for the conventional FLOAT32 accumulator
+ * (the sensible default for every existing caller); a caller wanting e.g. a
+ * SYM momentum accumulator may pass a SYM quantization instead, subject to
+ * getQLike's supported-type set (BOOL is not supported for state clones).
+ *
+ * \param momentumQuant: Quantization template for momentum state buffers
+ *        (caller-owned; not consumed -- cloned once per state via getQLike).
+ */
 optimizer_t *sgdMCreateOptim(float learningRate, float momentumFactor, float weightDecay,
-                             layer_t **model, size_t sizeModel, qtype_t qType);
+                             layer_t **model, size_t sizeModel, qtype_t qType,
+                             quantization_t *momentumQuant);
 
 void freeOptimSgdM(optimizer_t *sgdM);
 

--- a/test/unit/layer/UnitTestLinear.c
+++ b/test/unit/layer/UnitTestLinear.c
@@ -1550,7 +1550,8 @@ void testLinearSymInt32GradAccumulatesOverTwoMicrobatchesAndSteps(void) {
 
     /* ---- Optimizer step on the SYM_INT32 layer ("updates the param without crashing"). ---- */
     layer_t *symModel[] = {symLayer};
-    optimizer_t *symOptim = sgdMCreateOptim(0.1f, 0.0f, 0.0f, symModel, 1, SYM_INT32);
+    quantization_t *momentumQ = quantizationInitFloat();
+    optimizer_t *symOptim = sgdMCreateOptim(0.1f, 0.0f, 0.0f, symModel, 1, SYM_INT32, momentumQ);
     optimizerFunctions[symOptim->type].step(symOptim);
     tensor_t *symWParam = symLayer->config->linear->weights->param;
     int paramFinite = 1;
@@ -1622,6 +1623,7 @@ void testLinearSymInt32GradAccumulatesOverTwoMicrobatchesAndSteps(void) {
     freeTensor(symProp1);
     freeTensor(symLoss1);
     freeTensor(symIn1);
+    freeQuantization(momentumQ);
     freeQuantization(bwd);
     freeQuantization(fwd);
 

--- a/test/unit/optimizer/CMakeLists.txt
+++ b/test/unit/optimizer/CMakeLists.txt
@@ -11,5 +11,6 @@ add_elastic_ai_unit_test(
         ReluApi
         LayerQuant
         ArithmeticType
+        RNG
         odt_test_death
 )

--- a/test/unit/optimizer/UnitTestSgd.c
+++ b/test/unit/optimizer/UnitTestSgd.c
@@ -12,6 +12,7 @@
 #include "Optimizer.h"
 #include "OptimizerApi.h"
 #include "QuantizationApi.h"
+#include "RNG.h"
 #include "Sgd.h"
 #include "SgdApi.h"
 #include "StorageApi.h"
@@ -1021,6 +1022,130 @@ void testSgdStepMMixedDtypeMovesBothParamsCorrectly(void) {
     TEST_ASSERT_FLOAT_WITHIN(0.01f, -0.6f, bAfter[1]);
 }
 
+/* #279 SRHTE dead-zone fixture (optimizer epic #277, Task 3): shape-[2]
+ * SYM_INT32 param. Index 0 is a large "anchor" (grad=0, weightDecay=0) whose
+ * decoded value always equals the tensor's absmax by construction -- writeOut's
+ * FLOAT32->SYM_INT32 requant (convertFloatTensorToSymInt32Tensor) RE-DERIVES
+ * the per-tensor scale from the current decoded values on every OUT_WRITE
+ * (there is no hidden full-precision accumulator), so pinning the absmax
+ * pins the scale essentially constant across iterations too. Index 1 is the
+ * "target": its constant grad produces a per-step update of exactly
+ * fraction*scale (fraction=0.25, comfortably sub-ULP: < the 0.5 half-grid
+ * boundary round-to-nearest needs to move a code). Caller owns freeing the
+ * returned parameter_t (freeParameter cascades param+grad). */
+static parameter_t *buildSymDeadZoneFixture(roundingMode_t roundingMode, float lr) {
+    size_t *pDims = reserveMemory(1 * sizeof(size_t));
+    pDims[0] = 2;
+    size_t *pOrder = reserveMemory(1 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(1, pOrder);
+    shape_t *pShape = reserveMemory(sizeof(shape_t));
+    setShape(pShape, pDims, 1, pOrder);
+    tensor_t *p = initTensor(pShape, quantizationInitSymInt32(roundingMode), NULL);
+
+    const float anchorVal = 100.f;
+    tensorFillFromFloatBuffer(p, (float[]){anchorVal, 0.f}, 2);
+
+    /* qMax for the default 12-bit SYM_INT32 operand width (ODT_SYM_OPERAND_QMAXBITS,
+     * #227): 2^(12-1) - 1. Mirrors convertFloatTensorToSymInt32Tensor's own
+     * derivation so `scale` here matches what the OUT_WRITE epilogue computes. */
+    const float qMax = 2047.f;
+    const float scale = anchorVal / qMax;
+    const float fraction = 0.25f;
+    const float delta = fraction * scale;
+    const float targetGrad = delta / lr; /* so that lr*targetGrad == delta */
+
+    tensor_t *g = gradInitFloat(p, NULL);
+    tensorFillFromFloatBuffer(g, (float[]){0.f, targetGrad}, 2);
+
+    return parameterInit(p, g);
+}
+
+void testSgdStepHalfAwayNeverEscapesSymDeadZone(void) {
+    /* #279 control: HALF_AWAY (round-to-nearest) on the target's own qConfig.
+     * Every sgdStep re-decodes the target from its (unchanged) integer code,
+     * applies the same sub-ULP delta, and requants -- landing back on the
+     * exact same code every time. Mutation guard: if writeOut ever stopped
+     * re-deriving the target's value from its stored code (e.g. a latent
+     * float accumulator were added), this would go RED (code would drift and
+     * eventually move), so this test also pins that absence of hidden state. */
+    const float lr = 0.1f;
+    parameter_t *param = buildSymDeadZoneFixture(HALF_AWAY, lr);
+
+    int32_t initialTargetCode = ((int32_t *)param->param->data)[1];
+    TEST_ASSERT_EQUAL_INT(0, initialTargetCode); /* fixture guard */
+
+    sgd_t sgd;
+    sgdInit(&sgd, lr, 0.f, 0.f);
+    parameter_t *params[1] = {param};
+    optimImpl_t impl;
+    impl.sgd = &sgd;
+    optimizer_t optim;
+    optim.parameter = params;
+    optim.sizeStates = 1;
+    optim.qtype = SYM_INT32; /* vestigial post-#278: irrelevant to per-tensor funnel dispatch */
+    optim.impl = &impl;
+
+    int codeEverMoved = 0;
+    for (int i = 0; i < 500; i++) {
+        sgdStep(&optim);
+        if (((int32_t *)param->param->data)[1] != initialTargetCode) {
+            codeEverMoved = 1;
+        }
+    }
+    int32_t finalTargetCode = ((int32_t *)param->param->data)[1];
+
+    freeParameter(param);
+
+    TEST_ASSERT_FALSE_MESSAGE(codeEverMoved, "#279 dead-zone: HALF_AWAY must never move a sub-ULP "
+                                             "SYM_INT32 code across 500 identical updates");
+    TEST_ASSERT_EQUAL_INT(0, finalTargetCode);
+}
+
+void testSgdStepSrHalfAwayEscapesSymDeadZone(void) {
+    /* #279 treatment: same fixture, but the param's own qConfig carries
+     * SR_HALF_AWAY. executeOp's OUT_WRITE epilogue requants by the TARGET
+     * tensor's roundingMode (ExecuteOp.c writeOut -> convertTensor ->
+     * convertFloatTensorToSymInt32Tensor(..., outputSymInt32QC->roundingMode)),
+     * so a SYM param that opts into SR_HALF_AWAY gets a stochastic write-back
+     * "for free" -- no optimizer-side numerics change (Task 1 already routed
+     * the update through executeOp). Per-step P(code moves) == fraction ==
+     * 0.25 (stochastic rounding is unbiased: jitter ~ Uniform[-0.5, 0.5) added
+     * before round-half-away), so P(never escapes in 500 iterations) =
+     * 0.75^500 -- astronomically small; seeded for reproducibility. */
+    rngSetSeed(12345u);
+
+    const float lr = 0.1f;
+    parameter_t *param = buildSymDeadZoneFixture(SR_HALF_AWAY, lr);
+
+    int32_t initialTargetCode = ((int32_t *)param->param->data)[1];
+    TEST_ASSERT_EQUAL_INT(0, initialTargetCode); /* fixture guard */
+
+    sgd_t sgd;
+    sgdInit(&sgd, lr, 0.f, 0.f);
+    parameter_t *params[1] = {param};
+    optimImpl_t impl;
+    impl.sgd = &sgd;
+    optimizer_t optim;
+    optim.parameter = params;
+    optim.sizeStates = 1;
+    optim.qtype = SYM_INT32;
+    optim.impl = &impl;
+
+    int codeEverMoved = 0;
+    for (int i = 0; i < 500; i++) {
+        sgdStep(&optim);
+        if (((int32_t *)param->param->data)[1] != initialTargetCode) {
+            codeEverMoved = 1;
+        }
+    }
+
+    freeParameter(param);
+
+    TEST_ASSERT_TRUE_MESSAGE(codeEverMoved,
+                             "#279 mechanism: SR_HALF_AWAY must escape the SYM_INT32 "
+                             "dead-zone within 500 iterations");
+}
+
 int main() {
     UNITY_BEGIN();
     RUN_TEST(testSgdMCreateOptim);
@@ -1037,5 +1162,7 @@ int main() {
     RUN_TEST(testSgdZeroGradAsymSubByteZeroesAllPackedBytes);
     RUN_TEST(testSgdZeroGradSymSubByteZeroesAllPackedBytesAndResetsScale);
     RUN_TEST(testSgdStepMMixedDtypeMovesBothParamsCorrectly);
+    RUN_TEST(testSgdStepHalfAwayNeverEscapesSymDeadZone);
+    RUN_TEST(testSgdStepSrHalfAwayEscapesSymDeadZone);
     return UNITY_END();
 }

--- a/test/unit/optimizer/UnitTestSgd.c
+++ b/test/unit/optimizer/UnitTestSgd.c
@@ -865,8 +865,8 @@ void testSgdStepMFloatReadsPackedSymGradGeneric(void) {
      * (no rounding ties: HALF_AWAY only matters at x.5, none of these land
      * on one). momentumFactor=0 and weightDecay=0 collapse the momentum
      * update to state=grad, param -= lr*dequant(grad).
-     * Mutation: reverting the generic read (raw float-cast of the packed SYM
-     * bytes, i.e. dropping the FLOAT32/else branch in sgdStepMFloat) misreads
+     * Mutation: forcing the executeOp prologue to raw-cast the packed SYM bytes
+     * instead of dequantizing them (its per-dtype operand conversion) misreads
      * the storage as raw floats -> garbage grad values -> RED. */
     size_t *pDims = reserveMemory(1 * sizeof(size_t));
     pDims[0] = 3;

--- a/test/unit/optimizer/UnitTestSgd.c
+++ b/test/unit/optimizer/UnitTestSgd.c
@@ -136,8 +136,9 @@ void testSgdMCreateOptim() {
     float momentumFactor = 0.9f;
     float weightDecay = 0.5f;
 
+    quantization_t *momentumQ = quantizationInitFloat();
     optimizer_t *optim =
-        sgdMCreateOptim(lr, momentumFactor, weightDecay, model, sizeModel, FLOAT32);
+        sgdMCreateOptim(lr, momentumFactor, weightDecay, model, sizeModel, FLOAT32, momentumQ);
     sgd_t *sgd = optim->impl->sgd;
 
     linearConfig_t *linear0Conf = linear0->config->linear;
@@ -199,6 +200,7 @@ void testSgdMCreateOptim() {
     freeLinearLayerShellOnly(linear1);
     freeReluLayer(relu0);
     freeLinearLayerShellOnly(linear0);
+    freeQuantization(momentumQ);
     freeQuantization(layerQ);
 
     /* ASSERT. */
@@ -258,7 +260,9 @@ void testSGDStep() {
     float momentumFactor = 0.9f;
     float weightDecay = 0.01f;
 
-    optimizer_t *sgd = sgdMCreateOptim(lr, momentumFactor, weightDecay, model, modelSize, FLOAT32);
+    quantization_t *momentumQ = quantizationInitFloat();
+    optimizer_t *sgd =
+        sgdMCreateOptim(lr, momentumFactor, weightDecay, model, modelSize, FLOAT32, momentumQ);
 
     optimizerFunctions_t sgdFns = optimizerFunctions[sgd->type];
     sgdFns.step(sgd);
@@ -289,6 +293,7 @@ void testSGDStep() {
      * weights/bias — freeLinearLayer would double-free them. */
     freeOptimSgdM(sgd);
     freeLinearLayerShellOnly(linear);
+    freeQuantization(momentumQ);
     freeQuantization(layerQ);
 
     /* ASSERT. */
@@ -345,7 +350,9 @@ void testSGDZeroGrad() {
     float momentumFactor = 0.9f;
     float weightDecay = 0.01f;
 
-    optimizer_t *sgd = sgdMCreateOptim(lr, momentumFactor, weightDecay, model, modelSize, FLOAT32);
+    quantization_t *momentumQ = quantizationInitFloat();
+    optimizer_t *sgd =
+        sgdMCreateOptim(lr, momentumFactor, weightDecay, model, modelSize, FLOAT32, momentumQ);
 
     sgdZeroGrad(sgd);
 
@@ -363,6 +370,7 @@ void testSGDZeroGrad() {
      * weights/bias — freeLinearLayer would double-free them. */
     freeOptimSgdM(sgd);
     freeLinearLayerShellOnly(linear);
+    freeQuantization(momentumQ);
     freeQuantization(layerQ);
 
     /* ASSERT. */
@@ -402,7 +410,8 @@ void testSgdZeroGradOnSymInt32GradZeroesMantissasAndResetsScale(void) {
     ((symInt32QConfig_t *)wGrad->quantization->qConfig)->scale = 0.07f;
 
     layer_t *model[] = {layer};
-    optimizer_t *optim = sgdMCreateOptim(0.1f, 0.9f, 0.0f, model, 1, SYM_INT32);
+    quantization_t *momentumQ = quantizationInitFloat();
+    optimizer_t *optim = sgdMCreateOptim(0.1f, 0.9f, 0.0f, model, 1, SYM_INT32, momentumQ);
 
     sgdZeroGrad(optim);
 
@@ -423,12 +432,71 @@ void testSgdZeroGradOnSymInt32GradZeroesMantissasAndResetsScale(void) {
     freeReservedMemory(layer->config->linear);
     freeReservedMemory(layer->config);
     freeReservedMemory(layer);
+    freeQuantization(momentumQ);
     freeQuantization(bwd);
     freeQuantization(fwd);
 
     TEST_ASSERT_TRUE_MESSAGE(allZero, "sgdZeroGrad must zero SYM_INT32 grad mantissas");
     TEST_ASSERT_FLOAT_WITHIN(1e-6f, 1.0f, scaleAfterZero);
     TEST_ASSERT_TRUE(accumWorks);
+}
+
+/* TDD RED for #277 Task 2: momentum state must carry its OWN quantization
+ * config, decoupled from the parameter's dtype. Before this change,
+ * sgdMCreateOptim built each state via getTensorLike(param->param), so a
+ * SYM_INT32 weight/bias produced a SYM_INT32 momentum accumulator -- this
+ * pins a FLOAT32 momentumQuant against a SYM_INT32 param and asserts the
+ * state buffer lands FLOAT32 regardless. */
+void testSgdMCreateOptimMomentumStateIsFloatIndependentOfSymInt32ParamDtype(void) {
+    quantization_t *symQ = quantizationInitSymInt32(HALF_AWAY);
+
+    /* weights: SYM_INT32 param + SYM_INT32 grad, shape [2, 3]. */
+    size_t *wDims = reserveMemory(2 * sizeof(size_t));
+    wDims[0] = 2;
+    wDims[1] = 3;
+    size_t *wOrder = reserveMemory(2 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(2, wOrder);
+    shape_t *wShape = reserveMemory(sizeof(shape_t));
+    setShape(wShape, wDims, 2, wOrder);
+    tensor_t *wParam = initTensor(wShape, quantizationInitSymInt32(HALF_AWAY), NULL);
+    tensorFillFromFloatBuffer(wParam, (float[]){0.f, 0.f, 0.f, 0.f, 0.f, 0.f}, 6);
+    tensor_t *wGrad = gradInitSymInt32(wParam, HALF_AWAY, NULL);
+    parameter_t *weights = parameterInit(wParam, wGrad);
+
+    /* bias: SYM_INT32 param + SYM_INT32 grad, shape [2]. */
+    size_t *bDims = reserveMemory(1 * sizeof(size_t));
+    bDims[0] = 2;
+    size_t *bOrder = reserveMemory(1 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(1, bOrder);
+    shape_t *bShape = reserveMemory(sizeof(shape_t));
+    setShape(bShape, bDims, 1, bOrder);
+    tensor_t *bParam = initTensor(bShape, quantizationInitSymInt32(HALF_AWAY), NULL);
+    tensorFillFromFloatBuffer(bParam, (float[]){0.f, 0.f}, 2);
+    tensor_t *bGrad = gradInitSymInt32(bParam, HALF_AWAY, NULL);
+    parameter_t *bias = parameterInit(bParam, bGrad);
+
+    layer_t *layer = buildBorrowedLinearLayer(weights, bias, symQ);
+    layer_t *model[1] = {layer};
+
+    quantization_t *momentumQ = quantizationInitFloat();
+    optimizer_t *optim = sgdMCreateOptim(0.1f, 0.9f, 0.0f, model, 1, SYM_INT32, momentumQ);
+
+    /* CAPTURE before frees. */
+    qtype_t capturedWeightParamType =
+        weights->param->quantization->type; /* guard: stays SYM_INT32 */
+    qtype_t capturedBiasParamType = bias->param->quantization->type;
+    qtype_t capturedWeightStateType = optim->states[0]->stateBuffers[0]->quantization->type;
+    qtype_t capturedBiasStateType = optim->states[1]->stateBuffers[0]->quantization->type;
+
+    freeOptimSgdM(optim);
+    freeLinearLayerShellOnly(layer);
+    freeQuantization(momentumQ);
+    freeQuantization(symQ);
+
+    TEST_ASSERT_EQUAL_INT(SYM_INT32, capturedWeightParamType);
+    TEST_ASSERT_EQUAL_INT(SYM_INT32, capturedBiasParamType);
+    TEST_ASSERT_EQUAL_INT(FLOAT32, capturedWeightStateType);
+    TEST_ASSERT_EQUAL_INT(FLOAT32, capturedBiasStateType);
 }
 
 void testSgdMCreateOptimRegistersLayerNormGammaAndBeta(void) {
@@ -481,8 +549,9 @@ void testSgdMCreateOptimRegistersLayerNormGammaAndBeta(void) {
     float momentumFactor = 0.9f;
     float weightDecay = 0.0f;
 
+    quantization_t *momentumQ = quantizationInitFloat();
     optimizer_t *optim =
-        sgdMCreateOptim(lr, momentumFactor, weightDecay, model, sizeModel, FLOAT32);
+        sgdMCreateOptim(lr, momentumFactor, weightDecay, model, sizeModel, FLOAT32, momentumQ);
 
     /* CAPTURE before frees. */
     size_t capturedSizeStates = optim->sizeStates;
@@ -501,6 +570,7 @@ void testSgdMCreateOptimRegistersLayerNormGammaAndBeta(void) {
     freeReservedMemory(lnLayer);
     freeReservedMemory(lcfg);
     freeReservedMemory(normShape);
+    freeQuantization(momentumQ);
     freeQuantization(bq);
     freeQuantization(fq);
     freeReservedMemory(lnCfg);
@@ -718,7 +788,8 @@ void testSgdMCreateOptimAdmitsPackedSymGradStorage(void) {
     layer_t *layer = buildBorrowedLinearLayer(weights, bias, fQ);
     layer_t *model[1] = {layer};
 
-    optimizer_t *optim = sgdMCreateOptim(0.1f, 0.0f, 0.0f, model, 1, FLOAT32);
+    quantization_t *momentumQ = quantizationInitFloat();
+    optimizer_t *optim = sgdMCreateOptim(0.1f, 0.0f, 0.0f, model, 1, FLOAT32, momentumQ);
 
     /* CAPTURE before frees. */
     qtype_t capturedWGradType = weights->grad->quantization->type;
@@ -727,6 +798,7 @@ void testSgdMCreateOptimAdmitsPackedSymGradStorage(void) {
     /* freeOptimSgdM cascades to the registered parameters (weights, bias). */
     freeOptimSgdM(optim);
     freeLinearLayerShellOnly(layer);
+    freeQuantization(momentumQ);
     freeQuantization(fQ);
 
     TEST_ASSERT_EQUAL_INT(SYM, capturedWGradType);
@@ -766,12 +838,14 @@ void testSgdMCreateOptimRejectsBoolGradStorage(void) {
     layer_t *layer = buildBorrowedLinearLayer(weights, bias, fQ);
     layer_t *model[1] = {layer};
 
-    ASSERT_EXITS_WITH_FAILURE(sgdMCreateOptim(0.1f, 0.0f, 0.0f, model, 1, FLOAT32));
+    quantization_t *momentumQ = quantizationInitFloat();
+    ASSERT_EXITS_WITH_FAILURE(sgdMCreateOptim(0.1f, 0.0f, 0.0f, model, 1, FLOAT32, momentumQ));
 
     /* Teardown (parent continues after the fork-based assert; file convention). */
     freeLinearLayerShellOnly(layer);
     freeParameter(weights);
     freeParameter(bias);
+    freeQuantization(momentumQ);
     freeQuantization(fQ);
 }
 
@@ -953,6 +1027,7 @@ int main() {
     RUN_TEST(testSGDStep);
     RUN_TEST(testSGDZeroGrad);
     RUN_TEST(testSgdZeroGradOnSymInt32GradZeroesMantissasAndResetsScale);
+    RUN_TEST(testSgdMCreateOptimMomentumStateIsFloatIndependentOfSymInt32ParamDtype);
     RUN_TEST(testLayerNormContributesTwoOptimizerStates);
     RUN_TEST(testSgdMCreateOptimRegistersLayerNormGammaAndBeta);
     RUN_TEST(testSgdStepSymInt32DoesNotRoundTripGrad);

--- a/test/unit/optimizer/UnitTestSgd.c
+++ b/test/unit/optimizer/UnitTestSgd.c
@@ -851,6 +851,102 @@ void testSgdStepMFloatReadsPackedSymGradGeneric(void) {
     TEST_ASSERT_FLOAT_WITHIN(1e-6f, expected2, p2);
 }
 
+void testSgdStepMMixedDtypeMovesBothParamsCorrectly(void) {
+    /* TDD RED (Task 1, optimizer epic #277, closes #278): sgdStep{,M} dispatch
+     * on optim->qtype today, so a model with BOTH a FLOAT32 and a SYM_INT32
+     * parameter cannot be trained correctly in one call -- sgdStepMFloat
+     * (the FLOAT32 arm) raw-casts param->param->data/state->data to float*
+     * unconditionally, so a SYM_INT32 param/state gets its int32 mantissas
+     * reinterpreted as float bit patterns (garbage). This must fail today;
+     * the executeOp-funnel rewrite (per-tensor dtype dispatch via the
+     * funnel's own conversionMatrix lookups, no qtype switch) is what makes
+     * it pass. */
+
+    /* Parameter A: FLOAT32 param + grad, shape [2]. */
+    size_t *aDims = reserveMemory(1 * sizeof(size_t));
+    aDims[0] = 2;
+    size_t *aOrder = reserveMemory(1 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(1, aOrder);
+    shape_t *aShape = reserveMemory(sizeof(shape_t));
+    setShape(aShape, aDims, 1, aOrder);
+    tensor_t *paramA = initTensor(aShape, quantizationInitFloat(), NULL);
+    tensorFillFromFloatBuffer(paramA, (float[]){1.f, 2.f}, 2);
+    tensor_t *gradA = gradInitFloat(paramA, NULL);
+    tensorFillFromFloatBuffer(gradA, (float[]){1.f, 1.f}, 2);
+    parameter_t *A = parameterInit(paramA, gradA);
+
+    /* Parameter B: SYM_INT32 param + grad, shape [2]. */
+    size_t *bDims = reserveMemory(1 * sizeof(size_t));
+    bDims[0] = 2;
+    size_t *bOrder = reserveMemory(1 * sizeof(size_t));
+    setOrderOfDimsForNewTensor(1, bOrder);
+    shape_t *bShape = reserveMemory(sizeof(shape_t));
+    setShape(bShape, bDims, 1, bOrder);
+    tensor_t *paramB = initTensor(bShape, quantizationInitSymInt32(HALF_AWAY), NULL);
+    tensorFillFromFloatBuffer(paramB, (float[]){0.5f, -0.5f}, 2);
+    tensor_t *gradB = gradInitSymInt32(paramB, HALF_AWAY, NULL);
+    tensorFillFromFloatBuffer(gradB, (float[]){1.f, 1.f}, 2);
+    parameter_t *B = parameterInit(paramB, gradB);
+
+    tensor_t *stateA = getTensorLike(paramA);
+    tensor_t *stateB = getTensorLike(paramB);
+
+    /* Minimal stack optimizer around two heterogeneous-dtype parameters (file
+     * convention, UnitTestSgd.c:545-556 pattern extended to 2 params). */
+    sgd_t sgd;
+    sgdInit(&sgd, 0.1f, 0.0f, 0.0f);
+    parameter_t *params[2] = {A, B};
+    tensor_t *stateBuffersA[1] = {stateA};
+    tensor_t *stateBuffersB[1] = {stateB};
+    states_t statesA = {.stateBuffers = stateBuffersA, .statesPerParameter = 1};
+    states_t statesB = {.stateBuffers = stateBuffersB, .statesPerParameter = 1};
+    states_t *states[2] = {&statesA, &statesB};
+    optimImpl_t impl;
+    impl.sgd = &sgd;
+    optimizer_t optim;
+    optim.parameter = params;
+    optim.states = states;
+    optim.sizeStates = 2;
+    optim.qtype = FLOAT32; /* vestigial post-#278: irrelevant to per-tensor funnel dispatch */
+    optim.impl = &impl;
+
+    sgdStepM(&optim);
+
+    /* CAPTURE -> free -> assert (file convention). */
+    float aAfter[2];
+    aAfter[0] = ((float *)paramA->data)[0];
+    aAfter[1] = ((float *)paramA->data)[1];
+
+    float bBefore[2] = {0.5f, -0.5f};
+    tensor_t bAfterFloat;
+    quantization_t bAfterFloatQ;
+    initFloat32Quantization(&bAfterFloatQ);
+    uint8_t bAfterFloatData[2 * sizeof(float)];
+    setTensorValuesForConversion(bAfterFloatData, &bAfterFloatQ, paramB, &bAfterFloat);
+    convertTensor(paramB, &bAfterFloat);
+    float bAfter[2];
+    bAfter[0] = ((float *)bAfterFloat.data)[0];
+    bAfter[1] = ((float *)bAfterFloat.data)[1];
+
+    freeTensor(stateA);
+    freeTensor(stateB);
+    freeParameter(A);
+    freeParameter(B);
+
+    /* A: pure FLOAT32 arithmetic, no quantization noise -- state = grad
+     * (momentum=0), param -= lr*state = param - 0.1*1.0. */
+    TEST_ASSERT_FLOAT_WITHIN(1e-6f, 0.9f, aAfter[0]);
+    TEST_ASSERT_FLOAT_WITHIN(1e-6f, 1.9f, aAfter[1]);
+
+    /* B: SYM_INT32 param must move in the gradient-descent direction (param
+     * decreases where grad > 0), within int12 quantization noise
+     * (qMaxBits=12 -> scale ~ 0.6/2047, error << 0.01). */
+    TEST_ASSERT_TRUE_MESSAGE(bAfter[0] < bBefore[0], "SYM_INT32 param[0] must decrease");
+    TEST_ASSERT_TRUE_MESSAGE(bAfter[1] < bBefore[1], "SYM_INT32 param[1] must decrease");
+    TEST_ASSERT_FLOAT_WITHIN(0.01f, 0.4f, bAfter[0]);
+    TEST_ASSERT_FLOAT_WITHIN(0.01f, -0.6f, bAfter[1]);
+}
+
 int main() {
     UNITY_BEGIN();
     RUN_TEST(testSgdMCreateOptim);
@@ -865,5 +961,6 @@ int main() {
     RUN_TEST(testSgdStepMFloatReadsPackedSymGradGeneric);
     RUN_TEST(testSgdZeroGradAsymSubByteZeroesAllPackedBytes);
     RUN_TEST(testSgdZeroGradSymSubByteZeroesAllPackedBytesAndResetsScale);
+    RUN_TEST(testSgdStepMMixedDtypeMovesBothParamsCorrectly);
     return UNITY_END();
 }

--- a/test/unit/userAPI/UnitTestAdaptiveAvgPool1dIntegration.c
+++ b/test/unit/userAPI/UnitTestAdaptiveAvgPool1dIntegration.c
@@ -104,11 +104,13 @@ void testOptimizer_ZeroStatesForParameterlessPool(void) {
     layer_t *model[1] = {pool};
 
     size_t numStates = calcTotalNumberOfStates(model, 1);
-    optimizer_t *optim = sgdMCreateOptim(0.01f, 0.9f, 0.0f, model, 1, FLOAT32);
+    quantization_t *momentumQ = quantizationInitFloat();
+    optimizer_t *optim = sgdMCreateOptim(0.01f, 0.9f, 0.0f, model, 1, FLOAT32, momentumQ);
     size_t sizeStates = optim->sizeStates;
 
     freeOptimSgdM(optim);
     freeAdaptiveAvgPool1dLayer(pool);
+    freeQuantization(momentumQ);
     freeQuantization(q);
 
     TEST_ASSERT_EQUAL_UINT(0, numStates);

--- a/test/unit/userAPI/UnitTestDropoutIntegration.c
+++ b/test/unit/userAPI/UnitTestDropoutIntegration.c
@@ -138,12 +138,14 @@ void testOptimizer_ZeroStatesForDropout(void) {
     layer_t *model[1] = {drop};
 
     size_t numStates = calcTotalNumberOfStates(model, 1);
-    optimizer_t *optim = sgdMCreateOptim(0.01f, 0.9f, 0.0f, model, 1, FLOAT32);
+    quantization_t *momentumQ = quantizationInitFloat();
+    optimizer_t *optim = sgdMCreateOptim(0.01f, 0.9f, 0.0f, model, 1, FLOAT32, momentumQ);
     size_t sizeStates = optim->sizeStates;
 
     freeOptimSgdM(optim);
     freeDropoutLayer(drop);
     freeTensor(mask);
+    freeQuantization(momentumQ);
     freeQuantization(bq);
     freeQuantization(fq);
 

--- a/test/unit/userAPI/UnitTestLayerNormIntegration.c
+++ b/test/unit/userAPI/UnitTestLayerNormIntegration.c
@@ -97,7 +97,8 @@ void testLinearLayerNormLinearOneTrainingStep(void) {
     float gammaBefore = ((float *)norm->config->layerNorm->gamma->param->data)[0];
     float betaBefore = ((float *)norm->config->layerNorm->beta->param->data)[0];
 
-    optimizer_t *optim = sgdMCreateOptim(0.1f, 0.9f, 0.0f, model, 3, FLOAT32);
+    quantization_t *momentumQ = quantizationInitFloat();
+    optimizer_t *optim = sgdMCreateOptim(0.1f, 0.9f, 0.0f, model, 3, FLOAT32, momentumQ);
 
     trainingStats_t *stats =
         calculateGradsSequential(model, 3, defaultLossConfig(MSE), REDUCTION_MEAN, input, label);
@@ -128,6 +129,7 @@ void testLinearLayerNormLinearOneTrainingStep(void) {
     freeLinearLayerShell(linear1);
     freeLayerNormLayerShell(norm);
     freeLinearLayerShell(linear0);
+    freeQuantization(momentumQ);
     freeQuantization(q);
 
     TEST_ASSERT_TRUE(statsNotNull);
@@ -182,7 +184,8 @@ void testLayerNormSymInt32SingleLayerTrainingStep(void) {
 
     bool gradSymDtype = (lnSym->config->layerNorm->gamma->grad->quantization->type == SYM_INT32);
 
-    optimizer_t *optimSym = sgdMCreateOptim(0.1f, 0.0f, 0.0f, modelSym, 1, SYM_INT32);
+    quantization_t *momentumQSym = quantizationInitFloat();
+    optimizer_t *optimSym = sgdMCreateOptim(0.1f, 0.0f, 0.0f, modelSym, 1, SYM_INT32, momentumQSym);
     trainingStats_t *statsSym = calculateGradsSequential(modelSym, 1, defaultLossConfig(MSE),
                                                          REDUCTION_MEAN, inSym, labelSym);
     sgdStepM(optimSym);
@@ -211,7 +214,8 @@ void testLayerNormSymInt32SingleLayerTrainingStep(void) {
     tensor_t *inF = build2DFloat(2, 4, inputVals, 8);
     tensor_t *labelF = build2DFloat(2, 4, labelVals, 8);
 
-    optimizer_t *optimF = sgdMCreateOptim(0.1f, 0.0f, 0.0f, modelF, 1, FLOAT32);
+    quantization_t *momentumQF = quantizationInitFloat();
+    optimizer_t *optimF = sgdMCreateOptim(0.1f, 0.0f, 0.0f, modelF, 1, FLOAT32, momentumQF);
     trainingStats_t *statsF =
         calculateGradsSequential(modelF, 1, defaultLossConfig(MSE), REDUCTION_MEAN, inF, labelF);
     sgdStepM(optimF);
@@ -232,6 +236,8 @@ void testLayerNormSymInt32SingleLayerTrainingStep(void) {
     freeOptimSgdM(optimSym);
     freeLayerNormLayerShell(lnF);
     freeLayerNormLayerShell(lnSym);
+    freeQuantization(momentumQF);
+    freeQuantization(momentumQSym);
     freeQuantization(fQ);
     freeQuantization(symQ);
 

--- a/test/unit/userAPI/UnitTestMnistSmoke.c
+++ b/test/unit/userAPI/UnitTestMnistSmoke.c
@@ -160,7 +160,8 @@ void testMnistSmoke_FullTrainingPipelineReducesLoss() {
     quantization_t *q = NULL;
     buildModel(model, &q);
 
-    optimizer_t *sgd = sgdMCreateOptim(0.1f, 0.0f, 0.0f, model, MODEL_SIZE, FLOAT32);
+    quantization_t *momentumQ = quantizationInitFloat();
+    optimizer_t *sgd = sgdMCreateOptim(0.1f, 0.0f, 0.0f, model, MODEL_SIZE, FLOAT32, momentumQ);
 
     cbInvocations = 0;
     size_t numberOfEpochs = 20;
@@ -186,6 +187,7 @@ void testMnistSmoke_FullTrainingPipelineReducesLoss() {
     freeLinearLayerShellOnly(model[0]);
     freeDataLoader(evalDl);
     freeDataLoader(trainDl);
+    freeQuantization(momentumQ);
     freeQuantization(q);
     freeDataset();
 
@@ -217,7 +219,8 @@ void testMnistSmoke_SnprintfGmtimeRBetweenSetupAndTrainingRun_NoSilentExit() {
     quantization_t *q = NULL;
     buildModel(model, &q);
 
-    optimizer_t *sgd = sgdMCreateOptim(0.1f, 0.0f, 0.0f, model, MODEL_SIZE, FLOAT32);
+    quantization_t *momentumQ = quantizationInitFloat();
+    optimizer_t *sgd = sgdMCreateOptim(0.1f, 0.0f, 0.0f, model, MODEL_SIZE, FLOAT32, momentumQ);
 
     /* The poison block from #94's reproducer: gmtime_r + snprintf wedged
      * between setup and trainingRun. Pre-fix this triggered silent exit(1). */
@@ -246,6 +249,7 @@ void testMnistSmoke_SnprintfGmtimeRBetweenSetupAndTrainingRun_NoSilentExit() {
     freeLinearLayerShellOnly(model[0]);
     freeDataLoader(evalDl);
     freeDataLoader(trainDl);
+    freeQuantization(momentumQ);
     freeQuantization(q);
     freeDataset();
 

--- a/test/unit/userAPI/UnitTestMultiLayerTraining.c
+++ b/test/unit/userAPI/UnitTestMultiLayerTraining.c
@@ -388,7 +388,8 @@ void testMultiLayerTraining_MultipleSteps_GradsAccumulate() {
     size_t sizeModel = 4;
 
     /* Optimizer takes references to w0/b0/w1/b1 — its free will cascade. */
-    optimizer_t *sgd = sgdMCreateOptim(0.01f, 0.f, 0.f, model, sizeModel, FLOAT32);
+    quantization_t *momentumQ = quantizationInitFloat();
+    optimizer_t *sgd = sgdMCreateOptim(0.01f, 0.f, 0.f, model, sizeModel, FLOAT32, momentumQ);
     optimizerFunctions_t sgdFns = optimizerFunctions[SGD_M];
 
     /* Input (1x3). */
@@ -441,6 +442,7 @@ void testMultiLayerTraining_MultipleSteps_GradsAccumulate() {
     freeLinearLayerShellOnly(linear1);
     freeReluLayer(relu);
     freeLinearLayerShellOnly(linear0);
+    freeQuantization(momentumQ);
     freeQuantization(q);
 
     /* ASSERT on captured. */

--- a/test/unit/userAPI/UnitTestOptimizerScaling.c
+++ b/test/unit/userAPI/UnitTestOptimizerScaling.c
@@ -202,8 +202,8 @@ void testScaleOptimizerGradients_FactorNaN_DoesNotAbort() {
  * scale are written directly (NOT via tensorFillFromFloatBuffer, which would
  * route through convertTensor and recompute scale from the float source).
  * The param data stays at default-zero, which matches the scale=1.0 default
- * from initSymInt32QConfig — sgdStepSymInt32 round-trips it through float and
- * back, but for the scaling assertions below the param values are irrelevant. */
+ * from initSymInt32QConfig — the executeOp funnel round-trips it through float
+ * and back, but for the scaling assertions below the param values are irrelevant. */
 static optimizer_t *buildSymInt32OneLayerOptim(layer_t **modelOut, parameter_t **wOut,
                                                parameter_t **bOut, float wInitialScale,
                                                const int32_t *wInitialGradInt32,
@@ -413,7 +413,7 @@ void testScaleOptimizerGradients_SymInt32_MomentumSgdAppliesScaledGradient() {
     freeOptimSgdM(sgd);
     freeLinearLayerShellOnly(model[0]);
 
-    /* Tolerance accounts for the int32 round-trip in sgdStepSymInt32 — the
+    /* Tolerance accounts for the int32 round-trip in the executeOp funnel — the
      * intermediate float value gets requantized through wScale0 (post-step
      * scale unchanged on param tensor in this iteration). 1e-3f is generous
      * enough for the small magnitudes here. */

--- a/test/unit/userAPI/UnitTestOptimizerScaling.c
+++ b/test/unit/userAPI/UnitTestOptimizerScaling.c
@@ -102,8 +102,13 @@ static optimizer_t *buildOneLayerOptimWithGrads(layer_t **modelOut, parameter_t 
     *wOut = w;
     *bOut = b;
 
-    /* SGD optimizer wraps both parameters via the standard helper. */
-    return sgdMCreateOptim(0.01f, 0.f, 0.f, modelOut, 1, FLOAT32);
+    /* SGD optimizer wraps both parameters via the standard helper. Momentum
+     * config is a transient template -- sgdMCreateOptim clones it per state
+     * via getQLike, so it's safe to free right after the call. */
+    quantization_t *momentumQ = quantizationInitFloat();
+    optimizer_t *optim = sgdMCreateOptim(0.01f, 0.f, 0.f, modelOut, 1, FLOAT32, momentumQ);
+    freeQuantization(momentumQ);
+    return optim;
 }
 
 void testScaleOptimizerGradients_DoublesGradients() {
@@ -253,7 +258,10 @@ static optimizer_t *buildSymInt32OneLayerOptim(layer_t **modelOut, parameter_t *
     *wOut = w;
     *bOut = b;
 
-    return sgdMCreateOptim(lr, momentum, 0.f, modelOut, 1, SYM_INT32);
+    quantization_t *momentumQ = quantizationInitFloat();
+    optimizer_t *optim = sgdMCreateOptim(lr, momentum, 0.f, modelOut, 1, SYM_INT32, momentumQ);
+    freeQuantization(momentumQ);
+    return optim;
 }
 
 void testScaleOptimizerGradients_SymInt32_ScalesScaleOnly() {
@@ -480,7 +488,10 @@ static optimizer_t *buildSymOneLayerOptim(layer_t **modelOut, parameter_t **wOut
     *wOut = w;
     *bOut = b;
 
-    return sgdMCreateOptim(lr, momentum, 0.f, modelOut, 1, FLOAT32);
+    quantization_t *momentumQ = quantizationInitFloat();
+    optimizer_t *optim = sgdMCreateOptim(lr, momentum, 0.f, modelOut, 1, FLOAT32, momentumQ);
+    freeQuantization(momentumQ);
+    return optim;
 }
 
 void testScaleOptimizerGradients_Sym_ScalesScaleOnly(void) {
@@ -604,7 +615,10 @@ static optimizer_t *buildAsymOneLayerOptim(layer_t **modelOut, parameter_t **wOu
     *wOut = w;
     *bOut = b;
 
-    return sgdMCreateOptim(lr, momentum, 0.f, modelOut, 1, FLOAT32);
+    quantization_t *momentumQ = quantizationInitFloat();
+    optimizer_t *optim = sgdMCreateOptim(lr, momentum, 0.f, modelOut, 1, FLOAT32, momentumQ);
+    freeQuantization(momentumQ);
+    return optim;
 }
 
 void testScaleOptimizerGradients_Asym_ScalesScaleOnly(void) {

--- a/test/unit/userAPI/UnitTestQuantLayerIntegration.c
+++ b/test/unit/userAPI/UnitTestQuantLayerIntegration.c
@@ -189,12 +189,14 @@ void testSgdMCreateOptimSkipsQuantizationLayer(void) {
     layer_t *quant = buildQuantLayer(symQ, symQ);
     layer_t *model[2] = {linear, quant};
 
-    optimizer_t *optim = sgdMCreateOptim(0.1f, 0.0f, 0.0f, model, 2, SYM_INT32);
+    quantization_t *momentumQ = quantizationInitFloat();
+    optimizer_t *optim = sgdMCreateOptim(0.1f, 0.0f, 0.0f, model, 2, SYM_INT32, momentumQ);
     size_t sizeStates = optim->sizeStates;
 
     freeOptimSgdM(optim); /* frees the Linear weights/bias parameter_t */
     freeQuantLayerShell(quant);
     freeLinearLayerShell(linear);
+    freeQuantization(momentumQ);
     freeQuantization(symQ);
 
     TEST_ASSERT_EQUAL_UINT(2, sizeStates); /* Linear w+b; QUANTIZATION contributes 0 states */
@@ -344,7 +346,8 @@ void testFullSymChainTrainingStepMatchesFloatTwin(void) {
     tensor_t *inS = build2DSym(2, 4, INPUT_VALS, 8);
     tensor_t *labelS = build2DSym(2, 2, LABEL_VALS, 4);
 
-    optimizer_t *optimS = sgdMCreateOptim(0.1f, 0.0f, 0.0f, modelSym, 5, SYM_INT32);
+    quantization_t *momentumQS = quantizationInitFloat();
+    optimizer_t *optimS = sgdMCreateOptim(0.1f, 0.0f, 0.0f, modelSym, 5, SYM_INT32, momentumQS);
     trainingStats_t *statsS =
         calculateGradsSequential(modelSym, 5, defaultLossConfig(MSE), REDUCTION_MEAN, inS, labelS);
     sgdStepM(optimS);
@@ -376,7 +379,8 @@ void testFullSymChainTrainingStepMatchesFloatTwin(void) {
     tensor_t *inF = build2DFloat(2, 4, INPUT_VALS, 8);
     tensor_t *labelF = build2DFloat(2, 2, LABEL_VALS, 4);
 
-    optimizer_t *optimF = sgdMCreateOptim(0.1f, 0.0f, 0.0f, modelF, 3, FLOAT32);
+    quantization_t *momentumQF = quantizationInitFloat();
+    optimizer_t *optimF = sgdMCreateOptim(0.1f, 0.0f, 0.0f, modelF, 3, FLOAT32, momentumQF);
     trainingStats_t *statsF =
         calculateGradsSequential(modelF, 3, defaultLossConfig(MSE), REDUCTION_MEAN, inF, labelF);
     sgdStepM(optimF);
@@ -405,6 +409,8 @@ void testFullSymChainTrainingStepMatchesFloatTwin(void) {
     freeLayerNormLayerShell(lnS);
     freeQuantLayer(quant1);
     freeLinearLayerShell(lin0S);
+    freeQuantization(momentumQF);
+    freeQuantization(momentumQS);
     freeQuantization(fQ);
     freeQuantization(symQ);
 
@@ -473,7 +479,8 @@ void testConv1dTransposedSymChainTrains(void) {
     static const float IN_VALS[3] = {0.5f, -0.3f, 0.8f};
     static const float LABEL_VALS[4] = {0.10f, 0.20f, -0.15f, 0.05f};
 
-    optimizer_t *opt = sgdMCreateOptim(0.05f, 0.0f, 0.0f, model, 2, SYM_INT32);
+    quantization_t *momentumQ2 = quantizationInitFloat();
+    optimizer_t *opt = sgdMCreateOptim(0.05f, 0.0f, 0.0f, model, 2, SYM_INT32, momentumQ2);
 
     size_t STEPS = 40;
     float firstLoss = NAN;
@@ -499,6 +506,7 @@ void testConv1dTransposedSymChainTrains(void) {
 
     freeOptimSgdM(opt); /* frees cw/cb parameter_t */
     freeQuantLayerShell(quant);
+    freeQuantization(momentumQ2);
     freeQuantization(symQ);
 
     TEST_ASSERT_TRUE_MESSAGE(finite, "SYM ConvT chain losses must be finite");

--- a/test/unit/userAPI/UnitTestTrainingLoopApi.c
+++ b/test/unit/userAPI/UnitTestTrainingLoopApi.c
@@ -102,7 +102,8 @@ void testCalculateGradsSequential_MatchesPyTorch() {
     tensor_t *label1 = buildFloatTensor2D(1, 2, (float[]){43.f, 249.f}, 2);
     tensor_t *label2 = buildFloatTensor2D(1, 2, (float[]){23.f, 457.f}, 2);
 
-    optimizer_t *sgd = sgdMCreateOptim(0.01f, 0.f, 0.f, model, sizeModel, FLOAT32);
+    quantization_t *momentumQ = quantizationInitFloat();
+    optimizer_t *sgd = sgdMCreateOptim(0.01f, 0.f, 0.f, model, sizeModel, FLOAT32, momentumQ);
     optimizerFunctions_t sgdFns = optimizerFunctions[SGD_M];
     /* Pre-existing test hack: only step weights, leaving bias unchanged across
      * iterations. We restore sizeStates to 2 before the free below so
@@ -151,6 +152,7 @@ void testCalculateGradsSequential_MatchesPyTorch() {
      * to both weights and bias parameters + their state buffers. */
     sgd->sizeStates = 2;
     freeOptimSgdM(sgd);
+    freeQuantization(momentumQ);
     freeTensor(label2);
     freeTensor(label1);
     freeTensor(label0);
@@ -541,7 +543,8 @@ void testTrainingEpochDefault_DoesOptimizerStepPerBatch() {
         initWeights[i] = wInitData[i];
     }
 
-    optimizer_t *sgd = sgdMCreateOptim(0.01f, 0.f, 0.f, model, sizeModel, FLOAT32);
+    quantization_t *momentumQ = quantizationInitFloat();
+    optimizer_t *sgd = sgdMCreateOptim(0.01f, 0.f, 0.f, model, sizeModel, FLOAT32, momentumQ);
 
     /* Use epoch dataset (batchSize=1 → 4 batches) */
     initEpochDataset();
@@ -568,6 +571,7 @@ void testTrainingEpochDefault_DoesOptimizerStepPerBatch() {
     /* FREE. freeOptimSgdM cascades to w and b parameters; do NOT also free
      * those (would double-free). */
     freeOptimSgdM(sgd);
+    freeQuantization(momentumQ);
     freeDataLoader(dl);
     freeLinearLayerShellOnly(linear);
     freeEpochDataset();
@@ -603,7 +607,8 @@ void testTrainingEpochDefault_MinibatchStepsOncePerMinibatch() {
         initWeights[i] = wInitData[i];
     }
 
-    optimizer_t *sgd = sgdMCreateOptim(0.01f, 0.f, 0.f, model, sizeModel, FLOAT32);
+    quantization_t *momentumQ = quantizationInitFloat();
+    optimizer_t *sgd = sgdMCreateOptim(0.01f, 0.f, 0.f, model, sizeModel, FLOAT32, momentumQ);
 
     initEpochDataset();
     dataLoader_t *dl =
@@ -628,6 +633,7 @@ void testTrainingEpochDefault_MinibatchStepsOncePerMinibatch() {
 
     /* FREE. */
     freeOptimSgdM(sgd);
+    freeQuantization(momentumQ);
     freeDataLoader(dl);
     freeLinearLayerShellOnly(linear);
     freeEpochDataset();
@@ -651,7 +657,8 @@ void testTrainingRun_ReturnsResult() {
     layer_t *linear = buildBorrowedLinearLayer(w, b, &testQ);
     layer_t *model[] = {linear};
 
-    optimizer_t *sgd = sgdMCreateOptim(0.01f, 0.f, 0.f, model, 1, FLOAT32);
+    quantization_t *momentumQ = quantizationInitFloat();
+    optimizer_t *sgd = sgdMCreateOptim(0.01f, 0.f, 0.f, model, 1, FLOAT32, momentumQ);
 
     initEpochDataset();
     dataLoader_t *trainDl =
@@ -670,6 +677,7 @@ void testTrainingRun_ReturnsResult() {
 
     /* FREE. */
     freeOptimSgdM(sgd);
+    freeQuantization(momentumQ);
     freeDataLoader(evalDl);
     freeDataLoader(trainDl);
     freeLinearLayerShellOnly(linear);
@@ -713,7 +721,8 @@ void testTrainingRun_CallsCallbackEachEpochWithStats() {
     layer_t *linear = buildBorrowedLinearLayer(w, b, &testQ);
     layer_t *model[] = {linear};
 
-    optimizer_t *sgd = sgdMCreateOptim(0.01f, 0.f, 0.f, model, 1, FLOAT32);
+    quantization_t *momentumQ = quantizationInitFloat();
+    optimizer_t *sgd = sgdMCreateOptim(0.01f, 0.f, 0.f, model, 1, FLOAT32, momentumQ);
 
     initEpochDataset();
     dataLoader_t *trainDl =
@@ -738,6 +747,7 @@ void testTrainingRun_CallsCallbackEachEpochWithStats() {
 
     /* FREE. */
     freeOptimSgdM(sgd);
+    freeQuantization(momentumQ);
     freeDataLoader(evalDl);
     freeDataLoader(trainDl);
     freeLinearLayerShellOnly(linear);
@@ -882,7 +892,8 @@ void testTrainingEpochDefault_MeanScalesGradByOneOverNF() {
     layer_t *model[] = {linear};
 
     /* momentumFactor=0 makes SGD_M behave like plain SGD. */
-    optimizer_t *sgd = sgdMCreateOptim(0.01f, 0.f, 0.f, model, 1, FLOAT32);
+    quantization_t *momentumQ = quantizationInitFloat();
+    optimizer_t *sgd = sgdMCreateOptim(0.01f, 0.f, 0.f, model, 1, FLOAT32, momentumQ);
 
     initSingleSampleDataset();
     dataLoader_t *dl =
@@ -898,6 +909,7 @@ void testTrainingEpochDefault_MeanScalesGradByOneOverNF() {
     float capturedW01 = ((float *)wParam->data)[1];
 
     freeOptimSgdM(sgd);
+    freeQuantization(momentumQ);
     freeDataLoader(dl);
     freeLinearLayerShellOnly(linear);
     freeSingleSampleDataset();
@@ -1242,7 +1254,8 @@ void testTrainingEpochDefault_SumBackwardSkipsOptimizerScaling() {
 
     /* Use a very small learning rate so SUM doesn't NaN — SUM gradients are
      * larger by N*F than MEAN gradients on the same data. */
-    optimizer_t *sgd = sgdMCreateOptim(0.001f, 0.f, 0.f, model, 1, FLOAT32);
+    quantization_t *momentumQ = quantizationInitFloat();
+    optimizer_t *sgd = sgdMCreateOptim(0.001f, 0.f, 0.f, model, 1, FLOAT32, momentumQ);
 
     initEpochDataset();
     dataLoader_t *dl =
@@ -1269,6 +1282,7 @@ void testTrainingEpochDefault_SumBackwardSkipsOptimizerScaling() {
     float capturedEpochLoss = epochLoss;
 
     freeOptimSgdM(sgd);
+    freeQuantization(momentumQ);
     freeDataLoader(dl);
     freeLinearLayerShellOnly(linear);
     freeEpochDataset();
@@ -1297,7 +1311,8 @@ void testTrainingEpochDefault_MeanForwardSumBackward_MixedCombination() {
     layer_t *linear = buildBorrowedLinearLayer(w, b, &testQ);
     layer_t *model[] = {linear};
 
-    optimizer_t *sgd = sgdMCreateOptim(0.001f, 0.f, 0.f, model, 1, FLOAT32);
+    quantization_t *momentumQ = quantizationInitFloat();
+    optimizer_t *sgd = sgdMCreateOptim(0.001f, 0.f, 0.f, model, 1, FLOAT32, momentumQ);
 
     initEpochDataset();
     dataLoader_t *dl =
@@ -1324,6 +1339,7 @@ void testTrainingEpochDefault_MeanForwardSumBackward_MixedCombination() {
     float capturedEpochLoss = epochLoss;
 
     freeOptimSgdM(sgd);
+    freeQuantization(momentumQ);
     freeDataLoader(dl);
     freeLinearLayerShellOnly(linear);
     freeEpochDataset();
@@ -1424,7 +1440,8 @@ void testTrainingRun_HardcodesForwardReductionMean() {
     layer_t *linear = buildBorrowedLinearLayer(w, b, &testQ);
     layer_t *model[] = {linear};
 
-    optimizer_t *sgd = sgdMCreateOptim(0.01f, 0.f, 0.f, model, 1, FLOAT32);
+    quantization_t *momentumQ = quantizationInitFloat();
+    optimizer_t *sgd = sgdMCreateOptim(0.01f, 0.f, 0.f, model, 1, FLOAT32, momentumQ);
 
     initEpochDataset();
     dataLoader_t *trainDl =
@@ -1445,6 +1462,7 @@ void testTrainingRun_HardcodesForwardReductionMean() {
     float capturedEval = result.finalEvalStats.loss;
 
     freeOptimSgdM(sgd);
+    freeQuantization(momentumQ);
     freeDataLoader(evalDl);
     freeDataLoader(trainDl);
     freeLinearLayerShellOnly(linear);


### PR DESCRIPTION
## What & why

Epic **#277**: the optimizer was the last compute path still hand-rolling its own dequant→compute→requant, keyed on a single per-*optimizer* dtype. This routes the SGD parameter-update through the `executeOp` funnel — the same funnel every layer already uses — so it dispatches **per-tensor**, fixing the quantized-update path.

## The four commits

1. **Route `sgdStep`/`sgdStepM` through `executeOp`** (per target: `sgdStep` = 1 call, `sgdStepM` = 2 — state then param). Dispatch is now per-parameter dtype via the funnel → a mixed FLOAT32/SYM model trains through one code path. Deletes the hand-rolled per-dtype arms + the tensor-sized stack VLAs from `src/optimizer/`. **Closes #278**; satisfies #280 on the optimizer side.
2. **Momentum state gets its own quantization config** (default FLOAT32), decoupled from the param dtype (`getQLike(momentumQuant)`, not `getTensorLike(param)`). `sgdMCreateOptim` signature + 42 callers updated.
3. **#279 dead-zone escape via SRHTE** — regression test proving a sub-ULP weight update never moves the integer code under `HALF_AWAY` (the dead-zone) but does under `SR_HALF_AWAY`, with **zero optimizer numerics code**: the funnel epilogue rounds by the target config's `roundingMode`, so stochastic rounding is enabled purely by config. **Memory-light — no float master weights.**
4. **Hygiene** — remove the dead `optimizerInit` declaration; document `SGD` == momentum-factor-0.

## Correctness & integrity (whole-branch reviewed)

- **FLOAT32 path is bit-preserved** — verified element-by-element: plain SGD and FLOAT32 momentum are bit-for-bit identical to the deleted hand-rolled path (same expression tree; the funnel's FLOAT32→FLOAT32 epilogue is a `memmove`). No trajectory drift for the demos.
- **Aliasing safe** — `param` is both operand and target; the kernel writes a separate funnel-local buffer and the epilogue is the sole writer to the target.
- **#279 is honestly bounded** — the in-PR artifact is the mechanism + regression tests. A 3-seed toy *sanity* shows SRHTE closes the loss gap (`HALF_AWAY` ~3.3× the FLOAT32-twin loss, `SR_HALF_AWAY` ~1.0–1.1×); the **full ≥10-seed acceptance is the post-epic HAR SYM@x sweep** (documented, not overclaimed). Cites Gupta et al. 2015 (ICML) for stochastic rounding — not homegrown numerics.
- No int64 in SYM kernels (the update math runs in FLOAT32 via the funnel).

## Verification

- `ctest --preset unit_test_debug` → **67/67** (new mixed-dtype dispatch test, momentum-decoupling test, and SRHTE dead-zone regression — all mutation-verified).
- clang-format clean (CI-exact check, exit 0); allocation-locality clean (VLAs deleted from `src/optimizer/`).
- Four per-task reviews + one whole-branch review — merge-ready, no Critical/Important.

## Behavior note (not a regression)

SYM_INT32-param examples (e.g. `mixed_width_mlp`) now get **FLOAT32 momentum** (was SYM_INT32). Memory is unchanged (both 4 B/elem), it tracks PyTorch's always-FLOAT32 momentum *more* closely, and no CI gate breaks — it's the intended clean-accumulator default from commit 2.

## Deferred (own issues, out of scope here)

- **#282** — rounding-ownership refactor (make the funnel epilogue round by `arithmetic.roundingMode` instead of the target's qConfig).
- **#280** — funnel-scratch VLAs in `ExecuteOp.c` (low priority).
- **#283** — drop the now-vestigial `qType` param / `qtype` field (a second mechanical caller sweep).

Closes #278. Addresses #277 (children #278 done, #279 mechanism done — acceptance via the HAR sweep, #280 deferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
