### PR TITLE
fix(examples): convergence diagnostic needs >=2 epochs — skip on single-epoch probes

### DIFF
--- a/examples/har_classifier/train_c_sym.c
+++ b/examples/har_classifier/train_c_sym.c
@@ -609,7 +609,13 @@ int main(void) {
      * those still hard-fail on a genuinely broken build. */
     fprintf(stdout, "train_loss first=%.6f last=%.6f\n", (double)g_firstTrainLoss,
             (double)g_lastTrainLoss);
-    if (g_lastTrainLoss < g_firstTrainLoss) {
+    if (g_epochs < 2) {
+        /* first/last are per-EPOCH means: with one epoch they are the same
+         * number by construction, so the comparison below would always WARN
+         * (bit the CI stack-watermark probe, which runs EPOCHS=1). */
+        fprintf(stdout, "CONVERGENCE SKIP: single-epoch run — first/last epoch means are "
+                        "identical by construction\n");
+    } else if (g_lastTrainLoss < g_firstTrainLoss) {
         fprintf(stdout, "CONVERGENCE OK: train loss decreased (%.6f -> %.6f)\n",
                 (double)g_firstTrainLoss, (double)g_lastTrainLoss);
     } else {

--- a/src/arithmetic/include/ExecuteOp.h
+++ b/src/arithmetic/include/ExecuteOp.h
@@ -46,7 +46,7 @@ typedef enum {
  *         converted; NULL for single-output ops (e.g. MaxPool1d's argmax
  *         indices live here). */
 typedef struct opSpec {
-    opKernelFn_t kernel;
+    opKernelFn_t kernel; // has nothing to do with convolution
     const void *ctx;
     tensor_t **inputs;
     size_t nInputs;


### PR DESCRIPTION
The HAR SYM trainer's convergence diagnostic compares per-EPOCH mean losses (first vs last). With `EPOCHS=1` — exactly what the `c-stack-watermark` CI probe runs — the two values are the same number **by construction**, so the check warned on every probe run with a misleading "SYM@8 may be too coarse to descend at lr=0.0100".

The 50-epoch sweep data says the opposite: sym8 converges indistinguishably from float (train_loss 1.681→0.091 vs 1.684→0.086; test acc 0.905 vs 0.908 over 9 seeds), and even sym4 trains (0.886).

Fix: `EPOCHS < 2` now prints `CONVERGENCE SKIP: single-epoch run — first/last epoch means are identical by construction` instead of entering the comparison. OK/WARN behavior for real multi-epoch runs is unchanged.

Smoke-verified: `EPOCHS=1 SYM_BITS=8` run prints the SKIP line (and `train_loss first=1.680596` — matching the sweep's epoch-1 sym8 loss, confirming the probe always trained normally within its single epoch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)