### PR TITLE
fix(optimizer): count/collect states for bias-less linear (mirrors conv fix)

### DIFF
--- a/src/optimizer/CMakeLists.txt
+++ b/src/optimizer/CMakeLists.txt
@@ -6,6 +6,7 @@ target_link_libraries(Optimizer PRIVATE
         Layer
         Conv1d
         Conv1dTransposed
+        Linear
         Tensor
         Common
 )

--- a/src/optimizer/Optimizer.c
+++ b/src/optimizer/Optimizer.c
@@ -5,18 +5,21 @@
 #include "Common.h"
 #include "Conv1d.h"
 #include "Conv1dTransposed.h"
+#include "Linear.h"
 #include "Optimizer.h"
 #include "Sgd.h"
 
 optimizerFunctions_t optimizerFunctions[] = {
     [SGD] = {sgdStep, sgdZeroGrad}, [SGD_M] = {sgdStepM, sgdZeroGrad}};
 
-/* Conv1d/Conv1dTransposed are bias-optional (BIAS_FALSE, header-sanctioned):
- * a bias-less conv contributes only its weight state, not a weight+bias
- * pair. Every other trainable layer type still has a fixed contribution. */
+/* Linear/Conv1d/Conv1dTransposed are bias-optional (BIAS_FALSE,
+ * header-sanctioned): a bias-less layer contributes only its weight state,
+ * not a weight+bias pair. Every other trainable layer type still has a
+ * fixed contribution. */
 static size_t calcNumberOfStatesByLayer(const layer_t *layer) {
     switch (layer->type) {
     case LINEAR:
+        return layer->config->linear->bias != NULL ? 2 : 1;
     case LAYERNORM:
     case GROUPNORM:
         return 2;

--- a/src/userApi/optimizer/SgdApi.c
+++ b/src/userApi/optimizer/SgdApi.c
@@ -57,24 +57,30 @@ optimizer_t *sgdMCreateOptim(float learningRate, float momentumFactor, float wei
             optim->parameter[paramSlot] = weights;
             tensor_t *weightStateBuffer = momentumStateInit(weights->param, momentumQuant);
 
-            parameter_t *bias = linearConfig->bias;
-            optim->parameter[paramSlot + 1] = bias;
-            tensor_t *biasStateBuffer = momentumStateInit(bias->param, momentumQuant);
-
             states_t *weightStates = reserveMemory(sizeof(states_t));
             weightStates->statesPerParameter = statesPerParam;
             weightStates->stateBuffers = reserveMemory(sizeof(tensor_t *));
             weightStates->stateBuffers[0] = weightStateBuffer;
 
-            states_t *biasStates = reserveMemory(sizeof(states_t));
-            biasStates->statesPerParameter = statesPerParam;
-            biasStates->stateBuffers = reserveMemory(sizeof(tensor_t *));
-            biasStates->stateBuffers[0] = biasStateBuffer;
-
             states[paramSlot] = weightStates;
-            states[paramSlot + 1] = biasStates;
 
-            paramSlot += 2;
+            /* BIAS_FALSE (header-sanctioned): no bias parameter to collect. */
+            if (linearConfig->bias != NULL) {
+                parameter_t *bias = linearConfig->bias;
+                optim->parameter[paramSlot + 1] = bias;
+                tensor_t *biasStateBuffer = momentumStateInit(bias->param, momentumQuant);
+
+                states_t *biasStates = reserveMemory(sizeof(states_t));
+                biasStates->statesPerParameter = statesPerParam;
+                biasStates->stateBuffers = reserveMemory(sizeof(tensor_t *));
+                biasStates->stateBuffers[0] = biasStateBuffer;
+
+                states[paramSlot + 1] = biasStates;
+
+                paramSlot += 2;
+            } else {
+                paramSlot += 1;
+            }
             break;
         case CONV1D: {
             conv1dConfig_t *conv1dCfg = layerConfig->conv1d;

--- a/test/unit/userAPI/CMakeLists.txt
+++ b/test/unit/userAPI/CMakeLists.txt
@@ -356,6 +356,8 @@ target_link_libraries(UnitTestBiaslessConvOptim PRIVATE
         ConvTranspose1dKernel
         Conv1dKernel
         SlidingWindow1d
+        LinearApi
+        Linear
         SgdApi
         Sgd
         Optimizer

--- a/test/unit/userAPI/UnitTestBiaslessConvOptim.c
+++ b/test/unit/userAPI/UnitTestBiaslessConvOptim.c
@@ -9,6 +9,8 @@
 #include "Layer.h"
 #include "LayerCommon.h"
 #include "LayerQuant.h"
+#include "Linear.h"
+#include "LinearApi.h"
 #include "Optimizer.h"
 #include "QuantizationApi.h"
 #include "SgdApi.h"
@@ -39,6 +41,16 @@ static void freeConv1dLayerShell(layer_t *layer) {
 static void freeConv1dTransposedLayerShell(layer_t *layer) {
     freeReservedMemory(layer->config->conv1dTransposed->kernel);
     freeReservedMemory(layer->config->conv1dTransposed);
+    freeReservedMemory(layer->config);
+    freeReservedMemory(layer);
+}
+
+/* Linear counterpart of freeConv1dLayerShell: freeOptimSgdM already freed the
+ * linear's weights parameter_t (its bias slot is NULL and never registered),
+ * so this only tears down the config/layer wrapper. Linear has no kernel
+ * (unlike Conv1d/Conv1dTransposed), so there is one fewer level to free. */
+static void freeLinearLayerShell(layer_t *layer) {
+    freeReservedMemory(layer->config->linear);
     freeReservedMemory(layer->config);
     freeReservedMemory(layer);
 }
@@ -148,10 +160,46 @@ void testOptimizer_OneStateForBiaslessConv1dTransposed(void) {
     TEST_ASSERT_TRUE(optimNotNull);
 }
 
+/* Same bias-less state-count/collection guard as the Conv1d test, but for a
+ * LINEAR layer (BIAS_FALSE, header-sanctioned, cfg->bias == NULL): the
+ * CASE LINEAR arm in calcNumberOfStatesByLayer must count 1 (not the fixed
+ * 2), and sgdMCreateOptim's LINEAR collection block must skip the bias
+ * momentum state instead of NULL-dereferencing linearConfig->bias->param
+ * (issue #292, mirrors the CONV1D fix from PR #291). */
+void testBiaslessLinearCountsOneStateAndOptimizerSurvives(void) {
+    quantization_t *q = quantizationInitFloat();
+    layerQuant_t lq;
+    layerQuantInitUniform(&lq, q);
+
+    layer_t *linear = linearLayerInit(
+        &(linearInit_t){
+            .inFeatures = 3,
+            .outFeatures = 2,
+            .bias = BIAS_FALSE,
+        },
+        &lq);
+    layer_t *model[1] = {linear};
+
+    size_t numStates = calcTotalNumberOfStates(model, 1);
+
+    quantization_t *momentumQuant = quantizationInitFloat();
+    optimizer_t *optim = sgdMCreateOptim(0.1f, 0.0f, 0.0f, model, 1, FLOAT32, momentumQuant);
+    bool optimNotNull = (optim != NULL);
+
+    freeOptimSgdM(optim); /* frees the linear's weights parameter_t */
+    freeLinearLayerShell(linear);
+    freeQuantization(momentumQuant);
+    freeQuantization(q);
+
+    TEST_ASSERT_EQUAL_UINT(1, numStates);
+    TEST_ASSERT_TRUE(optimNotNull);
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(testOptimizer_OneStateForBiaslessConv1d);
     RUN_TEST(testOptimizer_TwoStatesForBiasedConv1d);
     RUN_TEST(testOptimizer_OneStateForBiaslessConv1dTransposed);
+    RUN_TEST(testBiaslessLinearCountsOneStateAndOptimizerSurvives);
     return UNITY_END();
 }


### PR DESCRIPTION
## Summary

Closes #292 (manual close needed after develop-merge — auto-close only fires on main).

Bias-less LINEAR (`BIAS_FALSE`, header-sanctioned `cfg->bias == NULL`) crashed `sgdMCreateOptim` — the exact bug class fixed for conv layers in PR #291, now mirrored for LINEAR:

- `Optimizer.c`: `case LINEAR:` → `bias != NULL ? 2 : 1` (+ `Linear.h` include + explicit CMake dep, mirroring #291's conv handling).
- `SgdApi.c`: LINEAR bias slot wrapped in `if (bias != NULL) { … paramSlot += 2; } else { paramSlot += 1; }` — guard insertion, retained lines byte-identical, weights unconditional.
- New joint test in `UnitTestBiaslessConvOptim.c` (RED = SIGSEGV reproduced pre-fix; neither site alone passes it): count==1, optimizer non-NULL, ASan-balanced shell teardown.

Also independently flagged by CodeRabbit on PR #294 (Optimizer.c thread) — this PR resolves that finding.

## Verification
UnitTestBiaslessConvOptim 4/4; full unit suite 72/72; clang-format clean. Review: approved (spec + quality, zero Critical/Important findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)