### PR TITLE
fix(arithmetic): enforce Reduce SYM guards — requant-target contract + value-sum N-bound

### DIFF
--- a/src/arithmetic/Reduce.c
+++ b/src/arithmetic/Reduce.c
@@ -25,6 +25,23 @@
  * ODT_SYM_GRAD_QMAXBITS (same numeric value, different contract). */
 #define REDUCE_SYM_VALUESUM_QMAXBITS 16
 
+/* Width bound for the SYM_INT32 REQUANT TARGET (rsqrtSymInt32's `out`), NOT an
+ * operand-guard alias. Numerically identical to REDUCE_SYM_VALUESUM_QMAXBITS
+ * (16) but for a wholly different reason -- do NOT fold the two guards:
+ *   - The operand guard (reduceValidateSymOperand) bounds an int32
+ *     ACCUMULATOR reading pre-existing mantissas (overflow argument).
+ *   - This bound polices a WRITE target instead: rsqrtSymInt32 derives out's
+ *     scale dynamically every call (scale = absMax/qMax) and requantizes into
+ *     it. Widths above 16 bits are, by design, reserved for scale=1
+ *     raw-integer semantics (see the wide-SYM design intent in
+ *     docs/conventions -- qMaxBits > 16 only makes sense at scale=1). A
+ *     dynamic per-call scale on a >16-bit target would silently violate that
+ *     contract, and a scale=1 rsqrt output is meaningless anyway (rsqrt
+ *     results are fractional, not raw integers). So <=16 here is a
+ *     DELIBERATE contract for requant targets, not a leftover overflow bound
+ *     -- it would stay 16 even if the operand guard's bound ever changed. */
+#define REDUCE_SYM_REQUANT_QMAXBITS 16
+
 /* K = product of the leading (rank-k) logical dims (block count); N = product of
  * the trailing k logical dims (per-block element count). Logical sizes honor
  * orderOfDimensions via getDimensionsByIndex. k == rank -> K = 1 (whole-tensor
@@ -125,16 +142,47 @@ float rsqrtFloat32(float x, float eps) {
  * mantissas sum in an int32 accumulator without overflow for N < 2^(32-qMaxBits)
  * (>= 65536 terms at qMaxBits = 16) -- no int12 product-headroom argument
  * applies. (mirrors layerNormValidateSymTensor, whose value-sum path is likewise
- * sound at qMaxBits <= 16.) */
+ * sound at qMaxBits <= 16.) Also rejects qMaxBits == 0: a zero-width SYM operand
+ * is degenerate/invalid, and excluding it guarantees qMaxBits in [1,16] for every
+ * downstream user -- notably the N-guard's `32 - qMaxBits` shift in
+ * meanOverTrailingAxesSymInt32, which would otherwise shift by 32 and be UB on
+ * 32-bit size_t targets. */
 static void reduceValidateSymOperand(tensor_t *t, const char *what) {
     if (t->quantization->type != SYM_INT32) {
         PRINT_ERROR("Reduce SYM_INT32: %s must be SYM_INT32", what);
         exit(1);
     }
     symInt32QConfig_t *qc = t->quantization->qConfig;
+    if (qc->qMaxBits == 0) {
+        PRINT_ERROR("Reduce SYM_INT32: %s qMaxBits is 0 -- a zero-width SYM operand is "
+                    "degenerate/invalid",
+                    what);
+        exit(1);
+    }
     if (qc->qMaxBits > REDUCE_SYM_VALUESUM_QMAXBITS) {
         PRINT_ERROR("Reduce SYM_INT32: %s qMaxBits (%u) exceeds the value-sum bound (%u)", what,
                     (unsigned)qc->qMaxBits, (unsigned)REDUCE_SYM_VALUESUM_QMAXBITS);
+        exit(1);
+    }
+}
+
+/* Guard for a SYM_INT32 REQUANT TARGET (a tensor rsqrtSymInt32 writes into,
+ * not reads from) -- distinct contract from reduceValidateSymOperand above.
+ * A FLOAT32 buffer written with int32 mantissas is silent garbage, so the
+ * dtype check is shared. The width bound is NOT shared: see
+ * REDUCE_SYM_REQUANT_QMAXBITS for why <=16 here is a requant-target contract
+ * (dynamic-scale write validity), not a value-sum accumulator bound. Use this
+ * guard ONLY on tensors being requantized into, never on read-only operands
+ * (those use reduceValidateSymOperand). */
+static void reduceValidateSymRequantTarget(tensor_t *t, const char *what) {
+    if (t->quantization->type != SYM_INT32) {
+        PRINT_ERROR("Reduce SYM_INT32: %s must be SYM_INT32", what);
+        exit(1);
+    }
+    symInt32QConfig_t *qc = t->quantization->qConfig;
+    if (qc->qMaxBits > REDUCE_SYM_REQUANT_QMAXBITS) {
+        PRINT_ERROR("Reduce SYM_INT32: %s qMaxBits (%u) exceeds the requant-target bound (%u)",
+                    what, (unsigned)qc->qMaxBits, (unsigned)REDUCE_SYM_REQUANT_QMAXBITS);
         exit(1);
     }
 }
