### PR TITLE
fix(ci,docs): address release-review findings from PR #311

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [main, develop]
 
+# Least privilege: every job only reads the repo (build/test/cache; nothing
+# pushes, comments, or releases). Widen per-job if a future job needs more.
+permissions:
+  contents: read
+
 jobs:
   alloc-locality:
     runs-on: ubuntu-latest
@@ -346,6 +351,9 @@ jobs:
         run: |
           curl -fsSL -o /tmp/arm-gnu.tar.xz \
             "https://developer.arm.com/-/media/Files/downloads/gnu/13.3.rel1/binrel/arm-gnu-toolchain-13.3.rel1-x86_64-arm-none-eabi.tar.xz"
+          # Pinned from Arm's official .sha256asc for 13.3.rel1 (fetched 2026-07-08);
+          # supply-chain guard: fail before extracting a tampered tarball.
+          echo "95c011cee430e64dd6087c75c800f04b9c49832cc1000127a92a97f9c8d83af4  /tmp/arm-gnu.tar.xz" | sha256sum -c -
           mkdir -p ~/arm-gnu-toolchain
           tar -xJf /tmp/arm-gnu.tar.xz -C ~/arm-gnu-toolchain --strip-components=1
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ Read in this order:
 
 The C framework is layered; upper layers only reach lower ones:
 
-```
+```text
 src/userApi/          TrainingLoopApi, InferenceApi, TensorApi, SgdApi, StateDictApi, …
     ↓
 src/layer/ + src/loss_functions/ + src/optimizer/
