### PR TITLE
docs: fix README drift + add CONTRIBUTING.md onboarding hub

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,199 @@
+# Contributing to OnDeviceTraining
+
+Welcome! This repository is a pure-C framework for **inference and on-device
+training (backpropagation) of DNNs on microcontrollers** — plus the beginnings
+of a Python pipeline that will compile PyTorch models down to it. This page is
+the map: where things live, how to build and test, and where the canonical
+rules are written down. It links rather than duplicates — when in doubt, the
+linked document wins.
+
+## Start here
+
+Read in this order:
+
+1. [`README.md`](README.md) — motivation, design principles, roadmap
+2. [`docs/FEATURES.md`](docs/FEATURES.md) — what the framework can do **today**
+   (layer/optimizer/serialization matrix)
+3. [`examples/README.md`](examples/README.md) — runnable end-to-end demos with
+   PyTorch twins and bit-parity checks; the best way to see the user-facing API
+4. [`docs/CONVENTIONS.md`](docs/CONVENTIONS.md) — contributor conventions index
+   and the project vision (memory over float accuracy); per-subsystem rules
+   live in [`docs/conventions/`](docs/conventions/)
+
+## Repository map
+
+| Path | What it is |
+|---|---|
+| `src/` | The C framework — one or more static libraries per subdirectory |
+| `test/unit/` | Unity unit tests, one `UnitTest<LibName>.c` per library |
+| `examples/` | End-to-end training demos (PyTorch reference + C twin + parity harness) |
+| `python/odt/` | Python package skeleton: `providers/`, `ir2c/`, `resource_estimator/` (not started yet) |
+| `docs/` | Feature matrix, conventions index, per-subsystem conventions |
+| `cmake/` | Build helpers and external dependencies (Unity via FetchContent) |
+| `.github/workflows/` | CI pipeline (see [CI](#branches-prs--ci)) |
+
+The C framework is layered; upper layers only reach lower ones:
+
+```
+src/userApi/          TrainingLoopApi, InferenceApi, TensorApi, SgdApi, StateDictApi, …
+    ↓
+src/layer/ + src/loss_functions/ + src/optimizer/
+    ↓
+src/arithmetic/       Matmul, Add, Comparison, Distributions, …
+    ↓
+src/tensor/           Tensor, Quantization, TensorConversion, DTypes
+```
+
+Support modules (`common/`, `csv/`, `data_loader/`, `rng/`, `serial/`) sit
+alongside. Dispatch is via C-style vtables — global function-pointer arrays
+(`layerFunctions[]`, `optimizerFunctions[]`, `lossFunctions[]`,
+`conversionMatrix[][]`) indexed by enum. Within each module, public headers
+live in its `include/` subdirectory and implementations at the directory root.
+
+## Development environment
+
+The supported setup is [devenv](https://devenv.sh) (requires Nix; devenv's
+Getting Started covers installing both): `devenv shell`
+provides cmake, ninja, gcc, arm-gcc, uv and Python 3.12 in known-good
+versions, plus these scripts:
+
+| Script | Does |
+|---|---|
+| `setup_cmake` | Configure the `unit_test` preset (with `CC=gcc`) |
+| `build_unit_tests` | Build the unit-test suite |
+| `run_ai_unit_tests` | Run all Unity unit tests via ctest |
+| `run_asan_tests` | Configure + build + run the suite under ASan/UBSan |
+| `clean_cmake` | Clean the `unit_test` build tree |
+| `ci` | Most of the CI pipeline locally: allocation-locality gate, `clang-format` check, C tests, ASan/UBSan tests, Python tests |
+
+Without devenv you need CMake ≥ 3.20, Ninja, a C compiler, and
+[uv](https://docs.astral.sh/uv/) for anything Python. Python work always goes
+through `uv run` / `uv sync` — never a bare `python` or `pip`.
+
+## Build & test
+
+The build is driven entirely by presets in
+[`CMakePresets.json`](CMakePresets.json):
+
+```sh
+cmake --preset unit_test_debug          # configure
+cmake --build --preset unit_test_debug  # build (target: all_unit_tests)
+ctest --preset unit_test_debug          # run all unit tests
+```
+
+| Configure preset | Purpose |
+|---|---|
+| `unit_test` | Plain unit-test build (what CI runs) |
+| `unit_test_error` / `unit_test_info` / `unit_test_debug` | Increasing log verbosity (`DEBUG_MODE_*`); `debug` also enables `ODT_MEM_PROFILE` |
+| `unit_test_asan` | AddressSanitizer + UBSan. On macOS this needs compiler-rt ≥ LLVM 22 — see [`docs/conventions/testing.md`](docs/conventions/testing.md) (the devenv shell handles it) |
+| `unit_test_ubsan` | Signed-overflow / float-cast UBSan build |
+| `examples` | `BUILD_EXAMPLES=ON`; the default `all` target compiles **every** example binary |
+| `examples_memprofile` | `examples` + `ODT_MEM_PROFILE=ON` |
+
+Each preset builds into its own `build/<preset>/` directory. Test presets
+exist for the six `unit_test*` presets; test binaries in
+`build/<preset>/test/unit/` can also be executed directly. Two practical
+notes:
+
+- The DataLoader test needs MNIST fixture files — generate once with
+  `uv run test/unit/data_loader/MNISTLoader.py`.
+- The unit-test build itself shells out to `uv run` for build-time gold-value
+  generators (PyTorch-computed expected values baked into headers), so `uv`
+  must be on `PATH` even for "C-only" work — and the first build syncs the
+  Python deps, including a sizable PyTorch download. The devenv shell brings
+  `uv`; CI has a dedicated sync step for this.
+- No `CMAKE_C_STANDARD` is set; the compiler default (typically gnu17) is
+  what CI builds with.
+
+Python tests: `uv run pytest` (from the repo root).
+
+## Examples
+
+Almost every example in [`examples/`](examples/README.md) pairs a PyTorch
+reference with a C twin and a deterministic **bit-parity** gate that CI
+enforces (the exception: `mixed_width_mlp` is a C-only acceptance demo) —
+they double as living documentation of the user-facing API and as regression
+tests. If your change touches training behavior, expect the bit-parity CI job
+to notice. Determinism rules live in
+[`examples/_shared/DETERMINISM.md`](examples/_shared/DETERMINISM.md).
+
+## Adding code
+
+Canonical rules: [`docs/CONVENTIONS.md`](docs/CONVENTIONS.md). The ones you
+will hit immediately:
+
+- `#define SOURCE_FILE "<filename>"` is the first line of every `.c` file
+  (before the `Common.h` include).
+- **Allocation locality**: `malloc`/`calloc`/`free` are allowed only in
+  `src/userApi/`; everything else goes through
+  `reserveMemory`/`freeReservedMemory` (StorageApi). CI greps for violations —
+  see [`docs/conventions/allocation.md`](docs/conventions/allocation.md).
+- Formatting is `clang-format` **21** (the major version CI pins; the devenv
+  shell provides it) with the repo `.clang-format`, 4-space indent — enforced
+  by CI. Other clang-format majors may format differently and fail the check.
+- Datasets deliver samples in their natural geometric shape; any
+  reshape/flatten is the first *layer* of the model — see
+  [`docs/conventions/data-shape.md`](docs/conventions/data-shape.md).
+
+### Adding a unit test
+
+1. Create `test/unit/<module>/UnitTest<LibName>.c` — the name must match the
+   CMake target of the library under test.
+2. Register it in that directory's `CMakeLists.txt` with
+   `add_elastic_ai_unit_test(LIB_UNDER_TEST <name> [MORE_LIBS ...])`
+   (defined in [`test/unit/unit_test.cmake`](test/unit/unit_test.cmake)).
+3. Tests use Unity (fetched automatically): `UNITY_BEGIN()`, `RUN_TEST(...)`,
+   `UNITY_END()` — registration is manual, there is no test discovery.
+   `setUp`/`tearDown` are empty stubs by convention.
+
+More in [`docs/conventions/testing.md`](docs/conventions/testing.md)
+(sanitizer gating, heap-tier memory discipline, build-time gold-value
+generators).
+
+## Branches, PRs & CI
+
+- `main` is the default/release branch; **`develop` is the integration
+  branch — branch off `develop` and target your PR back at `develop`**.
+- Branch protection requires green checks before merge; direct pushes are
+  blocked, all changes go through PRs.
+- Commit subjects follow conventional-commit style
+  (`feat(scope): …`, `fix(scope): …`, `docs: …`), as in the existing history.
+- GitHub's `Closes #NN` auto-close only fires on merges to the default branch
+  (`main`) — after a `develop` merge, close the issue manually.
+
+CI ([`.github/workflows/ci.yml`](.github/workflows/ci.yml)) runs on pushes and
+PRs to `main`/`develop`:
+
+| Job | Checks |
+|---|---|
+| `alloc-locality` | No allocation primitives outside `src/userApi/` |
+| `c-format-check` | `clang-format --dry-run -Werror` over `src`, `test`, `examples` |
+| `c-build-and-test` | `unit_test` preset: configure, build, ctest |
+| `c-asan-build-and-test` | The suite under ASan + UBSan |
+| `c-ubsan-build-and-test` | The suite under overflow-focused UBSan |
+| `c-bit-parity` | Builds **all** example binaries, then parity of the C twins against PyTorch (exact int32 predictions; ECG reconstructions via allclose) |
+| `python-test` | `uv run pytest` |
+
+The devenv `ci` script mirrors this pipeline locally (all but the UBSan and
+bit-parity jobs) — run it before opening a PR. If your change touches
+numerics or training behavior, also run the `unit_test_ubsan` preset and the
+affected examples' parity checks yourself.
+
+## The bigger picture
+
+This repo is half of a two-repo pipeline with
+[es-ude/elastic-ai.creator](https://github.com/es-ude/elastic-ai.creator):
+
+```
+PyTorch model → torch2ir → IR + shapes → annotated IR → ir2c → C code → MCU
+              ╰―― elastic-ai.creator ――╯               ╰――― this repo ―――╯
+```
+
+**creator** owns the IR definition, shape inference and protocol interfaces;
+**this repo** owns the provider implementations, `ir2c` code generation, the
+C training framework, resource estimation, and all hardware-specific logic.
+The Python side here (`python/odt/`) is a skeleton awaiting that work.
+
+## License
+
+MIT — see [`LICENSE.md`](LICENSE.md).

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,8 +1,9 @@
-# Examples — End-to-End 1D-CNN Demos with PyTorch + C Parity
+# Examples — End-to-End Demos with PyTorch + C Parity
 
 Each subdirectory is a self-contained example demonstrating the same model
 in PyTorch (reference) and the ODT C framework, with final-state parity
-checking and visualizations.
+checking and visualizations — except `mixed_width_mlp/`, which is a C-only
+acceptance demo with no PyTorch twin.
 
 ## Currently shipping
 
@@ -10,10 +11,11 @@ checking and visualizations.
 |---|---|---|
 | `mnist_mlp/` | MNIST dense-MLP digit classification | ✅ |
 | `mnist_cnn/` | MNIST 1D-CNN digit classification | ✅ |
-| `har_classifier/` | UCI HAR 6-class activity classification | Stage 1 |
+| `har_classifier/` | UCI HAR 6-class activity classification | Stage 1 ✅ |
 | `ecg_anomaly_ae/` | ECG5000 reconstruction-based anomaly detection | Stage 2 ✅ |
 | `kws_mfcc/` | SpeechCommands keyword spotting (MFCC features) | Stage 3 ✅ |
 | `kws_raw/` | SpeechCommands keyword spotting (raw waveform + in-model downsample) | Stage 3 ✅ |
+| `mixed_width_mlp/` | Mixed-width SYM_INT32 MLP on MNIST (C-only, no PyTorch twin) | ✅ |
 | `kws_denoising_ae/` | SpeechCommands additive-noise denoising | Stage 4 (planned) |
 
 ## Running an example
@@ -27,15 +29,20 @@ cmake --build --preset examples --target train_c_<name>
 uv run python examples/<name>/compare.py
 ```
 
-Each `train_c_<name>` binary also has a **bit-parity** mode: run it with
-`BIT_PARITY=1` and it loads the PyTorch reference weights (instead of training
-from scratch) and emits predictions that must match PyTorch exactly. This is
-the deterministic check CI runs; see each example's README for the precise
-`compare_predictions.py` invocation.
+`mixed_width_mlp/` has no Python steps: build its target and run the binary
+directly. It reads `examples/mnist_mlp/data/`, so run the `mnist_mlp`
+prepare step first.
 
-The C-side executables only build when configured with the `examples`
-preset (`BUILD_EXAMPLES=ON`); the default `unit_test_*` presets do not
-build them.
+Each `train_c_<name>` binary except `train_c_mixed_width_mlp` also has a
+**bit-parity** mode: run it with `BIT_PARITY=1` and it loads the PyTorch
+reference weights (instead of training from scratch) and emits predictions
+that must match PyTorch exactly. This is the deterministic check CI runs;
+see each example's README for the precise `compare_predictions.py`
+invocation.
+
+The C-side executables only build when configured with `BUILD_EXAMPLES=ON`
+(the `examples` or `examples_memprofile` presets); the default `unit_test_*`
+presets do not build them.
 
 ## Shared infrastructure
 

--- a/examples/ecg_anomaly_ae/README.md
+++ b/examples/ecg_anomaly_ae/README.md
@@ -53,7 +53,7 @@ After the train-from-scratch demo, `examples/ecg_anomaly_ae/` contains:
 ## Model
 
 - Input: `[1, 140]` (univariate ECG beat, 140 samples)
-- Encoder: `Conv1d(1→8, K=7, S=2, SAME)` → ReLU → `MaxPool1d(K=2, S=2)`
+- Encoder: `Conv1d(1→8, K=7, S=2, EXPLICIT pad=3)` → ReLU → `MaxPool1d(K=2, S=2)`
   → `Conv1d(8→16, K=5, SAME)` → ReLU → `AvgPool1d(K=5, S=5)` → `[16, 7]`
 - Decoder: `Conv1dTransposed(16→8, K=5, S=5)` → ReLU
   → `Conv1dTransposed(8→4, K=2, S=2)` → ReLU

--- a/examples/har_classifier/README.md
+++ b/examples/har_classifier/README.md
@@ -49,7 +49,7 @@ After the train-from-scratch demo, `examples/har_classifier/` contains:
 ## Model
 
 - Input: `[9, 128]` (9 IMU channels, 2.56 s window @ 50 Hz)
-- 3 × `Conv1d → ReLU → MaxPool1d` blocks
+- 2 × `Conv1d → ReLU → MaxPool1d` blocks, then `Conv1d → ReLU`
 - Global `AvgPool1d` → `Flatten → Linear → Softmax → CrossEntropy`
 - ~10 K parameters
 
@@ -74,8 +74,8 @@ FLOAT32 trainer as the reference.
 
 Key design points (see `docs/CONVENTIONS.md` and the source comments):
 
-- **Weights + biases** are packed `SYM@x` (`ceil(x·N/8)` bytes → @16 = 50%, @8 =
-  75%, @4 = 87.5% smaller than FLOAT32's `4N`). Everything else — gradients,
+- **Weights + biases** are packed `SYM@x` (`ceil(x·N/8)` bytes → @12 = 62.5%,
+  @8 = 75%, @4 = 87.5% smaller than FLOAT32's `4N`). Everything else — gradients,
   momentum, activation wires — is FLOAT32.
 - **Momentum is FLOAT32**, decoupled from the packed-SYM params via the optimizer's
   own-config knob (`sgdMCreateOptim(..., momentumQuant)`). A packed-SYM momentum
@@ -106,7 +106,7 @@ heap/stack/RSS peaks, and the **reconciliation gap** (`heap_peak − mcu_total`,
 ### Offline sweep + honest aggregation
 
 ```bash
-# Full study: {float, sym@16, sym@12, sym@8, sym@4} × seed 1..10 = 50 runs.
+# Full study: {float, sym@12, sym@10, sym@8, sym@6, sym@4} × seed 1..10 = 60 runs.
 # LONG (~40 h offline; NOT wired into CI). Use --configs/--seeds/--epochs to smoke.
 uv run examples/har_classifier/run_matrix.py                 # full
 uv run examples/har_classifier/run_matrix.py --configs float sym8 --seeds 1 2 --epochs 2  # smoke

--- a/examples/kws_mfcc/README.md
+++ b/examples/kws_mfcc/README.md
@@ -46,7 +46,7 @@ Run the full 35-class set with `KWS_CLASSES=35 …` on every command (local-only
 - Input: `[40, 32]` (40 MFCC channels, 32 frames) → `reshapeItemsAddBatchDim` → `[1, 40, 32]`
 - `Conv1d(40→32,K3,SAME) → ReLU → MaxPool(2) → Conv1d(32→64,K3,SAME) → ReLU →
   MaxPool(2) → AdaptiveAvgPool1d(1) → Flatten → Linear(64→C) → Softmax → CE`
-- Lengths: 32 → 16 → 8 → 1; ~16 K params
+- Lengths: 32 → 16 → 8 → 1; ~10.5 K params
 - State-dict layers: `conv1`, `conv2`, `fc`
 
 The train-from-scratch tolerances (`test_acc ±2.5 pp`, `test_loss ±0.15 nats`) are

--- a/examples/kws_raw/README.md
+++ b/examples/kws_raw/README.md
@@ -7,8 +7,8 @@ native `[1, 16000]` waveform and **downsamples in-framework** — its first laye
 `AvgPool1d(K=16, S=16)`, a decimation-by-16 box filter that turns 16 kHz into
 1 kHz. Change `K` to change the effective rate (8 → 2 kHz, …) with no re-prep; the
 `AdaptiveAvgPool1d(1)` head is length-agnostic so the rest of the model is
-unchanged (only the three MaxPool nominal `inputLength`s in `train_c.c` need to
-track the new lengths).
+unchanged (only the three MaxPool nominal `inputLength`s and the three LayerNorm
+`normalizedShape`s in `train_c.c` need to track the new lengths).
 
 One binary, two modes — **bit-parity** (`BIT_PARITY=1`, the exact CI gate) and a
 **train-from-scratch** informational demo. See `kws_mfcc/README.md` for the mode


### PR DESCRIPTION
## Summary

Two docs commits:

1. **README drift sweep** — every checkable claim in the repo READMEs verified against the sources, confirmed drift fixed with minimal edits, each fix independently re-verified with file:line evidence.
2. **New `CONTRIBUTING.md`** — a committed, link-first onboarding hub for new developers (much of this info previously lived only in untracked local notes).

## CONTRIBUTING.md

Layout: Start-here reading path → repository map + C architecture stack → devenv setup & scripts → preset-driven build/test (incl. the uv-at-build-time gold-value generators and the macOS ASan LLVM ≥ 22 pointer) → examples/bit-parity → code conventions quick-ref + adding-a-unit-test recipe → branch/PR/CI model (with the `Closes #NN`-only-on-`main` caveat) → two-repo pipeline context with elastic-ai.creator.

It deliberately carries only what no committed doc had (build commands, repo map, branch model, CI-job table) and links the canonical docs (`docs/CONVENTIONS.md` + `docs/conventions/`, `docs/FEATURES.md`, `examples/README.md`) for everything else. Every link target, preset name, script name, CI job and command was fact-checked against the repo; the devenv `ci`-script description explicitly notes it does *not* cover the UBSan and bit-parity CI jobs.

## README drift fixes

- **examples/README.md** — title no longer claims all examples are 1D-CNNs (`mnist_mlp`/`mixed_width_mlp` are MLPs); added the missing `mixed_width_mlp/` table row plus its C-only exceptions (no PyTorch twin, no bit-parity mode, reads `examples/mnist_mlp/data/` so that prepare step must run first); HAR marked `Stage 1 ✅` (its CI `BIT_PARITY=1` gate + exact prediction diff exist, same criteria as the other ✅ rows); `BUILD_EXAMPLES` paragraph now also names the `examples_memprofile` preset
- **har_classifier/README.md** — architecture is 2× `Conv1d → ReLU → MaxPool1d` then `Conv1d → ReLU` (third block has no MaxPool); packed-SYM width bullet starts at `@12 = 62.5%` since `SYM_BITS` is capped to `[1,12]` (#227, enforced in `train_c_sym.c`); offline sweep is `{float, sym@12, sym@10, sym@8, sym@6, sym@4} × seed 1..10 = 60 runs` (post HAR-searchspace update)
- **ecg_anomaly_ae/README.md** — encoder conv1 padding is `EXPLICIT pad=3`, not `SAME` (#177)
- **kws_mfcc/README.md** — param count is ~10.5 K (3872 + 6208 + 390 = 10470 for the 6-class default), not ~16 K
- **kws_raw/README.md** — a decimation-rate change must also track the three LayerNorm `normalizedShape`s in `train_c.c`, not just the MaxPool `inputLength`s

Root `README.md`, `mnist_mlp/README.md`, `mnist_cnn/README.md`: verified, drift-free — no changes.

## Confirmed findings deliberately NOT in this PR (code drift, not docs)

- **`ecg_anomaly_ae` train-from-scratch flow is broken**: `compare.py` unconditionally loads `outputs/c_train_recons.npy`, but the writer was dropped from `train_c.c` in the consolidation commit 5b996f4 → `FileNotFoundError` on README step 4b. README and `compare.py` agree on the intended contract, so the fix belongs in `train_c.c` (restore the train-set reconstruction dump), not in the README. Needs a follow-up issue.
- `har_classifier/run_matrix.py` docstring + `--configs` help still say 5 configs / 50 runs (stale after the 6-config searchspace).
- Stale comments in `mnist_mlp/train_c.c` and `kws_mfcc/train_c.c` reference a nonexistent `train_pytorch.py --save-weights` flag (the script always saves weights).

## Test plan

- Docs-only diff (5 × `.md` edits + 1 new `.md`); CI on this PR covers the usual C + Python jobs
- All 8 CMake presets were built and tested green today on this checkout (72/72 unit tests on all six test presets; both examples presets link all 9 example binaries)
- All CONTRIBUTING.md links, presets, scripts, CI jobs and commands fact-checked against the repo by two independent verification passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
