### PR TITLE
fix(TensorConversion): bug when using stochastic rounding for big num…

### DIFF
--- a/examples/har_classifier/run_matrix.py
+++ b/examples/har_classifier/run_matrix.py
@@ -39,7 +39,6 @@ BUILD_DIR = ROOT / "build" / "examples_memprofile" / "examples" / "har_classifie
 # each SYM config is the same binary at a different packed weight width.
 CONFIGS: dict[str, tuple[str, dict[str, str]]] = {
     "float": ("train_c_har_classifier", {}),
-    "sym16": ("train_c_har_classifier_sym", {"SYM_BITS": "16"}),
     "sym12": ("train_c_har_classifier_sym", {"SYM_BITS": "12"}),
     "sym8": ("train_c_har_classifier_sym", {"SYM_BITS": "8"}),
     "sym4": ("train_c_har_classifier_sym", {"SYM_BITS": "4"}),

--- a/examples/har_classifier/train_c_sym.c
+++ b/examples/har_classifier/train_c_sym.c
@@ -97,12 +97,12 @@ static dataset_t g_valDataset;
 static dataset_t g_testDataset;
 
 /* Runtime config (env-overridable). */
-static float g_lr = 0.03f;
+static float g_lr = 0.01f;
 static float g_momentum = 0.9f;
-static int g_epochs = 2;
+static int g_epochs = 50;
 static unsigned g_seed = 1;
-static unsigned g_shuffleSeed = 42;
-static int g_symBits = 8;
+static unsigned g_shuffleSeed = 1;
+static int g_symBits = 12;
 
 static float envFloat(const char *name, float dflt) {
     const char *v = getenv(name);
@@ -405,8 +405,17 @@ int main(void) {
     g_shuffleSeed = (unsigned)envInt("SHUFFLE_SEED", (int)g_shuffleSeed);
     const char *logPath = getenv("LOG_PATH");
 
-    if (g_symBits < 1 || g_symBits > 31) {
-        fprintf(stderr, "SYM_BITS must be in [1, 31] (packed SYM range); got %d\n", g_symBits);
+    /* Packed-SYM STORAGE supports up to 31 bits, but this example's forward is
+     * ARITH_SYM_INT32: it multiplies the packed-SYM weights as integer operands
+     * accumulated in an int32 accumulator, and matmul/conv cap the SYM_INT32
+     * operand at 12 bits (#227) — wider weights (e.g. 16) would overflow int32
+     * over the conv accumulation length, so the kernel rejects them mid-forward.
+     * Fail fast here with the reason instead of crashing deep in the matmul. */
+    if (g_symBits < 1 || g_symBits > 12) {
+        fprintf(stderr,
+                "SYM_BITS must be in [1, 12]: the SYM_INT32 forward operand contract caps at 12 "
+                "bits (#227; int32 accumulator would overflow at wider widths). Got %d.\n",
+                g_symBits);
         return 2;
     }
 

--- a/src/arithmetic/Rounding.c
+++ b/src/arithmetic/Rounding.c
@@ -1,7 +1,6 @@
 #define SOURCE_FILE "ROUNDING"
 
 #include <math.h>
-#include <stdio.h>
 #include <stdlib.h>
 
 #include "Common.h"
@@ -45,6 +44,16 @@ int32_t rescaleIntoAccumulatorScale(int32_t paramQ, float paramScale, float accu
     }
 #endif
     return roundByMode(rescaled, roundingMode);
+}
+
+int32_t clampInt32(int32_t input, int32_t min, int32_t max) {
+    if (input < min) {
+        return min;
+    }
+    if (input > max) {
+        return max;
+    }
+    return input;
 }
 
 float clamp(float input, float min, float max) {

--- a/src/arithmetic/include/Rounding.h
+++ b/src/arithmetic/include/Rounding.h
@@ -26,6 +26,8 @@ int32_t roundByMode(float input, roundingMode_t roundingMode);
 int32_t rescaleIntoAccumulatorScale(int32_t paramQ, float paramScale, float accumulatorScale,
                                     roundingMode_t roundingMode);
 
+int32_t clampInt32(int32_t input, int32_t min, int32_t max);
+
 float clamp(float input, float min, float max);
 
 #endif // ROUNDING_H

--- a/src/tensor/TensorConversion.c
+++ b/src/tensor/TensorConversion.c
@@ -62,8 +62,9 @@ static void quantizeFloatToAsym(const float *values, size_t n, asymQConfig_t *ou
     int16_t zeroPoint = (int16_t)roundByMode(mn / scale, outQC->roundingMode);
     int32_t codes[n];
     for (size_t i = 0; i < n; i++) {
-        codes[i] = roundByMode(clamp(values[i] / scale - (float)zeroPoint, 0.f, qMax),
-                               outQC->roundingMode);
+        codes[i] =
+            clampInt32(roundByMode(values[i] / scale - (float)zeroPoint, outQC->roundingMode), 0,
+                       (int32_t)qMax);
     }
     outQC->scale = scale;
     outQC->zeroPoint = zeroPoint;
@@ -120,7 +121,8 @@ void convertFloatTensorToSymInt32Tensor(tensor_t *inputTensor, tensor_t *outputT
 
     for (size_t i = 0; i < numberOfElements; i++) {
         outputInt32[i] =
-            roundByMode(clamp(inputFloat[i] / scale, qMin, qMax), outputSymInt32QC->roundingMode);
+            clampInt32(roundByMode(inputFloat[i] / scale, outputSymInt32QC->roundingMode),
+                       (int32_t)qMin, (int32_t)qMax);
     }
 }
 
@@ -208,8 +210,9 @@ void requantSymInt32Tensor(tensor_t *inputTensor, tensor_t *outputTensor) {
 
     /* pass B: same-index read-then-write — in-place safe (int32 both sides) */
     for (size_t i = 0; i < numberOfElements; i++) {
-        outputInt32[i] = roundByMode(clamp(((float)inputInt32[i] * inScale) / scale, qMin, qMax),
-                                     outputSymInt32QC->roundingMode);
+        outputInt32[i] = clampInt32(
+            roundByMode((float)inputInt32[i] * (inScale / scale), outputSymInt32QC->roundingMode),
+            (int32_t)qMin, (int32_t)qMax);
     }
 }
 
@@ -448,7 +451,8 @@ static void packFloatBufferAsSym(const float *values, size_t n, symQConfig_t *ou
     outQC->scale = scale;
     int32_t codes[n];
     for (size_t i = 0; i < n; i++) {
-        codes[i] = roundByMode(clamp(values[i] / scale, qMin, qMax), outQC->roundingMode);
+        codes[i] = clampInt32(roundByMode(values[i] / scale, outQC->roundingMode), (int32_t)qMin,
+                              (int32_t)qMax);
     }
     packFitGuarded(codes, n, dst, outQC->qBits, what);
 }


### PR DESCRIPTION
…bers led to errors. Swapping Round(Clamp(x)) -> Clamp(Round(x)). Therefore, we need a clamp that can work with int32.