### PR TITLE
refactor(optimizer)!: remove vestigial qType param / qtype field (#283)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,199 @@
+# Contributing to OnDeviceTraining
+
+Welcome! This repository is a pure-C framework for **inference and on-device
+training (backpropagation) of DNNs on microcontrollers** — plus the beginnings
+of a Python pipeline that will compile PyTorch models down to it. This page is
+the map: where things live, how to build and test, and where the canonical
+rules are written down. It links rather than duplicates — when in doubt, the
+linked document wins.
+
+## Start here
+
+Read in this order:
+
+1. [`README.md`](README.md) — motivation, design principles, roadmap
+2. [`docs/FEATURES.md`](docs/FEATURES.md) — what the framework can do **today**
+   (layer/optimizer/serialization matrix)
+3. [`examples/README.md`](examples/README.md) — runnable end-to-end demos with
+   PyTorch twins and bit-parity checks; the best way to see the user-facing API
+4. [`docs/CONVENTIONS.md`](docs/CONVENTIONS.md) — contributor conventions index
+   and the project vision (memory over float accuracy); per-subsystem rules
+   live in [`docs/conventions/`](docs/conventions/)
+
+## Repository map
+
+| Path | What it is |
+|---|---|
+| `src/` | The C framework — one or more static libraries per subdirectory |
+| `test/unit/` | Unity unit tests, one `UnitTest<LibName>.c` per library |
+| `examples/` | End-to-end training demos (PyTorch reference + C twin + parity harness) |
+| `python/odt/` | Python package skeleton: `providers/`, `ir2c/`, `resource_estimator/` (not started yet) |
+| `docs/` | Feature matrix, conventions index, per-subsystem conventions |
+| `cmake/` | Build helpers and external dependencies (Unity via FetchContent) |
+| `.github/workflows/` | CI pipeline (see [CI](#branches-prs--ci)) |
+
+The C framework is layered; upper layers only reach lower ones:
+
+```
+src/userApi/          TrainingLoopApi, InferenceApi, TensorApi, SgdApi, StateDictApi, …
+    ↓
+src/layer/ + src/loss_functions/ + src/optimizer/
+    ↓
+src/arithmetic/       Matmul, Add, Comparison, Distributions, …
+    ↓
+src/tensor/           Tensor, Quantization, TensorConversion, DTypes
+```
+
+Support modules (`common/`, `csv/`, `data_loader/`, `rng/`, `serial/`) sit
+alongside. Dispatch is via C-style vtables — global function-pointer arrays
+(`layerFunctions[]`, `optimizerFunctions[]`, `lossFunctions[]`,
+`conversionMatrix[][]`) indexed by enum. Within each module, public headers
+live in its `include/` subdirectory and implementations at the directory root.
+
+## Development environment
+
+The supported setup is [devenv](https://devenv.sh) (requires Nix; devenv's
+Getting Started covers installing both): `devenv shell`
+provides cmake, ninja, gcc, arm-gcc, uv and Python 3.12 in known-good
+versions, plus these scripts:
+
+| Script | Does |
+|---|---|
+| `setup_cmake` | Configure the `unit_test` preset (with `CC=gcc`) |
+| `build_unit_tests` | Build the unit-test suite |
+| `run_ai_unit_tests` | Run all Unity unit tests via ctest |
+| `run_asan_tests` | Configure + build + run the suite under ASan/UBSan |
+| `clean_cmake` | Clean the `unit_test` build tree |
+| `ci` | Most of the CI pipeline locally: allocation-locality gate, `clang-format` check, C tests, ASan/UBSan tests, Python tests |
+
+Without devenv you need CMake ≥ 3.20, Ninja, a C compiler, and
+[uv](https://docs.astral.sh/uv/) for anything Python. Python work always goes
+through `uv run` / `uv sync` — never a bare `python` or `pip`.
+
+## Build & test
+
+The build is driven entirely by presets in
+[`CMakePresets.json`](CMakePresets.json):
+
+```sh
+cmake --preset unit_test_debug          # configure
+cmake --build --preset unit_test_debug  # build (target: all_unit_tests)
+ctest --preset unit_test_debug          # run all unit tests
+```
+
+| Configure preset | Purpose |
+|---|---|
+| `unit_test` | Plain unit-test build (what CI runs) |
+| `unit_test_error` / `unit_test_info` / `unit_test_debug` | Increasing log verbosity (`DEBUG_MODE_*`); `debug` also enables `ODT_MEM_PROFILE` |
+| `unit_test_asan` | AddressSanitizer + UBSan. On macOS this needs compiler-rt ≥ LLVM 22 — see [`docs/conventions/testing.md`](docs/conventions/testing.md) (the devenv shell handles it) |
+| `unit_test_ubsan` | Signed-overflow / float-cast UBSan build |
+| `examples` | `BUILD_EXAMPLES=ON`; the default `all` target compiles **every** example binary |
+| `examples_memprofile` | `examples` + `ODT_MEM_PROFILE=ON` |
+
+Each preset builds into its own `build/<preset>/` directory. Test presets
+exist for the six `unit_test*` presets; test binaries in
+`build/<preset>/test/unit/` can also be executed directly. Two practical
+notes:
+
+- The DataLoader test needs MNIST fixture files — generate once with
+  `uv run test/unit/data_loader/MNISTLoader.py`.
+- The unit-test build itself shells out to `uv run` for build-time gold-value
+  generators (PyTorch-computed expected values baked into headers), so `uv`
+  must be on `PATH` even for "C-only" work — and the first build syncs the
+  Python deps, including a sizable PyTorch download. The devenv shell brings
+  `uv`; CI has a dedicated sync step for this.
+- No `CMAKE_C_STANDARD` is set; the compiler default (typically gnu17) is
+  what CI builds with.
+
+Python tests: `uv run pytest` (from the repo root).
+
+## Examples
+
+Almost every example in [`examples/`](examples/README.md) pairs a PyTorch
+reference with a C twin and a deterministic **bit-parity** gate that CI
+enforces (the exception: `mixed_width_mlp` is a C-only acceptance demo) —
+they double as living documentation of the user-facing API and as regression
+tests. If your change touches training behavior, expect the bit-parity CI job
+to notice. Determinism rules live in
+[`examples/_shared/DETERMINISM.md`](examples/_shared/DETERMINISM.md).
+
+## Adding code
+
+Canonical rules: [`docs/CONVENTIONS.md`](docs/CONVENTIONS.md). The ones you
+will hit immediately:
+
+- `#define SOURCE_FILE "<filename>"` is the first line of every `.c` file
+  (before the `Common.h` include).
+- **Allocation locality**: `malloc`/`calloc`/`free` are allowed only in
+  `src/userApi/`; everything else goes through
+  `reserveMemory`/`freeReservedMemory` (StorageApi). CI greps for violations —
+  see [`docs/conventions/allocation.md`](docs/conventions/allocation.md).
+- Formatting is `clang-format` **21** (the major version CI pins; the devenv
+  shell provides it) with the repo `.clang-format`, 4-space indent — enforced
+  by CI. Other clang-format majors may format differently and fail the check.
+- Datasets deliver samples in their natural geometric shape; any
+  reshape/flatten is the first *layer* of the model — see
+  [`docs/conventions/data-shape.md`](docs/conventions/data-shape.md).
+
+### Adding a unit test
+
+1. Create `test/unit/<module>/UnitTest<LibName>.c` — the name must match the
+   CMake target of the library under test.
+2. Register it in that directory's `CMakeLists.txt` with
+   `add_elastic_ai_unit_test(LIB_UNDER_TEST <name> [MORE_LIBS ...])`
+   (defined in [`test/unit/unit_test.cmake`](test/unit/unit_test.cmake)).
+3. Tests use Unity (fetched automatically): `UNITY_BEGIN()`, `RUN_TEST(...)`,
+   `UNITY_END()` — registration is manual, there is no test discovery.
+   `setUp`/`tearDown` are empty stubs by convention.
+
+More in [`docs/conventions/testing.md`](docs/conventions/testing.md)
+(sanitizer gating, heap-tier memory discipline, build-time gold-value
+generators).
+
+## Branches, PRs & CI
+
+- `main` is the default/release branch; **`develop` is the integration
+  branch — branch off `develop` and target your PR back at `develop`**.
+- Branch protection requires green checks before merge; direct pushes are
+  blocked, all changes go through PRs.
+- Commit subjects follow conventional-commit style
+  (`feat(scope): …`, `fix(scope): …`, `docs: …`), as in the existing history.
+- GitHub's `Closes #NN` auto-close only fires on merges to the default branch
+  (`main`) — after a `develop` merge, close the issue manually.
+
+CI ([`.github/workflows/ci.yml`](.github/workflows/ci.yml)) runs on pushes and
+PRs to `main`/`develop`:
+
+| Job | Checks |
+|---|---|
+| `alloc-locality` | No allocation primitives outside `src/userApi/` |
+| `c-format-check` | `clang-format --dry-run -Werror` over `src`, `test`, `examples` |
+| `c-build-and-test` | `unit_test` preset: configure, build, ctest |
+| `c-asan-build-and-test` | The suite under ASan + UBSan |
+| `c-ubsan-build-and-test` | The suite under overflow-focused UBSan |
+| `c-bit-parity` | Builds **all** example binaries, then parity of the C twins against PyTorch (exact int32 predictions; ECG reconstructions via allclose) |
+| `python-test` | `uv run pytest` |
+
+The devenv `ci` script mirrors this pipeline locally (all but the UBSan and
+bit-parity jobs) — run it before opening a PR. If your change touches
+numerics or training behavior, also run the `unit_test_ubsan` preset and the
+affected examples' parity checks yourself.
+
+## The bigger picture
+
+This repo is half of a two-repo pipeline with
+[es-ude/elastic-ai.creator](https://github.com/es-ude/elastic-ai.creator):
+
+```
+PyTorch model → torch2ir → IR + shapes → annotated IR → ir2c → C code → MCU
+              ╰―― elastic-ai.creator ――╯               ╰――― this repo ―――╯
+```
+
+**creator** owns the IR definition, shape inference and protocol interfaces;
+**this repo** owns the provider implementations, `ir2c` code generation, the
+C training framework, resource estimation, and all hardware-specific logic.
+The Python side here (`python/odt/`) is a skeleton awaiting that work.
+
+## License
+
+MIT — see [`LICENSE.md`](LICENSE.md).

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,8 +1,9 @@
-# Examples — End-to-End 1D-CNN Demos with PyTorch + C Parity
+# Examples — End-to-End Demos with PyTorch + C Parity
 
 Each subdirectory is a self-contained example demonstrating the same model
 in PyTorch (reference) and the ODT C framework, with final-state parity
-checking and visualizations.
+checking and visualizations — except `mixed_width_mlp/`, which is a C-only
+acceptance demo with no PyTorch twin.
 
 ## Currently shipping
 
@@ -10,10 +11,11 @@ checking and visualizations.
 |---|---|---|
 | `mnist_mlp/` | MNIST dense-MLP digit classification | ✅ |
 | `mnist_cnn/` | MNIST 1D-CNN digit classification | ✅ |
-| `har_classifier/` | UCI HAR 6-class activity classification | Stage 1 |
+| `har_classifier/` | UCI HAR 6-class activity classification | Stage 1 ✅ |
 | `ecg_anomaly_ae/` | ECG5000 reconstruction-based anomaly detection | Stage 2 ✅ |
 | `kws_mfcc/` | SpeechCommands keyword spotting (MFCC features) | Stage 3 ✅ |
 | `kws_raw/` | SpeechCommands keyword spotting (raw waveform + in-model downsample) | Stage 3 ✅ |
+| `mixed_width_mlp/` | Mixed-width SYM_INT32 MLP on MNIST (C-only, no PyTorch twin) | ✅ |
 | `kws_denoising_ae/` | SpeechCommands additive-noise denoising | Stage 4 (planned) |
 
 ## Running an example
@@ -27,15 +29,20 @@ cmake --build --preset examples --target train_c_<name>
 uv run python examples/<name>/compare.py
 ```
 
-Each `train_c_<name>` binary also has a **bit-parity** mode: run it with
-`BIT_PARITY=1` and it loads the PyTorch reference weights (instead of training
-from scratch) and emits predictions that must match PyTorch exactly. This is
-the deterministic check CI runs; see each example's README for the precise
-`compare_predictions.py` invocation.
+`mixed_width_mlp/` has no Python steps: build its target and run the binary
+directly. It reads `examples/mnist_mlp/data/`, so run the `mnist_mlp`
+prepare step first.
 
-The C-side executables only build when configured with the `examples`
-preset (`BUILD_EXAMPLES=ON`); the default `unit_test_*` presets do not
-build them.
+Each `train_c_<name>` binary except `train_c_mixed_width_mlp` also has a
+**bit-parity** mode: run it with `BIT_PARITY=1` and it loads the PyTorch
+reference weights (instead of training from scratch) and emits predictions
+that must match PyTorch exactly. This is the deterministic check CI runs;
+see each example's README for the precise `compare_predictions.py`
+invocation.
+
+The C-side executables only build when configured with `BUILD_EXAMPLES=ON`
+(the `examples` or `examples_memprofile` presets); the default `unit_test_*`
+presets do not build them.
 
 ## Shared infrastructure
 

--- a/examples/ecg_anomaly_ae/README.md
+++ b/examples/ecg_anomaly_ae/README.md
@@ -53,7 +53,7 @@ After the train-from-scratch demo, `examples/ecg_anomaly_ae/` contains:
 ## Model
 
 - Input: `[1, 140]` (univariate ECG beat, 140 samples)
-- Encoder: `Conv1d(1→8, K=7, S=2, SAME)` → ReLU → `MaxPool1d(K=2, S=2)`
+- Encoder: `Conv1d(1→8, K=7, S=2, EXPLICIT pad=3)` → ReLU → `MaxPool1d(K=2, S=2)`
   → `Conv1d(8→16, K=5, SAME)` → ReLU → `AvgPool1d(K=5, S=5)` → `[16, 7]`
 - Decoder: `Conv1dTransposed(16→8, K=5, S=5)` → ReLU
   → `Conv1dTransposed(8→4, K=2, S=2)` → ReLU

--- a/examples/ecg_anomaly_ae/train_c.c
+++ b/examples/ecg_anomaly_ae/train_c.c
@@ -317,7 +317,7 @@ int main(void) {
                                                  /*dropLast*/ true);
 
         optimizer_t *sgd = sgdMCreateOptim(LR, MOMENTUM, /*weightDecay*/ 0.0f, model, MODEL_SIZE,
-                                           FLOAT32, quantizationInitFloat());
+                                           quantizationInitFloat());
 
         g_log_file = fopen("examples/ecg_anomaly_ae/logs/c.json", "w");
         if (!g_log_file) {

--- a/examples/har_classifier/README.md
+++ b/examples/har_classifier/README.md
@@ -49,7 +49,7 @@ After the train-from-scratch demo, `examples/har_classifier/` contains:
 ## Model
 
 - Input: `[9, 128]` (9 IMU channels, 2.56 s window @ 50 Hz)
-- 3 × `Conv1d → ReLU → MaxPool1d` blocks
+- 2 × `Conv1d → ReLU → MaxPool1d` blocks, then `Conv1d → ReLU`
 - Global `AvgPool1d` → `Flatten → Linear → Softmax → CrossEntropy`
 - ~10 K parameters
 
@@ -74,8 +74,8 @@ FLOAT32 trainer as the reference.
 
 Key design points (see `docs/CONVENTIONS.md` and the source comments):
 
-- **Weights + biases** are packed `SYM@x` (`ceil(x·N/8)` bytes → @16 = 50%, @8 =
-  75%, @4 = 87.5% smaller than FLOAT32's `4N`). Everything else — gradients,
+- **Weights + biases** are packed `SYM@x` (`ceil(x·N/8)` bytes → @12 = 62.5%,
+  @8 = 75%, @4 = 87.5% smaller than FLOAT32's `4N`). Everything else — gradients,
   momentum, activation wires — is FLOAT32.
 - **Momentum is FLOAT32**, decoupled from the packed-SYM params via the optimizer's
   own-config knob (`sgdMCreateOptim(..., momentumQuant)`). A packed-SYM momentum
@@ -106,7 +106,7 @@ heap/stack/RSS peaks, and the **reconciliation gap** (`heap_peak − mcu_total`,
 ### Offline sweep + honest aggregation
 
 ```bash
-# Full study: {float, sym@16, sym@12, sym@8, sym@4} × seed 1..10 = 50 runs.
+# Full study: {float, sym@12, sym@10, sym@8, sym@6, sym@4} × seed 1..10 = 60 runs.
 # LONG (~40 h offline; NOT wired into CI). Use --configs/--seeds/--epochs to smoke.
 uv run examples/har_classifier/run_matrix.py                 # full
 uv run examples/har_classifier/run_matrix.py --configs float sym8 --seeds 1 2 --epochs 2  # smoke

--- a/examples/har_classifier/train_c.c
+++ b/examples/har_classifier/train_c.c
@@ -367,8 +367,7 @@ int main(void) {
         /* FLOAT32 momentum accumulator (the conventional default). The optimizer
          * clones this config per state via getQLike and does NOT take ownership. */
         quantization_t *momentumQ = quantizationInitFloat();
-        sgd = sgdMCreateOptim(g_lr, g_momentum, /*weightDecay*/ 0.0f, model, MODEL_SIZE, FLOAT32,
-                              momentumQ);
+        sgd = sgdMCreateOptim(g_lr, g_momentum, /*weightDecay*/ 0.0f, model, MODEL_SIZE, momentumQ);
 #ifdef ODT_MEM_PROFILE
         markAfterOpt = memProfileMark(); /* optstate_b = delta */
 #endif

--- a/examples/har_classifier/train_c_sym.c
+++ b/examples/har_classifier/train_c_sym.c
@@ -513,8 +513,8 @@ int main(void) {
      * dead-zone in the accumulator; a FLOAT32 accumulator keeps velocity precise
      * so ONLY the weights carry the memory win. */
     quantization_t *momentumQ = quantizationInitFloat();
-    optimizer_t *sgd = sgdMCreateOptim(g_lr, g_momentum, /*weightDecay*/ 0.0f, model, MODEL_SIZE,
-                                       SYM_INT32, momentumQ);
+    optimizer_t *sgd =
+        sgdMCreateOptim(g_lr, g_momentum, /*weightDecay*/ 0.0f, model, MODEL_SIZE, momentumQ);
 #ifdef ODT_MEM_PROFILE
     size_t markAfterOpt = memProfileMark(); /* optstate_b = delta */
 #endif

--- a/examples/kws_mfcc/README.md
+++ b/examples/kws_mfcc/README.md
@@ -46,7 +46,7 @@ Run the full 35-class set with `KWS_CLASSES=35 …` on every command (local-only
 - Input: `[40, 32]` (40 MFCC channels, 32 frames) → `reshapeItemsAddBatchDim` → `[1, 40, 32]`
 - `Conv1d(40→32,K3,SAME) → ReLU → MaxPool(2) → Conv1d(32→64,K3,SAME) → ReLU →
   MaxPool(2) → AdaptiveAvgPool1d(1) → Flatten → Linear(64→C) → Softmax → CE`
-- Lengths: 32 → 16 → 8 → 1; ~16 K params
+- Lengths: 32 → 16 → 8 → 1; ~10.5 K params
 - State-dict layers: `conv1`, `conv2`, `fc`
 
 The train-from-scratch tolerances (`test_acc ±2.5 pp`, `test_loss ±0.15 nats`) are

--- a/examples/kws_mfcc/train_c.c
+++ b/examples/kws_mfcc/train_c.c
@@ -323,7 +323,7 @@ int main(void) {
                                                  /*dropLast*/ true);
 
         optimizer_t *sgd = sgdMCreateOptim(LR, MOMENTUM, /*weightDecay*/ 0.0f, model, MODEL_SIZE,
-                                           FLOAT32, quantizationInitFloat());
+                                           quantizationInitFloat());
 
         char logPath[300];
         snprintf(logPath, sizeof(logPath), "%s/c.json", logsDir);

--- a/examples/kws_raw/README.md
+++ b/examples/kws_raw/README.md
@@ -7,8 +7,8 @@ native `[1, 16000]` waveform and **downsamples in-framework** — its first laye
 `AvgPool1d(K=16, S=16)`, a decimation-by-16 box filter that turns 16 kHz into
 1 kHz. Change `K` to change the effective rate (8 → 2 kHz, …) with no re-prep; the
 `AdaptiveAvgPool1d(1)` head is length-agnostic so the rest of the model is
-unchanged (only the three MaxPool nominal `inputLength`s in `train_c.c` need to
-track the new lengths).
+unchanged (only the three MaxPool nominal `inputLength`s and the three LayerNorm
+`normalizedShape`s in `train_c.c` need to track the new lengths).
 
 One binary, two modes — **bit-parity** (`BIT_PARITY=1`, the exact CI gate) and a
 **train-from-scratch** informational demo. See `kws_mfcc/README.md` for the mode

--- a/examples/kws_raw/trace_c.c
+++ b/examples/kws_raw/trace_c.c
@@ -339,7 +339,7 @@ int main(int argc, char **argv) {
     }
 
     optimizer_t *sgd = sgdMCreateOptim(LR, MOMENTUM, /*weightDecay*/ 0.0f, model, MODEL_SIZE,
-                                       FLOAT32, quantizationInitFloat());
+                                       quantizationInitFloat());
     optimizerFunctions_t optimFns = optimizerFunctions[sgd->type];
 
     lossConfig_t lossCfg = {

--- a/examples/kws_raw/train_c.c
+++ b/examples/kws_raw/train_c.c
@@ -365,7 +365,7 @@ int main(void) {
                                                  /*dropLast*/ true);
 
         optimizer_t *sgd = sgdMCreateOptim(LR, MOMENTUM, /*weightDecay*/ 0.0f, model, MODEL_SIZE,
-                                           FLOAT32, quantizationInitFloat());
+                                           quantizationInitFloat());
 
         char logPath[300];
         snprintf(logPath, sizeof(logPath), "%s/c.json", logsDir);

--- a/examples/mixed_width_mlp/train_c.c
+++ b/examples/mixed_width_mlp/train_c.c
@@ -389,7 +389,7 @@ int main(void) {
     }
 
     optimizer_t *sgd = sgdMCreateOptim(LR, MOMENTUM, /*weightDecay*/ 0.0f, model, MODEL_SIZE,
-                                       SYM_INT32, quantizationInitFloat());
+                                       quantizationInitFloat());
     optimizerFunctions_t optimFns = optimizerFunctions[sgd->type];
 
     lossConfig_t lossCfg = defaultLossConfig(CROSS_ENTROPY);

--- a/examples/mnist_cnn/train_c.c
+++ b/examples/mnist_cnn/train_c.c
@@ -288,7 +288,7 @@ int main(void) {
                                                  /*dropLast*/ true);
 
         optimizer_t *sgd = sgdMCreateOptim(LR, MOMENTUM, /*weightDecay*/ 0.0f, model, MODEL_SIZE,
-                                           FLOAT32, quantizationInitFloat());
+                                           quantizationInitFloat());
 
         g_log_file = fopen("examples/mnist_cnn/logs/c.json", "w");
         if (!g_log_file) {

--- a/examples/mnist_mlp/train_c.c
+++ b/examples/mnist_mlp/train_c.c
@@ -238,7 +238,7 @@ int main(void) {
                                                  /*dropLast*/ true);
 
         optimizer_t *sgd = sgdMCreateOptim(LR, MOMENTUM, /*weightDecay*/ 0.0f, model, MODEL_SIZE,
-                                           FLOAT32, quantizationInitFloat());
+                                           quantizationInitFloat());
 
         g_log_file = fopen("examples/mnist_mlp/logs/c.json", "w");
         if (!g_log_file) {

--- a/src/optimizer/include/Optimizer.h
+++ b/src/optimizer/include/Optimizer.h
@@ -20,7 +20,6 @@ typedef enum { SGD, SGD_M } optimizerType_t;
 
 typedef struct optimizer {
     optimizerType_t type;
-    qtype_t qtype;
     optimImpl_t *impl;
     parameter_t **parameter;
     states_t **states;

--- a/src/userApi/optimizer/SgdApi.c
+++ b/src/userApi/optimizer/SgdApi.c
@@ -23,11 +23,9 @@ static tensor_t *momentumStateInit(tensor_t *param, quantization_t *momentumQuan
 }
 
 optimizer_t *sgdMCreateOptim(float learningRate, float momentumFactor, float weightDecay,
-                             layer_t **model, size_t sizeModel, qtype_t qType,
-                             quantization_t *momentumQuant) {
+                             layer_t **model, size_t sizeModel, quantization_t *momentumQuant) {
     optimizer_t *optim = reserveMemory(sizeof(optimizer_t));
     optim->type = SGD_M;
-    optim->qtype = qType;
 
     optimImpl_t *sgdImpl = reserveMemory(sizeof(optimImpl_t));
     sgd_t *sgd = reserveMemory(sizeof(sgd_t));

--- a/src/userApi/optimizer/include/SgdApi.h
+++ b/src/userApi/optimizer/include/SgdApi.h
@@ -17,8 +17,7 @@
  *        (caller-owned; not consumed -- cloned once per state via getQLike).
  */
 optimizer_t *sgdMCreateOptim(float learningRate, float momentumFactor, float weightDecay,
-                             layer_t **model, size_t sizeModel, qtype_t qType,
-                             quantization_t *momentumQuant);
+                             layer_t **model, size_t sizeModel, quantization_t *momentumQuant);
 
 void freeOptimSgdM(optimizer_t *sgdM);
 

--- a/test/unit/layer/UnitTestLinear.c
+++ b/test/unit/layer/UnitTestLinear.c
@@ -1551,7 +1551,7 @@ void testLinearSymInt32GradAccumulatesOverTwoMicrobatchesAndSteps(void) {
     /* ---- Optimizer step on the SYM_INT32 layer ("updates the param without crashing"). ---- */
     layer_t *symModel[] = {symLayer};
     quantization_t *momentumQ = quantizationInitFloat();
-    optimizer_t *symOptim = sgdMCreateOptim(0.1f, 0.0f, 0.0f, symModel, 1, SYM_INT32, momentumQ);
+    optimizer_t *symOptim = sgdMCreateOptim(0.1f, 0.0f, 0.0f, symModel, 1, momentumQ);
     optimizerFunctions[symOptim->type].step(symOptim);
     tensor_t *symWParam = symLayer->config->linear->weights->param;
     int paramFinite = 1;

--- a/test/unit/optimizer/UnitTestSgd.c
+++ b/test/unit/optimizer/UnitTestSgd.c
@@ -23,6 +23,16 @@
 
 #include <ReluApi.h>
 
+/* #283 contract: sgdMCreateOptim takes NO qtype_t -- the optimizer dispatches
+ * per-tensor via executeOp since #278, so a creation-time qType is dead API.
+ * _Generic picks 1 only for the exact 6-arg signature; anything else hits
+ * default: 0 and fails the assert at compile time. */
+_Static_assert(_Generic(&sgdMCreateOptim,
+                   optimizer_t *(*)(float, float, float, layer_t **, size_t, quantization_t *): 1,
+                   default: 0),
+               "#283: sgdMCreateOptim must be (lr, momentumFactor, weightDecay, "
+               "model, sizeModel, momentumQuant)");
+
 void setUp() {}
 void tearDown() {}
 
@@ -139,7 +149,7 @@ void testSgdMCreateOptim() {
 
     quantization_t *momentumQ = quantizationInitFloat();
     optimizer_t *optim =
-        sgdMCreateOptim(lr, momentumFactor, weightDecay, model, sizeModel, FLOAT32, momentumQ);
+        sgdMCreateOptim(lr, momentumFactor, weightDecay, model, sizeModel, momentumQ);
     sgd_t *sgd = optim->impl->sgd;
 
     linearConfig_t *linear0Conf = linear0->config->linear;
@@ -263,7 +273,7 @@ void testSGDStep() {
 
     quantization_t *momentumQ = quantizationInitFloat();
     optimizer_t *sgd =
-        sgdMCreateOptim(lr, momentumFactor, weightDecay, model, modelSize, FLOAT32, momentumQ);
+        sgdMCreateOptim(lr, momentumFactor, weightDecay, model, modelSize, momentumQ);
 
     optimizerFunctions_t sgdFns = optimizerFunctions[sgd->type];
     sgdFns.step(sgd);
@@ -353,7 +363,7 @@ void testSGDZeroGrad() {
 
     quantization_t *momentumQ = quantizationInitFloat();
     optimizer_t *sgd =
-        sgdMCreateOptim(lr, momentumFactor, weightDecay, model, modelSize, FLOAT32, momentumQ);
+        sgdMCreateOptim(lr, momentumFactor, weightDecay, model, modelSize, momentumQ);
 
     sgdZeroGrad(sgd);
 
@@ -412,7 +422,7 @@ void testSgdZeroGradOnSymInt32GradZeroesMantissasAndResetsScale(void) {
 
     layer_t *model[] = {layer};
     quantization_t *momentumQ = quantizationInitFloat();
-    optimizer_t *optim = sgdMCreateOptim(0.1f, 0.9f, 0.0f, model, 1, SYM_INT32, momentumQ);
+    optimizer_t *optim = sgdMCreateOptim(0.1f, 0.9f, 0.0f, model, 1, momentumQ);
 
     sgdZeroGrad(optim);
 
@@ -480,7 +490,7 @@ void testSgdMCreateOptimMomentumStateIsFloatIndependentOfSymInt32ParamDtype(void
     layer_t *model[1] = {layer};
 
     quantization_t *momentumQ = quantizationInitFloat();
-    optimizer_t *optim = sgdMCreateOptim(0.1f, 0.9f, 0.0f, model, 1, SYM_INT32, momentumQ);
+    optimizer_t *optim = sgdMCreateOptim(0.1f, 0.9f, 0.0f, model, 1, momentumQ);
 
     /* CAPTURE before frees. */
     qtype_t capturedWeightParamType =
@@ -552,7 +562,7 @@ void testSgdMCreateOptimRegistersLayerNormGammaAndBeta(void) {
 
     quantization_t *momentumQ = quantizationInitFloat();
     optimizer_t *optim =
-        sgdMCreateOptim(lr, momentumFactor, weightDecay, model, sizeModel, FLOAT32, momentumQ);
+        sgdMCreateOptim(lr, momentumFactor, weightDecay, model, sizeModel, momentumQ);
 
     /* CAPTURE before frees. */
     size_t capturedSizeStates = optim->sizeStates;
@@ -624,7 +634,6 @@ void testSgdStepSymInt32DoesNotRoundTripGrad(void) {
     optimizer_t optim;
     optim.parameter = params;
     optim.sizeStates = 1;
-    optim.qtype = SYM_INT32;
     optim.impl = &impl;
 
     sgdStep(&optim);
@@ -678,7 +687,6 @@ void testSgdZeroGradAsymSubByteZeroesAllPackedBytes(void) {
     optimizer_t optim;
     optim.parameter = params;
     optim.sizeStates = 1;
-    optim.qtype = FLOAT32;
     optim.impl = &impl;
 
     sgdZeroGrad(&optim);
@@ -732,7 +740,6 @@ void testSgdZeroGradSymSubByteZeroesAllPackedBytesAndResetsScale(void) {
     optimizer_t optim;
     optim.parameter = params;
     optim.sizeStates = 1;
-    optim.qtype = FLOAT32;
     optim.impl = &impl;
 
     sgdZeroGrad(&optim);
@@ -790,7 +797,7 @@ void testSgdMCreateOptimAdmitsPackedSymGradStorage(void) {
     layer_t *model[1] = {layer};
 
     quantization_t *momentumQ = quantizationInitFloat();
-    optimizer_t *optim = sgdMCreateOptim(0.1f, 0.0f, 0.0f, model, 1, FLOAT32, momentumQ);
+    optimizer_t *optim = sgdMCreateOptim(0.1f, 0.0f, 0.0f, model, 1, momentumQ);
 
     /* CAPTURE before frees. */
     qtype_t capturedWGradType = weights->grad->quantization->type;
@@ -840,7 +847,7 @@ void testSgdMCreateOptimRejectsBoolGradStorage(void) {
     layer_t *model[1] = {layer};
 
     quantization_t *momentumQ = quantizationInitFloat();
-    ASSERT_EXITS_WITH_FAILURE(sgdMCreateOptim(0.1f, 0.0f, 0.0f, model, 1, FLOAT32, momentumQ));
+    ASSERT_EXITS_WITH_FAILURE(sgdMCreateOptim(0.1f, 0.0f, 0.0f, model, 1, momentumQ));
 
     /* Teardown (parent continues after the fork-based assert; file convention). */
     freeLinearLayerShellOnly(layer);
@@ -899,7 +906,6 @@ void testSgdStepMFloatReadsPackedSymGradGeneric(void) {
     optim.parameter = params;
     optim.states = states;
     optim.sizeStates = 1;
-    optim.qtype = FLOAT32;
     optim.impl = &impl;
 
     sgdStepM(&optim);
@@ -982,7 +988,6 @@ void testSgdStepMMixedDtypeMovesBothParamsCorrectly(void) {
     optim.parameter = params;
     optim.states = states;
     optim.sizeStates = 2;
-    optim.qtype = FLOAT32; /* vestigial post-#278: irrelevant to per-tensor funnel dispatch */
     optim.impl = &impl;
 
     sgdStepM(&optim);
@@ -1082,7 +1087,6 @@ void testSgdStepHalfAwayNeverEscapesSymDeadZone(void) {
     optimizer_t optim;
     optim.parameter = params;
     optim.sizeStates = 1;
-    optim.qtype = SYM_INT32; /* vestigial post-#278: irrelevant to per-tensor funnel dispatch */
     optim.impl = &impl;
 
     int codeEverMoved = 0;
@@ -1128,7 +1132,6 @@ void testSgdStepSrHalfAwayEscapesSymDeadZone(void) {
     optimizer_t optim;
     optim.parameter = params;
     optim.sizeStates = 1;
-    optim.qtype = SYM_INT32;
     optim.impl = &impl;
 
     int codeEverMoved = 0;

--- a/test/unit/userAPI/UnitTestAdaptiveAvgPool1dIntegration.c
+++ b/test/unit/userAPI/UnitTestAdaptiveAvgPool1dIntegration.c
@@ -105,7 +105,7 @@ void testOptimizer_ZeroStatesForParameterlessPool(void) {
 
     size_t numStates = calcTotalNumberOfStates(model, 1);
     quantization_t *momentumQ = quantizationInitFloat();
-    optimizer_t *optim = sgdMCreateOptim(0.01f, 0.9f, 0.0f, model, 1, FLOAT32, momentumQ);
+    optimizer_t *optim = sgdMCreateOptim(0.01f, 0.9f, 0.0f, model, 1, momentumQ);
     size_t sizeStates = optim->sizeStates;
 
     freeOptimSgdM(optim);

--- a/test/unit/userAPI/UnitTestBiaslessConvOptim.c
+++ b/test/unit/userAPI/UnitTestBiaslessConvOptim.c
@@ -79,7 +79,7 @@ void testOptimizer_OneStateForBiaslessConv1d(void) {
     size_t numStates = calcTotalNumberOfStates(model, 1);
 
     quantization_t *momentumQuant = quantizationInitFloat();
-    optimizer_t *optim = sgdMCreateOptim(0.1f, 0.0f, 0.0f, model, 1, FLOAT32, momentumQuant);
+    optimizer_t *optim = sgdMCreateOptim(0.1f, 0.0f, 0.0f, model, 1, momentumQuant);
     bool optimNotNull = (optim != NULL);
 
     freeOptimSgdM(optim); /* frees the conv's weights parameter_t */
@@ -114,7 +114,7 @@ void testOptimizer_TwoStatesForBiasedConv1d(void) {
     size_t numStates = calcTotalNumberOfStates(model, 1);
 
     quantization_t *momentumQuant = quantizationInitFloat();
-    optimizer_t *optim = sgdMCreateOptim(0.1f, 0.0f, 0.0f, model, 1, FLOAT32, momentumQuant);
+    optimizer_t *optim = sgdMCreateOptim(0.1f, 0.0f, 0.0f, model, 1, momentumQuant);
     bool optimNotNull = (optim != NULL);
 
     freeOptimSgdM(optim); /* frees the conv's weights AND bias parameter_t */
@@ -148,7 +148,7 @@ void testOptimizer_OneStateForBiaslessConv1dTransposed(void) {
     size_t numStates = calcTotalNumberOfStates(model, 1);
 
     quantization_t *momentumQuant = quantizationInitFloat();
-    optimizer_t *optim = sgdMCreateOptim(0.1f, 0.0f, 0.0f, model, 1, FLOAT32, momentumQuant);
+    optimizer_t *optim = sgdMCreateOptim(0.1f, 0.0f, 0.0f, model, 1, momentumQuant);
     bool optimNotNull = (optim != NULL);
 
     freeOptimSgdM(optim); /* frees the convT's weights parameter_t (bias slot NULL) */
@@ -183,7 +183,7 @@ void testBiaslessLinearCountsOneStateAndOptimizerSurvives(void) {
     size_t numStates = calcTotalNumberOfStates(model, 1);
 
     quantization_t *momentumQuant = quantizationInitFloat();
-    optimizer_t *optim = sgdMCreateOptim(0.1f, 0.0f, 0.0f, model, 1, FLOAT32, momentumQuant);
+    optimizer_t *optim = sgdMCreateOptim(0.1f, 0.0f, 0.0f, model, 1, momentumQuant);
     bool optimNotNull = (optim != NULL);
 
     freeOptimSgdM(optim); /* frees the linear's weights parameter_t */

--- a/test/unit/userAPI/UnitTestDropoutIntegration.c
+++ b/test/unit/userAPI/UnitTestDropoutIntegration.c
@@ -139,7 +139,7 @@ void testOptimizer_ZeroStatesForDropout(void) {
 
     size_t numStates = calcTotalNumberOfStates(model, 1);
     quantization_t *momentumQ = quantizationInitFloat();
-    optimizer_t *optim = sgdMCreateOptim(0.01f, 0.9f, 0.0f, model, 1, FLOAT32, momentumQ);
+    optimizer_t *optim = sgdMCreateOptim(0.01f, 0.9f, 0.0f, model, 1, momentumQ);
     size_t sizeStates = optim->sizeStates;
 
     freeOptimSgdM(optim);

--- a/test/unit/userAPI/UnitTestGroupNormIntegration.c
+++ b/test/unit/userAPI/UnitTestGroupNormIntegration.c
@@ -236,7 +236,7 @@ void testGroupNormClassifierTrainsAndRoundTrips(void) {
      * the halving threshold across the whole hyperparameter neighborhood, so the
      * assertion is deterministic and far from the knife-edge (weight init is
      * RNG-seeded to a fixed constant, so every run is bit-identical). */
-    optimizer_t *optim = sgdMCreateOptim(0.1f, 0.5f, 0.0f, model, MODEL_SIZE, FLOAT32, momentumQ);
+    optimizer_t *optim = sgdMCreateOptim(0.1f, 0.5f, 0.0f, model, MODEL_SIZE, momentumQ);
 
     /* (b) 30 epochs; captureEpoch records the first and last training loss. */
     cbInvocations = 0;

--- a/test/unit/userAPI/UnitTestLayerNormIntegration.c
+++ b/test/unit/userAPI/UnitTestLayerNormIntegration.c
@@ -98,7 +98,7 @@ void testLinearLayerNormLinearOneTrainingStep(void) {
     float betaBefore = ((float *)norm->config->layerNorm->beta->param->data)[0];
 
     quantization_t *momentumQ = quantizationInitFloat();
-    optimizer_t *optim = sgdMCreateOptim(0.1f, 0.9f, 0.0f, model, 3, FLOAT32, momentumQ);
+    optimizer_t *optim = sgdMCreateOptim(0.1f, 0.9f, 0.0f, model, 3, momentumQ);
 
     trainingStats_t *stats =
         calculateGradsSequential(model, 3, defaultLossConfig(MSE), REDUCTION_MEAN, input, label);
@@ -185,7 +185,7 @@ void testLayerNormSymInt32SingleLayerTrainingStep(void) {
     bool gradSymDtype = (lnSym->config->layerNorm->gamma->grad->quantization->type == SYM_INT32);
 
     quantization_t *momentumQSym = quantizationInitFloat();
-    optimizer_t *optimSym = sgdMCreateOptim(0.1f, 0.0f, 0.0f, modelSym, 1, SYM_INT32, momentumQSym);
+    optimizer_t *optimSym = sgdMCreateOptim(0.1f, 0.0f, 0.0f, modelSym, 1, momentumQSym);
     trainingStats_t *statsSym = calculateGradsSequential(modelSym, 1, defaultLossConfig(MSE),
                                                          REDUCTION_MEAN, inSym, labelSym);
     sgdStepM(optimSym);
@@ -215,7 +215,7 @@ void testLayerNormSymInt32SingleLayerTrainingStep(void) {
     tensor_t *labelF = build2DFloat(2, 4, labelVals, 8);
 
     quantization_t *momentumQF = quantizationInitFloat();
-    optimizer_t *optimF = sgdMCreateOptim(0.1f, 0.0f, 0.0f, modelF, 1, FLOAT32, momentumQF);
+    optimizer_t *optimF = sgdMCreateOptim(0.1f, 0.0f, 0.0f, modelF, 1, momentumQF);
     trainingStats_t *statsF =
         calculateGradsSequential(modelF, 1, defaultLossConfig(MSE), REDUCTION_MEAN, inF, labelF);
     sgdStepM(optimF);

--- a/test/unit/userAPI/UnitTestMnistSmoke.c
+++ b/test/unit/userAPI/UnitTestMnistSmoke.c
@@ -161,7 +161,7 @@ void testMnistSmoke_FullTrainingPipelineReducesLoss() {
     buildModel(model, &q);
 
     quantization_t *momentumQ = quantizationInitFloat();
-    optimizer_t *sgd = sgdMCreateOptim(0.1f, 0.0f, 0.0f, model, MODEL_SIZE, FLOAT32, momentumQ);
+    optimizer_t *sgd = sgdMCreateOptim(0.1f, 0.0f, 0.0f, model, MODEL_SIZE, momentumQ);
 
     cbInvocations = 0;
     size_t numberOfEpochs = 20;
@@ -220,7 +220,7 @@ void testMnistSmoke_SnprintfGmtimeRBetweenSetupAndTrainingRun_NoSilentExit() {
     buildModel(model, &q);
 
     quantization_t *momentumQ = quantizationInitFloat();
-    optimizer_t *sgd = sgdMCreateOptim(0.1f, 0.0f, 0.0f, model, MODEL_SIZE, FLOAT32, momentumQ);
+    optimizer_t *sgd = sgdMCreateOptim(0.1f, 0.0f, 0.0f, model, MODEL_SIZE, momentumQ);
 
     /* The poison block from #94's reproducer: gmtime_r + snprintf wedged
      * between setup and trainingRun. Pre-fix this triggered silent exit(1). */

--- a/test/unit/userAPI/UnitTestMultiLayerTraining.c
+++ b/test/unit/userAPI/UnitTestMultiLayerTraining.c
@@ -389,7 +389,7 @@ void testMultiLayerTraining_MultipleSteps_GradsAccumulate() {
 
     /* Optimizer takes references to w0/b0/w1/b1 — its free will cascade. */
     quantization_t *momentumQ = quantizationInitFloat();
-    optimizer_t *sgd = sgdMCreateOptim(0.01f, 0.f, 0.f, model, sizeModel, FLOAT32, momentumQ);
+    optimizer_t *sgd = sgdMCreateOptim(0.01f, 0.f, 0.f, model, sizeModel, momentumQ);
     optimizerFunctions_t sgdFns = optimizerFunctions[SGD_M];
 
     /* Input (1x3). */

--- a/test/unit/userAPI/UnitTestOptimizerScaling.c
+++ b/test/unit/userAPI/UnitTestOptimizerScaling.c
@@ -106,7 +106,7 @@ static optimizer_t *buildOneLayerOptimWithGrads(layer_t **modelOut, parameter_t 
      * config is a transient template -- sgdMCreateOptim clones it per state
      * via getQLike, so it's safe to free right after the call. */
     quantization_t *momentumQ = quantizationInitFloat();
-    optimizer_t *optim = sgdMCreateOptim(0.01f, 0.f, 0.f, modelOut, 1, FLOAT32, momentumQ);
+    optimizer_t *optim = sgdMCreateOptim(0.01f, 0.f, 0.f, modelOut, 1, momentumQ);
     freeQuantization(momentumQ);
     return optim;
 }
@@ -259,7 +259,7 @@ static optimizer_t *buildSymInt32OneLayerOptim(layer_t **modelOut, parameter_t *
     *bOut = b;
 
     quantization_t *momentumQ = quantizationInitFloat();
-    optimizer_t *optim = sgdMCreateOptim(lr, momentum, 0.f, modelOut, 1, SYM_INT32, momentumQ);
+    optimizer_t *optim = sgdMCreateOptim(lr, momentum, 0.f, modelOut, 1, momentumQ);
     freeQuantization(momentumQ);
     return optim;
 }
@@ -489,7 +489,7 @@ static optimizer_t *buildSymOneLayerOptim(layer_t **modelOut, parameter_t **wOut
     *bOut = b;
 
     quantization_t *momentumQ = quantizationInitFloat();
-    optimizer_t *optim = sgdMCreateOptim(lr, momentum, 0.f, modelOut, 1, FLOAT32, momentumQ);
+    optimizer_t *optim = sgdMCreateOptim(lr, momentum, 0.f, modelOut, 1, momentumQ);
     freeQuantization(momentumQ);
     return optim;
 }
@@ -616,7 +616,7 @@ static optimizer_t *buildAsymOneLayerOptim(layer_t **modelOut, parameter_t **wOu
     *bOut = b;
 
     quantization_t *momentumQ = quantizationInitFloat();
-    optimizer_t *optim = sgdMCreateOptim(lr, momentum, 0.f, modelOut, 1, FLOAT32, momentumQ);
+    optimizer_t *optim = sgdMCreateOptim(lr, momentum, 0.f, modelOut, 1, momentumQ);
     freeQuantization(momentumQ);
     return optim;
 }

--- a/test/unit/userAPI/UnitTestQuantLayerIntegration.c
+++ b/test/unit/userAPI/UnitTestQuantLayerIntegration.c
@@ -190,7 +190,7 @@ void testSgdMCreateOptimSkipsQuantizationLayer(void) {
     layer_t *model[2] = {linear, quant};
 
     quantization_t *momentumQ = quantizationInitFloat();
-    optimizer_t *optim = sgdMCreateOptim(0.1f, 0.0f, 0.0f, model, 2, SYM_INT32, momentumQ);
+    optimizer_t *optim = sgdMCreateOptim(0.1f, 0.0f, 0.0f, model, 2, momentumQ);
     size_t sizeStates = optim->sizeStates;
 
     freeOptimSgdM(optim); /* frees the Linear weights/bias parameter_t */
@@ -347,7 +347,7 @@ void testFullSymChainTrainingStepMatchesFloatTwin(void) {
     tensor_t *labelS = build2DSym(2, 2, LABEL_VALS, 4);
 
     quantization_t *momentumQS = quantizationInitFloat();
-    optimizer_t *optimS = sgdMCreateOptim(0.1f, 0.0f, 0.0f, modelSym, 5, SYM_INT32, momentumQS);
+    optimizer_t *optimS = sgdMCreateOptim(0.1f, 0.0f, 0.0f, modelSym, 5, momentumQS);
     trainingStats_t *statsS =
         calculateGradsSequential(modelSym, 5, defaultLossConfig(MSE), REDUCTION_MEAN, inS, labelS);
     sgdStepM(optimS);
@@ -380,7 +380,7 @@ void testFullSymChainTrainingStepMatchesFloatTwin(void) {
     tensor_t *labelF = build2DFloat(2, 2, LABEL_VALS, 4);
 
     quantization_t *momentumQF = quantizationInitFloat();
-    optimizer_t *optimF = sgdMCreateOptim(0.1f, 0.0f, 0.0f, modelF, 3, FLOAT32, momentumQF);
+    optimizer_t *optimF = sgdMCreateOptim(0.1f, 0.0f, 0.0f, modelF, 3, momentumQF);
     trainingStats_t *statsF =
         calculateGradsSequential(modelF, 3, defaultLossConfig(MSE), REDUCTION_MEAN, inF, labelF);
     sgdStepM(optimF);
@@ -480,7 +480,7 @@ void testConv1dTransposedSymChainTrains(void) {
     static const float LABEL_VALS[4] = {0.10f, 0.20f, -0.15f, 0.05f};
 
     quantization_t *momentumQ2 = quantizationInitFloat();
-    optimizer_t *opt = sgdMCreateOptim(0.05f, 0.0f, 0.0f, model, 2, SYM_INT32, momentumQ2);
+    optimizer_t *opt = sgdMCreateOptim(0.05f, 0.0f, 0.0f, model, 2, momentumQ2);
 
     size_t STEPS = 40;
     float firstLoss = NAN;

--- a/test/unit/userAPI/UnitTestTrainingLoopApi.c
+++ b/test/unit/userAPI/UnitTestTrainingLoopApi.c
@@ -103,7 +103,7 @@ void testCalculateGradsSequential_MatchesPyTorch() {
     tensor_t *label2 = buildFloatTensor2D(1, 2, (float[]){23.f, 457.f}, 2);
 
     quantization_t *momentumQ = quantizationInitFloat();
-    optimizer_t *sgd = sgdMCreateOptim(0.01f, 0.f, 0.f, model, sizeModel, FLOAT32, momentumQ);
+    optimizer_t *sgd = sgdMCreateOptim(0.01f, 0.f, 0.f, model, sizeModel, momentumQ);
     optimizerFunctions_t sgdFns = optimizerFunctions[SGD_M];
     /* Pre-existing test hack: only step weights, leaving bias unchanged across
      * iterations. We restore sizeStates to 2 before the free below so
@@ -544,7 +544,7 @@ void testTrainingEpochDefault_DoesOptimizerStepPerBatch() {
     }
 
     quantization_t *momentumQ = quantizationInitFloat();
-    optimizer_t *sgd = sgdMCreateOptim(0.01f, 0.f, 0.f, model, sizeModel, FLOAT32, momentumQ);
+    optimizer_t *sgd = sgdMCreateOptim(0.01f, 0.f, 0.f, model, sizeModel, momentumQ);
 
     /* Use epoch dataset (batchSize=1 → 4 batches) */
     initEpochDataset();
@@ -608,7 +608,7 @@ void testTrainingEpochDefault_MinibatchStepsOncePerMinibatch() {
     }
 
     quantization_t *momentumQ = quantizationInitFloat();
-    optimizer_t *sgd = sgdMCreateOptim(0.01f, 0.f, 0.f, model, sizeModel, FLOAT32, momentumQ);
+    optimizer_t *sgd = sgdMCreateOptim(0.01f, 0.f, 0.f, model, sizeModel, momentumQ);
 
     initEpochDataset();
     dataLoader_t *dl =
@@ -658,7 +658,7 @@ void testTrainingRun_ReturnsResult() {
     layer_t *model[] = {linear};
 
     quantization_t *momentumQ = quantizationInitFloat();
-    optimizer_t *sgd = sgdMCreateOptim(0.01f, 0.f, 0.f, model, 1, FLOAT32, momentumQ);
+    optimizer_t *sgd = sgdMCreateOptim(0.01f, 0.f, 0.f, model, 1, momentumQ);
 
     initEpochDataset();
     dataLoader_t *trainDl =
@@ -722,7 +722,7 @@ void testTrainingRun_CallsCallbackEachEpochWithStats() {
     layer_t *model[] = {linear};
 
     quantization_t *momentumQ = quantizationInitFloat();
-    optimizer_t *sgd = sgdMCreateOptim(0.01f, 0.f, 0.f, model, 1, FLOAT32, momentumQ);
+    optimizer_t *sgd = sgdMCreateOptim(0.01f, 0.f, 0.f, model, 1, momentumQ);
 
     initEpochDataset();
     dataLoader_t *trainDl =
@@ -893,7 +893,7 @@ void testTrainingEpochDefault_MeanScalesGradByOneOverNF() {
 
     /* momentumFactor=0 makes SGD_M behave like plain SGD. */
     quantization_t *momentumQ = quantizationInitFloat();
-    optimizer_t *sgd = sgdMCreateOptim(0.01f, 0.f, 0.f, model, 1, FLOAT32, momentumQ);
+    optimizer_t *sgd = sgdMCreateOptim(0.01f, 0.f, 0.f, model, 1, momentumQ);
 
     initSingleSampleDataset();
     dataLoader_t *dl =
@@ -1255,7 +1255,7 @@ void testTrainingEpochDefault_SumBackwardSkipsOptimizerScaling() {
     /* Use a very small learning rate so SUM doesn't NaN — SUM gradients are
      * larger by N*F than MEAN gradients on the same data. */
     quantization_t *momentumQ = quantizationInitFloat();
-    optimizer_t *sgd = sgdMCreateOptim(0.001f, 0.f, 0.f, model, 1, FLOAT32, momentumQ);
+    optimizer_t *sgd = sgdMCreateOptim(0.001f, 0.f, 0.f, model, 1, momentumQ);
 
     initEpochDataset();
     dataLoader_t *dl =
@@ -1312,7 +1312,7 @@ void testTrainingEpochDefault_MeanForwardSumBackward_MixedCombination() {
     layer_t *model[] = {linear};
 
     quantization_t *momentumQ = quantizationInitFloat();
-    optimizer_t *sgd = sgdMCreateOptim(0.001f, 0.f, 0.f, model, 1, FLOAT32, momentumQ);
+    optimizer_t *sgd = sgdMCreateOptim(0.001f, 0.f, 0.f, model, 1, momentumQ);
 
     initEpochDataset();
     dataLoader_t *dl =
@@ -1441,7 +1441,7 @@ void testTrainingRun_HardcodesForwardReductionMean() {
     layer_t *model[] = {linear};
 
     quantization_t *momentumQ = quantizationInitFloat();
-    optimizer_t *sgd = sgdMCreateOptim(0.01f, 0.f, 0.f, model, 1, FLOAT32, momentumQ);
+    optimizer_t *sgd = sgdMCreateOptim(0.01f, 0.f, 0.f, model, 1, momentumQ);
 
     initEpochDataset();
     dataLoader_t *trainDl =


### PR DESCRIPTION
Closes #283.

Removes the dead `qtype_t qType` parameter from `sgdMCreateOptim` and the write-only `qtype` field from `optimizer_t`. Dead since #277/#278 routed the SGD update through `executeOp` (per-tensor dispatch on the target dtype; the grad-dtype validation reads `grad->quantization->type`, not the field — `Sgd.c` even documents "dispatch without a qtype switch here"). Breaking API change by design — all 21 caller files (12 tests + 9 examples) swept in this PR.

- RED: `_Static_assert` + `_Generic` signature contract in `UnitTestSgd.c` (fails to compile against the old 7-arg signature)
- GREEN: full `ctest --preset unit_test_debug` 72/72 + full `examples` preset build (all targets, incl. all 9 example binaries)
- `#include "Quantization.h"` deliberately kept in `Optimizer.h` (SgdApi.h's `quantization_t *` flows through `Sgd.h → Optimizer.h`; include-chain repointing is out of scope for a mechanical sweep)
- No doc changes needed (FEATURES.md / conventions/testing.md / har README mention the function without the argument)

Noted for a possible follow-up (pre-existing, deliberately untouched): stale comments referencing the pre-#278 `sgdStepMFloat`/`sgdStepMSymInt32` kernels at `test/unit/optimizer/UnitTestSgd.c:937` and `examples/har_classifier/train_c_sym.c:23,502`.

Reminder: `Closes #NN` only auto-fires on main-merges — close #283 manually after the develop merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)