@@ -184,7 +184,7 @@ affected examples' parity checks yourself.
 This repo is half of a two-repo pipeline with
 [es-ude/elastic-ai.creator](https://github.com/es-ude/elastic-ai.creator):
 
-```
+```text
 PyTorch model → torch2ir → IR + shapes → annotated IR → ir2c → C code → MCU
               ╰―― elastic-ai.creator ――╯               ╰――― this repo ―――╯
 ```

--- a/examples/har_classifier/train_c_sym.c
+++ b/examples/har_classifier/train_c_sym.c
@@ -20,11 +20,10 @@
  *     and grad storage FLOAT32 (weightGradStorage/biasGradStorage left NULL =
  *     per-layer FLOAT32 default). No sub-byte packing on the grad side here.
  *   - all activation + dx wires FLOAT32.
- *   - optimizer: SGD-M, qType tag SYM_INT32 — routes through sgdStepMSymInt32,
- *     the dtype-generic dequant->float-update->requant path. convertTensor
- *     dispatches on the ACTUAL param dtype, so the SYM param round-trips
- *     SYM->FLOAT32->SYM (both cells exist); the "SYM_INT32" tag is a misnomer
- *     for "quantized param, dequant-update-requant".
+ *   - optimizer: SGD-M; the update routes through executeOp (#278), which
+ *     dispatches per tensor on its ACTUAL dtype — the packed-SYM params
+ *     round-trip SYM->FLOAT32->SYM each step, FLOAT32 grads and momentum are
+ *     used directly. No optimizer-level dtype tag exists (#283).
  *
  * SYM_BITS / SEED / LR / MOMENTUM / EPOCHS / LOG_PATH are env-overridable. */
 
@@ -499,11 +498,11 @@ int main(void) {
         return 2;
     }
 
-    /* qType tag SYM_INT32 -> sgdStepMSymInt32, the dtype-generic
-     * dequant->float-update->requant path. convertTensor dispatches on each
-     * tensor's ACTUAL dtype: the packed-SYM weights round-trip SYM<->FLOAT32 per
-     * step (write-back stochastic via symRounding), while the FLOAT32 grad and
-     * the FLOAT32 momentum state (below) are read/written directly. */
+    /* The SGD-M update routes through executeOp (#278): prologue/epilogue
+     * dispatch on each tensor's ACTUAL dtype. The packed-SYM weights round-trip
+     * SYM<->FLOAT32 per step (write-back stochastic via symRounding), while the
+     * FLOAT32 grad and the FLOAT32 momentum state (below) are read/written
+     * directly. */
 #ifdef ODT_MEM_PROFILE
     size_t markBeforeOpt = memProfileMark();
 #endif

--- a/test/unit/optimizer/UnitTestSgd.c
+++ b/test/unit/optimizer/UnitTestSgd.c
@@ -933,15 +933,15 @@ void testSgdStepMFloatReadsPackedSymGradGeneric(void) {
 }
 
 void testSgdStepMMixedDtypeMovesBothParamsCorrectly(void) {
-    /* TDD RED (Task 1, optimizer epic #277, closes #278): sgdStep{,M} dispatch
-     * on optim->qtype today, so a model with BOTH a FLOAT32 and a SYM_INT32
-     * parameter cannot be trained correctly in one call -- sgdStepMFloat
-     * (the FLOAT32 arm) raw-casts param->param->data/state->data to float*
-     * unconditionally, so a SYM_INT32 param/state gets its int32 mantissas
-     * reinterpreted as float bit patterns (garbage). This must fail today;
-     * the executeOp-funnel rewrite (per-tensor dtype dispatch via the
-     * funnel's own conversionMatrix lookups, no qtype switch) is what makes
-     * it pass. */
+    /* TDD RED history (Task 1, optimizer epic #277, closed #278): pre-#278,
+     * sgdStep{,M} dispatched on the since-removed optim->qtype (#283), so a
+     * model with BOTH a FLOAT32 and a SYM_INT32 parameter could not be trained
+     * correctly in one call -- the then-existing sgdStepMFloat arm raw-cast
+     * param/state data to float* unconditionally, reinterpreting SYM_INT32
+     * mantissas as float bit patterns (garbage). The executeOp-funnel rewrite
+     * (per-tensor dtype dispatch via the funnel's own conversionMatrix
+     * lookups, no qtype switch) is what makes this pass -- this test pins that
+     * mixed-dtype contract. */
 
     /* Parameter A: FLOAT32 param + grad, shape [2]. */
     size_t *aDims = reserveMemory(1 * sizeof(size_t));


### PR DESCRIPTION
Triage of CodeRabbit's 5 findings on the release PR #311 (develop→main) — 4 accepted, 1 rejected. Landing on develop so #311 picks it up before the main merge.

**Accepted:**
1. **ARM tarball SHA256 (Major/Security):** pinned from Arm's official `.sha256asc` for 13.3.rel1 (`95c011ce…83af4`, fetched 2026-07-08); `sha256sum -c` runs before extraction — a tampered download now fails the job instead of executing.
2. **Workflow permissions (Major/Security):** top-level `permissions: contents: read` — deliberately broader than the suggested per-job blocks: it covers ALL jobs (none pushes, comments, or releases), not just the two new ones.
3. **CONTRIBUTING.md fences (Minor):** both ASCII diagrams tagged `text` (markdownlint MD040).
4. **Stale `sgdStepM*`/qType comments (Minor):** all three sites reworded to the executeOp per-tensor dispatch (train_c_sym.c header + optimizer block; UnitTestSgd.c keeps its TDD-RED history, now in past tense). Matches the follow-up we flagged ourselves in #301.

**Rejected (false positive):** "CONTRIBUTING.md branch guidance — develop branch does not exist." `develop` exists and is the integration branch (#311 itself merges develop→main; branch protection and CI target it). The reviewer's sandbox `git branch -a` only saw the PR checkout.

Verified: YAML valid; full `ctest --preset unit_test_debug` green; `train_c_har_classifier_sym` builds (comment-only C changes).

Note: the parallel #308/#310 work will sweep `sgdMCreateOptim` callers — trivial comment-adjacent conflicts possible in `train_c_sym.c`; this PR is deliberately tiny so it lands first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)