@@ -144,6 +192,20 @@ void meanOverTrailingAxesSymInt32(tensor_t *in, size_t k, tensor_t *meanOut) {
     size_t K;
     size_t N;
     blockGeom(in, k, &K, &N);
+    uint8_t qMaxBits = ((symInt32QConfig_t *)in->quantization->qConfig)->qMaxBits;
+    /* Shift safety: reduceValidateSymOperand now guarantees qMaxBits in [1,16], so
+     * the shift amount (32 - qMaxBits) is in [16,31] -- the relevant fact is the
+     * upper bound (<= 31, no UB on a 32-bit size_t), not the lower one (>= 16 was
+     * never what made this safe). Conservative bound -- the worst-case value-sum
+     * reaches exactly INT32_MIN at N = 2^(32-qMaxBits); the guard rejects from
+     * that boundary on. */
+    size_t bound = (size_t)1 << (32u - qMaxBits);
+    if (N >= bound) {
+        PRINT_ERROR("meanOverTrailingAxesSymInt32: N (%zu) exceeds the value-sum bound for "
+                    "qMaxBits (%u) -- must be < 2^(32-qMaxBits) (%zu)",
+                    N, (unsigned)qMaxBits, bound);
+        exit(1);
+    }
     int32_t *q = (int32_t *)in->data;
     float *m = (float *)meanOut->data;
     float s = ((symInt32QConfig_t *)in->quantization->qConfig)->scale;
@@ -179,7 +241,7 @@ void varianceBiasedOverTrailingAxesSymInt32(tensor_t *in, size_t k, tensor_t *me
 
 void rsqrtSymInt32(tensor_t *in, float eps, tensor_t *out) {
     reduceValidateSymOperand(in, "input");
-    reduceValidateSymOperand(out, "output");
+    reduceValidateSymRequantTarget(out, "output");
     size_t n = calcNumberOfElementsByTensor(in);
     int32_t *qIn = (int32_t *)in->data;
     int32_t *qOut = (int32_t *)out->data;

--- a/src/optimizer/CMakeLists.txt
+++ b/src/optimizer/CMakeLists.txt
@@ -6,6 +6,7 @@ target_link_libraries(Optimizer PRIVATE
         Layer
         Conv1d
         Conv1dTransposed
+        Linear
         Tensor
         Common
 )

--- a/src/optimizer/Optimizer.c
+++ b/src/optimizer/Optimizer.c
@@ -5,18 +5,21 @@
 #include "Common.h"
 #include "Conv1d.h"
 #include "Conv1dTransposed.h"
+#include "Linear.h"
 #include "Optimizer.h"
 #include "Sgd.h"
 
 optimizerFunctions_t optimizerFunctions[] = {
     [SGD] = {sgdStep, sgdZeroGrad}, [SGD_M] = {sgdStepM, sgdZeroGrad}};
 
-/* Conv1d/Conv1dTransposed are bias-optional (BIAS_FALSE, header-sanctioned):
- * a bias-less conv contributes only its weight state, not a weight+bias
- * pair. Every other trainable layer type still has a fixed contribution. */
+/* Linear/Conv1d/Conv1dTransposed are bias-optional (BIAS_FALSE,
+ * header-sanctioned): a bias-less layer contributes only its weight state,
+ * not a weight+bias pair. Every other trainable layer type still has a
+ * fixed contribution. */
 static size_t calcNumberOfStatesByLayer(const layer_t *layer) {
     switch (layer->type) {
     case LINEAR:
+        return layer->config->linear->bias != NULL ? 2 : 1;
     case LAYERNORM:
     case GROUPNORM:
         return 2;

--- a/src/userApi/optimizer/SgdApi.c
+++ b/src/userApi/optimizer/SgdApi.c
@@ -57,24 +57,30 @@ optimizer_t *sgdMCreateOptim(float learningRate, float momentumFactor, float wei
             optim->parameter[paramSlot] = weights;
             tensor_t *weightStateBuffer = momentumStateInit(weights->param, momentumQuant);
 
-            parameter_t *bias = linearConfig->bias;
-            optim->parameter[paramSlot + 1] = bias;
-            tensor_t *biasStateBuffer = momentumStateInit(bias->param, momentumQuant);
-
             states_t *weightStates = reserveMemory(sizeof(states_t));
             weightStates->statesPerParameter = statesPerParam;
             weightStates->stateBuffers = reserveMemory(sizeof(tensor_t *));
             weightStates->stateBuffers[0] = weightStateBuffer;
 
-            states_t *biasStates = reserveMemory(sizeof(states_t));
-            biasStates->statesPerParameter = statesPerParam;
-            biasStates->stateBuffers = reserveMemory(sizeof(tensor_t *));
-            biasStates->stateBuffers[0] = biasStateBuffer;
-
             states[paramSlot] = weightStates;
-            states[paramSlot + 1] = biasStates;
 
-            paramSlot += 2;
+            /* BIAS_FALSE (header-sanctioned): no bias parameter to collect. */
+            if (linearConfig->bias != NULL) {
+                parameter_t *bias = linearConfig->bias;
+                optim->parameter[paramSlot + 1] = bias;
+                tensor_t *biasStateBuffer = momentumStateInit(bias->param, momentumQuant);
+
+                states_t *biasStates = reserveMemory(sizeof(states_t));
+                biasStates->statesPerParameter = statesPerParam;
+                biasStates->stateBuffers = reserveMemory(sizeof(tensor_t *));
+                biasStates->stateBuffers[0] = biasStateBuffer;
+
+                states[paramSlot + 1] = biasStates;
+
+                paramSlot += 2;
+            } else {
+                paramSlot += 1;
+            }
             break;
         case CONV1D: {
             conv1dConfig_t *conv1dCfg = layerConfig->conv1d;

--- a/test/unit/arithmetic/UnitTestReduce.c
+++ b/test/unit/arithmetic/UnitTestReduce.c
@@ -295,6 +295,21 @@ void testRsqrtSymInt32MatchesFloatTwin(void) {
     }
 }
 
+void testRsqrtSymInt32RejectsWideOutput(void) {
+    // Valid <=16-bit input; out configured with qMaxBits=17. This must be
+    // rejected by the OUTPUT's own requant-target guard (dynamic-scale write),
+    // not the input's value-sum operand guard -> fail fast either way, but the
+    // two guards police different contracts (see reduceValidateSymRequantTarget).
+    size_t dims[] = {3};
+    tensor_t *symIn = buildSymInt32TensorND(1, dims, (float[]){1.25f, 4.0f, 0.25f});
+    tensor_t *wideOut = buildSymInt32TensorNDBits(1, dims, NULL, 17);
+
+    ASSERT_EXITS_WITH_FAILURE(rsqrtSymInt32(symIn, 1e-5f, wideOut));
+
+    freeTensor(wideOut);
+    freeTensor(symIn);
+}
+
 void testMeanWholeTensorKEqualsRank(void) {
     // k == rank -> K = 1 (whole-tensor reduction). mean over all six elements
     // {1..6} of a [2,3] tensor = 21/6 = 3.5.
@@ -341,6 +356,38 @@ void testMeanSymInt32RejectsWideOperand(void) {
     freeTensor(wideIn);
 }
 
+void testMeanSymInt32RejectsOverlongAxis(void) {
+    // N == 2^(32-qMaxBits) with qMaxBits=16 -> N == 65536, exactly AT the
+    // value-sum boundary. Conservative bound -- the worst-case sum reaches
+    // exactly INT32_MIN at N = 2^(32-qMaxBits); the guard rejects from the
+    // boundary on.
+    size_t inDims[] = {1, 65536};
+    tensor_t *in = buildSymInt32TensorNDBits(2, inDims, NULL, 16);
+    size_t outDims[] = {1};
+    tensor_t *meanOut = buildFloatTensorND(1, outDims, NULL);
+
+    ASSERT_EXITS_WITH_FAILURE(meanOverTrailingAxesSymInt32(in, 1, meanOut));
+
+    freeTensor(meanOut);
+    freeTensor(in);
+}
+
+void testMeanSymInt32RejectsZeroWidthOperand(void) {
+    // qMaxBits=0 is a degenerate/invalid SYM operand -- it is also the one value
+    // that would make the N-guard's shift amount (32-qMaxBits) hit 32, which is
+    // UB for a size_t shift on 32-bit MCU targets. reduceValidateSymOperand must
+    // reject it before the shift is ever computed.
+    size_t inDims[] = {1, 3};
+    tensor_t *in = buildSymInt32TensorNDBits(2, inDims, NULL, 0);
+    size_t outDims[] = {1};
+    tensor_t *meanOut = buildFloatTensorND(1, outDims, NULL);
+
+    ASSERT_EXITS_WITH_FAILURE(meanOverTrailingAxesSymInt32(in, 1, meanOut));
+
+    freeTensor(meanOut);
+    freeTensor(in);
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(testAbsFloat32);
@@ -356,6 +403,9 @@ int main(void) {
     RUN_TEST(testMeanSymInt32MatchesFloatTwin);
     RUN_TEST(testVarianceSymInt32MatchesFloatTwin);
     RUN_TEST(testRsqrtSymInt32MatchesFloatTwin);
+    RUN_TEST(testRsqrtSymInt32RejectsWideOutput);
     RUN_TEST(testMeanSymInt32RejectsWideOperand);
+    RUN_TEST(testMeanSymInt32RejectsOverlongAxis);
+    RUN_TEST(testMeanSymInt32RejectsZeroWidthOperand);
     return UNITY_END();
 }

--- a/test/unit/userAPI/CMakeLists.txt
+++ b/test/unit/userAPI/CMakeLists.txt
@@ -356,6 +356,8 @@ target_link_libraries(UnitTestBiaslessConvOptim PRIVATE
         ConvTranspose1dKernel
         Conv1dKernel
         SlidingWindow1d
+        LinearApi
+        Linear
         SgdApi
         Sgd
         Optimizer

--- a/test/unit/userAPI/UnitTestBiaslessConvOptim.c
+++ b/test/unit/userAPI/UnitTestBiaslessConvOptim.c
@@ -9,6 +9,8 @@
 #include "Layer.h"
 #include "LayerCommon.h"
 #include "LayerQuant.h"
+#include "Linear.h"
+#include "LinearApi.h"
 #include "Optimizer.h"
 #include "QuantizationApi.h"
 #include "SgdApi.h"
@@ -39,6 +41,16 @@ static void freeConv1dLayerShell(layer_t *layer) {
 static void freeConv1dTransposedLayerShell(layer_t *layer) {
     freeReservedMemory(layer->config->conv1dTransposed->kernel);
     freeReservedMemory(layer->config->conv1dTransposed);
+    freeReservedMemory(layer->config);
+    freeReservedMemory(layer);
+}
+
+/* Linear counterpart of freeConv1dLayerShell: freeOptimSgdM already freed the
+ * linear's weights parameter_t (its bias slot is NULL and never registered),
+ * so this only tears down the config/layer wrapper. Linear has no kernel
+ * (unlike Conv1d/Conv1dTransposed), so there is one fewer level to free. */
+static void freeLinearLayerShell(layer_t *layer) {
+    freeReservedMemory(layer->config->linear);
     freeReservedMemory(layer->config);
     freeReservedMemory(layer);
 }
@@ -148,10 +160,46 @@ void testOptimizer_OneStateForBiaslessConv1dTransposed(void) {
     TEST_ASSERT_TRUE(optimNotNull);
 }
 
+/* Same bias-less state-count/collection guard as the Conv1d test, but for a
+ * LINEAR layer (BIAS_FALSE, header-sanctioned, cfg->bias == NULL): the
+ * CASE LINEAR arm in calcNumberOfStatesByLayer must count 1 (not the fixed
+ * 2), and sgdMCreateOptim's LINEAR collection block must skip the bias
+ * momentum state instead of NULL-dereferencing linearConfig->bias->param
+ * (issue #292, mirrors the CONV1D fix from PR #291). */
+void testBiaslessLinearCountsOneStateAndOptimizerSurvives(void) {
+    quantization_t *q = quantizationInitFloat();
+    layerQuant_t lq;
+    layerQuantInitUniform(&lq, q);
+
+    layer_t *linear = linearLayerInit(
+        &(linearInit_t){
+            .inFeatures = 3,
+            .outFeatures = 2,
+            .bias = BIAS_FALSE,
+        },
+        &lq);
+    layer_t *model[1] = {linear};
+
+    size_t numStates = calcTotalNumberOfStates(model, 1);
+
+    quantization_t *momentumQuant = quantizationInitFloat();
+    optimizer_t *optim = sgdMCreateOptim(0.1f, 0.0f, 0.0f, model, 1, FLOAT32, momentumQuant);
+    bool optimNotNull = (optim != NULL);
+
+    freeOptimSgdM(optim); /* frees the linear's weights parameter_t */
+    freeLinearLayerShell(linear);
+    freeQuantization(momentumQuant);
+    freeQuantization(q);
+
+    TEST_ASSERT_EQUAL_UINT(1, numStates);
+    TEST_ASSERT_TRUE(optimNotNull);
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(testOptimizer_OneStateForBiaslessConv1d);
     RUN_TEST(testOptimizer_TwoStatesForBiasedConv1d);
     RUN_TEST(testOptimizer_OneStateForBiaslessConv1dTransposed);
+    RUN_TEST(testBiaslessLinearCountsOneStateAndOptimizerSurvives);
     return UNITY_END();
 }


### PR DESCRIPTION
## Summary

Closes #293 (manual close needed after develop-merge — auto-close only fires on main). Also resolves the CodeRabbit `Reduce.c` finding on PR #294.

Three guard refinements in the `Reduce` arithmetic module, one commit:

1. **#293 — requant-target contract:** `rsqrtSymInt32`'s OUTPUT was validated by the value-sum *operand* guard whose rationale doesn't apply to a requant target. Guards are now split: `reduceValidateSymOperand` (inputs; value-sum soundness, `REDUCE_SYM_VALUESUM_QMAXBITS`=16) vs. new `reduceValidateSymRequantTarget` (rsqrt out; dynamic absmax-derived scale — widths >16 bit are reserved by design for scale=1 raw-integer semantics, so ≤16 is a deliberate contract, not an overflow bound). Same numeric value, different contract — each guard's comment forbids folding them.
2. **PR #294 CodeRabbit finding — value-sum N-bound enforced:** `meanOverTrailingAxesSymInt32`'s soundness bound was comment-only; now a runtime fail-fast (`N >= 2^(32−qMaxBits)` → exit(1); conservative by one — the worst-case sum reaches exactly INT32_MIN at the boundary). Decision (Leo): keep the 16-bit width bound, enforce N. Variance needs no guard (float accumulation — the CodeRabbit claim was half-right).
3. **Review finding — latent shift-UB closed:** `qMaxBits == 0` now rejected by the operand guard (zero-width SYM is degenerate), which also pins the N-bound shift into [16,31] on 32-bit-`size_t` MCU targets.

New death tests: wide (17-bit) rsqrt output; N=65536 @ 16-bit boundary; zero-width operand — each vacuity-checked (guard removed → test fails).

## Verification
UnitTestReduce 17/17; full unit suite 72/72; clang-format clean; two independent reviews (initial: approved-with-fixes → findings fixed; the Important one was the qMaxBits=0 shift-UB, host-invisible, MCU-relevant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)